### PR TITLE
fix: correct inverted focus direction for Ricoh GR III and GR IV

### DIFF
--- a/src/lens-data/RicohGR328f28.data.js
+++ b/src/lens-data/RicohGR328f28.data.js
@@ -132,10 +132,12 @@ const LENS_DATA = {
 
   /* ── Variable air spacings (focus mechanism) ──
    *  Unit focus: entire lens translates; only BFD changes.
-   *  Close focus ≈ 0.10 m (normal mode); BFD shortens by ~4.1 mm.
+   *  Close focus ≈ 0.10 m (normal mode); BFD extends by ~3.8 mm.
+   *  Paraxial trace: air-equiv BFD 14.431 → 18.216 mm (+3.785 mm).
+   *  Physical BFD includes filter path (0.476 mm shift).
    */
   var: {
-    "11A": [14.907, 10.80],
+    "11A": [14.907, 18.69],
   },
 
   varLabels: [

--- a/src/lens-data/RicohGR428f28.data.js
+++ b/src/lens-data/RicohGR428f28.data.js
@@ -5,7 +5,7 @@
  * ║  Data source: JP2025-069516A Example 2 (Ricoh / Takahiro Nakayama) ║
  * ║  Quasi-symmetric positive–negative wide-angle for APS-C compact.   ║
  * ║  7 elements / 5 groups, 5 aspherical surfaces (3 asph elements).   ║
- * ║  Focus: G1+G2 translate as unit; G3 fixed to sensor.               ║
+ * ║  Focus: G1+G2 translate forward as unit; G3 fixed to sensor.        ║
  * ║                                                                    ║
  * ║  NOTE ON SCALING:                                                  ║
  * ║    No scaling applied — patent prescription is at production       ║
@@ -136,13 +136,13 @@ const LENS_DATA = {
   },
 
   /* ── Variable air spacings (focus mechanism) ──
-   *  Front focus: G1+G2 (surfaces 1–11A) translate toward sensor for close focus.
+   *  Front focus: G1+G2 (surfaces 1–11A) translate forward for close focus.
    *  G3 (surfaces 12A–13A) is fixed relative to the sensor.
    *  Only the D23 air gap (surface 11A) changes.
-   *  Close-focus value computed by paraxial ray trace at 0.12 m object distance.
+   *  Paraxial trace at 0.12 m: G1+G2 extend +2.07 mm, D23 increases to 5.17 mm.
    */
   var: {
-    "11A": [3.10, 1.27],   // [d_infinity, d_close_0.12m]
+    "11A": [3.10, 5.17],   // [d_infinity, d_close_0.12m]
   },
 
   varLabels: [
@@ -163,7 +163,7 @@ const LENS_DATA = {
 
   /* ── Focus configuration ── */
   closeFocusM:       0.12,
-  focusDescription:  "Front focus — G1+G2 translate as a unit toward the sensor for close focus (D23 decreases from 3.10 to 1.27 mm). G3 remains fixed. Macro mode: 0.12 m.",
+  focusDescription:  "Front focus — G1+G2 translate forward as a unit for close focus (D23 increases from 3.10 to 5.17 mm). G3 remains fixed. Macro mode: 0.12 m.",
 
   /* ── Aperture configuration ── */
   nominalFno:   2.8,


### PR DESCRIPTION
Both lenses had their close-focus variable spacings applied in the wrong direction, causing elements to move backward (toward sensor) instead of forward when focusing closer. Corrected via paraxial ray trace through the full patent prescriptions:

- GR III (unit focus): BFD 14.907 → 18.69 mm (+3.79 mm extension) was incorrectly 14.907 → 10.80 mm
- GR IV (front focus): D23 gap 3.10 → 5.17 mm (+2.07 mm, G1+G2 forward) was incorrectly 3.10 → 1.27 mm

Verified against the original GR (US 5,760,973) which had correct values.

https://claude.ai/code/session_011u8o7XBKNQB1BaTFTQRs4r