### PR TITLE
Upgrade traceRay to exact meridional Snell's law for realistic ray paths

### DIFF
--- a/__tests__/optics.test.js
+++ b/__tests__/optics.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { sag, renderSag, thick, doLayout, formatDist,
-         traceToImage, conjugateK,
+import { sag, renderSag, sagSlope, thick, doLayout, formatDist,
+         traceRay, traceToImage, conjugateK,
          FLAT_R_THRESHOLD, FOCUS_INFINITY_THRESHOLD } from '../optics.js';
 
 describe('sag', () => {
@@ -79,6 +79,138 @@ describe('doLayout', () => {
     const { z, imgZ } = doLayout(0, L);
     expect(z).toEqual([0, 2.0, 5.0]);
     expect(imgZ).toBe(10.0);
+  });
+});
+
+describe('sagSlope', () => {
+  it('returns 0 at h = 0', () => {
+    const L = { S: [{ R: 50 }], asphByIdx: {} };
+    expect(sagSlope(0, 0, L)).toBe(0);
+  });
+
+  it('returns 0 for flat surface', () => {
+    const L = { S: [{ R: 1e15 }], asphByIdx: {} };
+    expect(sagSlope(10, 0, L)).toBe(0);
+  });
+
+  it('computes correct slope for spherical surface', () => {
+    const R = 50;
+    const h = 10;
+    const L = { S: [{ R }], asphByIdx: {} };
+    const c = 1 / R;
+    const expected = c * h / Math.sqrt(1 - c * c * h * h);
+    expect(sagSlope(h, 0, L)).toBeCloseTo(expected, 10);
+  });
+
+  it('computes correct slope for negative R', () => {
+    const R = -50;
+    const h = 10;
+    const L = { S: [{ R }], asphByIdx: {} };
+    const c = 1 / R;
+    const expected = c * h / Math.sqrt(1 - c * c * h * h);
+    expect(sagSlope(h, 0, L)).toBeCloseTo(expected, 10);
+  });
+
+  it('matches finite-difference of renderSag for spherical surface', () => {
+    const R = 30;
+    const h = 8;
+    const eps = 1e-6;
+    const L = { S: [{ R }], asphByIdx: {} };
+    const fd = (renderSag(h + eps, 0, L) - renderSag(h - eps, 0, L)) / (2 * eps);
+    expect(sagSlope(h, 0, L)).toBeCloseTo(fd, 5);
+  });
+
+  it('matches finite-difference of renderSag for aspheric surface', () => {
+    const R = 40;
+    const h = 6;
+    const eps = 1e-6;
+    const asph = { K: -0.5, A4: 1e-5, A6: -2e-8, A8: 0, A10: 0, A12: 0, A14: 0 };
+    const L = { S: [{ R }], asphByIdx: { 0: asph } };
+    const fd = (renderSag(h + eps, 0, L) - renderSag(h - eps, 0, L)) / (2 * eps);
+    expect(sagSlope(h, 0, L)).toBeCloseTo(fd, 4);
+  });
+});
+
+describe('traceRay — exact Snell', () => {
+  // Single positive element: two spherical surfaces with glass between
+  const mkSingleElement = () => ({
+    S: [
+      { R: 50, nd: 1.5168, sd: 15, d: 5 },   // front surface
+      { R: -50, nd: 1.0, sd: 15, d: 80 },     // rear surface
+    ],
+    N: 2,
+    stopIdx: 0,
+    clipMargin: 1.0,
+    rayLead: 5,
+    asphByIdx: {},
+    varByIdx: {},
+  });
+
+  it('on-axis ray (h=0, u=0) passes through unchanged', () => {
+    const L = mkSingleElement();
+    const zPos = [0, 5];
+    const { y, u, clipped } = traceRay(0, 0, zPos, 0, 15, false, L);
+    expect(y).toBeCloseTo(0, 10);
+    expect(u).toBeCloseTo(0, 10);
+    expect(clipped).toBe(false);
+  });
+
+  it('small-h ray agrees closely with paraxial trace', () => {
+    const L = mkSingleElement();
+    const zPos = [0, 5];
+    const h = 0.1;  // very small height
+    const { y: yReal, u: uReal } = traceRay(h, 0, zPos, 0, 15, false, L);
+    // traceRay stops at last surface; traceToImage propagates through final gap
+    // Extrapolate real ray to image plane for comparison
+    const imgZ = 5 + 80;  // last surface z + last d
+    const lastSurfZ = zPos[1];
+    const yRealAtImage = yReal + (imgZ - lastSurfZ) * uReal;
+    const yParax = traceToImage(h, 0, 0, L);
+    expect(yRealAtImage).toBeCloseTo(yParax, 3);
+  });
+
+  it('marginal ray shows undercorrected SA (focuses shorter than paraxial)', () => {
+    const L = mkSingleElement();
+    const zPos = [0, 5];
+    const h = 12;  // near full aperture
+    const { y: yReal, u: uReal } = traceRay(h, 0, zPos, 0, 15, false, L);
+    // Extrapolate real ray to image plane
+    const imgZ = 5 + 80;
+    const lastSurfZ = zPos[1];
+    const yRealAtImage = yReal + (imgZ - lastSurfZ) * uReal;
+    // Paraxial image height
+    const yParax = traceToImage(h, 0, 0, L);
+    // Real ray at paraxial image plane should differ from paraxial (spherical aberration)
+    expect(Math.abs(yRealAtImage - yParax)).toBeGreaterThan(0.01);
+  });
+
+  it('returns clipped=true on total internal reflection', () => {
+    // Extreme case: high-index to low-index at steep angle
+    const L = {
+      S: [
+        { R: 10, nd: 2.0, sd: 20, d: 5 },
+        { R: 1e15, nd: 1.0, sd: 20, d: 10 },
+      ],
+      N: 2,
+      stopIdx: 0,
+      clipMargin: 1.0,
+      rayLead: 1,
+      asphByIdx: {},
+      varByIdx: {},
+    };
+    const zPos = [0, 5];
+    // Ray at steep angle entering high-index glass, then hitting flat exit surface
+    const { clipped } = traceRay(9, 0.5, zPos, 0, 20, true, L);
+    expect(clipped).toBe(true);
+  });
+
+  it('generates rendering points for each surface', () => {
+    const L = mkSingleElement();
+    const zPos = [0, 5];
+    const { pts, clipped } = traceRay(5, 0, zPos, 0, 15, false, L);
+    expect(clipped).toBe(false);
+    // pts: lead point + 2 surface points + (no image extrapolation in traceRay itself)
+    expect(pts.length).toBe(3);
   });
 });
 

--- a/optics.js
+++ b/optics.js
@@ -36,6 +36,21 @@ export function renderSag(h, surfIdx, L) {
   return conic + poly;
 }
 
+export function sagSlope(h, surfIdx, L) {
+  const R = L.S[surfIdx].R;
+  const a = L.asphByIdx[surfIdx];
+  if (Math.abs(R) > FLAT_R_THRESHOLD && !a) return 0;
+  const c = Math.abs(R) > FLAT_R_THRESHOLD ? 0 : 1.0 / R;
+  const K = a ? a.K : 0;
+  const h2 = h * h;
+  const denom2 = 1 - (1 + K) * c * c * h2;
+  const conicSlope = c * h / Math.sqrt(denom2 > 0 ? denom2 : 1e-12);
+  if (!a) return conicSlope;
+  const polySlope = h * (4*a.A4*h2 + 6*a.A6*h2*h2 + 8*a.A8*h2**3
+                       + 10*a.A10*h2**4 + 12*a.A12*h2**5 + 14*a.A14*h2**6);
+  return conicSlope + polySlope;
+}
+
 export function gapTrimHeight(surfIdx, sd, maxSag, L) {
   if (maxSag <= 0 || L.gapSagFrac <= 0) return sd;
   if (Math.abs(renderSag(sd, surfIdx, L)) <= maxSag) return sd;
@@ -68,7 +83,8 @@ export function traceRay(y0, u0, zPos, t, stopSD, ghost, L) {
   const pts = [];
   const ghostPts = [];
   pts.push([zPos[0] - L.rayLead, y0 - u0 * L.rayLead]);
-  let y = y0, u = u0, n = 1.0;
+  let y = y0, n = 1.0;
+  let U = Math.atan(u0);
   let clipped = false;
   for (let i = 0; i < L.N; i++) {
     const { R, nd, sd } = L.S[i];
@@ -82,11 +98,23 @@ export function traceRay(y0, u0, zPos, t, stopSD, ghost, L) {
     const pt = [z + renderSag(Math.abs(y), i, L), y];
     if (clipped) ghostPts.push(pt); else pts.push(pt);
     const nn = nd === 1.0 ? 1.0 : nd;
-    if (nn !== n) u = Math.abs(R) < FLAT_R_THRESHOLD ? (n * u - y * (nn - n) / R) / nn : (n * u) / nn;
+    if (nn !== n) {
+      const absY = Math.abs(y);
+      const slope = sagSlope(absY, i, L);
+      const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
+      const I = U - alpha;
+      const sinIp = (n / nn) * Math.sin(I);
+      if (Math.abs(sinIp) > 1.0) {
+        if (!ghost) break;
+        clipped = true;
+      } else {
+        U = alpha + Math.asin(sinIp);
+      }
+    }
     n = nn;
-    if (i < L.N - 1) y += thick(i, t, L) * u;
+    if (i < L.N - 1) y += thick(i, t, L) * Math.tan(U);
   }
-  return { pts, ghostPts, y, u, clipped };
+  return { pts, ghostPts, y, u: Math.tan(U), clipped };
 }
 
 export function traceToImage(y0, u0, t, L) {


### PR DESCRIPTION
Replace paraxial (small-angle) refraction in traceRay() with exact Snell's law using true surface normals. This shows real spherical aberration at infinity focus and realistic imperfect convergence in track-focus mode.

- Add sagSlope() to compute surface normal angles from sag derivatives, supporting both spherical and aspheric (conic + polynomial) surfaces
- Track actual ray angle U = atan(u) through the system instead of paraxial slope, with exact sin/asin Snell's law at each refracting surface
- Handle total internal reflection gracefully (treated as clipped ray)
- Keep traceToImage()/conjugateK() paraxial for stable initial angle computation
- Add tests for sagSlope (analytical + finite-difference validation) and traceRay (on-axis identity, paraxial agreement, SA detection, TIR)

https://claude.ai/code/session_01DnbPCf7eZxyHCQnyhPWAne