### PR TITLE
Maximize lens diagram width with dynamic height sizing

### DIFF
--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -27,7 +27,7 @@ import { sag, renderSag, gapTrimHeight, thick, doLayout, eflAtZoom,
          epAtZoom, halfFieldAtZoom, yRatioAtZoom, bAtZoom,
          traceRay, traceRayChromatic, computeChromaticSpread, traceToImage,
          conjugateK, formatDist, SVG_PATH_SUBDIVISIONS } from '../optics/optics.js';
-import { ENABLE_COLOR_TRACING, ENABLE_ASPH_DIAMOND_FILL } from '../utils/featureFlags.js';
+import { ENABLE_COLOR_TRACING, ENABLE_ASPH_DIAMOND_FILL, ENABLE_DYNAMIC_DIAGRAM_HEIGHT } from '../utils/featureFlags.js';
 import { ErrorDisplay } from './ErrorBoundary.jsx';
 
 /* ── Panel-level error boundary — catches render errors within a single diagram ──
@@ -99,7 +99,7 @@ export default function LensDiagramPanel({
   compact,
   showControls = true,
   showSliders = true,
-  maxSvgHeight = "54vh",
+  maxSvgHeight = ENABLE_DYNAMIC_DIAGRAM_HEIGHT ? "calc(100vh - 260px)" : "54vh",
   minHeaderHeight,
   onFocusChange,
   onZoomChange,

--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -30,7 +30,8 @@ import { ENABLE_COLOR_TRACING, DEFAULT_COLOR_TRACING,
          ENABLE_ANALYSIS_VIEW,
          ENABLE_DESKTOP_VIEW_TOGGLE, ENABLE_DIAGRAM_ONLY, ENABLE_ANALYSIS_ONLY,
          ENABLE_COMPARISON, ENABLE_COMPARISON_MOBILE,
-         ENABLE_SLIDER_STICKY, ENABLE_SLIDER_STICKY_FLASH } from '../utils/featureFlags.js';
+         ENABLE_SLIDER_STICKY, ENABLE_SLIDER_STICKY_FLASH,
+         ENABLE_DYNAMIC_DIAGRAM_HEIGHT } from '../utils/featureFlags.js';
 import { computeFocusPair, computeAperturePair, computeZoomPair, snapToCommon } from '../utils/comparisonSliders.js';
 import { ErrorDisplay } from './ErrorBoundary.jsx';
 import ABOUT_ME_MD from '../content/AboutMe.md?raw';
@@ -558,7 +559,7 @@ export default function LensVisualization() {
           compact={true}
           showControls={true}
           showSliders={false}
-          maxSvgHeight={isWide ? "54vh" : "42vh"}
+          maxSvgHeight={isWide ? (ENABLE_DYNAMIC_DIAGRAM_HEIGHT ? "calc(100vh - 260px)" : "54vh") : "42vh"}
           onHeaderHeight={handleHeaderHeight}
           minHeaderHeight={isWide && maxHeaderHeight > 0 ? maxHeaderHeight : undefined}
           flashOverlay={flashPanel === 'a'}
@@ -576,7 +577,7 @@ export default function LensVisualization() {
           compact={true}
           showControls={true}
           showSliders={false}
-          maxSvgHeight={isWide ? "54vh" : "42vh"}
+          maxSvgHeight={isWide ? (ENABLE_DYNAMIC_DIAGRAM_HEIGHT ? "calc(100vh - 260px)" : "54vh") : "42vh"}
           onHeaderHeight={handleHeaderHeight}
           minHeaderHeight={isWide && maxHeaderHeight > 0 ? maxHeaderHeight : undefined}
           flashOverlay={flashPanel === 'b'}
@@ -753,10 +754,10 @@ export default function LensVisualization() {
         ) : (
           /* Both — side-by-side */
           <div style={{ display: "flex", minHeight: `calc(100vh - ${showDesktopToggle ? 82 : 45}px)` }}>
-            <div style={{ flex: "0 0 60%", minWidth: 0, overflow: "hidden" }}>
+            <div style={{ flex: "0 0 65%", minWidth: 0, overflow: "hidden" }}>
               {singleDiagramContent}
             </div>
-            <div style={{ flex: "0 0 40%", borderLeft: `1px solid ${t.descBorder}`, overflowY: "auto", maxHeight: `calc(100vh - ${showDesktopToggle ? 82 : 45}px)` }}>
+            <div style={{ flex: "0 0 35%", borderLeft: `1px solid ${t.descBorder}`, overflowY: "auto", maxHeight: `calc(100vh - ${showDesktopToggle ? 82 : 45}px)` }}>
               {descriptionContent}
             </div>
           </div>

--- a/src/lens-data/defaults.js
+++ b/src/lens-data/defaults.js
@@ -21,6 +21,7 @@ const LENS_DEFAULTS = {
   /* ── Layout tuning ── */
   svgW:             1080,
   svgH:             490,
+  scFill:           0.55,
   clipMargin:       1.0,
   maxRimAngleDeg:   40,
   gapSagFrac:       0.90,

--- a/src/utils/featureFlags.js
+++ b/src/utils/featureFlags.js
@@ -21,3 +21,5 @@ export const ENABLE_SLIDER_STICKY       = true;
 export const ENABLE_SLIDER_STICKY_FLASH = true;
 
 export const ENABLE_ASPH_DIAMOND_FILL   = false;
+
+export const ENABLE_DYNAMIC_DIAGRAM_HEIGHT = true;


### PR DESCRIPTION
Add ENABLE_DYNAMIC_DIAGRAM_HEIGHT feature flag that switches SVG maxHeight from fixed 54vh to calc(100vh - 260px), filling available viewport space without pushing controls off-screen. Widen diagram/description split from 60/40 to 65/35 in "both" mode. Add scFill: 0.55 default for slightly larger lens rendering within the SVG coordinate space.

https://claude.ai/code/session_01RcwivyxdkxVhQXhc8Yqzuj