### PR TITLE
Fix Sonnar f/1.5 ray trace failures: correct semi-diameters and add s…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ No React dependencies — fully testable in isolation.
 
 ### validateLensData.js
 
-Pure validation function that checks all required fields, surface label uniqueness, element ID references, asph/var/group/doublet references, STO surface presence, element edge thickness (surface crossing detection), and element SD consistency. Returns an array of error strings (empty = valid).
+Pure validation function that checks all required fields, surface label uniqueness, element ID references, asph/var/group/doublet references, STO surface presence, element edge thickness (surface crossing detection), element SD consistency, and surface sd/|R| ratio (≤ 0.90). Returns an array of error strings (empty = valid).
 
 ### themes.js — Theme System
 
@@ -183,8 +183,10 @@ Surface `sd` values are the most common source of rendering bugs. The validator 
 
 1. **Edge thickness**: For each element, `sag(sd, R_front) − sag(sd, R_rear)` must be less than center thickness `d`. Violation produces a bowtie-shaped element where surfaces cross at the rim.
 2. **SD consistency**: Front and rear surfaces of each element must have SDs within 25% of each other (ratio ≤ 1.25). Larger differences cause rays to appear outside the rendered element.
-3. **Cemented doublets**: Junction surfaces must have matching SDs — the bonded surfaces share a physical clear aperture.
-4. **Smooth progression**: SDs should decrease smoothly toward the aperture stop and increase smoothly after it.
+3. **sd/|R| ratio**: Surface sd must not exceed 0.90 × |R|. As sd approaches |R|, the surface slope at the rim becomes extreme, causing total internal reflection (TIR) at glass-air boundaries and rendering artifacts.
+4. **Cemented doublets**: Junction surfaces must have matching SDs — the bonded surfaces share a physical clear aperture.
+5. **Smooth progression**: SDs should decrease smoothly toward the aperture stop and increase smoothly after it.
+6. **Off-axis containment**: After estimating SDs from on-axis marginal rays, verify that off-axis ray bundles clip at element edges or air gaps — never inside cemented groups. Thick elements amplify off-axis beam divergence and may need tighter upstream SDs.
 
 See `lens-data/TEMPLATE.data.js.template` for detailed documentation and examples.
 

--- a/lens-data/Nokton50f1.data.js
+++ b/lens-data/Nokton50f1.data.js
@@ -63,7 +63,7 @@ const LENS_DATA = {
     { label: "3",   R:   32.975, d:  8.01, nd: 1.90043, elemId: 2, sd: 26.0  },
     { label: "4",   R:   84.150, d:  0.87, nd: 1.0,     elemId: 0, sd: 22.0  },
     { label: "5",   R:   58.596, d:  1.65, nd: 1.80518, elemId: 3, sd: 21.0  },
-    { label: "6",   R:   19.835, d: 12.05, nd: 1.0,     elemId: 0, sd: 18.5  },
+    { label: "6",   R:   19.835, d: 12.05, nd: 1.0,     elemId: 0, sd: 17.8  },
     { label: "STO", R:     1e15, d:  3.24, nd: 1.0,     elemId: 0, sd: 16.14 },
     { label: "8",   R:  -40.995, d:  1.55, nd: 1.76182, elemId: 4, sd: 17.0  },
     { label: "9",   R:   26.578, d: 10.80, nd: 1.88300, elemId: 5, sd: 17.0  },

--- a/lens-data/Sonnar50f15.data.js
+++ b/lens-data/Sonnar50f15.data.js
@@ -9,11 +9,12 @@
  * ║                                                                    ║
  * ║  NOTE ON SEMI-DIAMETERS:                                           ║
  * ║    Patent does not list semi-diameters. SDs estimated from         ║
- * ║    marginal ray trace at f/1.5 with 8–10% mechanical clearance,   ║
- * ║    constrained by surface radii (SD < 0.95×|R|) and the 1.25×    ║
- * ║    front/rear ratio rule. The steeply curved surfaces r6 and r9   ║
- * ║    (|R| ≈ 11 mm) are the binding constraints; all other SDs       ║
- * ║    are propagated outward from these limits.                       ║
+ * ║    marginal ray trace at f/1.5, verified against off-axis ray     ║
+ * ║    bundle at 60% half-field. The steeply curved surfaces r6       ║
+ * ║    and r9 (|R| ≈ 11 mm) are the binding constraints.  SDs are    ║
+ * ║    set so that off-axis clipping occurs at element edges (r6,     ║
+ * ║    r7) rather than inside cemented groups, and all sd/|R|         ║
+ * ║    ratios remain below 0.87 where feasible.                       ║
  * ║                                                                    ║
  * ║  NOTE ON SCALING:                                                  ║
  * ║    Patent prescription is at f = 100 mm. All values here are      ║
@@ -73,19 +74,19 @@ const LENS_DATA = {
     { label: "2",   R:  208.385,  d: 0.25,  nd: 1.0,    elemId: 0, sd: 17.0 },  // L1 rear → air
 
     /* ── Front cemented triplet: L2 – L3 – L4 ── */
-    { label: "3",   R:   18.630,  d: 5.85,  nd: 1.6727, elemId: 2, sd: 16.5 },  // L2 front
-    { label: "4",   R:   52.170,  d: 3.80,  nd: 1.4075, elemId: 3, sd: 14.5 },  // L2→L3 junction (L3 front)
-    { label: "5",   R: -123.500,  d: 0.95,  nd: 1.6890, elemId: 4, sd: 12.5 },  // L3→L4 junction (L4 front)
-    { label: "6",   R:   11.070,  d: 1.00,  nd: 1.0,    elemId: 0, sd: 10.5 },  // L4 rear → air
+    { label: "3",   R:   18.630,  d: 5.85,  nd: 1.6727, elemId: 2, sd: 15.5 },  // L2 front
+    { label: "4",   R:   52.170,  d: 3.80,  nd: 1.4075, elemId: 3, sd: 13.0 },  // L2→L3 junction (L3 front)
+    { label: "5",   R: -123.500,  d: 0.95,  nd: 1.6890, elemId: 4, sd: 10.5 },  // L3→L4 junction (L4 front)
+    { label: "6",   R:   11.070,  d: 1.00,  nd: 1.0,    elemId: 0, sd:  8.5 },  // L4 rear → air
 
     /* ── Aperture stop (in the air gap between front and rear components) ── */
     { label: "STO", R:     1e15,  d: 5.95,  nd: 1.0,    elemId: 0, sd: 10.0 },
 
     /* ── Rear cemented triplet: L5 – L6 – L7 ── */
-    { label: "7",   R:  952.000,  d: 1.70,  nd: 1.5481, elemId: 5, sd: 14.0 },  // L5 front (nearly flat)
-    { label: "8",   R:   29.925,  d: 11.20, nd: 1.6578, elemId: 6, sd: 12.5 },  // L5→L6 junction (L6 front)
-    { label: "9",   R:  -11.030,  d: 4.20,  nd: 1.5488, elemId: 7, sd: 10.4 },  // L6→L7 junction (L7 front)
-    { label: "10",  R:  -44.530,  d: 35.20, nd: 1.0,    elemId: 0, sd: 12.5 },  // L7 rear → air (d = BFD)
+    { label: "7",   R:  952.000,  d: 1.70,  nd: 1.5481, elemId: 5, sd:  8.5 },  // L5 front (nearly flat)
+    { label: "8",   R:   29.925,  d: 11.20, nd: 1.6578, elemId: 6, sd:  8.5 },  // L5→L6 junction (L6 front)
+    { label: "9",   R:  -11.030,  d: 4.20,  nd: 1.5488, elemId: 7, sd:  9.5 },  // L6→L7 junction (L7 front)
+    { label: "10",  R:  -44.530,  d: 35.20, nd: 1.0,    elemId: 0, sd: 11.0 },  // L7 rear → air (d = BFD)
   ],
 
   /* ── Aspherical coefficients ── */

--- a/lens-data/TEMPLATE.data.js.template
+++ b/lens-data/TEMPLATE.data.js.template
@@ -65,17 +65,24 @@ const LENS_DATA = {
    *    elemId  (number, REQUIRED)  Element ID this surface belongs to — 0 for air interfaces
    *    sd      (number, REQUIRED)  Semi-diameter (half clear aperture) in mm
    *
-   *  Semi-diameter constraints (1–2 validated automatically, 3–4 are guidance):
+   *  Semi-diameter constraints (1–3 validated automatically, 4–6 are guidance):
    *    1. Edge thickness: For each element, sag(sd, R_front) − sag(sd, R_rear) must
    *       be less than the center thickness d.  Otherwise the front and rear surfaces
    *       cross at the rim, producing a bowtie-shaped element.  (Validated)
    *    2. SD consistency: Front and rear surface SDs of each element should not differ
    *       by more than 25% (ratio ≤ 1.25).  Larger ratios cause rays to appear outside
    *       the rendered element boundary.  (Validated)
-   *    3. Cemented doublets: Junction surfaces should have nearly identical SDs on both
+   *    3. sd/|R| ratio: sd must not exceed 0.90 × |R|.  As sd approaches |R|, the
+   *       surface slope at the rim becomes extreme, causing total internal reflection
+   *       at glass–air boundaries and rendering artifacts.  (Validated)
+   *    4. Cemented doublets: Junction surfaces should have nearly identical SDs on both
    *       sides — the surfaces are physically bonded and share a common clear aperture.
-   *    4. Smooth progression: SDs should decrease smoothly toward the aperture stop and
+   *    5. Smooth progression: SDs should decrease smoothly toward the aperture stop and
    *       increase smoothly after it.  Abrupt jumps indicate data errors.
+   *    6. Off-axis containment: After estimating SDs from on-axis marginal rays, verify
+   *       that off-axis ray bundles (at offAxisFieldFrac × half-field) clip at element
+   *       edges or air gaps — never inside cemented groups.  Thick elements amplify
+   *       off-axis beam divergence and may need tighter upstream SDs.
    *
    *  Sign conventions:
    *    R > 0  →  center of curvature to the RIGHT of the surface

--- a/validateLensData.js
+++ b/validateLensData.js
@@ -178,6 +178,22 @@ export default function validateLensData(data) {
       errors.push(`Element ${elem.id} ("${elem.name}"): front/rear SD ratio ${(sdMax/sdMin).toFixed(2)} exceeds 1.25 — surfaces "${front.label}" (sd=${front.sd}) / "${rear.label}" (sd=${rear.sd}) may cause rays outside element`);
   }
 
+  /* ── Surface sd/|R| ratio check ──
+   *  When sd approaches |R|, the surface extends near its geometric equator.
+   *  This causes extreme sag slopes that trigger TIR at high-index glass/air
+   *  boundaries and numerical instability in the ray tracer.
+   */
+  const SD_R_WARN = 0.90;
+  for (let i = 0; i < S.length; i++) {
+    const s = S[i];
+    if (typeof s.sd !== 'number' || typeof s.R !== 'number') continue;
+    const absR = Math.abs(s.R);
+    if (absR > 1e10 || absR < 1e-10) continue;
+    const ratio = s.sd / absR;
+    if (ratio > SD_R_WARN)
+      errors.push(`Surface "${s.label}": sd/|R| ratio ${ratio.toFixed(3)} exceeds ${SD_R_WARN} — risk of TIR and rendering artifacts at the rim (reduce sd or verify off-axis ray containment)`);
+  }
+
   return errors;
 }
 


### PR DESCRIPTION
…d/|R| validation

The Sonnar 50mm f/1.5 had two off-axis ray trace failures caused by semi-diameters estimated from on-axis marginal rays only:

1. TIR at surface 6 (L4 rear, sd/|R| = 0.949): dense flint glass (nd=1.689) to air with surface slope 71.5° exceeding the 36.3° critical angle. Fixed by reducing sd from 10.5 to 8.5.

2. Clipping inside rear cemented triplet at surface 9 (sd/|R| = 0.943): off-axis rays diverged through thick L6 element to heights exceeding both sd and physical curvature limit. Fixed by reducing rear group SDs (surfaces 7-10) to enforce vignetting at element edges.

Also adds sd/|R| ratio validation (≤ 0.90) to catch this class of problem in future lens data, fixes the same issue in the Nokton 50mm f/1 (surface 6: 0.933 → 0.897), and updates documentation.

https://claude.ai/code/session_01TpDx7fD2gBMbcpfgi6cJq1