### PR TITLE
Add optional `visible` field to control lens catalog visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ Each `.data.js` file in `lens-data/` default-exports a `LENS_DATA` object with a
 ```javascript
 {
   key,                                       // Unique ID — used for auto-registration
+  visible,                                   // Optional: false hides from UI (default: true)
   name, subtitle, specs,
   nominalFno, closeFocusM,                   // Required: f-number and close focus
   fstopSeries,                               // Required: f-stop quick-select values

--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -49,7 +49,7 @@ for (const mod of Object.values(_modules)) {
   const data = mod.default;
   if (data?.key) LENS_CATALOG[data.key] = { ...LENS_DEFAULTS, ...data };
 }
-const CATALOG_KEYS = Object.keys(LENS_CATALOG);
+const CATALOG_KEYS = Object.keys(LENS_CATALOG).filter(k => LENS_CATALOG[k].visible !== false);
 
 const _mdModules = import.meta.glob('./lens-data/*.analysis.md', { eager: true, query: '?raw', import: 'default' });
 const MD_BY_STEM = {};

--- a/__tests__/validateLensData.test.js
+++ b/__tests__/validateLensData.test.js
@@ -65,6 +65,17 @@ describe('validateLensData', () => {
     expect(errors.some(e => e.includes('Duplicate surface label'))).toBe(true);
   });
 
+  it('catches non-boolean visible field', () => {
+    const data = makeValid({ visible: "false" });
+    const errors = validateLensData(data);
+    expect(errors.some(e => e.includes('"visible" must be a boolean'))).toBe(true);
+  });
+
+  it('accepts boolean visible field', () => {
+    expect(validateLensData(makeValid({ visible: true }))).toEqual([]);
+    expect(validateLensData(makeValid({ visible: false }))).toEqual([]);
+  });
+
   it('catches missing STO surface', () => {
     const data = makeValid({
       surfaces: [

--- a/lens-data/LENS_DATA_SPEC.md
+++ b/lens-data/LENS_DATA_SPEC.md
@@ -58,16 +58,17 @@ These must be specified in every lens file — they have no defaults.
 
 ### Optional
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `subtitle` | `string` | Patent reference shown in UI header |
-| `specs` | `string[]` | Spec strings displayed in header |
-| `focusDescription` | `string` | Human-readable focus mechanism description |
-| `asph` | `object` | Aspherical coefficients (see below) |
-| `var` | `object` | Variable air gaps for focus (see below) |
-| `varLabels` | `array` | Display labels for variable gaps |
-| `groups` | `array` | Group annotations for SVG diagram |
-| `doublets` | `array` | Cemented doublet annotations for SVG diagram |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `visible` | `boolean` | `true` | Controls whether the lens appears in the UI catalog. Set to `false` to hide a lens from the dropdown without removing its data file. |
+| `subtitle` | `string` | | Patent reference shown in UI header |
+| `specs` | `string[]` | | Spec strings displayed in header |
+| `focusDescription` | `string` | | Human-readable focus mechanism description |
+| `asph` | `object` | | Aspherical coefficients (see below) |
+| `var` | `object` | | Variable air gaps for focus (see below) |
+| `varLabels` | `array` | | Display labels for variable gaps |
+| `groups` | `array` | | Group annotations for SVG diagram |
+| `doublets` | `array` | | Cemented doublet annotations for SVG diagram |
 
 ---
 

--- a/lens-data/TEMPLATE.data.js.template
+++ b/lens-data/TEMPLATE.data.js.template
@@ -17,6 +17,7 @@ const LENS_DATA = {
 
   /* ── Identity ── */
   key:      "unique-lens-key",                          // REQUIRED: unique ID for auto-registration
+  // visible: true,                                     // optional: set to false to hide from the UI dropdown (default: true)
   name:     "MANUFACTURER LENS-NAME FLmm f/N",          // REQUIRED: full display name
   subtitle: "PATENT-NUMBER EXAMPLE N — COMPANY / INVENTOR",  // optional: shown in UI header
   specs: [                                               // optional: spec strings for header display

--- a/lens-data/defaults.js
+++ b/lens-data/defaults.js
@@ -8,6 +8,9 @@
 
 const LENS_DEFAULTS = {
 
+  /* ── Catalog visibility ── */
+  visible:          true,
+
   /* ── Ray fan configuration ── */
   rayFractions:     [-0.83, -0.50, -0.17, 0.17, 0.50, 0.83],
   rayLeadFrac:      0.35,

--- a/validateLensData.js
+++ b/validateLensData.js
@@ -37,6 +37,10 @@ export default function validateLensData(data) {
       errors.push(`Missing or empty required array field: "${f}"`);
   }
 
+  /* ── Optional boolean fields ── */
+  if (data.visible !== undefined && typeof data.visible !== 'boolean')
+    errors.push(`"visible" must be a boolean (got ${typeof data.visible})`);
+
   /* ── Early exit if surfaces/elements are missing — rest of checks depend on them ── */
   if (!Array.isArray(data.surfaces) || !Array.isArray(data.elements)) return errors;
 


### PR DESCRIPTION
## Summary
Adds an optional `visible` boolean field to lens data files that allows lenses to be hidden from the UI catalog dropdown without removing their data files. This is useful for archiving or deprecating lenses while preserving their data.

## Key Changes
- **Documentation**: Updated `LENS_DATA_SPEC.md` to document the new `visible` field with a default value of `true`
- **Validation**: Added type checking in `validateLensData.js` to ensure `visible` is a boolean when provided
- **Tests**: Added test cases to verify the validation catches non-boolean values and accepts valid boolean values
- **Defaults**: Added `visible: true` to `LENS_DEFAULTS` in `defaults.js`
- **Filtering**: Modified `LensViewer-v4.jsx` to filter out lenses where `visible` is explicitly set to `false` from the catalog dropdown
- **Template & Docs**: Updated `TEMPLATE.data.js.template` and `CLAUDE.md` to document the new field with usage examples

## Implementation Details
- The field is optional with a sensible default (`true`), so existing lens files require no changes
- Filtering is done at the UI level using `.filter(k => LENS_CATALOG[k].visible !== false)`, which preserves lenses with `visible: true` or undefined
- Validation only triggers if the field is explicitly provided, allowing it to be omitted entirely

https://claude.ai/code/session_019M6RMebAJb63wSTuJe5XWz