### PR TITLE
Fix Nikon Z 70-200 lens diagram distortion from overly aggressive lay…

### DIFF
--- a/src/lens-data/NikonNikkorZ70200f28.data.js
+++ b/src/lens-data/NikonNikkorZ70200f28.data.js
@@ -210,9 +210,9 @@ const LENS_DATA = {
   fstopSeries:  [2.8, 3.2, 3.5, 4, 4.5, 5.6, 6.3, 8, 11, 16, 22],
 
   /* ── Layout tuning ── */
-  scFill:           0.42,
+  scFill:           0.52,
   yScFill:          0.38,
-  maxAspectRatio:   2.5,
+  maxAspectRatio:   3.0,
 };
 
 export default LENS_DATA;


### PR DESCRIPTION
…out params

Increased scFill from 0.42 to 0.52 to give the horizontal axis more room, and raised maxAspectRatio from 2.5 to 3.0 to match the lens's physical proportions (~2.8:1), preventing the vertical scale from being clamped.

https://claude.ai/code/session_01RXDTpT6Jh9onPV3NLtz8Wt