### PR TITLE
Auto-detect dark mode and high contrast from device preferences

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -137,8 +137,12 @@ function DescriptionPanel({ markdown, theme: t }) {
 
 export default function LensVisualization() {
   const [lensKey, setLensKey] = useState(CATALOG_KEYS[0]);
-  const [dark, setDark] = useState(true);
-  const [highContrast, setHighContrast] = useState(false);
+  const [dark, setDark] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(prefers-color-scheme: dark)').matches : true
+  );
+  const [highContrast, setHighContrast] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(prefers-contrast: more)').matches : false
+  );
   const [focusT, setFocusT] = useState(0);
   const [hov, setHov] = useState(null);
   const [sel, setSel] = useState(null);


### PR DESCRIPTION
Initialize dark/light and high-contrast state from OS media queries (prefers-color-scheme, prefers-contrast) instead of hardcoded defaults. Manual toggle buttons still override the detected preference.

https://claude.ai/code/session_012fh8UcboZ4y6NwvgHbYLTE