### PR TITLE
Add lens data template and specification for AI-assisted lens creation

### DIFF
--- a/lens-data/LENS_DATA_SPEC.md
+++ b/lens-data/LENS_DATA_SPEC.md
@@ -1,0 +1,287 @@
+# Lens Data Specification
+
+Reference for creating new `*.data.js` files in `lens-data/`.
+
+## Quick Start
+
+1. Copy `TEMPLATE.data.js` to `YourLens.data.js`
+2. Fill in all fields following this spec
+3. Optionally add `YourLens.analysis.md` for the description panel
+4. Auto-registration picks it up — no imports or catalog edits needed
+
+File naming: `lens-data/*.data.js` (glob pattern used for auto-discovery).
+
+---
+
+## Top-Level Fields
+
+### Required (must be in every lens file)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | `string` | Unique identifier (e.g. `"nokton-50f1"`). Used as catalog key. |
+| `name` | `string` | Full display name (e.g. `"VOIGTLÄNDER NOKTON 50mm f/1.0"`) |
+| `elements` | `array` | Glass elements, front to rear (min 1) |
+| `surfaces` | `array` | Optical surfaces, front to rear (min 1) |
+| `nominalFno` | `number` | Nominal f-number for the design |
+| `closeFocusM` | `number` | Minimum focus distance in meters |
+| `fstopSeries` | `array` | F-stop values for quick-select UI buttons |
+
+### Required but have defaults (from `defaults.js`)
+
+These are merged automatically. Override only when needed.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `svgW` | `1080` | SVG viewport width (px) |
+| `svgH` | `490` | SVG viewport height (px) |
+| `clipMargin` | `1.0` | Clipping margin for element trimming |
+| `maxRimAngleDeg` | `40` | Max rim angle (degrees) |
+| `gapSagFrac` | `0.90` | Sag rendering fraction for air gaps |
+| `focusStep` | `0.004` | Focus slider step size |
+| `apertureStep` | `0.004` | Aperture slider step size |
+| `maxFstop` | `16` | Maximum f-number for aperture slider |
+| `rayFractions` | `[-0.83, -0.50, -0.17, 0.17, 0.50, 0.83]` | On-axis ray fan heights |
+| `rayLeadFrac` | `0.19` | Ray lead distance (fraction of total track) |
+| `offAxisFieldFrac` | `0.60` | Off-axis field angle (fraction of max half-field) |
+| `offAxisFractions` | `[-0.75, -0.375, 0, 0.375, 0.75]` | Off-axis ray fan heights |
+
+### Optional
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subtitle` | `string` | Patent reference shown in UI header |
+| `specs` | `string[]` | Spec strings displayed in header |
+| `focusDescription` | `string` | Human-readable focus mechanism description |
+| `asph` | `object` | Aspherical coefficients (see below) |
+| `var` | `object` | Variable air gaps for focus (see below) |
+| `varLabels` | `array` | Display labels for variable gaps |
+| `groups` | `array` | Group annotations for SVG diagram |
+| `doublets` | `array` | Cemented doublet annotations for SVG diagram |
+| `scFill` | `number` | Horizontal fill fraction (0–1) — layout tuning |
+| `yScFill` | `number` | Vertical fill fraction (0–1) — layout tuning |
+
+---
+
+## Element Object
+
+Each entry in the `elements` array describes one physical glass element.
+
+```javascript
+{
+  id:       1,                              // REQUIRED: unique integer, referenced by surfaces
+  name:     "L1",                           // REQUIRED: short name
+  label:    "Element 1",                    // REQUIRED: display label
+  type:     "Biconvex Positive",            // REQUIRED: optical shape/type description
+  nd:       1.90525,                        // REQUIRED: refractive index (d-line, 587.6 nm)
+  vd:       35.04,                          // REQUIRED: Abbe number
+  fl:       119.3,                          // REQUIRED: focal length in mm
+  glass:    "LaSF (LASF35 melt)",           // REQUIRED: glass name/catalog
+  apd:      false,                          // optional: false | "patent" | "inferred"
+  apdNote:  "dPgF = +0.0376",              // optional: APD details
+  role:     "Front positive meniscus...",    // optional: optical role description
+  cemented: "D1",                           // optional: doublet/triplet group name
+}
+```
+
+**Common `type` values:**
+- `"Biconvex Positive"`, `"Biconcave Negative"`
+- `"Positive Meniscus"`, `"Negative Meniscus"`
+- `"Pos. Meniscus (1× Asph)"`, `"Neg. Meniscus (2× Asph)"`
+- `"Plano-Convex"`, `"Plano-Concave"`
+
+**Validation rules:**
+- Each `id` must be unique across all elements
+- Every element must be referenced by at least one surface's `elemId`
+
+---
+
+## Surface Object
+
+Each entry in the `surfaces` array describes one optical surface, in strict front-to-rear order.
+
+```javascript
+{
+  label:  "3A",       // REQUIRED: unique label — append "A" for aspherical surfaces
+  R:      50.421,     // REQUIRED: radius of curvature in mm
+  d:      3.46,       // REQUIRED: axial thickness to next surface in mm
+  nd:     1.85249,    // REQUIRED: refractive index of medium AFTER this surface
+  elemId: 2,          // REQUIRED: element ID (0 = air interface)
+  sd:     14.5,       // REQUIRED: semi-diameter (half clear aperture) in mm
+}
+```
+
+### Sign Conventions
+
+| Value | Meaning |
+|-------|---------|
+| `R > 0` | Center of curvature to the RIGHT |
+| `R < 0` | Center of curvature to the LEFT |
+| `R = 1e15` | Flat surface (infinite radius) |
+| `d > 0` | Always positive (distance to next surface) |
+| `nd = 1.0` | Air gap |
+| `nd > 1.0` | Glass medium (use the glass's refractive index) |
+
+### Surface Label Convention
+
+- Sequential numbers: `"1"`, `"2"`, `"3"`, ...
+- Append `"A"` for aspherical surfaces: `"1A"`, `"3A"`, `"18A"`
+- The aperture stop MUST be labeled `"STO"` (exactly one required)
+
+### Pairing Rules
+
+- **Glass element entry:** Surface where light enters the glass — `nd` = glass refractive index, `elemId` = element ID
+- **Glass element exit (to air):** Surface where light exits — `nd = 1.0`, `elemId = 0`
+- **Cemented interface:** Rear surface of front element has `nd` = next element's glass, no air gap surface between them
+- **Last surface:** `d` = back focal distance to image plane
+
+### Aperture Stop
+
+Exactly one surface must have `label: "STO"`. This is typically a flat surface (`R: 1e15`) in an air gap (`nd: 1.0, elemId: 0`). The `sd` value is the physical stop semi-diameter — the renderer derives the entrance pupil from this via paraxial ray trace.
+
+---
+
+## Aspherical Coefficients (`asph`)
+
+Object keyed by surface label. Only include aspherical surfaces.
+
+```javascript
+asph: {
+  "3A": {
+    K:   0,              // Conic constant (0 = sphere, -1 = paraboloid)
+    A4:  -1.6435e-06,    // 4th-order coefficient
+    A6:   7.0442e-10,    // 6th-order
+    A8:   2.7291e-11,    // 8th-order
+    A10: -2.2674e-15,    // 10th-order
+    A12:  0,             // 12th-order (0 if not used)
+    A14:  0,             // 14th-order (0 if not used)
+  },
+}
+```
+
+**Sag equation:**
+```
+Z(h) = (h²/R) / [1 + √(1 − (1+K)·(h/R)²)] + A4·h⁴ + A6·h⁶ + A8·h⁸ + A10·h¹⁰ + A12·h¹² + A14·h¹⁴
+```
+
+**Rules:**
+- Keys must match existing surface labels
+- Set unused coefficients to `0`
+- For all-spherical designs: `asph: {}`
+
+---
+
+## Variable Air Spacings (`var`)
+
+Describes air gaps that change during focus.
+
+```javascript
+var: {
+  "10":  [5.49, 5.89],     // [d_at_infinity, d_at_close_focus]
+  "14":  [0.56, 3.57],
+  "19A": [15.00, 20.53],
+},
+varLabels: [
+  ["10",  "ZD10"],          // [surface_label, display_text]
+  ["14",  "ZD14"],
+  ["19A", "BF"],            // "BF" = back focus — conventional label for last gap
+],
+```
+
+**Rules:**
+- Keys must match existing surface labels
+- Each value is `[d_infinity, d_close]` — exactly 2 numbers
+- The surface's `d` field should equal `var[label][0]` (infinity value)
+- `varLabels` entries must reference keys present in `var`
+
+**Focus types by number of variable gaps:**
+
+| Gaps | Type | Description |
+|------|------|-------------|
+| 1 | Unit focus | Entire lens moves; only BFD changes |
+| 2 | Inner focus | Internal group moves; 2 gaps change |
+| 3+ | Floating focus | Multiple groups move independently |
+
+---
+
+## Group & Doublet Annotations
+
+Visual brackets shown on the SVG diagram.
+
+```javascript
+groups: [
+  { text: "FRONT (101)", fromSurface: "1",  toSurface: "10" },
+  { text: "REAR (102)",  fromSurface: "12", toSurface: "19A" },
+],
+doublets: [
+  { text: "Jb", fromSurface: "12", toSurface: "14" },
+  { text: "Ja", fromSurface: "15", toSurface: "17" },
+],
+```
+
+**Rules:**
+- `fromSurface` and `toSurface` must be valid surface labels
+- These are purely visual annotations — they don't affect optical calculations
+
+---
+
+## Validation
+
+`validateLensData()` runs automatically when a lens is loaded. It checks:
+
+1. All required fields are present and correctly typed
+2. Exactly one `"STO"` surface exists
+3. All element IDs are unique
+4. Every element is referenced by at least one surface
+5. All surface `elemId` values reference valid elements (or `0` for air)
+6. All `asph` keys match existing surface labels
+7. All `var` keys match existing surface labels with `[d_inf, d_close]` arrays
+8. All `varLabels` reference valid surface labels
+9. All `groups`/`doublets` reference valid surface labels
+
+On failure, `buildLens()` throws with all errors listed.
+
+---
+
+## Data Sourcing Checklist
+
+When transcribing from an optical patent:
+
+1. **Surfaces** — Copy the prescription table exactly (R, d, nd). Watch sign conventions — some patents use opposite R sign convention
+2. **Semi-diameters** — Use patent values if listed; otherwise estimate from entrance pupil geometry with 8–12% mechanical clearance
+3. **Aspherical coefficients** — Copy from the asph table. Watch for scientific notation format differences between patents
+4. **Variable gaps** — Look for "variable spacing" tables showing values at different object distances
+5. **Elements** — Derive from the surface data: consecutive surfaces with the same glass (nd > 1) form one element. Cemented elements share a boundary surface
+6. **Glass identification** — Match nd/vd pairs against catalogs (OHARA, SCHOTT, HOYA, Sumita). Note when matches are uncertain
+7. **Focal length** — Use the patent's stated EFL, or compute from the prescription via paraxial ray trace
+8. **F-number** — Use the patent's stated f-number. If the patent gives the stop diameter, compute `f/# = EFL / (2 × EP_SD)`
+
+---
+
+## Example: Minimal All-Spherical Singlet
+
+```javascript
+const LENS_DATA = {
+  key:      "example-singlet",
+  name:     "Example Singlet 50mm f/4",
+  elements: [
+    { id: 1, name: "L1", label: "Element 1", type: "Biconvex Positive", nd: 1.51633, vd: 64.06, fl: 50.0, glass: "N-BK7" },
+  ],
+  surfaces: [
+    { label: "STO", R:  1e15,   d: 1.0,  nd: 1.0,     elemId: 0, sd: 6.25 },
+    { label: "2",   R:  25.84,  d: 5.0,  nd: 1.51633,  elemId: 1, sd: 7.0  },
+    { label: "3",   R: -25.84,  d: 44.0, nd: 1.0,      elemId: 0, sd: 7.0  },
+  ],
+  asph:         {},
+  var:          { "3": [44.0, 42.0] },
+  varLabels:    [["3", "BF"]],
+  groups:       [],
+  doublets:     [],
+  closeFocusM:  0.45,
+  nominalFno:   4.0,
+  fstopSeries:  [4, 5.6, 8, 11, 16, 22],
+  scFill:       0.50,
+  yScFill:      0.30,
+};
+export default LENS_DATA;
+```

--- a/lens-data/TEMPLATE.data.js.template
+++ b/lens-data/TEMPLATE.data.js.template
@@ -1,0 +1,164 @@
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — [LENS NAME]                                  ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: [Patent number] [Example number] ([Company/Author]). ║
+ * ║  [Brief description of the design].                                ║
+ * ║  [N] elements / [N] groups, [N] aspherical surfaces.              ║
+ * ║  Focus: [focus mechanism description].                             ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    [Describe how SDs were determined — patent-listed, estimated    ║
+ * ║    from EP geometry, etc.]                                         ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+
+  /* ── Identity ── */
+  key:      "unique-lens-key",                          // REQUIRED: unique ID for auto-registration
+  name:     "MANUFACTURER LENS-NAME FLmm f/N",          // REQUIRED: full display name
+  subtitle: "PATENT-NUMBER EXAMPLE N — COMPANY / INVENTOR",  // optional: shown in UI header
+  specs: [                                               // optional: spec strings for header display
+    "N ELEMENTS / N GROUPS",
+    "f ≈ NN.N mm",
+    "F/N.N",
+    "2ω ≈ NN.N°",
+    "N ASPHERICAL SURFACES",
+  ],
+
+  /* ── Elements ──
+   *  One entry per physical glass element, front to rear.
+   *  Each element must have a unique `id` and be referenced by at least one surface.
+   *
+   *  Fields:
+   *    id       (number, REQUIRED)  Unique integer ID — referenced by surfaces via elemId
+   *    name     (string, REQUIRED)  Short name, e.g. "L1", "Lfa"
+   *    label    (string, REQUIRED)  Display label, e.g. "Element 1"
+   *    type     (string, REQUIRED)  Optical type, e.g. "Biconvex Positive", "Neg. Meniscus (2× Asph)"
+   *    nd       (number, REQUIRED)  Refractive index at d-line (587.6 nm)
+   *    vd       (number, REQUIRED)  Abbe number (dispersion)
+   *    fl       (number, REQUIRED)  Focal length in mm (positive or negative)
+   *    glass    (string, REQUIRED)  Glass designation or catalog match
+   *    apd      (string|false, optional)  Anomalous partial dispersion: false, "patent", or "inferred"
+   *    apdNote  (string, optional)  Additional APD details, e.g. "dPgF = +0.0376 (patent-listed)"
+   *    role     (string, optional)  Description of the element's optical role/function
+   *    cemented (string, optional)  Doublet/triplet group name if cemented, e.g. "Jb", "L4"
+   */
+  elements: [
+    { id: 1, name: "L1", label: "Element 1", type: "Biconvex Positive",  nd: 1.00000, vd: 00.00, fl:  00.0, glass: "Glass Name (CATALOG)", apd: false, role: "Description of optical role" },
+    // ... one entry per glass element, front to rear
+  ],
+
+  /* ── Surface prescription ──
+   *  One entry per optical surface, in strict front-to-rear order.
+   *  Includes glass surfaces AND air gaps.
+   *  Exactly one surface must have label "STO" (the aperture stop).
+   *
+   *  Fields:
+   *    label   (string, REQUIRED)  Unique surface label — append "A" for aspherical (e.g. "3A")
+   *    R       (number, REQUIRED)  Radius of curvature in mm — use 1e15 for flat surfaces
+   *    d       (number, REQUIRED)  Axial thickness to next surface in mm
+   *    nd      (number, REQUIRED)  Refractive index of the medium FOLLOWING this surface
+   *                                (1.0 for air, glass nd for entering a glass element)
+   *    elemId  (number, REQUIRED)  Element ID this surface belongs to — 0 for air interfaces
+   *    sd      (number, REQUIRED)  Semi-diameter (half clear aperture) in mm
+   *
+   *  Sign conventions:
+   *    R > 0  →  center of curvature to the RIGHT of the surface
+   *    R < 0  →  center of curvature to the LEFT of the surface
+   *    R = 1e15 → flat surface (effectively infinite radius)
+   *    d is always positive (distance to next surface along the axis)
+   *    nd = 1.0 for air gaps; nd = glass refractive index for glass media
+   *
+   *  Pairing rules:
+   *    A glass element with N surfaces has N entries with the same elemId.
+   *    A single-element lens: front surface (nd = glass nd), rear surface (nd = 1.0 for air after).
+   *    Cemented doublet: front elem rear surface has nd = next elem's glass nd (no air gap).
+   *    The last surface's d is the back focal distance (BFD) to the image plane.
+   */
+  surfaces: [
+    { label: "1",   R:   00.000, d: 0.00, nd: 1.00000, elemId: 1, sd: 00.0 },
+    { label: "2",   R:   00.000, d: 0.00, nd: 1.0,     elemId: 0, sd: 00.0 },
+    // ...
+    { label: "STO", R:     1e15, d: 0.00, nd: 1.0,     elemId: 0, sd: 00.0 },  // aperture stop — EXACTLY ONE required
+    // ...
+  ],
+
+  /* ── Aspherical coefficients ──
+   *  Keyed by surface label.  Only include surfaces that are aspherical.
+   *  For all-spherical designs, set asph: {}
+   *
+   *  Sag equation:
+   *    Z(h) = (h²/R) / [1 + √(1 − (1+K)·(h/R)²)] + A4·h⁴ + A6·h⁶ + A8·h⁸ + A10·h¹⁰ + A12·h¹² + A14·h¹⁴
+   *
+   *  Set unused higher-order coefficients to 0.
+   */
+  asph: {
+    // "3A": {
+    //   K: 0,
+    //   A4: 0, A6: 0, A8: 0, A10: 0, A12: 0, A14: 0,
+    // },
+  },
+
+  /* ── Variable air spacings (focus mechanism) ──
+   *  Keyed by surface label.  Each value is [d_at_infinity, d_at_close_focus].
+   *  Only include surfaces whose air gap changes during focus.
+   *
+   *  Focus types:
+   *    Unit focus:     One variable gap (BFD changes, entire lens moves)
+   *    Inner focus:    2+ variable gaps (internal groups move)
+   *    Floating focus: 3+ variable gaps (multiple groups move independently)
+   *
+   *  The surface's `d` field should match the infinity-focus value (var[label][0]).
+   *
+   *  varLabels: Display labels for the focus slider UI.
+   *    Each entry is [surface_label, display_text].
+   */
+  var: {
+    // "17": [18.74, 22.59],    // [d_infinity, d_close]
+  },
+
+  varLabels: [
+    // ["17", "BF"],             // [surface_label, display_text]
+  ],
+
+  /* ── Group and doublet annotations ──
+   *  Purely visual — brackets shown in the SVG diagram.
+   *  fromSurface and toSurface must be valid surface labels.
+   */
+  groups: [
+    // { text: "FRONT", fromSurface: "1", toSurface: "8" },
+    // { text: "REAR",  fromSurface: "10", toSurface: "17" },
+  ],
+
+  doublets: [
+    // { text: "D1", fromSurface: "5", toSurface: "7" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM:       0.45,       // REQUIRED: close focus distance in meters
+  focusDescription:  "Description of the focus mechanism.",  // optional: shown in UI
+
+  /* ── Aperture configuration ── */
+  nominalFno:   2.0,             // REQUIRED: nominal f-number — used to derive stop SD
+  fstopSeries:  [1.4, 1.8, 2, 2.5, 2.8, 3.5, 4, 4.5, 5.6, 6.3, 8, 11, 16, 22],  // REQUIRED: f-stop quick-select values
+
+  /* ── Layout tuning (overrides defaults from defaults.js) ──
+   *  Only include if the defaults don't work well for this lens.
+   *
+   *  scFill   (0–1)  Horizontal fill fraction for the lens diagram
+   *  yScFill  (0–1)  Vertical fill fraction for the lens diagram
+   *
+   *  Other overridable defaults (usually fine as-is):
+   *    svgW: 1080, svgH: 490, clipMargin: 1.0, maxRimAngleDeg: 40,
+   *    gapSagFrac: 0.90, focusStep: 0.004, apertureStep: 0.004, maxFstop: 16,
+   *    rayFractions: [-0.83, -0.50, -0.17, 0.17, 0.50, 0.83],
+   *    rayLeadFrac: 0.19, offAxisFieldFrac: 0.60,
+   *    offAxisFractions: [-0.75, -0.375, 0, 0.375, 0.75]
+   */
+  scFill:           0.50,
+  yScFill:          0.30,
+};
+
+export default LENS_DATA;


### PR DESCRIPTION
- TEMPLATE.data.js.template: copy-and-fill template with inline docs for every field
- LENS_DATA_SPEC.md: complete reference covering all fields, types, validation rules, sign conventions, pairing rules, data sourcing checklist, and a minimal example

Template uses .template extension to avoid Vite's *.data.js auto-registration glob.

https://claude.ai/code/session_019dNApyhsDySpEyj85QuMMk