### PR TITLE
Add conic asphere and cross-gap overlap validation

### DIFF
--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -140,11 +140,22 @@ export default function LensDiagramPanel({
       return L.ES.map(([eid, s1, s2]) => {
         const sd = Math.min(L.S[s1].sd, L.S[s2].sd);
         const R1 = Math.abs(L.S[s1].R), R2 = Math.abs(L.S[s2].R);
-        let trim1 = R1 < 1e10 ? Math.min(sd, R1 * L.maxRimSin) : sd;
-        let trim2 = R2 < 1e10 ? Math.min(sd, R2 * L.maxRimSin) : sd;
+        /* Conic-aware max height: surface slope → ∞ at h = |R|/√(1+K) when K > 0 */
+        const K1 = L.asphByIdx[s1]?.K || 0;
+        const K2 = L.asphByIdx[s2]?.K || 0;
+        const hMax1 = (K1 > 0 && R1 < 1e10) ? R1 / Math.sqrt(1 + K1) * 0.98 : Infinity;
+        const hMax2 = (K2 > 0 && R2 < 1e10) ? R2 / Math.sqrt(1 + K2) * 0.98 : Infinity;
+        let trim1 = R1 < 1e10 ? Math.min(sd, R1 * L.maxRimSin, hMax1) : Math.min(sd, hMax1);
+        let trim2 = R2 < 1e10 ? Math.min(sd, R2 * L.maxRimSin, hMax2) : Math.min(sd, hMax2);
+        /* Trim front surface if it curves backward into preceding air gap */
         if (s1 > 0 && L.gapSagFrac > 0 && renderSag(trim1, s1, L) < 0) {
           const gapBefore = L.S[s1 - 1].d;
           trim1 = gapTrimHeight(s1, trim1, gapBefore * L.gapSagFrac, L);
+        }
+        /* Trim rear surface if it curves forward into following air gap */
+        if (L.S[s2].nd === 1.0 && L.gapSagFrac > 0 && renderSag(trim2, s2, L) > 0) {
+          const gapAfter = L.S[s2].d;
+          trim2 = gapTrimHeight(s2, trim2, gapAfter * L.gapSagFrac, L);
         }
         const z1 = zPos[s1], z2 = zPos[s2], NN = SVG_PATH_SUBDIVISIONS;
         let d = "";

--- a/src/lens-data/RicohGR328f28.data.js
+++ b/src/lens-data/RicohGR328f28.data.js
@@ -9,8 +9,11 @@
  * ║                                                                    ║
  * ║  NOTE ON SEMI-DIAMETERS:                                           ║
  * ║    SDs estimated from paraxial marginal + chief ray trace at      ║
- * ║    ω = 38.2° with ~8% mechanical clearance.  Patent does not      ║
- * ║    list semi-diameters.                                            ║
+ * ║    ω = 38.2° with clearance.  Patent does not list SDs.           ║
+ * ║    Front group SDs reduced to avoid cross-gap surface overlap     ║
+ * ║    (deep asph on S02 extends into 2.46 mm air gap).  D2 SDs      ║
+ * ║    matched at junction for consistent rendering.  L23 rear SD     ║
+ * ║    kept below conic h_max (K = +7.28).                            ║
  * ║                                                                    ║
  * ║  NOTE ON BFD:                                                      ║
  * ║    Patent surface 11 d = 12.807 mm (to filter).  Filter: 1.40 mm ║
@@ -76,21 +79,21 @@ const LENS_DATA = {
    */
   surfaces: [
     // ── Front group LO ──
-    { label: "1",   R:  17.034,  d: 0.70,  nd: 1.51633,  elemId: 1, sd: 8.1 },   // L11 front
-    { label: "2A",  R:  10.894,  d: 2.46,  nd: 1.0,      elemId: 0, sd: 7.6 },   // L11 rear → air (asph)
-    { label: "3",   R: -18.486,  d: 0.60,  nd: 1.63980,  elemId: 2, sd: 5.8 },   // L12 front
-    { label: "4",   R:   8.332,  d: 2.75,  nd: 1.88100,  elemId: 3, sd: 5.6 },   // L12→L13 junction
+    { label: "1",   R:  17.034,  d: 0.70,  nd: 1.51633,  elemId: 1, sd: 6.0 },   // L11 front
+    { label: "2A",  R:  10.894,  d: 2.46,  nd: 1.0,      elemId: 0, sd: 5.5 },   // L11 rear → air (asph)
+    { label: "3",   R: -18.486,  d: 0.60,  nd: 1.63980,  elemId: 2, sd: 5.2 },   // L12 front
+    { label: "4",   R:   8.332,  d: 2.75,  nd: 1.88100,  elemId: 3, sd: 5.0 },   // L12→L13 junction
     { label: "5",   R: -25.206,  d: 1.10,  nd: 1.0,      elemId: 0, sd: 4.6 },   // L13 rear → air
 
     // ── Aperture stop ──
     { label: "STO", R:   1e15,   d: 1.20,  nd: 1.0,      elemId: 0, sd: 3.4 },   // stop (sd from marginal ray)
 
     // ── Rear group LI ──
-    { label: "7",   R:  13.099,  d: 2.76,  nd: 1.88100,  elemId: 4, sd: 4.5 },   // L21 front
-    { label: "8",   R:  -8.666,  d: 0.50,  nd: 1.69895,  elemId: 5, sd: 5.2 },   // L21→L22 junction
-    { label: "9",   R:  12.744,  d: 1.52,  nd: 1.0,      elemId: 0, sd: 5.3 },   // L22 rear → air
-    { label: "10A", R: -16.835,  d: 1.00,  nd: 1.88202,  elemId: 6, sd: 6.2 },   // L23 front (asph)
-    { label: "11A", R: -17.510,  d: 14.907, nd: 1.0,     elemId: 0, sd: 6.7 },   // L23 rear → air (asph) — BFD to image
+    { label: "7",   R:  13.099,  d: 2.76,  nd: 1.88100,  elemId: 4, sd: 4.8 },   // L21 front
+    { label: "8",   R:  -8.666,  d: 0.50,  nd: 1.69895,  elemId: 5, sd: 4.8 },   // L21→L22 junction
+    { label: "9",   R:  12.744,  d: 1.52,  nd: 1.0,      elemId: 0, sd: 5.0 },   // L22 rear → air
+    { label: "10A", R: -16.835,  d: 1.00,  nd: 1.88202,  elemId: 6, sd: 6.0 },   // L23 front (asph)
+    { label: "11A", R: -17.510,  d: 14.907, nd: 1.0,     elemId: 0, sd: 5.9 },   // L23 rear → air (asph) — BFD to image
   ],
 
   /* ── Aspherical coefficients ──
@@ -160,7 +163,7 @@ const LENS_DATA = {
 
   /* ── Layout tuning ── */
   scFill:           0.42,
-  yScFill:          0.35,
+  yScFill:          0.45,
 };
 
 export default LENS_DATA;

--- a/src/optics/validateLensData.js
+++ b/src/optics/validateLensData.js
@@ -192,6 +192,44 @@ export default function validateLensData(data) {
     const ratio = s.sd / absR;
     if (ratio > SD_R_WARN)
       errors.push(`Surface "${s.label}": sd/|R| ratio ${ratio.toFixed(3)} exceeds ${SD_R_WARN} — risk of TIR and rendering artifacts at the rim (reduce sd or verify off-axis ray containment)`);
+
+    /* Conic h_max check: when K > 0, surface slope → ∞ at h = |R|/√(1+K) */
+    const asph = asphByIdx[i];
+    if (asph && asph.K > 0 && absR < 1e10) {
+      const hMax = absR / Math.sqrt(1 + asph.K);
+      if (s.sd > hMax * 0.98)
+        errors.push(`Surface "${s.label}": sd=${s.sd} exceeds conic h_max=${hMax.toFixed(2)} mm (K=${asph.K}) — sag curve will have a discontinuity at the rim`);
+    }
+  }
+
+  /* ── Cross-gap surface overlap check ──
+   *  For each air gap between elements, verify that the combined sag intrusion
+   *  from both bounding surfaces does not exceed the gap thickness.
+   */
+  for (let i = 0; i < S.length - 1; i++) {
+    const curr = S[i], next = S[i + 1];
+    if (typeof curr.nd !== 'number' || curr.nd !== 1.0) continue;    // only air gaps
+    if (curr.elemId !== 0) continue;                                  // skip cemented junctions
+    if (typeof curr.d !== 'number' || curr.d <= 0) continue;
+    if (typeof next.elemId !== 'number' || next.elemId === 0) continue; // next must be an element
+    /* Find the element whose rear surface is curr (surface i) */
+    let prevElemRear = -1;
+    for (let j = i - 1; j >= 0; j--) {
+      if (S[j].elemId !== 0) { prevElemRear = j + 1; break; }
+    }
+    if (prevElemRear < 0 || prevElemRear !== i) continue;             // curr isn't a rear surface
+    const prevFront = i - 1;  // front surface of preceding element
+    if (prevFront < 0 || S[prevFront].elemId === 0) continue;
+    /* Use the minimum SD at which both surfaces are rendered */
+    const sdPrev = Math.min(S[prevFront].sd || Infinity, curr.sd || Infinity);
+    const sdNext = Math.min(next.sd || Infinity, (i + 2 < S.length ? S[i + 2].sd : Infinity) || Infinity);
+    const sdCheck = Math.min(sdPrev, sdNext);
+    if (!isFinite(sdCheck) || sdCheck <= 0) continue;
+    const sagFwd  = _renderSag(sdCheck, curr.R, asphByIdx[i]);       // rear surface sag (positive = extends into gap)
+    const sagBack = _renderSag(sdCheck, next.R, asphByIdx[i + 1]);   // front surface sag (negative = extends into gap)
+    const intrusion = sagFwd - sagBack;
+    if (intrusion > curr.d * 1.10)
+      errors.push(`Air gap "${curr.label}"→"${next.label}": combined surface sag (${intrusion.toFixed(2)} mm) exceeds gap thickness (${curr.d} mm) at sd=${sdCheck.toFixed(1)} — elements will overlap in rendering`);
   }
 
   return errors;


### PR DESCRIPTION
## Summary
This PR adds validation checks for aspherical surfaces with positive conic constants and cross-gap surface overlap detection. It also updates the RicohGR328f28 lens data to resolve detected overlap issues and improves diagram rendering to respect conic surface limits.

## Key Changes

- **Conic h_max validation**: Added check in `validateLensData.js` to detect when semi-diameter exceeds the maximum height where conic aspheres (K > 0) have infinite slope at h = |R|/√(1+K). This prevents sag curve discontinuities at the rim.

- **Cross-gap surface overlap detection**: Implemented comprehensive validation for air gaps between optical elements. The check verifies that combined sag intrusion from both bounding surfaces doesn't exceed gap thickness, preventing rendering artifacts and physical impossibilities.

- **RicohGR328f28 semi-diameter adjustments**: 
  - Reduced front group SDs (surfaces 1-4) to avoid overlap with the deep aspheric surface 2A extending into the 2.46 mm air gap
  - Adjusted rear group SDs (surfaces 7-11A) for consistent rendering at junctions
  - Kept surface 11A (L23 rear) below its conic h_max limit (K = +7.28)
  - Updated documentation to explain SD derivation and constraints

- **Diagram rendering improvements**: Enhanced `LensDiagramPanel.jsx` to:
  - Calculate conic-aware maximum heights for each surface based on K values
  - Apply h_max constraints alongside existing rim sine and SD limits
  - Trim rear surfaces that curve forward into following air gaps (complementing existing front-surface trimming)

## Implementation Details

The conic h_max calculation uses the formula: h_max = |R|/√(1+K) with a 0.98 safety factor to prevent numerical issues at the discontinuity. The cross-gap check uses the minimum SD at which both surfaces are rendered and compares actual sag intrusion against a 10% tolerance margin on gap thickness.

https://claude.ai/code/session_016wTkwXP68juMCaZpNkE2Dm