### PR TITLE
Fix selector artifacts: use backgroundColor and explicit transitions

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -538,13 +538,13 @@ export default function LensVisualization() {
           value={lensKey}
           onChange={e => switchLens(e.target.value)}
           style={{
-            background: t.selectorBg, border: `1px solid ${t.selectorBorder}`,
+            backgroundColor: t.selectorBg, border: `1px solid ${t.selectorBorder}`,
             borderRadius: 6, padding: "5px 28px 5px 10px", cursor: "pointer",
             fontSize: 10, color: t.selectorText, fontFamily: "inherit",
             letterSpacing: "0.06em", appearance: "none", outline: "none",
             backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6'><path d='M0 0l5 6 5-6z' fill='${t.selectorText}'/></svg>`)}")`,
             backgroundRepeat: "no-repeat", backgroundPosition: "right 8px center",
-            transition: "all 0.3s", flex: "0 1 300px",
+            transition: "background-color 0.3s, color 0.3s, border-color 0.3s", flex: "0 1 300px",
           }}
         >
           {CATALOG_KEYS.map(k => (


### PR DESCRIPTION
The real root cause of issue #10 was two interacting CSS problems on the <select> element:

1. `background` (shorthand) resets background-image to "none" before `backgroundImage` overrides it. During CSS transitions the browser can briefly show the reset state, causing SVG markup to flash as visible text. Fixed by using `backgroundColor` instead of the shorthand, so backgroundImage is never reset.

2. `transition: "all 0.3s"` told the browser to animate backgroundImage (a data URI), which is non-animatable. Browsers that attempt the interpolation render garbled SVG source as visible characters. In dark mode these artifacts were invisible (dark-on-dark) but became visible in light mode (dark-on-light). Fixed by restricting the transition to only animatable properties: background-color, color, and border-color.

https://claude.ai/code/session_01BqTe3uC9qxQLgjusrLghLY