### PR TITLE
Fix gradient-to-color transition causing text artifacts on selector bar

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -274,7 +274,7 @@ export default function LensVisualization() {
   const diagramContent = (
     <>
       {/* ── Header ── */}
-      <div style={{ padding: "18px 24px 10px", borderBottom: `1px solid ${t.headerBorder}`, background: t.headerBg, display: "flex", justifyContent: "space-between", alignItems: "flex-start", transition: "background 0.3s,border-color 0.3s" }}>
+      <div style={{ padding: "18px 24px 10px", borderBottom: `1px solid ${t.headerBorder}`, backgroundColor: t.headerBgColor, backgroundImage: t.headerBgImage, display: "flex", justifyContent: "space-between", alignItems: "flex-start", transition: "background-color 0.3s,border-color 0.3s" }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
             <h1 style={{ fontSize: 17, fontWeight: 700, letterSpacing: "0.04em", margin: 0, color: t.title, fontFamily: "'DM Sans','Helvetica Neue',sans-serif", transition: "color 0.3s" }}>{L.data.name}</h1>
@@ -533,7 +533,7 @@ export default function LensVisualization() {
   return (
     <div style={{ background: t.bg, color: t.body, fontFamily: "'JetBrains Mono','SF Mono','Fira Code',monospace", minHeight: "100vh", transition: "background 0.3s,color 0.3s" }}>
       {/* ── Top bar: lens selector ── */}
-      <div style={{ padding: "10px 24px", borderBottom: `1px solid ${t.headerBorder}`, background: t.headerBg, display: "flex", alignItems: "center", gap: 12, transition: "background 0.3s,border-color 0.3s" }}>
+      <div style={{ padding: "10px 24px", borderBottom: `1px solid ${t.headerBorder}`, backgroundColor: t.headerBgColor, backgroundImage: t.headerBgImage, display: "flex", alignItems: "center", gap: 12, transition: "background-color 0.3s,border-color 0.3s" }}>
         <select
           value={lensKey}
           onChange={e => switchLens(e.target.value)}
@@ -558,7 +558,7 @@ export default function LensVisualization() {
 
       {/* ── Mobile view toggle (narrow screens — own row for visibility) ── */}
       {!isWide && (
-        <div style={{ display: "flex", justifyContent: "center", padding: "8px 24px", borderBottom: `1px solid ${t.headerBorder}`, background: t.headerBg, transition: "background 0.3s,border-color 0.3s" }}>
+        <div style={{ display: "flex", justifyContent: "center", padding: "8px 24px", borderBottom: `1px solid ${t.headerBorder}`, backgroundColor: t.headerBgColor, backgroundImage: t.headerBgImage, transition: "background-color 0.3s,border-color 0.3s" }}>
           <div style={{ display: "flex", gap: 0, borderRadius: 5, overflow: "hidden", border: `1px solid ${t.toggleBorder}`, width: 220 }}>
             {[
               { label: "DIAGRAM", val: 'diagram' },

--- a/themes.js
+++ b/themes.js
@@ -31,7 +31,7 @@ function createTheme(t) {
 
 const T = {
   dark: createTheme({
-    bg: "#0c0d10", headerBg: "linear-gradient(180deg,rgba(14,16,22,1),rgba(10,11,14,1))",
+    bg: "#0c0d10", headerBgColor: "#0c0d12", headerBgImage: "linear-gradient(180deg,rgba(14,16,22,1),rgba(10,11,14,1))",
     headerBorder: "rgba(0,200,220,0.22)", panelBg: "rgba(8,10,15,0.98)",
     panelBorder: "rgba(0,200,220,0.16)", panelDivider: "rgba(0,200,220,0.10)",
     infoBgActive: "rgba(12,18,30,0.8)", infoBgIdle: "transparent",
@@ -83,7 +83,7 @@ const T = {
     _strokeInfer: "rgba(179,136,255,0.70)", _strokeDefault: "rgba(180,200,225,0.55)",
   }),
   light: createTheme({
-    bg: "#ffffff", headerBg: "#f5f6f8",
+    bg: "#ffffff", headerBgColor: "#f5f6f8", headerBgImage: "none",
     headerBorder: "#c8cdd6", panelBg: "#f5f6f8",
     panelBorder: "#c8cdd6", panelDivider: "#d0d5dc",
     infoBgActive: "#e8ecf2", infoBgIdle: "transparent",
@@ -135,7 +135,7 @@ const T = {
     _strokeInfer: "rgba(90,40,180,0.65)", _strokeDefault: "rgba(60,80,110,0.55)",
   }),
   darkHC: createTheme({
-    bg: "#000000", headerBg: "linear-gradient(180deg,rgba(8,10,14,1),rgba(0,0,0,1))",
+    bg: "#000000", headerBgColor: "#040507", headerBgImage: "linear-gradient(180deg,rgba(8,10,14,1),rgba(0,0,0,1))",
     headerBorder: "rgba(0,220,240,0.30)", panelBg: "rgba(4,5,8,0.99)",
     panelBorder: "rgba(0,220,240,0.24)", panelDivider: "rgba(0,220,240,0.15)",
     infoBgActive: "rgba(8,14,24,0.85)", infoBgIdle: "transparent",
@@ -187,7 +187,7 @@ const T = {
     _strokeInfer: "rgba(190,150,255,0.80)", _strokeDefault: "rgba(195,215,240,0.70)",
   }),
   lightHC: createTheme({
-    bg: "#ffffff", headerBg: "#f2f3f6",
+    bg: "#ffffff", headerBgColor: "#f2f3f6", headerBgImage: "none",
     headerBorder: "#b0b8c4", panelBg: "#f2f3f6",
     panelBorder: "#b0b8c4", panelDivider: "#bcc2cc",
     infoBgActive: "#e0e5ee", infoBgIdle: "transparent",


### PR DESCRIPTION
Root cause: headerBg used a CSS gradient in dark themes and a solid color in light themes. The `background` shorthand assigned this mixed value with `transition: "background 0.3s"`. When toggling themes, the browser attempted to transition between a background-image (gradient) and a background-color (solid hex) — a non-interpolable change. During the failed transition, browsers can briefly render the CSS gradient function string as visible text, producing the "random characters" that obscure the lens selector dropdown.

Fix: split headerBg into two tokens — headerBgColor (solid, safely transitionable) and headerBgImage (gradient or "none", never transitioned). All three elements using headerBg (selector bar, diagram header, mobile toggle bar) now use explicit backgroundColor + backgroundImage with only background-color in the transition list.

https://claude.ai/code/session_01BqTe3uC9qxQLgjusrLghLY