### PR TITLE
Add Flickr search link to lens visualization header

### DIFF
--- a/LensViewer-v4.jsx
+++ b/LensViewer-v4.jsx
@@ -408,6 +408,7 @@ export default function LensVisualization() {
           <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
             <h1 style={{ fontSize: 17, fontWeight: 700, letterSpacing: "0.04em", margin: 0, color: t.title, fontFamily: "'DM Sans','Helvetica Neue',sans-serif", transition: "color 0.3s" }}>{L.data.name}</h1>
             <span style={{ fontSize: 10.5, color: t.subtitle, letterSpacing: "0.08em", transition: "color 0.3s" }}>{L.data.subtitle}</span>
+            <a href={`https://www.flickr.com/search/?text=${encodeURIComponent(L.data.name)}`} target="_blank" rel="noopener noreferrer" title={`Search Flickr for "${L.data.name}"`} style={{ fontSize: 10, color: t.muted, letterSpacing: "0.08em", textDecoration: "none", whiteSpace: "nowrap", transition: "color 0.3s" }}>flickr</a>
           </div>
           <div style={{ display: "flex", gap: 22, marginTop: 6, fontSize: 10, color: t.specs, letterSpacing: "0.06em", transition: "color 0.3s", flexWrap: "wrap" }}>
             {L.data.specs.map((s, i) => <span key={i}>{s}</span>)}


### PR DESCRIPTION
## Summary
Added a clickable Flickr search link in the lens visualization header that allows users to search for the lens by name on Flickr.

## Changes
- Added a new anchor element next to the lens name and subtitle that links to Flickr's search with the lens name as the query parameter
- The link opens in a new tab with `target="_blank"` and includes security attributes (`rel="noopener noreferrer"`)
- Styled to match the existing header design with consistent typography, spacing, and color transitions
- Includes a descriptive title attribute for accessibility

## Implementation Details
- Uses `encodeURIComponent()` to safely encode the lens name in the URL
- Maintains consistent styling with the existing subtitle element (font size 10, muted color, letter spacing)
- Includes `whiteSpace: "nowrap"` to prevent the "flickr" text from wrapping
- Respects the theme's color transitions for seamless theme switching

https://claude.ai/code/session_01HapCakJ8GkgEryRRASvh3L