### PR TITLE
Add maxAspectRatio parameter to control lens diagram vertical scaling

### DIFF
--- a/buildLens.js
+++ b/buildLens.js
@@ -133,7 +133,9 @@ export default function buildLens(data) {
 
   const { svgW, svgH, scFill, yScFill, maxRimAngleDeg, gapSagFrac, clipMargin } = data;
   const SC  = svgW * scFill / totalTrack;
-  const YSC = svgH * yScFill / maxSD;
+  let   YSC = svgH * yScFill / maxSD;
+  const maxAR = data.maxAspectRatio;
+  if (maxAR > 0 && YSC / SC > maxAR) YSC = SC * maxAR;
   const maxRimSin  = Math.sin(maxRimAngleDeg * Math.PI / 180);
   const gridPitch  = totalTrack / 15;
   const gridCount  = Math.ceil(svgW / (gridPitch * SC)) + 4;

--- a/lens-data/LENS_DATA_SPEC.md
+++ b/lens-data/LENS_DATA_SPEC.md
@@ -38,6 +38,7 @@ These are merged automatically. Override only when needed.
 | `clipMargin` | `1.0` | Clipping margin for element trimming |
 | `maxRimAngleDeg` | `40` | Max rim angle (degrees) |
 | `gapSagFrac` | `0.90` | Sag rendering fraction for air gaps |
+| `maxAspectRatio` | `1.6` | Max YSC/SC ratio — clamps vertical scale to prevent horizontal squashing on long lenses |
 | `focusStep` | `0.004` | Focus slider step size |
 | `apertureStep` | `0.004` | Aperture slider step size |
 | `maxFstop` | `16` | Maximum f-number for aperture slider |

--- a/lens-data/TEMPLATE.data.js.template
+++ b/lens-data/TEMPLATE.data.js.template
@@ -203,7 +203,8 @@ const LENS_DATA = {
    *
    *  Other overridable defaults (usually fine as-is):
    *    svgW: 1080, svgH: 490, clipMargin: 1.0, maxRimAngleDeg: 40,
-   *    gapSagFrac: 0.90, focusStep: 0.004, apertureStep: 0.004, maxFstop: 16,
+   *    gapSagFrac: 0.90, maxAspectRatio: 1.6,
+   *    focusStep: 0.004, apertureStep: 0.004, maxFstop: 16,
    *    rayFractions: [-0.83, -0.50, -0.17, 0.17, 0.50, 0.83],
    *    rayLeadFrac: 0.35, lensShiftFrac: 0.08, offAxisFieldFrac: 0.60,
    *    offAxisFractions: [-0.75, -0.375, 0, 0.375, 0.75]

--- a/lens-data/defaults.js
+++ b/lens-data/defaults.js
@@ -24,6 +24,7 @@ const LENS_DEFAULTS = {
   clipMargin:       1.0,
   maxRimAngleDeg:   40,
   gapSagFrac:       0.90,
+  maxAspectRatio:   1.6,
 
   /* ── Controls ── */
   focusStep:        0.004,

--- a/validateLensData.js
+++ b/validateLensData.js
@@ -17,7 +17,7 @@ export default function validateLensData(data) {
   const requiredNumbers = [
     'nominalFno', 'closeFocusM', 'focusStep', 'maxFstop', 'apertureStep',
     'svgW', 'svgH', 'scFill', 'yScFill', 'clipMargin', 'maxRimAngleDeg',
-    'gapSagFrac', 'rayLeadFrac', 'offAxisFieldFrac',
+    'gapSagFrac', 'rayLeadFrac', 'offAxisFieldFrac', 'maxAspectRatio',
   ];
   const requiredArrays = [
     'elements', 'surfaces', 'fstopSeries',


### PR DESCRIPTION
## Summary
This PR introduces a new `maxAspectRatio` parameter that constrains the vertical scaling of lens diagrams to prevent excessive horizontal squashing on long focal length lenses.

## Key Changes
- **buildLens.js**: Added logic to clamp the YSC (vertical scale) based on a maximum aspect ratio constraint. If the YSC/SC ratio exceeds `maxAspectRatio`, YSC is recalculated as `SC * maxAR` to maintain proportional rendering.
- **validateLensData.js**: Added `maxAspectRatio` to the list of required numeric parameters for validation.
- **defaults.js**: Set default value of `maxAspectRatio` to `1.6`.
- **TEMPLATE.data.js.template**: Documented the new parameter in the template with its default value.
- **LENS_DATA_SPEC.md**: Added specification entry explaining that `maxAspectRatio` clamps the vertical scale to prevent horizontal squashing on long lenses.

## Implementation Details
- The aspect ratio constraint is applied after the initial YSC calculation but before it's used in rendering calculations.
- The parameter is optional in user data but required in validation, with a sensible default of 1.6 that works well for most lens designs.
- This prevents diagrams from becoming excessively tall and narrow for telephoto lenses while maintaining proper proportions for standard lenses.

https://claude.ai/code/session_01FVpMRz1cPG611akWCDug3A