### PR TITLE
Fix Nikkor 105mm f/1.4E crash: correct elemId convention in lens data

### DIFF
--- a/__tests__/buildLens.test.js
+++ b/__tests__/buildLens.test.js
@@ -2,14 +2,16 @@ import { describe, it, expect } from 'vitest';
 import buildLens, { paraxialTrace } from '../buildLens.js';
 import LENS_DEFAULTS from '../lens-data/defaults.js';
 
-/* ── Load all three production lens data files ── */
-import ApoLantharRaw from '../lens-data/ApoLanthar50f2.data.js';
-import NoktonRaw     from '../lens-data/Nokton50f1.data.js';
-import NikkorRaw     from '../lens-data/NikkorZ50mmf18S.data.js';
+/* ── Load all production lens data files ── */
+import ApoLantharRaw  from '../lens-data/ApoLanthar50f2.data.js';
+import NoktonRaw      from '../lens-data/Nokton50f1.data.js';
+import NikkorRaw      from '../lens-data/NikkorZ50mmf18S.data.js';
+import Nikkor105Raw   from '../lens-data/Nikkor105f14E.data.js';
 
-const ApoLanthar = { ...LENS_DEFAULTS, ...ApoLantharRaw };
-const Nokton     = { ...LENS_DEFAULTS, ...NoktonRaw };
-const Nikkor     = { ...LENS_DEFAULTS, ...NikkorRaw };
+const ApoLanthar  = { ...LENS_DEFAULTS, ...ApoLantharRaw };
+const Nokton      = { ...LENS_DEFAULTS, ...NoktonRaw };
+const Nikkor      = { ...LENS_DEFAULTS, ...NikkorRaw };
+const Nikkor105   = { ...LENS_DEFAULTS, ...Nikkor105Raw };
 
 
 describe('paraxialTrace', () => {
@@ -80,6 +82,11 @@ describe('buildLens — production lenses', () => {
     expect(isFinite(L.EFL)).toBe(true);
   });
 
+  it('Nikkor 105 f/1.4E EFL ≈ 102 mm', () => {
+    const L = buildLens(Nikkor105);
+    expect(L.EFL).toBeCloseTo(102, 0);
+  });
+
   /* ── f-number regression tests ── */
   it('ApoLanthar FOPEN ≈ f/1.93', () => {
     const L = buildLens(ApoLanthar);
@@ -98,14 +105,14 @@ describe('buildLens — production lenses', () => {
 
   /* ── Structural checks ── */
   it('all lenses have frozen output', () => {
-    for (const data of [ApoLanthar, Nokton, Nikkor]) {
+    for (const data of [ApoLanthar, Nokton, Nikkor, Nikkor105]) {
       const L = buildLens(data);
       expect(Object.isFrozen(L)).toBe(true);
     }
   });
 
   it('all lenses have a valid stopIdx', () => {
-    for (const data of [ApoLanthar, Nokton, Nikkor]) {
+    for (const data of [ApoLanthar, Nokton, Nikkor, Nikkor105]) {
       const L = buildLens(data);
       expect(L.stopIdx).toBeGreaterThanOrEqual(0);
       expect(L.stopIdx).toBeLessThan(L.N);
@@ -114,10 +121,26 @@ describe('buildLens — production lenses', () => {
   });
 
   it('all lenses have positive halfField', () => {
-    for (const data of [ApoLanthar, Nokton, Nikkor]) {
+    for (const data of [ApoLanthar, Nokton, Nikkor, Nikkor105]) {
       const L = buildLens(data);
       expect(L.halfField).toBeGreaterThan(0);
       expect(L.halfField).toBeLessThan(90);
+    }
+  });
+
+  it('all lenses have ES entries with valid surface indices', () => {
+    for (const data of [ApoLanthar, Nokton, Nikkor, Nikkor105]) {
+      const L = buildLens(data);
+      for (const [eid, s1, s2] of L.ES) {
+        expect(s1).toBeGreaterThanOrEqual(0);
+        expect(s2).toBeGreaterThanOrEqual(0);
+        expect(s1).toBeLessThan(L.N);
+        expect(s2).toBeLessThan(L.N);
+        expect(L.S[s1]).toBeDefined();
+        expect(L.S[s2]).toBeDefined();
+        expect(L.S[s1].sd).toBeGreaterThan(0);
+        expect(L.S[s2].sd).toBeGreaterThan(0);
+      }
     }
   });
 });

--- a/lens-data/Nikkor105f14E.data.js
+++ b/lens-data/Nikkor105f14E.data.js
@@ -53,52 +53,52 @@ const LENS_DATA = {
    *  Stop is between surfaces 15 and 17 (patent surface 16).
    *
    *  Cemented doublet convention:
-   *    Junction surface carries the first element's elemId.
+   *    Junction surface carries the second element's elemId.
    *    Its nd = the second element's glass index (medium after the junction).
-   *    The second element's rear surface carries the second element's elemId.
+   *    The second element's rear surface uses elemId: 0 (air interface).
    */
   surfaces: [
     /* ── G1: Front Positive Group ── */
     // L11 — Pos. meniscus, convex to object (near-plano rear)
     { label: "1",   R:   228.14790, d:  4.915, nd: 1.59349, elemId: 1,  sd: 39.4 },
-    { label: "2",   R:  6415.62050, d:  0.100, nd: 1.0,     elemId: 1,  sd: 39.1 },
+    { label: "2",   R:  6415.62050, d:  0.100, nd: 1.0,     elemId: 0,  sd: 39.1 },
     // L12 — Biconvex positive (ED glass, S-FPL51)
     { label: "3",   R:    98.03190, d:  9.004, nd: 1.49700, elemId: 2,  sd: 39.1 },
-    { label: "4",   R:  -860.70550, d:  0.100, nd: 1.0,     elemId: 2,  sd: 37.3 },
+    { label: "4",   R:  -860.70550, d:  0.100, nd: 1.0,     elemId: 0,  sd: 37.3 },
     // L13+L14 cemented doublet (ED + lanthanum flint)
     { label: "5",   R:    70.05610, d: 11.648, nd: 1.49700, elemId: 3,  sd: 37.3 },
-    { label: "6",   R:  -266.98950, d:  3.500, nd: 1.72047, elemId: 3,  sd: 32.8 },  // junction → L14 glass
-    { label: "7",   R:   168.27370, d:  7.956, nd: 1.0,     elemId: 4,  sd: 31.6 },  // L14 rear → air (D7, variable)
+    { label: "6",   R:  -266.98950, d:  3.500, nd: 1.72047, elemId: 4,  sd: 32.8 },  // junction → L14 glass
+    { label: "7",   R:   168.27370, d:  7.956, nd: 1.0,     elemId: 0,  sd: 31.6 },  // L14 rear → air (D7, variable)
 
     /* ── G2: Focusing Group (Negative) ── */
     // L21+L22 cemented doublet (APD glass + borosilicate crown)
     { label: "8",   R:  -156.94440, d:  4.000, nd: 1.65940, elemId: 5,  sd: 28.3 },
-    { label: "9",   R:   -74.82770, d:  2.500, nd: 1.51680, elemId: 5,  sd: 27.6 },  // junction → L22 glass
-    { label: "10",  R:    48.83690, d: 17.029, nd: 1.0,     elemId: 6,  sd: 27.0 },  // L22 rear → air (D10, variable)
+    { label: "9",   R:   -74.82770, d:  2.500, nd: 1.51680, elemId: 6,  sd: 27.6 },  // junction → L22 glass
+    { label: "10",  R:    48.83690, d: 17.029, nd: 1.0,     elemId: 0,  sd: 27.0 },  // L22 rear → air (D10, variable)
 
     /* ── G3: Rear Positive Group ── */
     // L31 — Biconvex positive (ultra-high-index, nd ≈ 2.001)
     { label: "11",  R:    59.41150, d:  7.084, nd: 2.00100, elemId: 7,  sd: 25.8 },
-    { label: "12",  R: -9603.99850, d:  0.100, nd: 1.0,     elemId: 7,  sd: 24.0 },
+    { label: "12",  R: -9603.99850, d:  0.100, nd: 1.0,     elemId: 0,  sd: 24.0 },
     // L32+L33 cemented doublet (lanthanum crown + specialty flint)
     { label: "13",  R:   101.99880, d:  8.889, nd: 1.69680, elemId: 8,  sd: 24.0 },
-    { label: "14",  R:   -54.38990, d:  1.800, nd: 1.71736, elemId: 8,  sd: 20.5 },  // junction → L33 glass
-    { label: "15",  R:    28.02300, d:  5.843, nd: 1.0,     elemId: 9,  sd: 19.8 },  // L33 rear → air
+    { label: "14",  R:   -54.38990, d:  1.800, nd: 1.71736, elemId: 9,  sd: 20.5 },  // junction → L33 glass
+    { label: "15",  R:    28.02300, d:  5.843, nd: 1.0,     elemId: 0,  sd: 19.8 },  // L33 rear → air
 
     // Aperture stop
     { label: "STO", R:       1e15,  d:  1.600, nd: 1.0,     elemId: 0,  sd: 16.8 },
 
     // L34 — Biconvex positive (ED glass, S-FPL51)
     { label: "17",  R:   118.55000, d:  5.540, nd: 1.49700, elemId: 10, sd: 18.6 },
-    { label: "18",  R:   -59.97360, d:  0.100, nd: 1.0,     elemId: 10, sd: 17.7 },
+    { label: "18",  R:   -59.97360, d:  0.100, nd: 1.0,     elemId: 0,  sd: 17.7 },
     // L35+L36 cemented doublet (lanthanum flint + lanthanum heavy flint)
     { label: "19",  R:   -74.13900, d:  1.600, nd: 1.72047, elemId: 11, sd: 17.7 },
-    { label: "20",  R:    23.56120, d:  8.119, nd: 1.76684, elemId: 11, sd: 17.5 },  // junction → L36 glass
-    { label: "21",  R:  -400.50550, d:  2.828, nd: 1.0,     elemId: 12, sd: 16.4 },  // L36 rear → air
+    { label: "20",  R:    23.56120, d:  8.119, nd: 1.76684, elemId: 12, sd: 17.5 },  // junction → L36 glass
+    { label: "21",  R:  -400.50550, d:  2.828, nd: 1.0,     elemId: 0,  sd: 16.4 },  // L36 rear → air
     // L37+L38 cemented doublet (titanium flint + ultra-high-index)
     { label: "22",  R:   -39.02080, d:  1.600, nd: 1.58144, elemId: 13, sd: 15.6 },
-    { label: "23",  R:   124.06960, d:  5.332, nd: 2.00100, elemId: 13, sd: 15.6 },  // junction → L38 glass
-    { label: "24",  R:   -52.63590, d: 39.632, nd: 1.0,     elemId: 14, sd: 15.3 },  // L38 rear → BF
+    { label: "23",  R:   124.06960, d:  5.332, nd: 2.00100, elemId: 14, sd: 15.6 },  // junction → L38 glass
+    { label: "24",  R:   -52.63590, d: 39.632, nd: 1.0,     elemId: 0,  sd: 15.3 },  // L38 rear → BF
   ],
 
   /* ── Aspherical coefficients ──

--- a/lens-data/TEMPLATE.data.js.template
+++ b/lens-data/TEMPLATE.data.js.template
@@ -71,11 +71,26 @@ const LENS_DATA = {
    *    d is always positive (distance to next surface along the axis)
    *    nd = 1.0 for air gaps; nd = glass refractive index for glass media
    *
-   *  Pairing rules:
-   *    A glass element with N surfaces has N entries with the same elemId.
-   *    A single-element lens: front surface (nd = glass nd), rear surface (nd = 1.0 for air after).
-   *    Cemented doublet: front elem rear surface has nd = next elem's glass nd (no air gap).
-   *    The last surface's d is the back focal distance (BFD) to the image plane.
+   *  elemId assignment rules:
+   *    - Each glass element gets EXACTLY ONE surface with its elemId: its front (entry) surface.
+   *    - Air gap surfaces (nd = 1.0 after a glass element) always use elemId: 0.
+   *    - The aperture stop (STO) uses elemId: 0.
+   *    - The last surface's d is the back focal distance (BFD) to the image plane.
+   *
+   *  Standalone element pattern:
+   *    { label: "1",  R: ..., d: ..., nd: 1.xxxxx, elemId: 1, sd: ... },  // L1 front — elemId: 1
+   *    { label: "2",  R: ..., d: ..., nd: 1.0,     elemId: 0, sd: ... },  // L1 rear → air — elemId: 0
+   *
+   *  Cemented doublet pattern (e.g. L3 + L4):
+   *    The junction surface carries the SECOND element's elemId.
+   *    Its nd = the second element's glass refractive index (the medium after the junction).
+   *    { label: "5",  R: ..., d: ..., nd: 1.49700, elemId: 3, sd: ... },  // L3 front — elemId: 3
+   *    { label: "6",  R: ..., d: ..., nd: 1.72047, elemId: 4, sd: ... },  // Junction — elemId: 4 (L4, second element)
+   *    { label: "7",  R: ..., d: ..., nd: 1.0,     elemId: 0, sd: ... },  // L4 rear → air — elemId: 0
+   *
+   *  Why: buildLens.js finds the FIRST surface with each elemId and uses (index, index+1)
+   *  as the element's front/rear pair for rendering. Tagging rear or air surfaces with
+   *  non-zero elemId will cause rendering errors or crashes.
    */
   surfaces: [
     { label: "1",   R:   00.000, d: 0.00, nd: 1.00000, elemId: 1, sd: 00.0 },


### PR DESCRIPTION
The Nikkor105f14E lens data file used the wrong elemId convention for surfaces, causing an out-of-bounds crash when rendering element shapes. Rear/air surfaces incorrectly carried the element's own elemId (should be 0), and cemented doublet junctions were assigned to the first element (should be the second). Also clarifies the elemId pairing rules in the template to prevent future data entry errors.

https://claude.ai/code/session_01Sps8ogEkxtJmfYAyGJMkzX