### PR TITLE
Fix Ricoh GR1 rendering: reduce surface 11A sd to stay within conic h…

### DIFF
--- a/src/lens-data/RicohGR28f28.data.js
+++ b/src/lens-data/RicohGR28f28.data.js
@@ -120,7 +120,7 @@ const LENS_DATA = {
     { label: "10",  R:  -19.156, d: 2.45, nd: 1.0,     elemId: 0, sd: 5.8 },  // L6 rear → air
 
     // ── Component L4: single negative meniscus, aspherical front ──
-    { label: "11A", R:   -9.270, d: 1.20, nd: 1.60342, elemId: 7, sd: 7.5 },  // L7 front (asph)
+    { label: "11A", R:   -9.270, d: 1.20, nd: 1.60342, elemId: 7, sd: 7.3 },  // L7 front (asph)
     { label: "12",  R:  -16.394, d: 17.22,nd: 1.0,     elemId: 0, sd: 7.8 },  // L7 rear → BFD
   ],
 


### PR DESCRIPTION
…_max

Surface "11A" (K=0.5327) had sd=7.5 which exceeds the conic singularity at h_max=7.49mm, causing buildLens validation to reject the lens data. Reduce sd to 7.3 (within estimation uncertainty — patent doesn't list SDs).

Closes #108

https://claude.ai/code/session_0181P4U5HjLnSKvV9bHpGLcr