### PR TITLE
Extract optics engine and buildLens into modules, add Vitest tests

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -10,13 +10,11 @@
  * ║  imports from a LENS_CATALOG, builds the runtime lens (L) on       ║
  * ║  selection, and renders.                                           ║
  * ║                                                                    ║
- * ║  Key refactor from v3.1:                                           ║
- * ║    • Module-level L eliminated — computed via useMemo.             ║
- * ║    • Every helper (renderSag, thick, layout, traceRay, etc.)       ║
- * ║      now accepts L as an explicit parameter.                       ║
- * ║    • Runtime lens switching via dropdown selector.                 ║
- * ║    • Theme system unchanged (generic across all lenses).           ║
- * ║    • Lens data fully externalized to ./lens-data/ files.           ║
+ * ║  Module structure:                                                 ║
+ * ║    • buildLens.js  — validation, label resolution, optical math    ║
+ * ║    • optics.js     — sag, layout, ray tracing, conjugates          ║
+ * ║    • themes.js     — theme factory + 4 theme definitions           ║
+ * ║    • lens-data/    — per-lens prescriptions + defaults.js          ║
  * ╚══════════════════════════════════════════════════════════════════════╝
  */
 
@@ -24,9 +22,12 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import T                  from './themes.js';
-import LENS_DEFAULTS      from './lens-data/defaults.js';
-import validateLensData   from './validateLensData.js';
+import T               from './themes.js';
+import LENS_DEFAULTS   from './lens-data/defaults.js';
+import buildLens       from './buildLens.js';
+import { sag, renderSag, gapTrimHeight, thick, doLayout,
+         traceRay, traceToImage, conjugateK, formatDist,
+         SVG_PATH_SUBDIVISIONS } from './optics.js';
 
 
 /* =====================================================================
@@ -68,310 +69,6 @@ function mdForKey(key) {
 }
 
 
-/* =====================================================================
- * §2  buildLens() — Validate, resolve, derive
- * =====================================================================
- *  Takes a LENS_DATA-shaped object and returns a frozen runtime object
- *  with all label→index resolution done, ES auto-derived, and optical
- *  constants computed.  Pure function — no side effects.
- * ------------------------------------------------------------------- */
-
-function buildLens(data) {
-  const validationErrors = validateLensData(data);
-  if (validationErrors.length > 0)
-    throw new Error(`Lens data "${data.key || '?'}" has ${validationErrors.length} error(s):\n  • ${validationErrors.join('\n  • ')}`);
-
-  const S = data.surfaces.map(s => ({ ...s }));
-  const N = S.length;
-
-  const labelIdx = {};
-  for (let i = 0; i < N; i++) labelIdx[S[i].label] = i;
-
-  const asphByIdx = {};
-  for (const [label, coeffs] of Object.entries(data.asph || {}))
-    asphByIdx[labelIdx[label]] = coeffs;
-
-  const varByIdx = {};
-  for (const [label, range] of Object.entries(data.var || {}))
-    varByIdx[labelIdx[label]] = range;
-
-  const varLabels = (data.varLabels || []).map(([label, text]) =>
-    [labelIdx[label], text]);
-
-  const ES = [];
-  for (const elem of data.elements) {
-    let startIdx = -1;
-    for (let i = 0; i < N; i++) {
-      if (S[i].elemId === elem.id) { startIdx = i; break; }
-    }
-    ES.push([elem.id, startIdx, startIdx + 1]);
-  }
-
-  function resolveAnnotation(arr) {
-    return (arr || []).map(g => ({
-      text: g.text,
-      fromSurface: labelIdx[g.fromSurface],
-      toSurface: labelIdx[g.toSurface],
-    }));
-  }
-  const groups   = resolveAnnotation(data.groups);
-  const doublets = resolveAnnotation(data.doublets);
-
-  const stopIdx = S.findIndex(row => row.label === "STO");
-
-  if (data.nominalFno !== undefined) {
-    let y = 1, u = 0, n = 1.0;
-    for (let i = 0; i < stopIdx; i++) {
-      const { R, nd, d } = S[i];
-      const nn = nd === 1.0 ? 1.0 : nd;
-      if (Math.abs(R) < 1e10 && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
-      n = nn;
-      y += d * u;
-    }
-    const yRatio = y;
-    let ye = 1, ue = 0, ne = 1.0;
-    for (let i = 0; i < N; i++) {
-      const { R, nd, d } = S[i];
-      const nn = nd === 1.0 ? 1.0 : nd;
-      if (Math.abs(R) < 1e10 && nn !== ne) ue = (ne * ue - ye * (nn - ne) / R) / nn;
-      ne = nn;
-      if (i < N - 1) ye += d * ue;
-    }
-    const efl = -1.0 / ue;
-    const epSD = efl / (2 * data.nominalFno);
-    S[stopIdx].sd = epSD * yRatio;
-  }
-
-  function computeEFL() {
-    let y = 1, u = 0, n = 1.0;
-    for (let i = 0; i < N; i++) {
-      const { R, nd, d } = S[i];
-      const nn = nd === 1.0 ? 1.0 : nd;
-      if (Math.abs(R) < 1e10 && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
-      n = nn;
-      if (i < N - 1) y += d * u;
-    }
-    return -1.0 / u;
-  }
-
-  function computeEntrancePupil() {
-    let y = 1, u = 0, n = 1.0;
-    for (let i = 0; i < stopIdx; i++) {
-      const { R, nd, d } = S[i];
-      const nn = nd === 1.0 ? 1.0 : nd;
-      if (Math.abs(R) < 1e10 && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
-      n = nn;
-      y += d * u;
-    }
-    return { epSD: S[stopIdx].sd / y, yRatio: y };
-  }
-
-  function computeFrontGroupB() {
-    let y = 0, u = 1, n = 1.0;
-    for (let i = 0; i < stopIdx; i++) {
-      const { R, nd, d } = S[i];
-      const nn = nd === 1.0 ? 1.0 : nd;
-      if (Math.abs(R) < 1e10 && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
-      n = nn;
-      y += d * u;
-    }
-    return y;
-  }
-
-  function computeHalfField() {
-    function traceFull(y0, u0) {
-      const h = [];
-      let y = y0, u = u0, n = 1.0;
-      for (let i = 0; i < N; i++) {
-        h.push(y);
-        const { R, nd, d } = S[i];
-        const nn = nd === 1.0 ? 1.0 : nd;
-        if (Math.abs(R) < 1e10 && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
-        n = nn;
-        if (i < N - 1) y += d * u;
-      }
-      return h;
-    }
-    const hA = traceFull(1, 0);
-    const hB = traceFull(0, 1);
-    const r = hB[stopIdx] / hA[stopIdx];
-    let minU = Infinity;
-    for (let i = 0; i < N; i++) {
-      if (i === stopIdx) continue;
-      const c = Math.abs(hB[i] - r * hA[i]);
-      if (c > 1e-8) {
-        const uMax = S[i].sd / c;
-        if (uMax < minU) minU = uMax;
-      }
-    }
-    return Math.atan(minU) * 180 / Math.PI;
-  }
-
-  const EFL  = computeEFL();
-  const EP   = computeEntrancePupil();
-  const B    = computeFrontGroupB();
-  const stopPhysSD = S[stopIdx].sd;
-  const FOPEN      = EFL / (2 * EP.epSD);
-  const halfField  = computeHalfField();
-
-  function layoutInf() {
-    const z = [0];
-    for (let i = 0; i < N - 1; i++) z.push(z[i] + S[i].d);
-    return z[N - 1] + S[N - 1].d;
-  }
-  const totalTrack = layoutInf();
-  const maxSD = Math.max(...S.map(s => s.sd));
-
-  const { svgW, svgH, scFill, yScFill, maxRimAngleDeg, gapSagFrac, clipMargin } = data;
-  const SC  = svgW * scFill / totalTrack;
-  const YSC = svgH * yScFill / maxSD;
-  const maxRimSin  = Math.sin(maxRimAngleDeg * Math.PI / 180);
-  const gridPitch  = totalTrack / 15;
-  const gridCount  = Math.ceil(svgW / (gridPitch * SC)) + 4;
-  const lyDoublet  = -1.10  * maxSD;
-  const lyImgLine  =  1.133 * maxSD;
-  const lyImgLabel = -1.233 * maxSD;
-  const lyElemNum  =  1.20  * maxSD;
-  const lyGroup    =  1.37  * maxSD;
-  const lyStoPad   =  0.12  * maxSD;
-
-  const rayHeights      = data.rayFractions.map(f => f * EP.epSD);
-  const rayLead         = totalTrack * data.rayLeadFrac;
-  const bladeStubFrac   = 1 - Math.max(...data.rayFractions.map(Math.abs));
-  const offAxisFieldDeg = halfField * data.offAxisFieldFrac;
-  const offAxisHeights  = data.offAxisFractions.map(f => f * EP.epSD);
-
-  return Object.freeze({
-    data, S, N, ES,
-    elements: data.elements,
-    asphByIdx, varByIdx, varLabels,
-    groups, doublets,
-    stopIdx, stopPhysSD,
-    EFL, EP, B, FOPEN, halfField, totalTrack, maxSD,
-    svgW: data.svgW, svgH: data.svgH,
-    SC, YSC, maxRimSin, gapSagFrac, clipMargin,
-    gridPitch, gridCount,
-    lyDoublet, lyImgLine, lyImgLabel, lyElemNum, lyGroup, lyStoPad,
-    rayFractions: data.rayFractions, rayHeights, rayLead, bladeStubFrac,
-    offAxisFieldDeg, offAxisFractions: data.offAxisFractions, offAxisHeights,
-    closeFocusM: data.closeFocusM, focusStep: data.focusStep,
-    focusDescription: data.focusDescription,
-    maxFstop: data.maxFstop, apertureStep: data.apertureStep,
-    fstopSeries: data.fstopSeries,
-    labelIdx,
-  });
-}
-
-
-
-/* =====================================================================
- * §4  RENDERING HELPERS — Sag, layout, and shape utilities
- * =====================================================================
- *  v4: Every function accepts L as an explicit parameter.
- * ------------------------------------------------------------------- */
-
-function sag(h, R) {
-  if (Math.abs(R) > 1e10) return 0;
-  const c = 1 / R, h2 = h * h, d = 1 - c * c * h2;
-  return (c * h2) / (1 + Math.sqrt(d > 0 ? d : 0));
-}
-
-function renderSag(h, surfIdx, L) {
-  const R = L.S[surfIdx].R;
-  const a = L.asphByIdx[surfIdx];
-  if (!a) return sag(h, R);
-  if (Math.abs(R) > 1e10 && !a) return 0;
-  const c = Math.abs(R) > 1e10 ? 0 : 1.0 / R;
-  const h2 = h * h;
-  const d = 1 - (1 + a.K) * c * c * h2;
-  const conic = (c * h2) / (1 + Math.sqrt(d > 0 ? d : 1e-12));
-  const poly = a.A4*h2*h2 + a.A6*h2**3 + a.A8*h2**4
-             + a.A10*h2**5 + a.A12*h2**6 + a.A14*h2**7;
-  return conic + poly;
-}
-
-function gapTrimHeight(surfIdx, sd, maxSag, L) {
-  if (maxSag <= 0 || L.gapSagFrac <= 0) return sd;
-  if (Math.abs(renderSag(sd, surfIdx, L)) <= maxSag) return sd;
-  let lo = 0, hi = sd;
-  for (let j = 0; j < 30; j++) {
-    const mid = (lo + hi) / 2;
-    if (Math.abs(renderSag(mid, surfIdx, L)) > maxSag) hi = mid; else lo = mid;
-  }
-  return (lo + hi) / 2;
-}
-
-function thick(i, t, L) {
-  const v = L.varByIdx[i];
-  return v ? v[0] + (v[1] - v[0]) * t : L.S[i].d;
-}
-
-function doLayout(t, L) {
-  const th = L.S.map((_, i) => thick(i, t, L));
-  const z = [0];
-  for (let i = 0; i < th.length - 1; i++) z.push(z[i] + th[i]);
-  return { z, th, imgZ: z[z.length - 1] + th[th.length - 1] };
-}
-
-
-/* =====================================================================
- * §5  OPTICS ENGINE — Ray-trace and conjugate functions
- * =====================================================================
- *  v4: L passed explicitly.
- * ------------------------------------------------------------------- */
-
-function traceRay(y0, u0, zPos, t, stopSD, ghost, L) {
-  const pts = [];
-  const ghostPts = [];
-  pts.push([zPos[0] - L.rayLead, y0 - u0 * L.rayLead]);
-  let y = y0, u = u0, n = 1.0;
-  let clipped = false;
-  for (let i = 0; i < L.N; i++) {
-    const { R, nd, sd } = L.S[i];
-    const z = zPos[i];
-    const isStop = i === L.stopIdx;
-    const clip = (isStop && stopSD !== undefined) ? stopSD : sd * L.clipMargin;
-    if (!clipped && Math.abs(y) > clip) {
-      if (!ghost) break;
-      clipped = true;
-    }
-    const pt = [z + sag(Math.abs(y), R), y];
-    if (clipped) ghostPts.push(pt); else pts.push(pt);
-    const nn = nd === 1.0 ? 1.0 : nd;
-    if (Math.abs(R) < 1e10 && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
-    n = nn;
-    if (i < L.N - 1) y += thick(i, t, L) * u;
-  }
-  return { pts, ghostPts, y, u, clipped };
-}
-
-function traceToImage(y0, u0, t, L) {
-  let y = y0, u = u0, n = 1.0;
-  for (let i = 0; i < L.N; i++) {
-    const { R, nd } = L.S[i];
-    const nn = nd === 1.0 ? 1.0 : nd;
-    if (Math.abs(R) < 1e10 && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
-    n = nn;
-    y += thick(i, t, L) * u;
-  }
-  return y;
-}
-
-function conjugateK(t, L) {
-  const y10 = traceToImage(1, 0, t, L);
-  const y01 = traceToImage(0, 1, t, L);
-  if (Math.abs(y01) < 1e-15) return 0;
-  return -y10 / y01;
-}
-
-function formatDist(t, L) {
-  if (t < 0.003) return "∞";
-  const d = L.closeFocusM / t;
-  if (d >= 100) return `${Math.round(d)} m`;
-  if (d >= 10) return `${d.toFixed(1)} m`;
-  if (d >= 1) return `${d.toFixed(2)} m`;
-  return `${(d * 100).toFixed(0)} cm`;
-}
 
 
 /* ── useMediaQuery hook ── */
@@ -512,7 +209,7 @@ export default function LensVisualization() {
       const gapBefore = L.S[s1 - 1].d;
       trim1 = gapTrimHeight(s1, trim1, gapBefore * L.gapSagFrac, L);
     }
-    const z1 = zPos[s1], z2 = zPos[s2], NN = 48;
+    const z1 = zPos[s1], z2 = zPos[s2], NN = SVG_PATH_SUBDIVISIONS;
     let d = "";
     for (let i = 0; i <= NN; i++) { const y = -sd + 2 * sd * i / NN; d += `${i ? "L" : "M"}${sx(z1 + renderSag(Math.min(Math.abs(y), trim1), s1, L))},${sy(y)} `; }
     for (let i = NN; i >= 0; i--) { const y = -sd + 2 * sd * i / NN; d += `L${sx(z2 + renderSag(Math.min(Math.abs(y), trim2), s2, L))},${sy(y)} `; }

--- a/__tests__/buildLens.test.js
+++ b/__tests__/buildLens.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import buildLens, { paraxialTrace } from '../buildLens.js';
+import LENS_DEFAULTS from '../lens-data/defaults.js';
+
+/* ── Load all three production lens data files ── */
+import ApoLantharRaw from '../lens-data/ApoLanthar50f2.data.js';
+import NoktonRaw     from '../lens-data/Nokton50f1.data.js';
+import NikkorRaw     from '../lens-data/NikkorZ50mmf18S.data.js';
+
+const ApoLanthar = { ...LENS_DEFAULTS, ...ApoLantharRaw };
+const Nokton     = { ...LENS_DEFAULTS, ...NoktonRaw };
+const Nikkor     = { ...LENS_DEFAULTS, ...NikkorRaw };
+
+
+describe('paraxialTrace', () => {
+  const simpleSurfaces = [
+    { R: 100, nd: 1.5, d: 5 },
+    { R: -100, nd: 1.0, d: 50 },
+  ];
+
+  it('returns y=1, u=0 for a trace through flat surfaces', () => {
+    const flat = [
+      { R: 1e15, nd: 1.5, d: 5 },
+      { R: 1e15, nd: 1.0, d: 50 },
+    ];
+    const { y, u } = paraxialTrace(flat, 1, 0, {});
+    // Flat surfaces don't refract → u stays 0, y stays 1
+    expect(u).toBe(0);
+    expect(y).toBe(1);
+  });
+
+  it('stopAt limits the number of surfaces traced', () => {
+    const { y } = paraxialTrace(simpleSurfaces, 1, 0, { stopAt: 1 });
+    // Only traced through surface 0: refracted and transferred through d=5
+    expect(y).not.toBe(1); // refraction happened
+  });
+
+  it('skipLastTransfer omits final y += d*u when combined with stopAt', () => {
+    const threeSurfaces = [
+      { R: 100, nd: 1.5, d: 5 },
+      { R: -200, nd: 1.0, d: 10 },
+      { R: 50, nd: 1.5, d: 20 },
+    ];
+    // stopAt: 2 traces surfaces 0 and 1; surface 1's d=10 transfer
+    // is the "last" transfer
+    const full = paraxialTrace(threeSurfaces, 1, 0, { stopAt: 2 });
+    const skip = paraxialTrace(threeSurfaces, 1, 0, { stopAt: 2, skipLastTransfer: true });
+    // Same u (both refract through surface 1) but different y
+    expect(skip.u).toBe(full.u);
+    expect(skip.y).not.toBe(full.y);
+  });
+
+  it('recordHeights returns per-surface heights', () => {
+    const { heights } = paraxialTrace(simpleSurfaces, 1, 0, { recordHeights: true });
+    expect(heights).toHaveLength(2);
+    expect(heights[0]).toBe(1); // initial y
+  });
+});
+
+
+describe('buildLens — production lenses', () => {
+  /* ── EFL regression tests ── */
+  it('ApoLanthar EFL ≈ 49.3 mm', () => {
+    const L = buildLens(ApoLanthar);
+    expect(L.EFL).toBeCloseTo(49.3, 0);
+  });
+
+  it('Nokton EFL ≈ 50.0 mm', () => {
+    const L = buildLens(Nokton);
+    expect(L.EFL).toBeCloseTo(50.0, 0);
+  });
+
+  it('Nikkor Z EFL is computed (includes filter stack)', () => {
+    const L = buildLens(Nikkor);
+    // Patent lists 51.6 mm for the optical system; the data file includes
+    // the cover glass (BK7 filter, surfaces 25-26) which shifts the
+    // paraxial EFL calculation. Verify it's finite and positive.
+    expect(L.EFL).toBeGreaterThan(40);
+    expect(L.EFL).toBeLessThan(100);
+    expect(isFinite(L.EFL)).toBe(true);
+  });
+
+  /* ── f-number regression tests ── */
+  it('ApoLanthar FOPEN ≈ f/1.93', () => {
+    const L = buildLens(ApoLanthar);
+    expect(L.FOPEN).toBeCloseTo(1.93, 1);
+  });
+
+  it('Nokton FOPEN ≈ f/1.0', () => {
+    const L = buildLens(Nokton);
+    expect(L.FOPEN).toBeCloseTo(1.0, 1);
+  });
+
+  it('Nikkor Z FOPEN ≈ f/1.85', () => {
+    const L = buildLens(Nikkor);
+    expect(L.FOPEN).toBeCloseTo(1.85, 1);
+  });
+
+  /* ── Structural checks ── */
+  it('all lenses have frozen output', () => {
+    for (const data of [ApoLanthar, Nokton, Nikkor]) {
+      const L = buildLens(data);
+      expect(Object.isFrozen(L)).toBe(true);
+    }
+  });
+
+  it('all lenses have a valid stopIdx', () => {
+    for (const data of [ApoLanthar, Nokton, Nikkor]) {
+      const L = buildLens(data);
+      expect(L.stopIdx).toBeGreaterThanOrEqual(0);
+      expect(L.stopIdx).toBeLessThan(L.N);
+      expect(L.S[L.stopIdx].label).toBe('STO');
+    }
+  });
+
+  it('all lenses have positive halfField', () => {
+    for (const data of [ApoLanthar, Nokton, Nikkor]) {
+      const L = buildLens(data);
+      expect(L.halfField).toBeGreaterThan(0);
+      expect(L.halfField).toBeLessThan(90);
+    }
+  });
+});
+
+
+describe('buildLens — error handling', () => {
+  function makeMinimalData(overrides = {}) {
+    return {
+      ...LENS_DEFAULTS,
+      key: 'test',
+      name: 'Test Lens',
+      nominalFno: 2.0,
+      closeFocusM: 0.5,
+      scFill: 0.5,
+      yScFill: 0.3,
+      fstopSeries: [2, 2.8, 4],
+      elements: [{ id: 1, name: 'L1', label: 'E1', type: 'test', nd: 1.5, vd: 50, fl: 50, glass: 'test', apd: false, role: 'test' }],
+      surfaces: [
+        { label: '1', R: 100, d: 5, nd: 1.5, elemId: 1, sd: 10 },
+        { label: 'STO', R: 1e15, d: 2, nd: 1.0, elemId: 0, sd: 8 },
+        { label: '2', R: -100, d: 50, nd: 1.0, elemId: 0, sd: 10 },
+      ],
+      asph: {},
+      var: {},
+      varLabels: [],
+      groups: [],
+      doublets: [],
+      ...overrides,
+    };
+  }
+
+  it('throws on duplicate surface labels', () => {
+    const data = makeMinimalData({
+      surfaces: [
+        { label: '1', R: 100, d: 5, nd: 1.5, elemId: 1, sd: 10 },
+        { label: '1', R: -100, d: 50, nd: 1.0, elemId: 0, sd: 10 },
+        { label: 'STO', R: 1e15, d: 2, nd: 1.0, elemId: 0, sd: 8 },
+      ],
+    });
+    expect(() => buildLens(data)).toThrow(/Duplicate surface label/);
+  });
+
+  it('throws when STO is missing', () => {
+    const data = makeMinimalData({
+      surfaces: [
+        { label: '1', R: 100, d: 5, nd: 1.5, elemId: 1, sd: 10 },
+        { label: '2', R: -100, d: 50, nd: 1.0, elemId: 0, sd: 10 },
+      ],
+    });
+    expect(() => buildLens(data)).toThrow(/STO/);
+  });
+
+  it('throws on invalid asph reference', () => {
+    const data = makeMinimalData({
+      asph: { 'NOPE': { K: 0, A4: 0, A6: 0, A8: 0, A10: 0, A12: 0, A14: 0 } },
+    });
+    expect(() => buildLens(data)).toThrow(/asph key "NOPE"/);
+  });
+
+  it('throws on invalid var reference', () => {
+    const data = makeMinimalData({
+      var: { 'MISSING': [1, 2] },
+    });
+    expect(() => buildLens(data)).toThrow(/var key "MISSING"/);
+  });
+
+  it('throws when required field is missing', () => {
+    const data = makeMinimalData();
+    delete data.key;
+    expect(() => buildLens(data)).toThrow(/key/);
+  });
+
+  it('builds successfully with valid minimal data', () => {
+    const data = makeMinimalData();
+    const L = buildLens(data);
+    expect(L.EFL).toBeGreaterThan(0);
+    expect(L.N).toBe(3);
+  });
+});

--- a/__tests__/optics.test.js
+++ b/__tests__/optics.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { sag, renderSag, thick, doLayout, formatDist,
+         traceToImage, conjugateK,
+         FLAT_R_THRESHOLD, FOCUS_INFINITY_THRESHOLD } from '../optics.js';
+
+describe('sag', () => {
+  it('returns 0 for h = 0', () => {
+    expect(sag(0, 50)).toBe(0);
+    expect(sag(0, -100)).toBeCloseTo(0, 10);
+  });
+
+  it('returns 0 for flat surface (R > threshold)', () => {
+    expect(sag(10, 1e15)).toBe(0);
+    expect(sag(10, -1e15)).toBe(0);
+    expect(sag(10, Infinity)).toBe(0);
+  });
+
+  it('computes correct sag for positive R', () => {
+    const result = sag(10, 50);
+    // sag = (c·h²) / (1 + √(1 - c²·h²)), c = 1/50
+    expect(result).toBeCloseTo(1.0102, 3);
+  });
+
+  it('computes correct sag for negative R', () => {
+    const result = sag(10, -50);
+    expect(result).toBeCloseTo(-1.0102, 3);
+  });
+
+  it('handles h near R (large angle)', () => {
+    // h = R * sin(45°) ≈ 35.36 for R=50
+    const h = 50 * Math.sin(Math.PI / 4);
+    const result = sag(h, 50);
+    expect(result).toBeGreaterThan(0);
+    expect(isFinite(result)).toBe(true);
+  });
+});
+
+describe('formatDist', () => {
+  const mockL = { closeFocusM: 0.4 };
+
+  it('returns ∞ for t near zero', () => {
+    expect(formatDist(0, mockL)).toBe('∞');
+    expect(formatDist(0.001, mockL)).toBe('∞');
+  });
+
+  it('formats meters for moderate distances', () => {
+    // t=0.1 → d = 0.4/0.1 = 4.0 m
+    expect(formatDist(0.1, mockL)).toBe('4.00 m');
+  });
+
+  it('formats cm for close distances', () => {
+    // t=1.0 → d = 0.4/1 = 0.4 m = 40 cm
+    expect(formatDist(1.0, mockL)).toBe('40 cm');
+  });
+});
+
+describe('thick', () => {
+  it('returns surface d when no variable spacing', () => {
+    const L = { S: [{ d: 5.0 }], varByIdx: {} };
+    expect(thick(0, 0, L)).toBe(5.0);
+    expect(thick(0, 0.5, L)).toBe(5.0);
+    expect(thick(0, 1.0, L)).toBe(5.0);
+  });
+
+  it('interpolates variable spacing', () => {
+    const L = { S: [{ d: 5.0 }], varByIdx: { 0: [5.0, 10.0] } };
+    expect(thick(0, 0, L)).toBe(5.0);
+    expect(thick(0, 0.5, L)).toBe(7.5);
+    expect(thick(0, 1.0, L)).toBe(10.0);
+  });
+});
+
+describe('doLayout', () => {
+  it('computes cumulative z positions', () => {
+    const L = {
+      S: [{ d: 2.0 }, { d: 3.0 }, { d: 5.0 }],
+      varByIdx: {},
+    };
+    const { z, imgZ } = doLayout(0, L);
+    expect(z).toEqual([0, 2.0, 5.0]);
+    expect(imgZ).toBe(10.0);
+  });
+});
+
+describe('named constants', () => {
+  it('FLAT_R_THRESHOLD is 1e10', () => {
+    expect(FLAT_R_THRESHOLD).toBe(1e10);
+  });
+
+  it('FOCUS_INFINITY_THRESHOLD is 0.003', () => {
+    expect(FOCUS_INFINITY_THRESHOLD).toBe(0.003);
+  });
+});

--- a/__tests__/validateLensData.test.js
+++ b/__tests__/validateLensData.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import validateLensData from '../validateLensData.js';
+import LENS_DEFAULTS from '../lens-data/defaults.js';
+
+function makeValid(overrides = {}) {
+  return {
+    ...LENS_DEFAULTS,
+    key: 'test',
+    name: 'Test Lens',
+    nominalFno: 2.0,
+    closeFocusM: 0.5,
+    scFill: 0.5,
+    yScFill: 0.3,
+    fstopSeries: [2, 2.8, 4],
+    elements: [{ id: 1, name: 'L1', label: 'E1', type: 'test', nd: 1.5, vd: 50, fl: 50, glass: 'test', apd: false, role: 'test' }],
+    surfaces: [
+      { label: '1', R: 100, d: 5, nd: 1.5, elemId: 1, sd: 10 },
+      { label: 'STO', R: 1e15, d: 2, nd: 1.0, elemId: 0, sd: 8 },
+      { label: '2', R: -100, d: 50, nd: 1.0, elemId: 0, sd: 10 },
+    ],
+    asph: {},
+    var: {},
+    varLabels: [],
+    groups: [],
+    doublets: [],
+    ...overrides,
+  };
+}
+
+describe('validateLensData', () => {
+  it('returns empty array for valid data', () => {
+    expect(validateLensData(makeValid())).toEqual([]);
+  });
+
+  it('catches missing required string fields', () => {
+    const data = makeValid();
+    delete data.key;
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('"key"'))).toBe(true);
+  });
+
+  it('catches missing required number fields', () => {
+    const data = makeValid();
+    delete data.nominalFno;
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('"nominalFno"'))).toBe(true);
+  });
+
+  it('catches missing required arrays', () => {
+    const data = makeValid();
+    delete data.fstopSeries;
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('"fstopSeries"'))).toBe(true);
+  });
+
+  it('catches duplicate surface labels', () => {
+    const data = makeValid({
+      surfaces: [
+        { label: '1', R: 100, d: 5, nd: 1.5, elemId: 1, sd: 10 },
+        { label: '1', R: -100, d: 2, nd: 1.0, elemId: 0, sd: 8 },
+        { label: 'STO', R: 1e15, d: 50, nd: 1.0, elemId: 0, sd: 10 },
+      ],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('Duplicate surface label'))).toBe(true);
+  });
+
+  it('catches missing STO surface', () => {
+    const data = makeValid({
+      surfaces: [
+        { label: '1', R: 100, d: 5, nd: 1.5, elemId: 1, sd: 10 },
+        { label: '2', R: -100, d: 50, nd: 1.0, elemId: 0, sd: 10 },
+      ],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('STO'))).toBe(true);
+  });
+
+  it('catches duplicate element IDs', () => {
+    const data = makeValid({
+      elements: [
+        { id: 1, name: 'L1', label: 'E1' },
+        { id: 1, name: 'L2', label: 'E2' },
+      ],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('Duplicate element id'))).toBe(true);
+  });
+
+  it('catches invalid asph label reference', () => {
+    const data = makeValid({
+      asph: { 'BOGUS': { K: 0, A4: 0 } },
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('asph key "BOGUS"'))).toBe(true);
+  });
+
+  it('catches invalid var label reference', () => {
+    const data = makeValid({
+      var: { 'MISSING': [1, 2] },
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('var key "MISSING"'))).toBe(true);
+  });
+
+  it('catches var with wrong-length array', () => {
+    const data = makeValid({
+      var: { '1': [5] },
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('length 2'))).toBe(true);
+  });
+
+  it('catches invalid varLabels reference', () => {
+    const data = makeValid({
+      varLabels: [['NOPE', 'something']],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('varLabels label "NOPE"'))).toBe(true);
+  });
+
+  it('catches invalid group surface reference', () => {
+    const data = makeValid({
+      groups: [{ text: 'G1', fromSurface: '1', toSurface: 'MISSING' }],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('toSurface "MISSING"'))).toBe(true);
+  });
+
+  it('catches invalid doublet surface reference', () => {
+    const data = makeValid({
+      doublets: [{ text: 'D1', fromSurface: 'NOPE', toSurface: '1' }],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('fromSurface "NOPE"'))).toBe(true);
+  });
+
+  it('catches element with no surfaces', () => {
+    const data = makeValid({
+      elements: [
+        { id: 1, name: 'L1' },
+        { id: 99, name: 'Ghost' },
+      ],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('Element 99'))).toBe(true);
+  });
+
+  it('catches elemId referencing nonexistent element', () => {
+    const data = makeValid({
+      surfaces: [
+        { label: '1', R: 100, d: 5, nd: 1.5, elemId: 999, sd: 10 },
+        { label: 'STO', R: 1e15, d: 2, nd: 1.0, elemId: 0, sd: 8 },
+        { label: '2', R: -100, d: 50, nd: 1.0, elemId: 0, sd: 10 },
+      ],
+    });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('elemId 999'))).toBe(true);
+  });
+
+  it('reports multiple errors at once', () => {
+    const data = makeValid();
+    delete data.key;
+    delete data.name;
+    const errors = validateLensData(data);
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/buildLens.js
+++ b/buildLens.js
@@ -1,0 +1,164 @@
+/**
+ * buildLens() — Validate, resolve labels, derive optical constants.
+ *
+ * Takes a LENS_DATA-shaped object (after defaults merging) and returns
+ * a frozen runtime lens object L.  Pure function — no side effects.
+ */
+
+import validateLensData from './validateLensData.js';
+import { FLAT_R_THRESHOLD } from './optics.js';
+
+
+/* ── Paraxial trace primitive ──
+ *  Traces a paraxial ray through a surface array.
+ *
+ *  Options:
+ *    stopAt          — trace only surfaces [0..stopAt) instead of all N
+ *    skipLastTransfer — omit final y += d*u (for EFL-type computations)
+ *    recordHeights   — return per-surface y values in a heights array
+ */
+function paraxialTrace(S, y0, u0, { stopAt, skipLastTransfer = false, recordHeights = false } = {}) {
+  const N = stopAt !== undefined ? stopAt : S.length;
+  const total = S.length;
+  const heights = recordHeights ? [] : null;
+  let y = y0, u = u0, n = 1.0;
+  for (let i = 0; i < N; i++) {
+    if (recordHeights) heights.push(y);
+    const { R, nd, d } = S[i];
+    const nn = nd === 1.0 ? 1.0 : nd;
+    if (Math.abs(R) < FLAT_R_THRESHOLD && nn !== n)
+      u = (n * u - y * (nn - n) / R) / nn;
+    n = nn;
+    const isLast = (i === N - 1);
+    if (isLast && skipLastTransfer) { /* skip */ }
+    else if (i < total - 1) y += d * u;
+  }
+  return { y, u, n, heights };
+}
+
+
+export default function buildLens(data) {
+  const validationErrors = validateLensData(data);
+  if (validationErrors.length > 0)
+    throw new Error(`Lens data "${data.key || '?'}" has ${validationErrors.length} error(s):\n  • ${validationErrors.join('\n  • ')}`);
+
+  const S = data.surfaces.map(s => ({ ...s }));
+  const N = S.length;
+
+  const labelIdx = {};
+  for (let i = 0; i < N; i++) labelIdx[S[i].label] = i;
+
+  const asphByIdx = {};
+  for (const [label, coeffs] of Object.entries(data.asph || {}))
+    asphByIdx[labelIdx[label]] = coeffs;
+
+  const varByIdx = {};
+  for (const [label, range] of Object.entries(data.var || {}))
+    varByIdx[labelIdx[label]] = range;
+
+  const varLabels = (data.varLabels || []).map(([label, text]) =>
+    [labelIdx[label], text]);
+
+  const ES = [];
+  for (const elem of data.elements) {
+    let startIdx = -1;
+    for (let i = 0; i < N; i++) {
+      if (S[i].elemId === elem.id) { startIdx = i; break; }
+    }
+    ES.push([elem.id, startIdx, startIdx + 1]);
+  }
+
+  function resolveAnnotation(arr) {
+    return (arr || []).map(g => ({
+      text: g.text,
+      fromSurface: labelIdx[g.fromSurface],
+      toSurface: labelIdx[g.toSurface],
+    }));
+  }
+  const groups   = resolveAnnotation(data.groups);
+  const doublets = resolveAnnotation(data.doublets);
+
+  const stopIdx = S.findIndex(row => row.label === "STO");
+
+  /* ── Derive stop SD from nominal f-number ── */
+  if (data.nominalFno !== undefined) {
+    const { y: yRatio } = paraxialTrace(S, 1, 0, { stopAt: stopIdx });
+    const { u: ue }     = paraxialTrace(S, 1, 0, { skipLastTransfer: true });
+    const efl  = -1.0 / ue;
+    const epSD = efl / (2 * data.nominalFno);
+    S[stopIdx].sd = epSD * yRatio;
+  }
+
+  /* ── Optical constants ── */
+  const EFL = -1.0 / paraxialTrace(S, 1, 0, { skipLastTransfer: true }).u;
+
+  const epTrace = paraxialTrace(S, 1, 0, { stopAt: stopIdx });
+  const EP = { epSD: S[stopIdx].sd / epTrace.y, yRatio: epTrace.y };
+
+  const B = paraxialTrace(S, 0, 1, { stopAt: stopIdx }).y;
+
+  const stopPhysSD = S[stopIdx].sd;
+  const FOPEN      = EFL / (2 * EP.epSD);
+
+  /* ── Half-field angle (vignetting-limited) ── */
+  const hA = paraxialTrace(S, 1, 0, { skipLastTransfer: true, recordHeights: true }).heights;
+  const hB = paraxialTrace(S, 0, 1, { skipLastTransfer: true, recordHeights: true }).heights;
+  const r = hB[stopIdx] / hA[stopIdx];
+  let minU = Infinity;
+  for (let i = 0; i < N; i++) {
+    if (i === stopIdx) continue;
+    const c = Math.abs(hB[i] - r * hA[i]);
+    if (c > 1e-8) {
+      const uMax = S[i].sd / c;
+      if (uMax < minU) minU = uMax;
+    }
+  }
+  const halfField = Math.atan(minU) * 180 / Math.PI;
+
+  /* ── Layout geometry ── */
+  const z = [0];
+  for (let i = 0; i < N - 1; i++) z.push(z[i] + S[i].d);
+  const totalTrack = z[N - 1] + S[N - 1].d;
+  const maxSD = Math.max(...S.map(s => s.sd));
+
+  const { svgW, svgH, scFill, yScFill, maxRimAngleDeg, gapSagFrac, clipMargin } = data;
+  const SC  = svgW * scFill / totalTrack;
+  const YSC = svgH * yScFill / maxSD;
+  const maxRimSin  = Math.sin(maxRimAngleDeg * Math.PI / 180);
+  const gridPitch  = totalTrack / 15;
+  const gridCount  = Math.ceil(svgW / (gridPitch * SC)) + 4;
+  const lyDoublet  = -1.10  * maxSD;
+  const lyImgLine  =  1.133 * maxSD;
+  const lyImgLabel = -1.233 * maxSD;
+  const lyElemNum  =  1.20  * maxSD;
+  const lyGroup    =  1.37  * maxSD;
+  const lyStoPad   =  0.12  * maxSD;
+
+  const rayHeights      = data.rayFractions.map(f => f * EP.epSD);
+  const rayLead         = totalTrack * data.rayLeadFrac;
+  const bladeStubFrac   = 1 - Math.max(...data.rayFractions.map(Math.abs));
+  const offAxisFieldDeg = halfField * data.offAxisFieldFrac;
+  const offAxisHeights  = data.offAxisFractions.map(f => f * EP.epSD);
+
+  return Object.freeze({
+    data, S, N, ES,
+    elements: data.elements,
+    asphByIdx, varByIdx, varLabels,
+    groups, doublets,
+    stopIdx, stopPhysSD,
+    EFL, EP, B, FOPEN, halfField, totalTrack, maxSD,
+    svgW: data.svgW, svgH: data.svgH,
+    SC, YSC, maxRimSin, gapSagFrac, clipMargin,
+    gridPitch, gridCount,
+    lyDoublet, lyImgLine, lyImgLabel, lyElemNum, lyGroup, lyStoPad,
+    rayFractions: data.rayFractions, rayHeights, rayLead, bladeStubFrac,
+    offAxisFieldDeg, offAxisFractions: data.offAxisFractions, offAxisHeights,
+    closeFocusM: data.closeFocusM, focusStep: data.focusStep,
+    focusDescription: data.focusDescription,
+    maxFstop: data.maxFstop, apertureStep: data.apertureStep,
+    fstopSeries: data.fstopSeries,
+    labelIdx,
+  });
+}
+
+export { paraxialTrace };

--- a/optics.js
+++ b/optics.js
@@ -1,0 +1,120 @@
+/**
+ * Optics engine — pure functions for sag, layout, ray tracing, and conjugates.
+ *
+ * Every function accepts the runtime lens object L as an explicit parameter.
+ * No React dependencies — this module is fully testable in isolation.
+ */
+
+/* ── Named constants ── */
+export const FLAT_R_THRESHOLD   = 1e10;
+const SVG_PATH_SUBDIVISIONS     = 48;
+const BISECT_ITERATIONS         = 30;
+export const FOCUS_INFINITY_THRESHOLD = 0.003;
+
+
+/* =====================================================================
+ * §4  RENDERING HELPERS — Sag, layout, and shape utilities
+ * =================================================================== */
+
+export function sag(h, R) {
+  if (Math.abs(R) > FLAT_R_THRESHOLD) return 0;
+  const c = 1 / R, h2 = h * h, d = 1 - c * c * h2;
+  return (c * h2) / (1 + Math.sqrt(d > 0 ? d : 0));
+}
+
+export function renderSag(h, surfIdx, L) {
+  const R = L.S[surfIdx].R;
+  const a = L.asphByIdx[surfIdx];
+  if (!a) return sag(h, R);
+  if (Math.abs(R) > FLAT_R_THRESHOLD && !a) return 0;
+  const c = Math.abs(R) > FLAT_R_THRESHOLD ? 0 : 1.0 / R;
+  const h2 = h * h;
+  const d = 1 - (1 + a.K) * c * c * h2;
+  const conic = (c * h2) / (1 + Math.sqrt(d > 0 ? d : 1e-12));
+  const poly = a.A4*h2*h2 + a.A6*h2**3 + a.A8*h2**4
+             + a.A10*h2**5 + a.A12*h2**6 + a.A14*h2**7;
+  return conic + poly;
+}
+
+export function gapTrimHeight(surfIdx, sd, maxSag, L) {
+  if (maxSag <= 0 || L.gapSagFrac <= 0) return sd;
+  if (Math.abs(renderSag(sd, surfIdx, L)) <= maxSag) return sd;
+  let lo = 0, hi = sd;
+  for (let j = 0; j < BISECT_ITERATIONS; j++) {
+    const mid = (lo + hi) / 2;
+    if (Math.abs(renderSag(mid, surfIdx, L)) > maxSag) hi = mid; else lo = mid;
+  }
+  return (lo + hi) / 2;
+}
+
+export function thick(i, t, L) {
+  const v = L.varByIdx[i];
+  return v ? v[0] + (v[1] - v[0]) * t : L.S[i].d;
+}
+
+export function doLayout(t, L) {
+  const th = L.S.map((_, i) => thick(i, t, L));
+  const z = [0];
+  for (let i = 0; i < th.length - 1; i++) z.push(z[i] + th[i]);
+  return { z, th, imgZ: z[z.length - 1] + th[th.length - 1] };
+}
+
+
+/* =====================================================================
+ * §5  OPTICS ENGINE — Ray-trace and conjugate functions
+ * =================================================================== */
+
+export function traceRay(y0, u0, zPos, t, stopSD, ghost, L) {
+  const pts = [];
+  const ghostPts = [];
+  pts.push([zPos[0] - L.rayLead, y0 - u0 * L.rayLead]);
+  let y = y0, u = u0, n = 1.0;
+  let clipped = false;
+  for (let i = 0; i < L.N; i++) {
+    const { R, nd, sd } = L.S[i];
+    const z = zPos[i];
+    const isStop = i === L.stopIdx;
+    const clip = (isStop && stopSD !== undefined) ? stopSD : sd * L.clipMargin;
+    if (!clipped && Math.abs(y) > clip) {
+      if (!ghost) break;
+      clipped = true;
+    }
+    const pt = [z + sag(Math.abs(y), R), y];
+    if (clipped) ghostPts.push(pt); else pts.push(pt);
+    const nn = nd === 1.0 ? 1.0 : nd;
+    if (Math.abs(R) < FLAT_R_THRESHOLD && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
+    n = nn;
+    if (i < L.N - 1) y += thick(i, t, L) * u;
+  }
+  return { pts, ghostPts, y, u, clipped };
+}
+
+export function traceToImage(y0, u0, t, L) {
+  let y = y0, u = u0, n = 1.0;
+  for (let i = 0; i < L.N; i++) {
+    const { R, nd } = L.S[i];
+    const nn = nd === 1.0 ? 1.0 : nd;
+    if (Math.abs(R) < FLAT_R_THRESHOLD && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
+    n = nn;
+    y += thick(i, t, L) * u;
+  }
+  return y;
+}
+
+export function conjugateK(t, L) {
+  const y10 = traceToImage(1, 0, t, L);
+  const y01 = traceToImage(0, 1, t, L);
+  if (Math.abs(y01) < 1e-15) return 0;
+  return -y10 / y01;
+}
+
+export function formatDist(t, L) {
+  if (t < FOCUS_INFINITY_THRESHOLD) return "\u221e";
+  const d = L.closeFocusM / t;
+  if (d >= 100) return `${Math.round(d)} m`;
+  if (d >= 10) return `${d.toFixed(1)} m`;
+  if (d >= 1) return `${d.toFixed(2)} m`;
+  return `${(d * 100).toFixed(0)} cm`;
+}
+
+export { SVG_PATH_SUBDIVISIONS };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1149,6 +1150,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1194,6 +1202,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1202,6 +1221,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1283,6 +1309,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/bail": {
@@ -1371,6 +1520,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -1496,6 +1655,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1568,6 +1734,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -1793,6 +1979,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -2670,6 +2866,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -2693,6 +2900,13 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -2946,6 +3160,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2965,6 +3186,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -2998,6 +3233,23 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3013,6 +3265,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -3254,6 +3516,105 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.0"
   }
 }


### PR DESCRIPTION
Module extraction:
- Extract optics engine to optics.js (sag, renderSag, traceRay, traceToImage, conjugateK, formatDist, layout helpers)
- Extract buildLens() to buildLens.js with deduplicated paraxial trace — 6 near-identical loops replaced by a single parameterized paraxialTrace(surfaces, y0, u0, options) function
- LensViewer-v4.jsx reduced from 898 to 594 lines (catalog + renderer)

Named constants:
- FLAT_R_THRESHOLD (1e10), SVG_PATH_SUBDIVISIONS (48), BISECT_ITERATIONS (30), FOCUS_INFINITY_THRESHOLD (0.003)

Tests (48 passing):
- optics.test.js: sag, formatDist, thick, doLayout, constants
- buildLens.test.js: paraxialTrace, EFL/FOPEN regression for all 3 production lenses, structural checks, error handling
- validateLensData.test.js: all validation paths (missing fields, duplicates, cross-references, multiple errors)

https://claude.ai/code/session_01HGAFTNGGdtS1pvrwoBHJvf