### PR TITLE
Add "About This Site" overlay with project background

### DIFF
--- a/AboutSite.md
+++ b/AboutSite.md
@@ -1,0 +1,21 @@
+# About This Site
+
+LensVisualizer is an interactive tool for exploring the optical design of real camera lenses. Each lens displayed here is derived from a published optical patent — the same surface prescriptions, glass types, and element arrangements that define the physical lens.
+
+The goal is to make these designs tangible: to show how light actually moves through a lens, how elements are shaped and spaced, and how focus and aperture adjustments change the optical path. Rather than static diagrams, every cross-section is computed in real time from the patent data, with ray tracing that responds to your inputs.
+
+## How It's Made
+
+This site is created by **Ron Buening**. The optical prescriptions are translated from patent filings — a process that involves interpreting lens tables, converting between notation conventions, and validating the data against known optical properties.
+
+**Claude** (Anthropic) is used extensively in the development of this project:
+
+- **Patent translation** — Extracting and converting surface data, glass specifications, and aspherical coefficients from patent documents into structured lens prescriptions
+- **Optical math** — Paraxial ray tracing, sag curve computation, entrance pupil calculation, and chromatic dispersion modeling
+- **Site development** — React components, SVG rendering logic, theme system, and the interactive controls that bring the lens data to life
+
+The result is a collaboration between human domain knowledge — understanding what matters in a lens design and why — and AI capability in handling the tedious, error-prone arithmetic and code that connects patent data to a visual, interactive experience.
+
+---
+
+**[View on GitHub](https://github.com/ronbuening/LensVisualizer)** · **[Request a Lens](https://github.com/ronbuening/LensVisualizer/issues/new)**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ LensVisualizer/
 ├── validateLensData.js     # Schema validation for lens data files
 ├── themes.js               # Theme system — 4 themes via createTheme() factory
 ├── featureFlags.js         # Feature flags — controls feature availability and defaults
+├── AboutMe.md              # Author bio (rendered in About: Author overlay)
+├── AboutSite.md            # Site description (rendered in About: Site overlay)
 ├── lens-data/              # Optical prescription data (one file per lens)
 │   ├── defaults.js         # Shared defaults (ray config, SVG sizing, control steps)
 │   ├── LENS_DATA_SPEC.md   # Full lens data format specification

--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -31,6 +31,7 @@ import { sag, renderSag, gapTrimHeight, thick, doLayout,
 import { ENABLE_COLOR_TRACING, DEFAULT_COLOR_TRACING,
          ENABLE_DESKTOP_VIEW_TOGGLE, ENABLE_DIAGRAM_ONLY, ENABLE_ANALYSIS_ONLY } from './featureFlags.js';
 import ABOUT_ME_MD from './AboutMe.md?raw';
+import ABOUT_SITE_MD from './AboutSite.md?raw';
 
 
 /* =====================================================================
@@ -186,6 +187,7 @@ export default function LensVisualization() {
   const [mobileView, setMobileView] = useState('diagram');
   const [desktopView, setDesktopView] = useState('both');
   const [showAbout, setShowAbout] = useState(false);
+  const [showAboutSite, setShowAboutSite] = useState(false);
 
   useEffect(() => {
     try {
@@ -197,11 +199,11 @@ export default function LensVisualization() {
   }, [dark, highContrast, lensKey, showOnAxis, showOffAxis, rayTracksF, showChromatic, chromR, chromG, chromB]);
 
   useEffect(() => {
-    if (!showAbout) return;
-    const handleKey = (e) => { if (e.key === 'Escape') setShowAbout(false); };
+    if (!showAbout && !showAboutSite) return;
+    const handleKey = (e) => { if (e.key === 'Escape') { setShowAbout(false); setShowAboutSite(false); } };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [showAbout]);
+  }, [showAbout, showAboutSite]);
 
   const isWide = useMediaQuery('(min-width: 900px)');
   const markdown = useMemo(() => mdForKey(lensKey), [lensKey]);
@@ -801,6 +803,19 @@ export default function LensVisualization() {
         <div style={{ flex: 1 }} />
         <span style={{ fontSize: 9, letterSpacing: "0.12em", color: t.muted, fontFamily: "inherit", whiteSpace: "nowrap" }}>ABOUT</span>
         <button
+          onClick={() => setShowAboutSite(true)}
+          style={{
+            backgroundColor: t.selectorBg, border: `1.5px solid ${t.sliderAccent}40`,
+            borderRadius: 6, padding: "5px 14px", cursor: "pointer",
+            fontSize: 11, color: t.selectorText, fontFamily: "inherit",
+            letterSpacing: "0.06em", outline: "none",
+            boxShadow: `0 0 6px ${t.sliderAccent}18`,
+            transition: "background-color 0.3s, color 0.3s, border-color 0.3s",
+          }}
+        >
+          Site
+        </button>
+        <button
           onClick={() => setShowAbout(true)}
           style={{
             backgroundColor: t.selectorBg, border: `1.5px solid ${t.sliderAccent}40`,
@@ -880,6 +895,44 @@ export default function LensVisualization() {
       ) : (
         /* Mobile: toggle between views */
         mobileView === 'diagram' ? diagramContent : descriptionContent
+      )}
+
+      {/* ── About Site overlay ── */}
+      {showAboutSite && (
+        <div
+          onClick={() => setShowAboutSite(false)}
+          style={{
+            position: "fixed", inset: 0, zIndex: 9999,
+            background: "rgba(0,0,0,0.5)", display: "flex",
+            alignItems: "center", justifyContent: "center",
+            transition: "background 0.2s",
+          }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              background: t.descBg, borderRadius: 10,
+              maxWidth: 480, width: "90%", maxHeight: "70vh",
+              overflowY: "auto", position: "relative",
+              boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
+              border: `1px solid ${t.descBorder}`,
+            }}
+          >
+            <button
+              onClick={() => setShowAboutSite(false)}
+              style={{
+                position: "sticky", top: 0, float: "right",
+                margin: "10px 10px 0 0", background: "none",
+                border: "none", color: t.muted, cursor: "pointer",
+                fontSize: 18, fontFamily: "inherit", lineHeight: 1,
+                padding: "2px 6px", borderRadius: 4, zIndex: 1,
+              }}
+            >
+              ×
+            </button>
+            <DescriptionPanel markdown={ABOUT_SITE_MD} theme={t} />
+          </div>
+        </div>
       )}
 
       {/* ── About Me overlay ── */}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # LensVisualizer
 
-Interactive web-based optical lens cross-section visualizer and ray-tracing tool. Renders 2D cross-sections of real camera lenses derived from optical patents, with real-time ray tracing, focus and aperture adjustment, element inspection, and multiple themes.
+Interactive web-based optical lens cross-section visualizer and ray-tracing tool. Renders 2D cross-sections of real camera lenses derived from optical patents, with real-time ray tracing, focus and aperture adjustment, element inspection, chromatic dispersion visualization, and multiple themes.
 
 **Live app:** [ronbuening.github.io/LensVisualizer](https://ronbuening.github.io/LensVisualizer/)
+
+Created by **Ron Buening** — see [About This Site](AboutSite.md) for background on how the project is built.
 
 ## Features
 
 - **SVG cross-section rendering** — Vector lens diagrams computed in real-time from optical prescription data
 - **Real-time ray tracing** — Visualize on-axis and off-axis light paths through the optical system
+- **Chromatic ray tracing** — RGB wavelength-separated rays showing longitudinal chromatic aberration (LCA) with inset display
 - **Focus control** — Adjust focus distance with an interactive slider; see how variable air gaps shift
 - **Aperture control** — Change f-number from wide open to stopped down with clickable f-stop presets
-- **Element inspection** — Hover or click elements to view refractive index, Abbe number, focal length, glass type, and optical role
-- **Design analysis** — Each lens includes a detailed markdown write-up of its optical design
+- **Ray modes** — Toggle between parallel rays (from infinity) and converging rays that track focus distance
+- **Element inspection** — Hover or click elements to view refractive index, Abbe number, focal length, glass type, dispersion data, and optical role
+- **Design analysis** — Each lens includes a detailed markdown write-up of its optical design, rendered in-app
 - **4 themes** — Dark, Light, and high-contrast variants of each
 - **Responsive layout** — Side-by-side diagram and analysis on desktop; tabbed view on mobile
+- **Persistent preferences** — Theme, lens selection, and ray settings saved to localStorage
 
 ## Available Lenses
 
@@ -24,16 +29,29 @@ Interactive web-based optical lens cross-section visualizer and ray-tracing tool
 | NIKKOR Z 50mm f/1.8 S | 12 / 9 | 2 aspherics + 2 ED elements |
 | NIKKOR 105mm f/1.4E ED | 14 / 9 | All-spherical; APD for secondary spectrum |
 
+New lenses are auto-registered — just add a `.data.js` file to `lens-data/`. See [Adding a New Lens](#adding-a-new-lens) below.
+
 ## Getting Started
 
 ```bash
 npm install        # Install dependencies
 npm run dev        # Start dev server at http://localhost:5173
-npm run build      # Production build
-npm run test       # Run unit tests
+npm run build      # Production build → dist/
+npm run preview    # Preview production build
+npm run test       # Run Vitest unit tests
 ```
 
 Requires Node.js 18+.
+
+## Adding a New Lens
+
+1. Copy `lens-data/TEMPLATE.data.js.template` to `lens-data/YourLens.data.js`
+2. Fill in the lens data following the template's field documentation
+3. Optionally add `lens-data/YourLens.analysis.md` for the description panel
+4. Run `npm run test` to verify validation passes
+5. That's it — `import.meta.glob` auto-registers all `./lens-data/*.data.js` files
+
+See `lens-data/LENS_DATA_SPEC.md` for the full data format specification.
 
 ## Request a Lens
 
@@ -44,4 +62,25 @@ Want to see a specific lens added? [Open an issue](https://github.com/ronbuening
 - React 18 + Vite 6
 - Inline SVG rendering (no canvas)
 - Vitest for unit testing
+- react-markdown + remark-gfm for in-app analysis rendering
 - Deployed to GitHub Pages via GitHub Actions
+
+## Project Structure
+
+```
+LensVisualizer/
+├── LensViewer-v4.jsx       # Main component: UI, state, SVG renderer
+├── buildLens.js            # Lens builder — validates data, computes EFL/pupil/field
+├── optics.js               # Optics engine — ray tracing, sag curves, layout math
+├── validateLensData.js     # Schema validation for lens data files
+├── themes.js               # Theme system — 4 themes via createTheme() factory
+├── featureFlags.js         # Feature flags — controls feature availability
+├── ErrorBoundary.jsx       # React error boundary with retry UI
+├── AboutMe.md              # Author bio (rendered in About: Author overlay)
+├── AboutSite.md            # Site description (rendered in About: Site overlay)
+├── lens-data/              # Optical prescription data (one file per lens)
+│   ├── defaults.js         # Shared defaults merged into each lens
+│   ├── LENS_DATA_SPEC.md   # Full lens data format specification
+│   └── *.data.js           # Individual lens prescriptions
+└── __tests__/              # Vitest unit tests
+```


### PR DESCRIPTION
## Summary
Adds a new "About This Site" modal overlay that provides background on the LensVisualizer project, its creation, and the role of AI in its development. This complements the existing "About Me" author bio with project-level context.

## Changes

- **New AboutSite.md file** — Markdown content explaining the project's purpose, how optical prescriptions are sourced from patents, and how Claude AI assists with patent translation, optical math, and site development

- **New "Site" button in About section** — Added alongside the existing "Author" button in the toolbar, with matching styling and theme integration

- **State management for About Site modal** — Added `showAboutSite` state and integrated it into the existing Escape-key handler that closes modals

- **Modal overlay UI** — Implemented a fixed-position overlay with semi-transparent backdrop, styled modal container, close button (×), and markdown rendering via `DescriptionPanel`

- **Updated README.md** — Enhanced documentation with:
  - Mention of chromatic dispersion visualization in features
  - Link to AboutSite.md in the intro
  - Expanded feature list with ray modes, persistent preferences, and auto-registration of new lenses
  - New "Adding a New Lens" section with step-by-step instructions
  - Project structure diagram showing all key files
  - Updated tech stack notes

- **Updated CLAUDE.md** — Added AboutMe.md and AboutSite.md to the project structure documentation

## Implementation Details

- The About Site modal reuses the same overlay pattern as the existing About Me modal, ensuring consistent UX and styling
- Both modals now share a unified Escape-key handler that closes whichever is open
- The modal content is rendered using the existing `DescriptionPanel` component with theme support
- Button styling matches the existing toolbar aesthetic with theme-aware colors and transitions

https://claude.ai/code/session_011gjV4qVQf3wf3q9M2P14JJ