### PR TITLE
Fix sticky slider and flash overlay reliability

### DIFF
--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -82,16 +82,28 @@ export default function LensDiagramPanel({
 }) {
   const [hov, setHov] = useState(null);
   const [sel, setSel] = useState(null);
-  const [flashOpacity, setFlashOpacity] = useState(0);
+  const [flashKey, setFlashKey] = useState(0);
+  const [flashVisible, setFlashVisible] = useState(false);
+  const [flashFading, setFlashFading] = useState(false);
 
   useEffect(() => { setHov(null); setSel(null); }, [lensKey]);
 
-  /* ── Flash overlay animation ── */
+  /* ── Flash overlay animation — two-phase: appear bright, then fade out ── */
   useEffect(() => {
     if (!flashOverlay) return;
-    setFlashOpacity(0.18);
-    const timer = setTimeout(() => setFlashOpacity(0), 50);
-    return () => clearTimeout(timer);
+    setFlashVisible(true);
+    setFlashFading(false);
+    setFlashKey(k => k + 1);
+    /* Phase 2: start fade after two frames so browser paints the bright state */
+    let raf1, raf2, timer;
+    raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        setFlashFading(true);
+        /* Phase 3: unmount after fade completes */
+        timer = setTimeout(() => setFlashVisible(false), 500);
+      });
+    });
+    return () => { cancelAnimationFrame(raf1); cancelAnimationFrame(raf2); clearTimeout(timer); };
   }, [flashOverlay]);
 
   /* ── Header height reporting for alignment ── */
@@ -562,10 +574,11 @@ export default function LensDiagramPanel({
         ))}
 
         {/* Flash overlay — brief highlight when slider sticks at common point */}
-        {flashOpacity > 0 && (
-          <rect x="0" y="0" width={L.svgW} height={L.svgH}
-            fill={dark ? "#ffffff" : "#000000"} opacity={flashOpacity}
-            style={{ transition: "opacity 0.35s ease-out", pointerEvents: "none" }} />
+        {flashVisible && (
+          <rect key={flashKey} x="0" y="0" width={L.svgW} height={L.svgH}
+            fill={dark ? "#ffffff" : "#000000"}
+            opacity={flashFading ? 0 : 0.22}
+            style={{ transition: flashFading ? "opacity 0.45s ease-out" : "none", pointerEvents: "none" }} />
         )}
       </svg>
 

--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -84,6 +84,8 @@ export default function LensVisualization() {
   /* ── Sticky slider state (slider pauses at common-point demarcation lines) ── */
   const focusStuck = useRef(false);
   const apertureStuck = useRef(false);
+  const prevFocusT = useRef(0);
+  const prevStopdownT = useRef(0);
   const [flashPanel, setFlashPanel] = useState(null);   // 'a' | 'b' | null
 
   /* ── Persist preferences ── */
@@ -182,6 +184,7 @@ export default function LensVisualization() {
     const cp = Math.abs(widerFOPEN - narrowerFOPEN) < 0.01
       ? 0
       : Math.log(narrowerFOPEN / widerFOPEN) / Math.log(sharedMaxFstop / widerFOPEN);
+    prevStopdownT.current = cp;
     setSharedStopdownT(cp);
   }, [comparisonLenses]);
 
@@ -195,6 +198,8 @@ export default function LensVisualization() {
       }
       setSharedFocusT(0);
       setSharedStopdownT(0);
+      prevFocusT.current = 0;
+      prevStopdownT.current = 0;
       justEnteredCompare.current = true;
       focusStuck.current = false;
       apertureStuck.current = false;
@@ -215,11 +220,20 @@ export default function LensVisualization() {
 
   const handleSharedFocusChange = useCallback((rawT) => {
     const cp = focusPair?.commonPoint;
-    if (ENABLE_SLIDER_STICKY && cp > 0.01 && cp < 0.99 && !focusStuck.current) {
-      const prev = sharedFocusT;
+    const stickyActive = ENABLE_SLIDER_STICKY && cp > 0.01 && cp < 0.99;
+
+    /* While stuck, reject all movement — hold at cp until pointerDown clears it */
+    if (stickyActive && focusStuck.current) {
+      setSharedFocusT(cp);
+      return;
+    }
+
+    if (stickyActive) {
+      const prev = prevFocusT.current;
       /* Crossing or reaching the common point from either side */
       if ((prev < cp && rawT >= cp) || (prev > cp && rawT <= cp)) {
         setSharedFocusT(cp);
+        prevFocusT.current = cp;
         focusStuck.current = true;
         /* The lens with longer MFD (less capable) is the one that stops */
         const { LA, LB } = comparisonLenses;
@@ -227,16 +241,27 @@ export default function LensVisualization() {
         return;
       }
     }
-    setSharedFocusT(snapToCommon(rawT, cp));
-  }, [focusPair, sharedFocusT, comparisonLenses, triggerFlash]);
+    const v = snapToCommon(rawT, cp);
+    prevFocusT.current = v;
+    setSharedFocusT(v);
+  }, [focusPair, comparisonLenses, triggerFlash]);
 
   const handleSharedStopdownChange = useCallback((rawT) => {
     const cp = aperturePair?.commonPoint;
-    if (ENABLE_SLIDER_STICKY && cp > 0.01 && cp < 0.99 && !apertureStuck.current) {
-      const prev = sharedStopdownT;
+    const stickyActive = ENABLE_SLIDER_STICKY && cp > 0.01 && cp < 0.99;
+
+    /* While stuck, reject all movement — hold at cp until pointerDown clears it */
+    if (stickyActive && apertureStuck.current) {
+      setSharedStopdownT(cp);
+      return;
+    }
+
+    if (stickyActive) {
+      const prev = prevStopdownT.current;
       /* Crossing or reaching the common point from either side */
       if ((prev < cp && rawT >= cp) || (prev > cp && rawT <= cp)) {
         setSharedStopdownT(cp);
+        prevStopdownT.current = cp;
         apertureStuck.current = true;
         /* The slower lens (larger FOPEN) is the one that stops */
         const { LA, LB } = comparisonLenses;
@@ -244,8 +269,10 @@ export default function LensVisualization() {
         return;
       }
     }
-    setSharedStopdownT(snapToCommon(rawT, cp));
-  }, [aperturePair, sharedStopdownT, comparisonLenses, triggerFlash]);
+    const v = snapToCommon(rawT, cp);
+    prevStopdownT.current = v;
+    setSharedStopdownT(v);
+  }, [aperturePair, comparisonLenses, triggerFlash]);
 
   const handleFocusPointerDown = useCallback(() => {
     focusStuck.current = false;


### PR DESCRIPTION
Sticky slider fixes:
- When stuck, reject ALL onChange events (hold slider at common point) instead of only blocking the initial crossing detection
- Use refs (prevFocusT, prevStopdownT) for previous-value tracking to avoid stale closure values during rapid onChange events from dragging
- Sync prev-value refs on comparison entry and default-aperture effect

Flash overlay fixes:
- Use two-phase animation: appear at full opacity, then fade out after two requestAnimationFrame ticks so the browser paints the bright state
- Keep element mounted during fade via separate flashVisible/flashFading states (previous approach unmounted via opacity > 0 guard before the CSS transition could play)
- Use key prop to force remount on repeated flashes

https://claude.ai/code/session_01TTcZEpB3sy8tVSe47f736G