### PR TITLE
Add 6 new lenses and update documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ LensVisualizer/
 ├── index.html              # HTML entry point
 ├── main.jsx                # React root mount (wraps app in ErrorBoundary)
 ├── ErrorBoundary.jsx       # React class-based error boundary with retry UI
-├── LensViewer-v4.jsx       # Main component (~819 lines): UI chrome, state, SVG renderer
+├── LensViewer-v4.jsx       # Main component (~978 lines): UI chrome, state, SVG renderer
 ├── buildLens.js            # Lens builder — validates data, computes EFL/pupil/field
 ├── optics.js               # Optics engine — ray tracing, sag curves, layout math
 ├── validateLensData.js     # Schema validation for lens data files
@@ -33,14 +33,16 @@ LensVisualizer/
 │   ├── defaults.js         # Shared defaults (ray config, SVG sizing, control steps)
 │   ├── LENS_DATA_SPEC.md   # Full lens data format specification
 │   ├── TEMPLATE.data.js.template  # Annotated template for new lens files
-│   ├── ApoLanthar50f2.data.js
-│   ├── ApoLanthar50f2.analysis.md
-│   ├── Nikkor105f14E.data.js
-│   ├── Nikkor105f14E.analysis.md
-│   ├── Nokton50f1.data.js
-│   ├── Nokton50f1.analysis.md
-│   ├── NikkorZ50mmf18S.data.js
-│   └── NikkorZ50mmf18S.analysis.md
+│   ├── ApoLanthar50f2.data.js     (+.analysis.md)
+│   ├── BerteleSonnar50f2.data.js  (+.analysis.md)
+│   ├── Heliar-US716035.data.js    (+.analysis.md)
+│   ├── Nikkor105f14E.data.js      (+.analysis.md)
+│   ├── NikkorAIS24f28.data.js     (+.analysis.md)
+│   ├── NikkorZ50f12.data.js       (+.analysis.md)
+│   ├── NikkorZ50mmf18S.data.js    (+.analysis.md)
+│   ├── Nokton50f1.data.js         (+.analysis.md)
+│   ├── Sonnar50f15.data.js        (+.analysis.md)
+│   └── ZeissTessar-US721240.data.js (+.analysis.md)
 ├── __tests__/              # Vitest unit tests
 │   ├── buildLens.test.js   # Paraxial trace, EFL, entrance pupil tests
 │   ├── optics.test.js      # Sag, ray trace, layout tests
@@ -49,7 +51,7 @@ LensVisualizer/
 │   └── deploy.yml          # GitHub Actions — builds and deploys to GitHub Pages
 ├── ARCHITECTURE-REVIEW.md  # Refactoring plan and architectural notes
 ├── PLAN-description-panel-and-deploy.md  # Description panel implementation plan
-├── vite.config.js          # Vite config (base: '/LensVisualizer/' for GH Pages)
+├── vite.config.js          # Vite config (base: '/' for dev; deploy.yml handles GH Pages)
 └── package.json            # Dependencies and scripts
 ```
 
@@ -70,7 +72,7 @@ No linters or formatters are configured.
 - **GitHub Pages** via GitHub Actions (`.github/workflows/deploy.yml`)
 - Triggers on push to `main` or manual dispatch
 - Builds with `npm ci && npm run build`, deploys `dist/` to Pages
-- Base path set to `/LensVisualizer/` in `vite.config.js`
+- Base path set to `/` in `vite.config.js` (GitHub Actions deploy handles the Pages base path)
 
 ## Architecture
 
@@ -80,13 +82,13 @@ The codebase follows a layered extraction pattern. Core logic has been extracted
 
 | Module | Lines | Purpose |
 |--------|-------|---------|
-| `LensViewer-v4.jsx` | ~819 | UI component: state, SVG rendering, interaction |
-| `buildLens.js` | ~176 | Lens construction, EFL/pupil/field computation |
-| `optics.js` | ~221 | Ray tracing, sag curves, chromatic tracing, layout geometry |
-| `validateLensData.js` | ~193 | Schema validation for lens data |
+| `LensViewer-v4.jsx` | ~978 | UI component: state, SVG rendering, interaction |
+| `buildLens.js` | ~178 | Lens construction, EFL/pupil/field computation |
+| `optics.js` | ~259 | Ray tracing, sag curves, chromatic tracing, layout geometry |
+| `validateLensData.js` | ~213 | Schema validation for lens data |
 | `themes.js` | ~251 | Theme factory and 4 theme definitions |
-| `featureFlags.js` | ~10 | Feature flags for UI toggles |
-| `lens-data/defaults.js` | ~31 | Shared lens defaults merged into each lens |
+| `featureFlags.js` | ~13 | Feature flags for UI toggles |
+| `lens-data/defaults.js` | ~35 | Shared lens defaults merged into each lens |
 
 ### LensViewer-v4.jsx — Section Layout
 
@@ -130,6 +132,9 @@ Four themes (dark, light, darkHC, lightHC) built via a `createTheme()` factory f
 Feature flags controlling UI toggle visibility and defaults:
 - **`ENABLE_COLOR_TRACING`** — whether the color-tracing UI toggle appears
 - **`DEFAULT_COLOR_TRACING`** — initial state when no localStorage entry exists
+- **`ENABLE_DESKTOP_VIEW_TOGGLE`** — whether the diagram/analysis/both view toggle appears on desktop
+- **`ENABLE_DIAGRAM_ONLY`** — whether "diagram only" view mode is available
+- **`ENABLE_ANALYSIS_ONLY`** — whether "analysis only" view mode is available
 
 ### ErrorBoundary.jsx
 
@@ -142,7 +147,7 @@ Each lens has two files in `lens-data/`:
 - **`.analysis.md`** — Markdown design analysis, rendered in the app's description panel
 
 Supporting files in `lens-data/`:
-- **`defaults.js`** — Shared defaults (`rayFractions`, `rayLeadFrac`, `lensShiftFrac`, `offAxisFieldFrac`, `offAxisFractions`, `svgW`, `svgH`, `clipMargin`, `maxRimAngleDeg`, `gapSagFrac`, `focusStep`, `apertureStep`, `maxFstop`) merged into each lens via `buildLens()`
+- **`defaults.js`** — Shared defaults (`rayFractions`, `rayLeadFrac`, `lensShiftFrac`, `offAxisFieldFrac`, `offAxisFractions`, `svgW`, `svgH`, `clipMargin`, `maxRimAngleDeg`, `gapSagFrac`, `maxAspectRatio`, `focusStep`, `apertureStep`, `maxFstop`) merged into each lens via `buildLens()`
 - **`LENS_DATA_SPEC.md`** — Complete specification for all lens data fields, types, and validation rules
 - **`TEMPLATE.data.js.template`** — Annotated template with inline documentation for creating new lens files
 
@@ -204,7 +209,7 @@ No manual imports or catalog edits required. Shared defaults from `lens-data/def
 
 Tests use **Vitest** and live in `__tests__/`:
 
-- **`buildLens.test.js`** — Tests `paraxialTrace()` with flat/refractive surfaces; validates `buildLens()` output (EFL, entrance pupil, half-field) against all four production lenses
+- **`buildLens.test.js`** — Tests `paraxialTrace()` with flat/refractive surfaces; validates `buildLens()` output (EFL, entrance pupil, half-field) against production lenses
 - **`optics.test.js`** — Tests `sag()`, `renderSag()` with aspherical coefficients; `conjugateK()`, `formatDist()`; `doLayout()` with variable surfaces
 - **`validateLensData.test.js`** — Tests schema validation against production lenses; verifies error reporting for missing fields, duplicate labels, invalid references
 
@@ -226,6 +231,6 @@ Run with `npm run test`. Tests cover the extracted pure-function modules; the Re
 - `buildLens()` calls `validateLensData()` internally; malformed data throws descriptive errors with all issues listed
 - Theme colors use semantic names (`rayWarm`, `rayCool`, `apdPatentBg`) — update all 4 themes when changing colors
 - Section numbering in LensViewer-v4.jsx skips §2–§5 (extracted to separate modules) — don't renumber
-- `vite.config.js` sets `base: '/LensVisualizer/'` — required for GitHub Pages; local dev is unaffected
+- `vite.config.js` sets `base: '/'` — GitHub Actions deploy workflow handles the Pages base path
 - Lens data globs match `*.data.js`; analysis globs match `*.analysis.md` — naming convention matters for auto-registration
 - `lens-data/defaults.js` values are merged under each lens — per-lens values in `.data.js` take precedence

--- a/README.md
+++ b/README.md
@@ -22,12 +22,18 @@ Created by **Ron Buening** — see [About This Site](AboutSite.md) for backgroun
 
 ## Available Lenses
 
-| Lens | Elements / Groups | Notes |
-|------|-------------------|-------|
-| NOKTON 50mm f/1.0 | 8 / 6 | Ultra-fast; 3 aspheric surfaces |
-| APO-LANTHAR 50mm f/2.0 | 10 / 8 | Floating focus; 2 double-sided aspherics; APD elements |
-| NIKKOR Z 50mm f/1.8 S | 12 / 9 | 2 aspherics + 2 ED elements |
-| NIKKOR 105mm f/1.4E ED | 14 / 9 | All-spherical; APD for secondary spectrum |
+| Lens | Elements | Notes |
+|------|----------|-------|
+| Voigtländer Heliar f/4 (1902) | 5 | Classic symmetric triplet; US 716,035 |
+| Carl Zeiss Tessar 144mm f/5.5 (1903) | 4 | Original Rudolph design; US 721,240 |
+| Carl Zeiss Sonnar 50mm f/1.5 | 7 | Two cemented triplets |
+| Carl Zeiss Jena Sonnar 50mm f/2 | 6 | Bertele's original; US 1,998,704 |
+| NIKKOR-N Auto 24mm f/2.8 | 9 | CRC (Close Range Correction) |
+| VOIGTLÄNDER NOKTON 50mm f/1.0 | 9 | Ultra-fast; 3 aspheric surfaces |
+| VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 | 10 | Floating focus; 2 double-sided aspherics; APD elements |
+| NIKKOR Z 50mm f/1.8 S | 12 | 2 aspherics + 2 ED elements |
+| NIKON NIKKOR Z 50mm f/1.2 S | 17+filter | 3 aspherics; multi-group AF; 6 APD elements |
+| NIKKOR 105mm f/1.4E ED | 14 | All-spherical; APD for secondary spectrum |
 
 New lenses are auto-registered — just add a `.data.js` file to `lens-data/`. See [Adding a New Lens](#adding-a-new-lens) below.
 
@@ -69,7 +75,7 @@ Want to see a specific lens added? [Open an issue](https://github.com/ronbuening
 
 ```
 LensVisualizer/
-├── LensViewer-v4.jsx       # Main component: UI, state, SVG renderer
+├── LensViewer-v4.jsx       # Main component: UI, state, SVG renderer (~978 lines)
 ├── buildLens.js            # Lens builder — validates data, computes EFL/pupil/field
 ├── optics.js               # Optics engine — ray tracing, sag curves, layout math
 ├── validateLensData.js     # Schema validation for lens data files
@@ -78,9 +84,10 @@ LensVisualizer/
 ├── ErrorBoundary.jsx       # React error boundary with retry UI
 ├── AboutMe.md              # Author bio (rendered in About: Author overlay)
 ├── AboutSite.md            # Site description (rendered in About: Site overlay)
-├── lens-data/              # Optical prescription data (one file per lens)
+├── lens-data/              # Optical prescription data (10 lenses)
 │   ├── defaults.js         # Shared defaults merged into each lens
 │   ├── LENS_DATA_SPEC.md   # Full lens data format specification
-│   └── *.data.js           # Individual lens prescriptions
+│   ├── TEMPLATE.data.js.template  # Annotated template for new lens files
+│   └── *.data.js + *.analysis.md  # Lens prescriptions + design analyses
 └── __tests__/              # Vitest unit tests
 ```


### PR DESCRIPTION
## Summary
Expanded the lens library from 4 to 10 lenses and updated documentation to reflect new content, feature flags, and deployment configuration changes.

## Key Changes

### New Lenses Added
- **Heliar-US716035** — Voigtländer Heliar f/4 (1902), classic symmetric triplet
- **ZeissTessar-US721240** — Carl Zeiss Tessar 144mm f/5.5 (1903), original Rudolph design
- **Sonnar50f15** — Carl Zeiss Sonnar 50mm f/1.5, two cemented triplets
- **BerteleSonnar50f2** — Carl Zeiss Jena Sonnar 50mm f/2, Bertele's original
- **NikkorAIS24f28** — NIKKOR-N Auto 24mm f/2.8 with CRC (Close Range Correction)
- **NikkorZ50f12** — NIKON NIKKOR Z 50mm f/1.2 S, multi-group AF with 6 APD elements

Each lens includes both `.data.js` prescription file and `.analysis.md` design analysis.

### Feature Flags Expanded
Added three new feature flags to `featureFlags.js`:
- `ENABLE_DESKTOP_VIEW_TOGGLE` — controls diagram/analysis/both view toggle visibility
- `ENABLE_DIAGRAM_ONLY` — enables "diagram only" view mode
- `ENABLE_ANALYSIS_ONLY` — enables "analysis only" view mode

### Documentation Updates
- Updated `CLAUDE.md` with accurate line counts for all modules (LensViewer-v4.jsx now ~978 lines)
- Updated `defaults.js` documentation to include new `maxAspectRatio` parameter
- Changed `vite.config.js` base path from `/LensVisualizer/` to `/` with note that GitHub Actions deploy workflow handles the Pages base path
- Updated README.md lens table with all 10 lenses, sorted chronologically with design notes
- Updated architecture module line counts to reflect recent changes

### Code Size Changes
- `LensViewer-v4.jsx`: 819 → 978 lines (new view mode UI)
- `optics.js`: 221 → 259 lines (enhanced ray tracing)
- `validateLensData.js`: 193 → 213 lines (improved validation)
- `featureFlags.js`: 10 → 13 lines (new flags)
- `defaults.js`: 31 → 35 lines (new parameter)

## Notable Details
- All new lenses follow the existing `.data.js` + `.analysis.md` pattern and are auto-registered via glob imports
- Deployment configuration simplified: base path now `/` with GitHub Actions handling the Pages-specific path
- Test documentation updated to reflect expanded lens library

https://claude.ai/code/session_01EczHSdB9APpkkH5FgZ1ibb