### PR TITLE
Fix EDGE PROJ sign inversion on final ray traces (#109)

### DIFF
--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -363,7 +363,7 @@ export default function LensDiagramPanel({
       const yChief = -(bAtZoom(zoomT, L) / yRatioAtZoom(zoomT, L)) * uField;
 
       /* Paraxial image height for "edge" mode */
-      const edgeImgH = eflAtZoom(zoomT, L) * Math.tan(currentOffAxisDeg * Math.PI / 180);
+      const edgeImgH = -(eflAtZoom(zoomT, L) * Math.tan(currentOffAxisDeg * Math.PI / 180));
       const edgeEnd = [sx(IMG_MM), sy(edgeImgH)];
       const useEdge = ENABLE_EDGE_PROJECTION && showOffAxis === 'edge';
 


### PR DESCRIPTION
The paraxial image height `edgeImgH` was computed with a positive sign (`EFL * tan(fieldAngle)`) while the ray entry slope `uField` used a negative sign (`-tan(fieldAngle)`). This mismatch projected rays to the wrong side of the optical axis. Negate `edgeImgH` to match the optics sign convention.

https://claude.ai/code/session_01Eg6VtrGbcskbWR1RgK4ptG