### PR TITLE
Fix lens selector obscured by random characters in light mode (#10)

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -542,7 +542,7 @@ export default function LensVisualization() {
             borderRadius: 6, padding: "5px 28px 5px 10px", cursor: "pointer",
             fontSize: 10, color: t.selectorText, fontFamily: "inherit",
             letterSpacing: "0.06em", appearance: "none", outline: "none",
-            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='${t.selectorText.replace("#", "%23")}'/%3E%3C/svg%3E")`,
+            backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6'><path d='M0 0l5 6 5-6z' fill='${t.selectorText}'/></svg>`)}")`,
             backgroundRepeat: "no-repeat", backgroundPosition: "right 8px center",
             transition: "all 0.3s", flex: "0 1 300px",
           }}


### PR DESCRIPTION
The dropdown chevron SVG data URI was only partially percent-encoded: <, >, and # were escaped but spaces, quotes, colons, and other special characters were left raw. Some browsers failed to parse the malformed URI and rendered the raw SVG markup as visible text. This was invisible in dark mode (dark artifacts on dark background) but visible in light mode (dark artifacts on light background).

Fix: use encodeURIComponent on the entire SVG string so all characters are properly encoded, eliminating the manual .replace("#", "%23") hack.

https://claude.ai/code/session_01BqTe3uC9qxQLgjusrLghLY