### PR TITLE
Add tests for gapTrimHeight, errorReporting, preferences, and themes

### DIFF
--- a/__tests__/errorReporting.test.js
+++ b/__tests__/errorReporting.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildIssueURL, REPO_URL } from '../src/utils/errorReporting.js';
+
+describe('REPO_URL', () => {
+  it('points to the correct GitHub repository', () => {
+    expect(REPO_URL).toMatch(/^https:\/\/github\.com\//);
+  });
+});
+
+describe('buildIssueURL', () => {
+  // Stub navigator.userAgent for deterministic output
+  let origNavigator;
+  beforeEach(() => {
+    origNavigator = globalThis.navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { userAgent: 'TestBrowser/1.0' },
+      writable: true, configurable: true,
+    });
+  });
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: origNavigator,
+      writable: true, configurable: true,
+    });
+  });
+
+  it('returns a valid GitHub new-issue URL', () => {
+    const url = buildIssueURL(new Error('test'));
+    expect(url).toMatch(new RegExp(`^${REPO_URL.replace(/[/.]/g, '\\$&')}/issues/new\\?`));
+    expect(url).toContain('title=');
+    expect(url).toContain('body=');
+  });
+
+  it('includes component and message in title', () => {
+    const url = buildIssueURL(new Error('Something broke'), { component: 'LensDiagram' });
+    const titleParam = new URL(url).searchParams.get('title');
+    expect(titleParam).toContain('[Bug]');
+    expect(titleParam).toContain('LensDiagram');
+    expect(titleParam).toContain('Something broke');
+  });
+
+  it('defaults component to Unknown', () => {
+    const url = buildIssueURL(new Error('oops'));
+    const titleParam = new URL(url).searchParams.get('title');
+    expect(titleParam).toContain('Unknown');
+  });
+
+  it('truncates long error messages in title to 80 chars', () => {
+    const longMsg = 'A'.repeat(200);
+    const url = buildIssueURL(new Error(longMsg));
+    const titleParam = new URL(url).searchParams.get('title');
+    // Title = "[Bug] Unknown: " + truncated msg. The msg part should end with "..."
+    expect(titleParam).toContain('...');
+    expect(titleParam.length).toBeLessThanOrEqual(200); // reasonable cap
+  });
+
+  it('includes stack trace in body when available', () => {
+    const err = new Error('stack test');
+    const url = buildIssueURL(err);
+    const body = new URL(url).searchParams.get('body');
+    expect(body).toContain('Stack trace');
+    expect(body).toContain('stack test');
+  });
+
+  it('includes lens key in context when provided', () => {
+    const url = buildIssueURL(new Error('x'), { lensKey: 'nikon_58' });
+    const body = new URL(url).searchParams.get('body');
+    expect(body).toContain('nikon_58');
+    expect(body).toContain('**Lens:**');
+  });
+
+  it('includes extra info when provided', () => {
+    const url = buildIssueURL(new Error('x'), { extra: 'Custom debug info' });
+    const body = new URL(url).searchParams.get('body');
+    expect(body).toContain('Additional Info');
+    expect(body).toContain('Custom debug info');
+  });
+
+  it('includes browser user agent', () => {
+    const url = buildIssueURL(new Error('x'));
+    const body = new URL(url).searchParams.get('body');
+    expect(body).toContain('TestBrowser/1.0');
+  });
+
+  it('truncates very long bodies', () => {
+    const err = new Error('x');
+    err.stack = 'Z'.repeat(10000);
+    const url = buildIssueURL(err);
+    const body = new URL(url).searchParams.get('body');
+    expect(body).toContain('truncated');
+    expect(body.length).toBeLessThanOrEqual(6100); // 6000 + truncation message
+  });
+
+  it('handles null/undefined error gracefully', () => {
+    const url = buildIssueURL(null);
+    const titleParam = new URL(url).searchParams.get('title');
+    expect(titleParam).toContain('Unknown error');
+  });
+
+  it('handles error with no stack', () => {
+    const err = { message: 'no stack' };
+    const url = buildIssueURL(err);
+    const body = new URL(url).searchParams.get('body');
+    expect(body).not.toContain('Stack trace');
+    expect(body).toContain('no stack');
+  });
+});

--- a/__tests__/gapTrimHeight.test.js
+++ b/__tests__/gapTrimHeight.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { gapTrimHeight, renderSag } from '../src/optics/optics.js';
+
+/**
+ * Minimal lens-like object for gapTrimHeight tests.
+ * gapTrimHeight needs: L.gapSagFrac, L.S[surfIdx].R, L.asphByIdx[surfIdx]
+ */
+function makeLens(R, gapSagFrac = 0.9, asph = null) {
+  return {
+    gapSagFrac,
+    S: [{ R }],
+    asphByIdx: { 0: asph },
+  };
+}
+
+describe('gapTrimHeight', () => {
+  it('returns sd unchanged when sag fits within maxSag', () => {
+    // R=100, sd=10 → sag ≈ 0.50 mm, well within maxSag=5
+    const L = makeLens(100);
+    expect(gapTrimHeight(0, 10, 5, L)).toBe(10);
+  });
+
+  it('returns sd unchanged when maxSag <= 0', () => {
+    const L = makeLens(20);
+    expect(gapTrimHeight(0, 15, 0, L)).toBe(15);
+    expect(gapTrimHeight(0, 15, -1, L)).toBe(15);
+  });
+
+  it('returns sd unchanged when gapSagFrac <= 0', () => {
+    const L = makeLens(20, 0);
+    expect(gapTrimHeight(0, 15, 0.5, L)).toBe(15);
+  });
+
+  it('trims height when sag exceeds maxSag', () => {
+    // R=20, sd=15 → sag ≈ 6.4 mm. With maxSag=2, must trim.
+    const L = makeLens(20);
+    const trimmed = gapTrimHeight(0, 15, 2, L);
+    expect(trimmed).toBeLessThan(15);
+    expect(trimmed).toBeGreaterThan(0);
+    // Verify the trimmed height has sag ≈ maxSag
+    expect(Math.abs(renderSag(trimmed, 0, L))).toBeCloseTo(2, 1);
+  });
+
+  it('trims height for negative R (concave surface)', () => {
+    // R=-20, sd=15 → sag ≈ -6.4 mm. |sag| > maxSag=2 → trim
+    const L = makeLens(-20);
+    const trimmed = gapTrimHeight(0, 15, 2, L);
+    expect(trimmed).toBeLessThan(15);
+    expect(trimmed).toBeGreaterThan(0);
+    expect(Math.abs(renderSag(trimmed, 0, L))).toBeCloseTo(2, 1);
+  });
+
+  it('works with aspherical surfaces', () => {
+    const asph = { K: -1.5, A4: 1e-5, A6: 0, A8: 0, A10: 0, A12: 0, A14: 0 };
+    const L = makeLens(30, 0.9, asph);
+    const sd = 12;
+    const sagAtSd = Math.abs(renderSag(sd, 0, L));
+    // Only trim if sag exceeds threshold
+    if (sagAtSd > 1.0) {
+      const trimmed = gapTrimHeight(0, sd, 1.0, L);
+      expect(trimmed).toBeLessThan(sd);
+      expect(Math.abs(renderSag(trimmed, 0, L))).toBeCloseTo(1.0, 1);
+    }
+  });
+
+  it('converges precisely via bisection', () => {
+    // Use a strongly curved surface for precision test
+    const L = makeLens(15);
+    const maxSag = 1.5;
+    const trimmed = gapTrimHeight(0, 14, maxSag, L);
+    // 30 bisection iterations → precision better than 1e-8
+    expect(Math.abs(Math.abs(renderSag(trimmed, 0, L)) - maxSag)).toBeLessThan(1e-6);
+  });
+
+  it('returns flat surface sd unchanged (zero sag always)', () => {
+    const L = makeLens(1e15); // flat
+    expect(gapTrimHeight(0, 20, 0.1, L)).toBe(20);
+  });
+});

--- a/__tests__/preferences.test.js
+++ b/__tests__/preferences.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadPrefs, PREFS_KEY } from '../src/utils/preferences.js';
+
+const KEYS = ['nikon_58', 'canon_50'];
+
+/* Minimal localStorage mock */
+let store = {};
+const mockLocalStorage = {
+  getItem: (key) => (key in store ? store[key] : null),
+  setItem: (key, val) => { store[key] = String(val); },
+  clear: () => { store = {}; },
+  removeItem: (key) => { delete store[key]; },
+};
+
+beforeEach(() => {
+  store = {};
+  globalThis.localStorage = mockLocalStorage;
+});
+
+afterEach(() => {
+  delete globalThis.localStorage;
+});
+
+describe('PREFS_KEY', () => {
+  it('is a non-empty string', () => {
+    expect(typeof PREFS_KEY).toBe('string');
+    expect(PREFS_KEY.length).toBeGreaterThan(0);
+  });
+});
+
+describe('loadPrefs', () => {
+  it('returns empty object when nothing stored', () => {
+    expect(loadPrefs(KEYS)).toEqual({});
+  });
+
+  it('returns empty object for non-JSON data', () => {
+    mockLocalStorage.setItem(PREFS_KEY, 'not json');
+    expect(loadPrefs(KEYS)).toEqual({});
+  });
+
+  it('returns empty object for JSON null', () => {
+    mockLocalStorage.setItem(PREFS_KEY, 'null');
+    expect(loadPrefs(KEYS)).toEqual({});
+  });
+
+  it('returns empty object for JSON array', () => {
+    mockLocalStorage.setItem(PREFS_KEY, '[1,2,3]');
+    expect(loadPrefs(KEYS)).toEqual({});
+  });
+
+  it('loads boolean preferences', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({
+      dark: true, highContrast: false, showOnAxis: true,
+      showOffAxis: false, rayTracksF: true,
+      showChromatic: true, chromR: false, chromG: true, chromB: true,
+    }));
+    const prefs = loadPrefs(KEYS);
+    expect(prefs.dark).toBe(true);
+    expect(prefs.highContrast).toBe(false);
+    expect(prefs.showOnAxis).toBe(true);
+    expect(prefs.showOffAxis).toBe(false);
+    expect(prefs.rayTracksF).toBe(true);
+    expect(prefs.showChromatic).toBe(true);
+    expect(prefs.chromR).toBe(false);
+    expect(prefs.chromG).toBe(true);
+    expect(prefs.chromB).toBe(true);
+  });
+
+  it('ignores non-boolean values for boolean fields', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({
+      dark: 'yes', highContrast: 1, showOnAxis: null,
+    }));
+    const prefs = loadPrefs(KEYS);
+    expect(prefs.dark).toBeUndefined();
+    expect(prefs.highContrast).toBeUndefined();
+    expect(prefs.showOnAxis).toBeUndefined();
+  });
+
+  it('validates lensKeyA against catalog keys', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ lensKeyA: 'nikon_58' }));
+    expect(loadPrefs(KEYS).lensKeyA).toBe('nikon_58');
+  });
+
+  it('rejects lensKeyA not in catalog', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ lensKeyA: 'unknown_lens' }));
+    expect(loadPrefs(KEYS).lensKeyA).toBeUndefined();
+  });
+
+  it('migrates v1 lensKey to lensKeyA', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ lensKey: 'canon_50' }));
+    const prefs = loadPrefs(KEYS);
+    expect(prefs.lensKeyA).toBe('canon_50');
+    expect(prefs.lensKey).toBeUndefined();
+  });
+
+  it('prefers lensKeyA over v1 lensKey', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({
+      lensKey: 'canon_50', lensKeyA: 'nikon_58',
+    }));
+    expect(loadPrefs(KEYS).lensKeyA).toBe('nikon_58');
+  });
+
+  it('validates lensKeyB against catalog keys', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ lensKeyB: 'canon_50' }));
+    expect(loadPrefs(KEYS).lensKeyB).toBe('canon_50');
+
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ lensKeyB: 'bad_key' }));
+    expect(loadPrefs(KEYS).lensKeyB).toBeUndefined();
+  });
+
+  it('loads comparing boolean', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ comparing: true }));
+    expect(loadPrefs(KEYS).comparing).toBe(true);
+  });
+
+  it('loads valid scaleMode values', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ scaleMode: 'independent' }));
+    expect(loadPrefs(KEYS).scaleMode).toBe('independent');
+
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ scaleMode: 'normalized' }));
+    expect(loadPrefs(KEYS).scaleMode).toBe('normalized');
+  });
+
+  it('rejects invalid scaleMode values', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ scaleMode: 'bogus' }));
+    expect(loadPrefs(KEYS).scaleMode).toBeUndefined();
+  });
+
+  it('strips unknown properties', () => {
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({
+      dark: true, unknownProp: 'foo', hacky: 42,
+    }));
+    const prefs = loadPrefs(KEYS);
+    expect(prefs.dark).toBe(true);
+    expect(prefs.unknownProp).toBeUndefined();
+    expect(prefs.hacky).toBeUndefined();
+  });
+});

--- a/__tests__/themes.test.js
+++ b/__tests__/themes.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import T from '../src/utils/themes.js';
+
+const THEME_NAMES = ['dark', 'light', 'darkHC', 'lightHC'];
+
+describe('theme definitions', () => {
+  it('exports all four themes', () => {
+    for (const name of THEME_NAMES) {
+      expect(T[name]).toBeDefined();
+    }
+  });
+
+  it('all themes have the same set of property keys', () => {
+    const baseKeys = Object.keys(T.dark).sort();
+    for (const name of THEME_NAMES) {
+      expect(Object.keys(T[name]).sort()).toEqual(baseKeys);
+    }
+  });
+
+  it('all themes have required color tokens', () => {
+    const required = [
+      'bg', 'title', 'body', 'rayWarm', 'rayCool', 'stop',
+      'axis', 'panelBg', 'sliderAccent', 'imgLine',
+    ];
+    for (const name of THEME_NAMES) {
+      for (const prop of required) {
+        expect(T[name][prop], `${name}.${prop}`).toBeTruthy();
+      }
+    }
+  });
+
+  it('no theme has undefined or null color values for string tokens', () => {
+    for (const name of THEME_NAMES) {
+      const theme = T[name];
+      for (const [key, val] of Object.entries(theme)) {
+        if (typeof val === 'string') {
+          expect(val, `${name}.${key}`).not.toBe('undefined');
+          expect(val, `${name}.${key}`).not.toBe('null');
+        }
+      }
+    }
+  });
+});
+
+describe('createTheme closure functions', () => {
+  describe('grid(i)', () => {
+    it('returns different values for odd vs even indices', () => {
+      for (const name of THEME_NAMES) {
+        const theme = T[name];
+        const even = theme.grid(0);
+        const odd = theme.grid(1);
+        expect(typeof even).toBe('string');
+        expect(typeof odd).toBe('string');
+      }
+    });
+  });
+
+  describe('gridDash(i)', () => {
+    it('returns "none" for even, dashed for odd', () => {
+      for (const name of THEME_NAMES) {
+        expect(T[name].gridDash(0)).toBe('none');
+        expect(T[name].gridDash(1)).toBe('2,5');
+        expect(T[name].gridDash(2)).toBe('none');
+      }
+    });
+  });
+
+  describe('elemNum(e)', () => {
+    it('returns APD color for APD elements', () => {
+      for (const name of THEME_NAMES) {
+        const apd = T[name].elemNum({ apd: 'patent' });
+        const std = T[name].elemNum({ apd: null });
+        expect(typeof apd).toBe('string');
+        expect(typeof std).toBe('string');
+        expect(apd).not.toBe(std);
+      }
+    });
+  });
+
+  describe('elemFill(e, on)', () => {
+    it('returns active fill when on=true', () => {
+      for (const name of THEME_NAMES) {
+        const fill = T[name].elemFill({ nd: 1.5 }, true);
+        expect(typeof fill).toBe('string');
+      }
+    });
+
+    it('returns APD active fill for APD elements when on=true', () => {
+      for (const name of THEME_NAMES) {
+        const apdFill = T[name].elemFill({ apd: 'patent', nd: 1.5 }, true);
+        const stdFill = T[name].elemFill({ nd: 1.5 }, true);
+        expect(apdFill).not.toBe(stdFill);
+      }
+    });
+
+    it('differentiates patent vs inferred APD fills', () => {
+      for (const name of THEME_NAMES) {
+        const patent = T[name].elemFill({ apd: 'patent', nd: 1.5 }, false);
+        const inferred = T[name].elemFill({ apd: 'inferred', nd: 1.5 }, false);
+        expect(patent).not.toBe(inferred);
+      }
+    });
+
+    it('differentiates by nd when not active and not APD', () => {
+      for (const name of THEME_NAMES) {
+        const high = T[name].elemFill({ nd: 1.85 }, false);
+        const mid = T[name].elemFill({ nd: 1.65 }, false);
+        const low = T[name].elemFill({ nd: 1.5 }, false);
+        expect(high).not.toBe(low);
+        expect(mid).not.toBe(high);
+      }
+    });
+  });
+
+  describe('elemStroke(e, on)', () => {
+    it('returns active stroke when on=true', () => {
+      for (const name of THEME_NAMES) {
+        const stroke = T[name].elemStroke({ nd: 1.5 }, true);
+        expect(typeof stroke).toBe('string');
+      }
+    });
+
+    it('differentiates patent vs inferred vs default strokes', () => {
+      for (const name of THEME_NAMES) {
+        const patent = T[name].elemStroke({ apd: 'patent' }, false);
+        const inferred = T[name].elemStroke({ apd: 'inferred' }, false);
+        const normal = T[name].elemStroke({}, false);
+        expect(patent).not.toBe(inferred);
+        expect(patent).not.toBe(normal);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Cover previously untested modules:
- gapTrimHeight(): bisection trim logic, flat/curved/aspheric surfaces
- buildIssueURL(): title truncation, body truncation, context fields, encoding
- loadPrefs(): localStorage parsing, v1 migration, type validation, key filtering
- createTheme(): structural consistency across 4 themes, closure function behavior

https://claude.ai/code/session_01PjB2rJ7H4SfksKdthqwKcx