### PR TITLE
Add sticky slider behavior with flash feedback in lens comparison

### DIFF
--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -78,11 +78,21 @@ export default function LensDiagramPanel({
   onDarkChange,
   onHighContrastChange,
   highContrast,
+  flashOverlay = false,
 }) {
   const [hov, setHov] = useState(null);
   const [sel, setSel] = useState(null);
+  const [flashOpacity, setFlashOpacity] = useState(0);
 
   useEffect(() => { setHov(null); setSel(null); }, [lensKey]);
+
+  /* ── Flash overlay animation ── */
+  useEffect(() => {
+    if (!flashOverlay) return;
+    setFlashOpacity(0.18);
+    const timer = setTimeout(() => setFlashOpacity(0), 50);
+    return () => clearTimeout(timer);
+  }, [flashOverlay]);
 
   /* ── Header height reporting for alignment ── */
   const headerRef = useRef(null);
@@ -550,6 +560,13 @@ export default function LensDiagramPanel({
         {L.doublets.map(({ text, fromSurface, toSurface }) => (
           <text key={text} x={sx((zPos[fromSurface] + zPos[toSurface]) / 2)} y={sy(L.lyDoublet)} textAnchor="middle" fill={t.doubletLabel} fontSize={7} fontFamily="inherit">{text}</text>
         ))}
+
+        {/* Flash overlay — brief highlight when slider sticks at common point */}
+        {flashOpacity > 0 && (
+          <rect x="0" y="0" width={L.svgW} height={L.svgH}
+            fill={dark ? "#ffffff" : "#000000"} opacity={flashOpacity}
+            style={{ transition: "opacity 0.35s ease-out", pointerEvents: "none" }} />
+        )}
       </svg>
 
       {/* ── Control panel ── */}

--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -28,7 +28,8 @@ import { PREFS_KEY, loadPrefs } from '../utils/preferences.js';
 import { parseComparisonParams, buildComparisonURL } from '../utils/parseComparisonParams.js';
 import { ENABLE_COLOR_TRACING, DEFAULT_COLOR_TRACING,
          ENABLE_DESKTOP_VIEW_TOGGLE, ENABLE_DIAGRAM_ONLY, ENABLE_ANALYSIS_ONLY,
-         ENABLE_COMPARISON, ENABLE_COMPARISON_MOBILE } from '../utils/featureFlags.js';
+         ENABLE_COMPARISON, ENABLE_COMPARISON_MOBILE,
+         ENABLE_SLIDER_STICKY, ENABLE_SLIDER_STICKY_FLASH } from '../utils/featureFlags.js';
 import { computeFocusPair, computeAperturePair, snapToCommon } from '../utils/comparisonSliders.js';
 import { ErrorDisplay } from './ErrorBoundary.jsx';
 import ABOUT_ME_MD from '../content/AboutMe.md?raw';
@@ -78,6 +79,12 @@ export default function LensVisualization() {
   const [sharedFocusT, setSharedFocusT] = useState(0);
   const [sharedStopdownT, setSharedStopdownT] = useState(0);
   const [headerHeights, setHeaderHeights] = useState({ a: 0, b: 0 });
+  const justEnteredCompare = useRef(false);
+
+  /* ── Sticky slider state (slider pauses at common-point demarcation lines) ── */
+  const focusStuck = useRef(false);
+  const apertureStuck = useRef(false);
+  const [flashPanel, setFlashPanel] = useState(null);   // 'a' | 'b' | null
 
   /* ── Persist preferences ── */
   useEffect(() => {
@@ -164,6 +171,20 @@ export default function LensVisualization() {
     return computeAperturePair(sharedStopdownT, comparisonLenses.LA, comparisonLenses.LB);
   }, [sharedStopdownT, comparisonLenses]);
 
+  /* ── Set default aperture to slowest lens wide-open when entering comparison ── */
+  useEffect(() => {
+    if (!justEnteredCompare.current || !comparisonLenses || comparisonLenses.error) return;
+    justEnteredCompare.current = false;
+    const { LA, LB } = comparisonLenses;
+    const widerFOPEN = Math.min(LA.FOPEN, LB.FOPEN);
+    const narrowerFOPEN = Math.max(LA.FOPEN, LB.FOPEN);
+    const sharedMaxFstop = Math.max(LA.maxFstop, LB.maxFstop);
+    const cp = Math.abs(widerFOPEN - narrowerFOPEN) < 0.01
+      ? 0
+      : Math.log(narrowerFOPEN / widerFOPEN) / Math.log(sharedMaxFstop / widerFOPEN);
+    setSharedStopdownT(cp);
+  }, [comparisonLenses]);
+
   /* ── Enter/exit comparison mode ── */
   const toggleCompare = useCallback(() => {
     if (!comparing) {
@@ -172,9 +193,11 @@ export default function LensVisualization() {
         const idx = CATALOG_KEYS.indexOf(lensKeyA);
         setLensKeyB(CATALOG_KEYS[(idx + 1) % CATALOG_KEYS.length]);
       }
-      /* Snap shared sliders to common points */
       setSharedFocusT(0);
       setSharedStopdownT(0);
+      justEnteredCompare.current = true;
+      focusStuck.current = false;
+      apertureStuck.current = false;
     } else {
       /* Exiting: map shared values back to single-lens values */
       if (focusPair) setFocusT(focusPair.focusA);
@@ -182,6 +205,55 @@ export default function LensVisualization() {
     }
     setComparing(c => !c);
   }, [comparing, lensKeyA, lensKeyB, focusPair, aperturePair]);
+
+  /* ── Sticky slider handlers ── */
+  const triggerFlash = useCallback((panel) => {
+    if (!ENABLE_SLIDER_STICKY_FLASH) return;
+    setFlashPanel(panel);
+    setTimeout(() => setFlashPanel(null), 400);
+  }, []);
+
+  const handleSharedFocusChange = useCallback((rawT) => {
+    const cp = focusPair?.commonPoint;
+    if (ENABLE_SLIDER_STICKY && cp > 0.01 && cp < 0.99 && !focusStuck.current) {
+      const prev = sharedFocusT;
+      /* Crossing or reaching the common point from either side */
+      if ((prev < cp && rawT >= cp) || (prev > cp && rawT <= cp)) {
+        setSharedFocusT(cp);
+        focusStuck.current = true;
+        /* The lens with longer MFD (less capable) is the one that stops */
+        const { LA, LB } = comparisonLenses;
+        triggerFlash(LA.closeFocusM > LB.closeFocusM ? 'a' : 'b');
+        return;
+      }
+    }
+    setSharedFocusT(snapToCommon(rawT, cp));
+  }, [focusPair, sharedFocusT, comparisonLenses, triggerFlash]);
+
+  const handleSharedStopdownChange = useCallback((rawT) => {
+    const cp = aperturePair?.commonPoint;
+    if (ENABLE_SLIDER_STICKY && cp > 0.01 && cp < 0.99 && !apertureStuck.current) {
+      const prev = sharedStopdownT;
+      /* Crossing or reaching the common point from either side */
+      if ((prev < cp && rawT >= cp) || (prev > cp && rawT <= cp)) {
+        setSharedStopdownT(cp);
+        apertureStuck.current = true;
+        /* The slower lens (larger FOPEN) is the one that stops */
+        const { LA, LB } = comparisonLenses;
+        triggerFlash(LA.FOPEN > LB.FOPEN ? 'a' : 'b');
+        return;
+      }
+    }
+    setSharedStopdownT(snapToCommon(rawT, cp));
+  }, [aperturePair, sharedStopdownT, comparisonLenses, triggerFlash]);
+
+  const handleFocusPointerDown = useCallback(() => {
+    focusStuck.current = false;
+  }, []);
+
+  const handleAperturePointerDown = useCallback(() => {
+    apertureStuck.current = false;
+  }, []);
 
   /* ── Header height alignment callback ── */
   const handleHeaderHeight = useCallback((panelId, height) => {
@@ -354,6 +426,7 @@ export default function LensVisualization() {
           maxSvgHeight={isWide ? "54vh" : "42vh"}
           onHeaderHeight={handleHeaderHeight}
           minHeaderHeight={isWide && maxHeaderHeight > 0 ? maxHeaderHeight : undefined}
+          flashOverlay={flashPanel === 'a'}
         />
       </div>
       <div style={{ flex: isWide ? "0 0 50%" : "none", minWidth: 0, overflow: "hidden" }}>
@@ -370,6 +443,7 @@ export default function LensVisualization() {
           maxSvgHeight={isWide ? "54vh" : "42vh"}
           onHeaderHeight={handleHeaderHeight}
           minHeaderHeight={isWide && maxHeaderHeight > 0 ? maxHeaderHeight : undefined}
+          flashOverlay={flashPanel === 'b'}
         />
       </div>
     </div>
@@ -519,8 +593,10 @@ export default function LensVisualization() {
           <SharedSlidersBar
             LA={comparisonLenses.LA} LB={comparisonLenses.LB}
             sharedFocusT={sharedFocusT} sharedStopdownT={sharedStopdownT}
-            onSharedFocusChange={v => setSharedFocusT(snapToCommon(v, focusPair.commonPoint))}
-            onSharedStopdownChange={v => setSharedStopdownT(snapToCommon(v, aperturePair.commonPoint))}
+            onSharedFocusChange={handleSharedFocusChange}
+            onSharedStopdownChange={handleSharedStopdownChange}
+            onFocusPointerDown={handleFocusPointerDown}
+            onAperturePointerDown={handleAperturePointerDown}
             focusPair={focusPair} aperturePair={aperturePair}
             theme={t} isWide={isWide}
           />

--- a/src/components/SharedSlidersBar.jsx
+++ b/src/components/SharedSlidersBar.jsx
@@ -5,7 +5,7 @@
 import { formatSharedFocusDist, sharedFNumber } from '../utils/comparisonSliders.js';
 import { formatDist } from '../optics/optics.js';
 
-export default function SharedSlidersBar({ LA, LB, sharedFocusT, sharedStopdownT, onSharedFocusChange, onSharedStopdownChange, focusPair, aperturePair, theme: t, isWide }) {
+export default function SharedSlidersBar({ LA, LB, sharedFocusT, sharedStopdownT, onSharedFocusChange, onSharedStopdownChange, onFocusPointerDown, onAperturePointerDown, focusPair, aperturePair, theme: t, isWide }) {
   const { commonPoint: focusCP, minCloseFocus, maxCloseFocus } = focusPair;
   const { commonPoint: apertureCP, widerFOPEN, narrowerFOPEN, sharedMaxFstop } = aperturePair;
   const fNum = sharedFNumber(sharedStopdownT, widerFOPEN, sharedMaxFstop);
@@ -39,6 +39,7 @@ export default function SharedSlidersBar({ LA, LB, sharedFocusT, sharedStopdownT
               {showFocusCP && <div style={markerStyle(focusCP)} />}
               {showFocusCP && <div style={markerLineStyle(focusCP)} />}
               <input type="range" min="0" max="1" step="0.004" value={sharedFocusT}
+                onPointerDown={onFocusPointerDown}
                 onChange={e => onSharedFocusChange(parseFloat(e.target.value))}
                 style={{ width: "100%", height: 4, appearance: "none", background: t.sliderTrack, borderRadius: 2, outline: "none", cursor: "pointer", accentColor: t.sliderAccent }} />
             </div>
@@ -65,6 +66,7 @@ export default function SharedSlidersBar({ LA, LB, sharedFocusT, sharedStopdownT
               {showApertureCP && <div style={markerStyle(apertureCP)} />}
               {showApertureCP && <div style={markerLineStyle(apertureCP)} />}
               <input type="range" min="0" max="1" step="0.004" value={sharedStopdownT}
+                onPointerDown={onAperturePointerDown}
                 onChange={e => onSharedStopdownChange(parseFloat(e.target.value))}
                 style={{ width: "100%", height: 4, appearance: "none", background: t.sliderTrack, borderRadius: 2, outline: "none", cursor: "pointer", accentColor: t.sliderAccent }} />
             </div>

--- a/src/utils/featureFlags.js
+++ b/src/utils/featureFlags.js
@@ -14,3 +14,6 @@ export const ENABLE_ANALYSIS_ONLY       = true;
 
 export const ENABLE_COMPARISON        = true;
 export const ENABLE_COMPARISON_MOBILE = true;
+
+export const ENABLE_SLIDER_STICKY       = true;
+export const ENABLE_SLIDER_STICKY_FLASH = true;


### PR DESCRIPTION
## Summary
Implements "sticky slider" functionality for the lens comparison mode, where sliders pause at common-point demarcation lines between lenses. When a slider reaches a common point, it sticks in place and the corresponding lens panel briefly flashes to provide visual feedback.

## Key Changes

- **Sticky slider logic**: Added `focusStuck` and `apertureStuck` refs to track when sliders are stuck at common points. When dragging crosses or reaches a common point, the slider locks to that position.

- **Flash feedback system**: Implemented `flashPanel` state and `triggerFlash` callback to briefly highlight the lens panel (the one with the limiting capability) when its slider sticks. The flash uses a 400ms timeout with a 0.35s ease-out animation.

- **Smart aperture initialization**: Added logic to set the default aperture to the slowest lens wide-open when entering comparison mode, calculated via the common point between the two lenses' maximum f-stops.

- **Pointer event handling**: Added `onFocusPointerDown` and `onAperturePointerDown` callbacks to reset the stuck state when the user begins dragging, allowing them to move past the common point if desired.

- **Component updates**:
  - `LensViewer.jsx`: Added sticky slider state management, handlers, and flash overlay props
  - `LensDiagramPanel.jsx`: Added flash overlay animation (white/black rect with opacity transition)
  - `SharedSlidersBar.jsx`: Connected pointer down events to reset stuck state
  - `featureFlags.js`: Added `ENABLE_SLIDER_STICKY` and `ENABLE_SLIDER_STICKY_FLASH` flags

## Implementation Details

- The sticky behavior only engages when the common point is between 1% and 99% of the slider range, avoiding edge cases
- Flash feedback identifies which lens is the limiting factor (longer MFD for focus, larger FOPEN for aperture) and highlights that panel
- The stuck state is automatically cleared when the user starts a new drag interaction, providing intuitive control

https://claude.ai/code/session_01TTcZEpB3sy8tVSe47f736G