### PR TITLE
Fix TDZ error: move useMediaQuery call before its first reference

### DIFF
--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -88,6 +88,8 @@ export default function LensVisualization() {
   const [showAbout, setShowAbout] = useState(false);
   const [showAboutSite, setShowAboutSite] = useState(false);
 
+  const isWide = useMediaQuery('(min-width: 900px)');
+
   /* ── Collapsible panel states (mobile optimization) ── */
   const [focusExpanded, setFocusExpanded] = useState(prefs.focusExpanded ?? isWide);
   const [apertureExpanded, setApertureExpanded] = useState(prefs.apertureExpanded ?? isWide);
@@ -152,7 +154,6 @@ export default function LensVisualization() {
     return () => window.removeEventListener('keydown', handleKey);
   }, [showAbout, showAboutSite]);
 
-  const isWide = useMediaQuery('(min-width: 900px)');
   const markdown = useMemo(() => mdForKey(lensKeyA), [lensKeyA]);
 
   const desktopViewOptions = useMemo(() => {


### PR DESCRIPTION
The `isWide` variable (from useMediaQuery) was declared on line 155 but referenced on lines 92-93 in useState initializers, causing a "Cannot access 'me' before initialization" error that crashed the entire app.

Fixes #119

https://claude.ai/code/session_01GLQoRrB5t3sd1RtTvX5hHa