### PR TITLE
Fix flat-surface refraction bug and add on-axis vignetting ghosts

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -261,11 +261,21 @@ export default function LensVisualization() {
     for (const f of L.rayFractions) {
       const h = f * currentEPSD;
       const uIn = rayTracksF ? h * focusK : 0;
-      const { pts, y, u } = traceRay(h, uIn, zPos, focusT, currentPhysStopSD, false, L);
+      const { pts, ghostPts, y, u, clipped } = traceRay(h, uIn, zPos, focusT, currentPhysStopSD, true, L);
       const sp = pts.map(([z, yy]) => [sx(z), sy(yy)]);
-      const last = pts[pts.length - 1];
-      if (last) { const dzI = IMG_MM - last[0]; sp.push([sx(IMG_MM), sy(last[1] + dzI * u)]); }
-      out.push(sp);
+      let gp = [];
+      if (clipped && ghostPts.length > 0) {
+        const lastSolid = pts[pts.length - 1];
+        if (lastSolid) gp.push([sx(lastSolid[0]), sy(lastSolid[1])]);
+        gp = gp.concat(ghostPts.map(([z, yy]) => [sx(z), sy(yy)]));
+        const lastGhost = ghostPts[ghostPts.length - 1];
+        if (lastGhost) { const dzI = IMG_MM - lastGhost[0]; gp.push([sx(IMG_MM), sy(lastGhost[1] + dzI * u)]); }
+      }
+      if (!clipped) {
+        const last = pts[pts.length - 1];
+        if (last) { const dzI = IMG_MM - last[0]; sp.push([sx(IMG_MM), sy(last[1] + dzI * u)]); }
+      }
+      out.push({ sp, gp });
     }
     return out;
   }, [zPos, focusT, sx, sy, currentPhysStopSD, currentEPSD, rayTracksF, focusK, L, IMG_MM]);
@@ -398,10 +408,15 @@ export default function LensVisualization() {
         })}
         <line x1={8} y1={sy(0)} x2={L.svgW - 8} y2={sy(0)} stroke={t.axis} strokeWidth={0.5} strokeDasharray="6,4" />
 
-        {showOnAxis && rays.map((pts, ri) => pts.length > 1 && (
-          <polyline key={`on${ri}`} points={pts.map(p => `${p[0]},${p[1]}`).join(" ")} fill="none"
-            stroke={ri < L.rayHeights.length / 2 ? t.rayCool : t.rayWarm} strokeWidth={1.2 * t.rayWidthScale} />
-        ))}
+        {showOnAxis && rays.map(({ sp, gp }, ri) => {
+          const color = ri < L.rayHeights.length / 2 ? t.rayCool : t.rayWarm;
+          return <g key={`on${ri}`}>
+            {sp.length > 1 && <polyline points={sp.map(p => `${p[0]},${p[1]}`).join(" ")} fill="none"
+              stroke={color} strokeWidth={1.2 * t.rayWidthScale} />}
+            {gp.length > 1 && <polyline points={gp.map(p => `${p[0]},${p[1]}`).join(" ")} fill="none"
+              stroke={color} strokeWidth={0.6 * t.rayWidthScale} strokeDasharray="3,4" opacity={0.3} />}
+          </g>;
+        })}
 
         {showOffAxis && offAxisRays.map(({ sp, gp }, ri) => {
           const color = ri < L.offAxisHeights.length / 2 ? t.rayOffCool : t.rayOffWarm;

--- a/buildLens.js
+++ b/buildLens.js
@@ -26,8 +26,8 @@ function paraxialTrace(S, y0, u0, { stopAt, skipLastTransfer = false, recordHeig
     if (recordHeights) heights.push(y);
     const { R, nd, d } = S[i];
     const nn = nd === 1.0 ? 1.0 : nd;
-    if (Math.abs(R) < FLAT_R_THRESHOLD && nn !== n)
-      u = (n * u - y * (nn - n) / R) / nn;
+    if (nn !== n)
+      u = Math.abs(R) < FLAT_R_THRESHOLD ? (n * u - y * (nn - n) / R) / nn : (n * u) / nn;
     n = nn;
     const isLast = (i === N - 1);
     if (isLast && skipLastTransfer) { /* skip */ }

--- a/optics.js
+++ b/optics.js
@@ -82,7 +82,7 @@ export function traceRay(y0, u0, zPos, t, stopSD, ghost, L) {
     const pt = [z + renderSag(Math.abs(y), i, L), y];
     if (clipped) ghostPts.push(pt); else pts.push(pt);
     const nn = nd === 1.0 ? 1.0 : nd;
-    if (Math.abs(R) < FLAT_R_THRESHOLD && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
+    if (nn !== n) u = Math.abs(R) < FLAT_R_THRESHOLD ? (n * u - y * (nn - n) / R) / nn : (n * u) / nn;
     n = nn;
     if (i < L.N - 1) y += thick(i, t, L) * u;
   }
@@ -94,7 +94,7 @@ export function traceToImage(y0, u0, t, L) {
   for (let i = 0; i < L.N; i++) {
     const { R, nd } = L.S[i];
     const nn = nd === 1.0 ? 1.0 : nd;
-    if (Math.abs(R) < FLAT_R_THRESHOLD && nn !== n) u = (n * u - y * (nn - n) / R) / nn;
+    if (nn !== n) u = Math.abs(R) < FLAT_R_THRESHOLD ? (n * u - y * (nn - n) / R) / nn : (n * u) / nn;
     n = nn;
     y += thick(i, t, L) * u;
   }


### PR DESCRIPTION
The ray tracing engine skipped refraction at flat surfaces (R >= 1e10), which is wrong when the medium changes at a flat boundary. This caused the Nikkor Z 50mm f/1.8 S lens (which has a plano rear surface on L33 at a glass-to-air boundary) to compute incorrect exit angles — rays converged too slowly and missed the image plane in infinity mode.

Fix the refraction condition in all three trace functions (traceRay, traceToImage, paraxialTrace) to apply u' = n*u/nn at flat interfaces.

Also add ghost rendering for vignetted on-axis rays, matching the existing off-axis ghost visualization behavior.

https://claude.ai/code/session_01HSdwSB7c3NipBi5gmYiMjr