### PR TITLE
Extend light rays further left and shift lens block right

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -199,7 +199,7 @@ export default function LensVisualization() {
   const dz = IMG_MM - cur.imgZ;
   const zPos = useMemo(() => cur.z.map(v => v + dz), [cur, dz]);
 
-  const MID = IMG_MM / 2, CX = L.svgW / 2, CY = L.svgH / 2;
+  const MID = IMG_MM / 2, CX = L.svgW / 2 + L.svgW * L.lensShiftFrac, CY = L.svgH / 2;
   const IX = CX + MID * L.SC;
   const sx = useCallback(z => IX - (IMG_MM - z) * L.SC, [IX, IMG_MM, L.SC]);
   const sy = useCallback(y => CY + y * L.YSC, [CY, L.YSC]);

--- a/buildLens.js
+++ b/buildLens.js
@@ -151,6 +151,7 @@ export default function buildLens(data) {
     SC, YSC, maxRimSin, gapSagFrac, clipMargin,
     gridPitch, gridCount,
     lyDoublet, lyImgLine, lyImgLabel, lyElemNum, lyGroup, lyStoPad,
+    lensShiftFrac: data.lensShiftFrac || 0,
     rayFractions: data.rayFractions, rayHeights, rayLead, bladeStubFrac,
     offAxisFieldDeg, offAxisFractions: data.offAxisFractions, offAxisHeights,
     closeFocusM: data.closeFocusM, focusStep: data.focusStep,

--- a/lens-data/defaults.js
+++ b/lens-data/defaults.js
@@ -10,7 +10,8 @@ const LENS_DEFAULTS = {
 
   /* ── Ray fan configuration ── */
   rayFractions:     [-0.83, -0.50, -0.17, 0.17, 0.50, 0.83],
-  rayLeadFrac:      0.19,
+  rayLeadFrac:      0.35,
+  lensShiftFrac:    0.08,
   offAxisFieldFrac: 0.60,
   offAxisFractions: [-0.75, -0.375, 0, 0.375, 0.75],
 


### PR DESCRIPTION
Increase rayLeadFrac from 0.19 to 0.35 so incoming rays extend further in front of the lens, making the change in angle visible when refocusing. Add lensShiftFrac (default 0.08) to offset the lens block and focal plane to the right, giving room for the longer ray leads.

Addresses #23.

https://claude.ai/code/session_01N43yEaD1mT7AKe9ZpV5Ue5