### PR TITLE
Fix desktop view preference not persisting on reload

### DIFF
--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -82,7 +82,7 @@ export default function LensVisualization() {
   const [chromB, setChromB] = useState(prefs.chromB ?? true);
   const [stopdownT, setStopdownT] = useState(urlState.aperture ?? 0);
   const [mobileView, setMobileView] = useState('diagram');
-  const [desktopView, setDesktopView] = useState('both');
+  const [desktopView, setDesktopView] = useState(prefs.desktopView || 'both');
   const [showAbout, setShowAbout] = useState(false);
   const [showAboutSite, setShowAboutSite] = useState(false);
   const [sharedFocusT, setSharedFocusT] = useState(urlState.comparing ? (urlState.focus ?? 0) : 0);
@@ -117,9 +117,10 @@ export default function LensVisualization() {
         lensKeyA, lensKeyB, comparing, scaleMode,
         showOnAxis, showOffAxis, rayTracksF,
         showChromatic, chromR, chromG, chromB,
+        desktopView,
       }));
     } catch { /* private browsing or quota — ignore */ }
-  }, [dark, highContrast, lensKeyA, lensKeyB, comparing, scaleMode, showOnAxis, showOffAxis, rayTracksF, showChromatic, chromR, chromG, chromB]);
+  }, [dark, highContrast, lensKeyA, lensKeyB, comparing, scaleMode, showOnAxis, showOffAxis, rayTracksF, showChromatic, chromR, chromG, chromB, desktopView]);
 
   /* ── URL update refs ── */
   const urlUpdateTimer = useRef(null);

--- a/src/utils/preferences.js
+++ b/src/utils/preferences.js
@@ -42,6 +42,7 @@ export function loadPrefs(catalogKeys) {
     if (typeof p.lensKeyB === 'string' && catalogKeys.includes(p.lensKeyB)) out.lensKeyB = p.lensKeyB;
     if (typeof p.comparing === 'boolean') out.comparing = p.comparing;
     if (p.scaleMode === 'independent' || p.scaleMode === 'normalized') out.scaleMode = p.scaleMode;
+    if (typeof p.desktopView === 'string' && ['diagram', 'both', 'analysis'].includes(p.desktopView)) out.desktopView = p.desktopView;
     return out;
   } catch { return {}; }
 }


### PR DESCRIPTION
Add desktopView to localStorage persistence so the user's chosen desktop layout (diagram/both/analysis) survives page reloads.

Closes #112

https://claude.ai/code/session_01WoqsV21DV74jYV5DJpCtEf