### PR TITLE
Extract testable geometry logic from LensDiagramPanel and add coverag…

### DIFF
--- a/__tests__/diagramGeometry.test.js
+++ b/__tests__/diagramGeometry.test.js
@@ -1,0 +1,303 @@
+import { describe, it, expect } from "vitest";
+import { createCoordinateTransforms, computeElementShapes } from "../src/optics/diagramGeometry.js";
+import { SVG_PATH_SUBDIVISIONS } from "../src/optics/optics.js";
+
+/* ═══════════════════════════════════════════════════════════════════
+ * §1  createCoordinateTransforms
+ * ═══════════════════════════════════════════════════════════════════ */
+
+describe("createCoordinateTransforms", () => {
+  /* Baseline params used across most tests */
+  const base = { svgW: 800, svgH: 400, SC: 2, YSC: 3, lensShiftFrac: 0, imgMM: 100, scaleRatio: null };
+
+  it("sx maps z=0 and z=imgMM to expected pixel positions", () => {
+    const { sx } = createCoordinateTransforms(base);
+    // CX = 800/2 + 0 = 400, MID = 50, IX = 400 + 50*2 = 500
+    // sx(0) = 500 - (100-0)*2 = 300
+    // sx(100) = 500 - (100-100)*2 = 500
+    expect(sx(0)).toBeCloseTo(300);
+    expect(sx(100)).toBeCloseTo(500);
+  });
+
+  it("sx is linear — midpoint maps to midpoint", () => {
+    const { sx } = createCoordinateTransforms(base);
+    expect(sx(50)).toBeCloseTo((sx(0) + sx(100)) / 2);
+  });
+
+  it("sy maps y=0 to vertical center", () => {
+    const { sy } = createCoordinateTransforms(base);
+    expect(sy(0)).toBeCloseTo(200); // svgH/2
+  });
+
+  it("sy positive Y maps downward (higher pixel value)", () => {
+    const { sy } = createCoordinateTransforms(base);
+    expect(sy(10)).toBeGreaterThan(sy(0));
+    expect(sy(10)).toBeCloseTo(200 + 10 * 3); // CY + y * YSC
+  });
+
+  it("sy negative Y maps upward (lower pixel value)", () => {
+    const { sy } = createCoordinateTransforms(base);
+    expect(sy(-10)).toBeLessThan(sy(0));
+    expect(sy(-10)).toBeCloseTo(200 - 10 * 3);
+  });
+
+  it("scaleRatio scales both axes proportionally", () => {
+    const scaled = createCoordinateTransforms({ ...base, scaleRatio: 0.5 });
+    const unscaled = createCoordinateTransforms(base);
+    // With scaleRatio=0.5, effectiveSC = 1, effectiveYSC = 1.5
+    // The pixel range should be half as wide
+    const rangeScaled = Math.abs(scaled.sx(100) - scaled.sx(0));
+    const rangeUnscaled = Math.abs(unscaled.sx(100) - unscaled.sx(0));
+    expect(rangeScaled).toBeCloseTo(rangeUnscaled * 0.5);
+  });
+
+  it("scaleRatio=null uses raw SC/YSC", () => {
+    const withNull = createCoordinateTransforms({ ...base, scaleRatio: null });
+    const withOne = createCoordinateTransforms({ ...base, scaleRatio: 1 });
+    // Both should produce identical results since null means "use raw"
+    expect(withNull.sx(50)).toBeCloseTo(withOne.sx(50));
+    expect(withNull.sy(10)).toBeCloseTo(withOne.sy(10));
+  });
+
+  it("lensShiftFrac offsets horizontally", () => {
+    const shifted = createCoordinateTransforms({ ...base, lensShiftFrac: 0.1 });
+    const unshifted = createCoordinateTransforms(base);
+    // CX shifts by svgW * lensShiftFrac = 800 * 0.1 = 80
+    expect(shifted.sx(50) - unshifted.sx(50)).toBeCloseTo(80);
+  });
+
+  it("yViewMax computed correctly", () => {
+    const { yViewMax } = createCoordinateTransforms(base);
+    // (svgH/2 - 10) / effectiveYSC = (200 - 10) / 3 ≈ 63.33
+    expect(yViewMax).toBeCloseTo(190 / 3);
+  });
+
+  it("clampedRayEnd passes through when ray is within viewport", () => {
+    const { clampedRayEnd, yViewMax } = createCoordinateTransforms(base);
+    // Small slope, ray stays within viewport
+    const result = clampedRayEnd(50, 0, 0.01, 60);
+    const { sx, sy } = createCoordinateTransforms(base);
+    const expectedY = 0 + (60 - 50) * 0.01; // 0.1, well within yViewMax
+    expect(result[0]).toBeCloseTo(sx(60));
+    expect(result[1]).toBeCloseTo(sy(expectedY));
+    expect(Math.abs(expectedY)).toBeLessThan(yViewMax);
+  });
+
+  it("clampedRayEnd clamps ray at viewport edge for large slopes", () => {
+    const { clampedRayEnd, yViewMax, sx, sy } = createCoordinateTransforms(base);
+    // Large slope that would exceed yViewMax
+    const result = clampedRayEnd(0, 0, 100, 100);
+    // yImg = 0 + 100*100 = 10000, way beyond yViewMax ≈ 63.3
+    // Should clamp to yViewMax
+    expect(result[1]).toBeCloseTo(sy(yViewMax));
+    // zEdge = 0 + (yViewMax - 0) / 100 = yViewMax/100
+    expect(result[0]).toBeCloseTo(sx(yViewMax / 100));
+  });
+
+  it("clampedRayEnd handles zero slope (parallel ray)", () => {
+    const { clampedRayEnd, sx, sy } = createCoordinateTransforms(base);
+    const result = clampedRayEnd(50, 5, 0, 80);
+    // u=0, yImg = 5, no clamping needed (small y)
+    expect(result[0]).toBeCloseTo(sx(80));
+    expect(result[1]).toBeCloseTo(sy(5));
+  });
+});
+
+/* ═══════════════════════════════════════════════════════════════════
+ * §2  computeElementShapes
+ * ═══════════════════════════════════════════════════════════════════ */
+
+describe("computeElementShapes", () => {
+  /* Identity transforms for interpretable coordinates */
+  const sx = (z) => z;
+  const sy = (y) => y;
+
+  /**
+   * Minimal lens-like object builder.
+   * computeElementShapes accesses: L.ES, L.S[].sd, L.S[].R, L.S[].nd, L.S[].d,
+   * L.asphByIdx, L.maxRimSin, L.gapSagFrac, L.N
+   */
+  function makeSingleElementLens({ R1 = 50, R2 = 1e15, sd = 15, nd = 1.5, asph1 = null, asph2 = null } = {}) {
+    return {
+      ES: [[0, 0, 1]],
+      S: [
+        { R: R1, sd, nd, d: 5 },
+        { R: R2, sd, nd: 1.0, d: 10 },
+      ],
+      asphByIdx: { 0: asph1, 1: asph2 },
+      maxRimSin: 0.95,
+      gapSagFrac: 0.9,
+      N: 2,
+    };
+  }
+
+  it("returns empty array for empty ES", () => {
+    const L = { ...makeSingleElementLens(), ES: [] };
+    expect(computeElementShapes(L, [0, 5], sx, sy)).toEqual([]);
+  });
+
+  it("single plano-convex element returns correct structure", () => {
+    const L = makeSingleElementLens({ R1: 50, R2: 1e15 });
+    const zPos = [0, 5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+
+    expect(shapes).toHaveLength(1);
+    expect(shapes[0].eid).toBe(0);
+    expect(shapes[0].z1).toBe(0);
+    expect(shapes[0].z2).toBe(5);
+    expect(shapes[0].d).toMatch(/^M.*Z$/); // starts with M, ends with Z (closed)
+    expect(shapes[0].asphPaths).toEqual([]);
+  });
+
+  it("path contains expected number of line segments", () => {
+    const L = makeSingleElementLens();
+    const zPos = [0, 5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+    const NN = SVG_PATH_SUBDIVISIONS;
+    // Front arc: 1 M + NN L = NN+1 points, Rear arc: NN+1 L points
+    const mCount = (shapes[0].d.match(/M/g) || []).length;
+    const lCount = (shapes[0].d.match(/L/g) || []).length;
+    expect(mCount).toBe(1);
+    expect(lCount).toBe(2 * NN + 1); // NN from front + (NN+1) from rear
+  });
+
+  it("flat surface produces vertical line (constant x per surface)", () => {
+    const L = makeSingleElementLens({ R1: 1e15, R2: 1e15 });
+    const zPos = [0, 5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+    // With identity sx and flat surfaces (sag ≈ 0), all front-arc x-coords ≈ z1=0
+    const coords = shapes[0].d.match(/[ML]([\d.e+-]+),([\d.e+-]+)/g);
+    const NN = SVG_PATH_SUBDIVISIONS;
+    // First NN+1 coords are front surface at z1=0
+    for (let i = 0; i <= NN; i++) {
+      const match = coords[i].match(/[ML]([\d.e+-]+)/);
+      expect(parseFloat(match[1])).toBeCloseTo(0, 3);
+    }
+    // Last NN+1 coords are rear surface at z2=5
+    for (let i = NN + 1; i < coords.length; i++) {
+      const match = coords[i].match(/[ML]([\d.e+-]+)/);
+      expect(parseFloat(match[1])).toBeCloseTo(5, 3);
+    }
+  });
+
+  it("conic height limit is applied when K > 0", () => {
+    // With K=3 and R=20: hMax = 20/√4 * 0.98 = 9.8, which is less than sd=15
+    const L = makeSingleElementLens({ R1: 20, sd: 15, asph1: { K: 3 } });
+    const zPos = [0, 5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+    // The path should exist (no error)
+    expect(shapes).toHaveLength(1);
+    // With identity transforms, we can check the x-coords near the edge.
+    // The trim should prevent rendering at the full sd=15 height,
+    // so the sag values near the edge should be smaller than for an untrimmed lens.
+    const untrimmedL = makeSingleElementLens({ R1: 20, sd: 15 });
+    const untrimmedShapes = computeElementShapes(untrimmedL, zPos, sx, sy);
+    // The trimmed path should differ from untrimmed
+    expect(shapes[0].d).not.toBe(untrimmedShapes[0].d);
+  });
+
+  it("aspheric front surface produces asphPaths entry", () => {
+    const L = makeSingleElementLens({ R1: 50, asph1: { K: -1 } });
+    const zPos = [0, 5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+
+    expect(shapes[0].asphPaths).toHaveLength(1);
+    const ap = shapes[0].asphPaths[0];
+    expect(ap.surfIdx).toBe(0);
+    expect(ap.pathD).toMatch(/^M/);
+    expect(ap.halfPathD).toMatch(/Z$/);
+    expect(typeof ap.labelX).toBe("number");
+    expect(typeof ap.labelY).toBe("number");
+  });
+
+  it("both surfaces aspheric produces two asphPaths entries", () => {
+    const L = makeSingleElementLens({ R1: 50, R2: -50, asph1: { K: -1 }, asph2: { K: -0.5 } });
+    const zPos = [0, 5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+
+    expect(shapes[0].asphPaths).toHaveLength(2);
+    expect(shapes[0].asphPaths[0].surfIdx).toBe(0);
+    expect(shapes[0].asphPaths[1].surfIdx).toBe(1);
+  });
+
+  it("multi-element system returns one shape per element", () => {
+    const L = {
+      ES: [
+        [0, 0, 1],
+        [1, 2, 3],
+        [2, 4, 5],
+      ],
+      S: [
+        { R: 50, sd: 15, nd: 1.5, d: 3 },
+        { R: -80, sd: 15, nd: 1.0, d: 2 },
+        { R: 30, sd: 12, nd: 1.7, d: 4 },
+        { R: -40, sd: 12, nd: 1.0, d: 2 },
+        { R: 60, sd: 10, nd: 1.5, d: 3 },
+        { R: 1e15, sd: 10, nd: 1.0, d: 50 },
+      ],
+      asphByIdx: {},
+      maxRimSin: 0.95,
+      gapSagFrac: 0.9,
+      N: 6,
+    };
+    const zPos = [0, 3, 5, 9, 11, 14];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+
+    expect(shapes).toHaveLength(3);
+    expect(shapes[0].eid).toBe(0);
+    expect(shapes[1].eid).toBe(1);
+    expect(shapes[2].eid).toBe(2);
+  });
+
+  it("gap trimming: rear surface with positive sag into narrow gap", () => {
+    // Element 0: front flat, rear with R=15 (positive sag curves forward)
+    // Element 1: front flat, rear flat
+    // Gap between them is only 0.5mm — should trigger rear trim on element 0
+    const L = {
+      ES: [
+        [0, 0, 1],
+        [1, 2, 3],
+      ],
+      S: [
+        { R: 1e15, sd: 12, nd: 1.5, d: 3 },
+        { R: 15, sd: 12, nd: 1.0, d: 0.5 }, // tight gap, positive-sag rear
+        { R: 1e15, sd: 12, nd: 1.5, d: 3 },
+        { R: 1e15, sd: 12, nd: 1.0, d: 50 },
+      ],
+      asphByIdx: {},
+      maxRimSin: 0.95,
+      gapSagFrac: 0.9,
+      N: 4,
+    };
+    const zPos = [0, 3, 3.5, 6.5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+    expect(shapes).toHaveLength(2);
+    // The shapes should compute without error — trimming handles the tight gap
+    expect(shapes[0].d).toMatch(/^M.*Z$/);
+  });
+
+  it("gap trimming: front surface with negative sag into narrow preceding gap", () => {
+    // Element 0: flat front, flat rear, followed by narrow gap
+    // Element 1: front with R=-15 (negative sag curves backward into gap), flat rear
+    const L = {
+      ES: [
+        [0, 0, 1],
+        [1, 2, 3],
+      ],
+      S: [
+        { R: 1e15, sd: 12, nd: 1.5, d: 3 },
+        { R: 1e15, sd: 12, nd: 1.0, d: 0.5 }, // tight gap
+        { R: -15, sd: 12, nd: 1.5, d: 3 }, // negative-sag front
+        { R: 1e15, sd: 12, nd: 1.0, d: 50 },
+      ],
+      asphByIdx: {},
+      maxRimSin: 0.95,
+      gapSagFrac: 0.9,
+      N: 4,
+    };
+    const zPos = [0, 3, 3.5, 6.5];
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+    expect(shapes).toHaveLength(2);
+    expect(shapes[1].d).toMatch(/^M.*Z$/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "^4.1.0",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
@@ -306,6 +307,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1534,6 +1545,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.0",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.0",
+        "vitest": "4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -1857,6 +1899,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -3334,6 +3395,13 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -3854,6 +3922,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4041,6 +4148,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-table": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{js,jsx}\" \"__tests__/**/*.js\" \"*.config.js\"",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",

--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -20,12 +20,10 @@
  * physical mm-per-pixel ratio.
  */
 
-import { useState, useMemo, useCallback, useEffect, useLayoutEffect, useRef, Component } from "react";
+import { useState, useMemo, useEffect, useLayoutEffect, useRef, Component } from "react";
 import { LENS_CATALOG } from "../utils/lensCatalog.js";
 import buildLens from "../optics/buildLens.js";
 import {
-  renderSag,
-  gapTrimHeight,
   thick,
   doLayout,
   eflAtZoom,
@@ -38,8 +36,8 @@ import {
   computeChromaticSpread,
   conjugateK,
   formatDist,
-  SVG_PATH_SUBDIVISIONS,
 } from "../optics/optics.js";
+import { createCoordinateTransforms, computeElementShapes } from "../optics/diagramGeometry.js";
 import {
   ENABLE_COLOR_TRACING,
   ENABLE_ASPH_DIAMOND_FILL,
@@ -261,158 +259,40 @@ export default function LensDiagramPanel({
   const dz = inf && cur ? IMG_MM - cur.imgZ : 0;
   const zPos = useMemo(() => (cur ? cur.z.map((v) => v + dz) : []), [cur, dz]);
 
-  /* ── Coordinate transforms (optical mm → SVG pixels) ──
-   * SC  = horizontal scale (mm → px), YSC = vertical scale.
-   * In normalized comparison mode, scaleRatio adjusts both so two lenses
-   * share the same physical mm-per-pixel, making sizes visually comparable.
-   * sx(z) maps an axial position z (mm) to an SVG x coordinate.
-   * sy(y) maps a ray height y (mm) to an SVG y coordinate (Y inverted). */
-  const effectiveSC = L ? (scaleRatio != null ? L.SC * scaleRatio : L.SC) : 1;
-  const effectiveYSC = L ? (scaleRatio != null ? L.YSC * scaleRatio : L.YSC) : 1;
-  const MID = IMG_MM / 2,
-    CX = L ? L.svgW / 2 + L.svgW * L.lensShiftFrac : 0,
-    CY = L ? L.svgH / 2 : 0;
-  const IX = CX + MID * effectiveSC;
-  const sx = useCallback((z) => IX - (IMG_MM - z) * effectiveSC, [IX, IMG_MM, effectiveSC]);
-  const sy = useCallback((y) => CY + y * effectiveYSC, [CY, effectiveYSC]);
-
-  /* Maximum ray height (optical mm) that fits within the SVG viewport.
-   * Rays projecting beyond this are terminated at the viewport edge so they
-   * exit at their true angle rather than extending to an invisible point. */
-  const yViewMax = L ? (L.svgH / 2 - 10) / effectiveYSC : 100;
-  const clampedRayEnd = useCallback(
-    (lastZ, lastY, u, targetZ) => {
-      const yImg = lastY + (targetZ - lastZ) * u;
-      const yClamped = Math.max(-yViewMax, Math.min(yViewMax, yImg));
-      if (yClamped !== yImg && Math.abs(u) > 1e-9) {
-        const zEdge = lastZ + (yClamped - lastY) / u;
-        return [sx(zEdge), sy(yClamped)];
-      }
-      return [sx(targetZ), sy(yImg)];
-    },
-    [yViewMax, sx, sy],
+  /* ── Coordinate transforms (optical mm → SVG pixels) ── */
+  const { sx, sy, clampedRayEnd, CX, IX, effectiveSC } = useMemo(
+    () =>
+      L
+        ? createCoordinateTransforms({
+            svgW: L.svgW,
+            svgH: L.svgH,
+            SC: L.SC,
+            YSC: L.YSC,
+            lensShiftFrac: L.lensShiftFrac,
+            imgMM: IMG_MM,
+            scaleRatio,
+          })
+        : {
+            sx: () => 0,
+            sy: () => 0,
+            clampedRayEnd: () => [0, 0],
+            CX: 0,
+            IX: 0,
+            effectiveSC: 1,
+          },
+    [L, IMG_MM, scaleRatio],
   );
 
-  /* ── Element shapes ──
-   * For each element [eid, frontSurfIdx, rearSurfIdx], build a closed SVG path:
-   *   front arc (top→bottom) + rear arc (bottom→top) → closed polygon.
-   *
-   * Trimming logic prevents surfaces from visually overlapping neighboring
-   * elements. Two trim passes handle front (backward-curving into preceding gap)
-   * and rear (forward-curving into following gap) surfaces independently.
-   * Each surface is also clamped to its conic height limit to avoid rendering
-   * artifacts where the conic slope approaches infinity. */
+  /* ── Element shapes ── */
   const shapes = useMemo(() => {
     if (!L) return [];
     try {
-      return L.ES.map(([eid, s1, s2]) => {
-        const sd = Math.min(L.S[s1].sd, L.S[s2].sd);
-        const R1 = Math.abs(L.S[s1].R),
-          R2 = Math.abs(L.S[s2].R);
-        /* Conic-aware max height: surface slope → ∞ at h = |R|/√(1+K) when K > 0 */
-        const K1 = L.asphByIdx[s1]?.K || 0;
-        const K2 = L.asphByIdx[s2]?.K || 0;
-        const hMax1 = K1 > 0 && R1 < 1e10 ? (R1 / Math.sqrt(1 + K1)) * 0.98 : Infinity;
-        const hMax2 = K2 > 0 && R2 < 1e10 ? (R2 / Math.sqrt(1 + K2)) * 0.98 : Infinity;
-        let trim1 = R1 < 1e10 ? Math.min(sd, R1 * L.maxRimSin, hMax1) : Math.min(sd, hMax1);
-        let trim2 = R2 < 1e10 ? Math.min(sd, R2 * L.maxRimSin, hMax2) : Math.min(sd, hMax2);
-        /* Trim front surface if it curves backward into preceding air gap.
-         * Mirror of the TRIM2 logic: the preceding element's rear surface
-         * may curve backward (negative sag) widening the effective clearance,
-         * or forward (positive sag) narrowing it. */
-        if (s1 > 0 && L.gapSagFrac > 0 && renderSag(trim1, s1, L) < 0) {
-          const prevES = L.ES.findLast(([, , ps2]) => ps2 < s1 && L.S[ps2].nd === 1.0);
-          const gapBefore = prevES ? zPos[s1] - zPos[prevES[2]] : L.S[s1 - 1].d;
-          let effectiveGap = gapBefore;
-          if (prevES) {
-            const ps2 = prevES[2],
-              ps1 = prevES[1];
-            const prevSD = Math.min(L.S[ps1].sd, L.S[ps2].sd);
-            /* Negative renderSag on rear surface = curves backward = widens gap */
-            effectiveGap -= renderSag(Math.min(trim1, prevSD), ps2, L);
-          }
-          effectiveGap = Math.max(effectiveGap, 0);
-          if (Math.abs(renderSag(trim1, s1, L)) > effectiveGap * L.gapSagFrac)
-            trim1 = gapTrimHeight(s1, trim1, effectiveGap * L.gapSagFrac, L);
-        }
-        /* Trim rear surface if it actually overlaps with the following element.
-         * A rear surface with positive sag curves forward into the gap, but the
-         * next element's front surface may also curve forward (positive sag),
-         * widening the effective clearance; or backward (negative sag), narrowing
-         * it.  Account for both to avoid false trims on fast lenses. */
-        if (L.S[s2].nd === 1.0 && L.gapSagFrac > 0 && renderSag(trim2, s2, L) > 0) {
-          const nextES = L.ES.find(([, ns1]) => ns1 > s2);
-          const gapAfter = nextES ? zPos[nextES[1]] - zPos[s2] : L.S[s2].d;
-          let effectiveGap = gapAfter;
-          if (nextES) {
-            const ns1 = nextES[1],
-              ns2 = ns1 + 1;
-            const nextSD = Math.min(L.S[ns1].sd, ns2 < L.N ? L.S[ns2].sd : Infinity);
-            effectiveGap += renderSag(Math.min(trim2, nextSD), ns1, L);
-          }
-          effectiveGap = Math.max(effectiveGap, 0);
-          if (renderSag(trim2, s2, L) > effectiveGap * L.gapSagFrac)
-            trim2 = gapTrimHeight(s2, trim2, effectiveGap * L.gapSagFrac, L);
-        }
-        const z1 = zPos[s1],
-          z2 = zPos[s2],
-          NN = SVG_PATH_SUBDIVISIONS;
-        let d = "";
-        for (let i = 0; i <= NN; i++) {
-          const y = -sd + (2 * sd * i) / NN;
-          d += `${i ? "L" : "M"}${sx(z1 + renderSag(Math.min(Math.abs(y), trim1), s1, L))},${sy(y)} `;
-        }
-        for (let i = NN; i >= 0; i--) {
-          const y = -sd + (2 * sd * i) / NN;
-          d += `L${sx(z2 + renderSag(Math.min(Math.abs(y), trim2), s2, L))},${sy(y)} `;
-        }
-        /* Aspheric surface overlay paths + diamond half-fill paths */
-        const asphPaths = [];
-        const midX = sx((z1 + z2) / 2);
-        if (L.asphByIdx[s1]) {
-          let p = "";
-          for (let i = 0; i <= NN; i++) {
-            const y = -sd + (2 * sd * i) / NN;
-            p += `${i ? "L" : "M"}${sx(z1 + renderSag(Math.min(Math.abs(y), trim1), s1, L))},${sy(y)} `;
-          }
-          /* Half-path: front surface top-to-bottom, then straight line back at midpoint */
-          let hp = p + `L${midX},${sy(sd)} L${midX},${sy(-sd)} Z`;
-          asphPaths.push({
-            surfIdx: s1,
-            pathD: p,
-            halfPathD: hp,
-            labelX: sx(z1 + renderSag(Math.min(sd, trim1), s1, L)),
-            labelY: sy(-sd) - 4,
-          });
-        }
-        if (L.asphByIdx[s2]) {
-          let p = "";
-          for (let i = 0; i <= NN; i++) {
-            const y = -sd + (2 * sd * i) / NN;
-            p += `${i ? "L" : "M"}${sx(z2 + renderSag(Math.min(Math.abs(y), trim2), s2, L))},${sy(y)} `;
-          }
-          /* Half-path: straight line at midpoint top-to-bottom, then rear surface bottom-to-top */
-          let hp = `M${midX},${sy(-sd)} L${midX},${sy(sd)} `;
-          for (let i = NN; i >= 0; i--) {
-            const y = -sd + (2 * sd * i) / NN;
-            hp += `L${sx(z2 + renderSag(Math.min(Math.abs(y), trim2), s2, L))},${sy(y)} `;
-          }
-          hp += "Z";
-          asphPaths.push({
-            surfIdx: s2,
-            pathD: p,
-            halfPathD: hp,
-            labelX: sx(z2 + renderSag(Math.min(sd, trim2), s2, L)),
-            labelY: sy(-sd) - 4,
-          });
-        }
-        return { eid, d: d + "Z", z1, z2, asphPaths };
-      });
+      return computeElementShapes(L, zPos, sx, sy);
     } catch (e) {
       console.error(`[LensDiagramPanel] Element shape computation failed for "${lensKey}":`, e);
       return [];
     }
-  }, [zPos, sx, sy, L, lensKey]);
+  }, [L, zPos, sx, sy, lensKey]);
 
   /* ── Aperture ──
    * Compute the current f-number and physical stop/entrance-pupil diameters

--- a/src/optics/diagramGeometry.js
+++ b/src/optics/diagramGeometry.js
@@ -1,0 +1,157 @@
+/**
+ * Pure-function utilities for diagram geometry, extracted from LensDiagramPanel.
+ * No React dependencies — these are testable coordinate-transform and
+ * element-shape computations used by the SVG rendering layer.
+ */
+
+import { renderSag, gapTrimHeight, SVG_PATH_SUBDIVISIONS } from "./optics.js";
+
+/* ── Coordinate transforms (optical mm → SVG pixels) ──
+ * SC  = horizontal scale (mm → px), YSC = vertical scale.
+ * In normalized comparison mode, scaleRatio adjusts both so two lenses
+ * share the same physical mm-per-pixel, making sizes visually comparable.
+ * sx(z) maps an axial position z (mm) to an SVG x coordinate.
+ * sy(y) maps a ray height y (mm) to an SVG y coordinate (Y inverted). */
+export function createCoordinateTransforms({ svgW, svgH, SC, YSC, lensShiftFrac, imgMM, scaleRatio }) {
+  const effectiveSC = scaleRatio != null ? SC * scaleRatio : SC;
+  const effectiveYSC = scaleRatio != null ? YSC * scaleRatio : YSC;
+  const MID = imgMM / 2;
+  const CX = svgW / 2 + svgW * lensShiftFrac;
+  const CY = svgH / 2;
+  const IX = CX + MID * effectiveSC;
+
+  const sx = (z) => IX - (imgMM - z) * effectiveSC;
+  const sy = (y) => CY + y * effectiveYSC;
+
+  /* Maximum ray height (optical mm) that fits within the SVG viewport.
+   * Rays projecting beyond this are terminated at the viewport edge so they
+   * exit at their true angle rather than extending to an invisible point. */
+  const yViewMax = (svgH / 2 - 10) / effectiveYSC;
+
+  const clampedRayEnd = (lastZ, lastY, u, targetZ) => {
+    const yImg = lastY + (targetZ - lastZ) * u;
+    const yClamped = Math.max(-yViewMax, Math.min(yViewMax, yImg));
+    if (yClamped !== yImg && Math.abs(u) > 1e-9) {
+      const zEdge = lastZ + (yClamped - lastY) / u;
+      return [sx(zEdge), sy(yClamped)];
+    }
+    return [sx(targetZ), sy(yImg)];
+  };
+
+  return { sx, sy, clampedRayEnd, yViewMax, CX, IX, effectiveSC };
+}
+
+/* ── Element shapes ──
+ * For each element [eid, frontSurfIdx, rearSurfIdx], build a closed SVG path:
+ *   front arc (top→bottom) + rear arc (bottom→top) → closed polygon.
+ *
+ * Trimming logic prevents surfaces from visually overlapping neighboring
+ * elements. Two trim passes handle front (backward-curving into preceding gap)
+ * and rear (forward-curving into following gap) surfaces independently.
+ * Each surface is also clamped to its conic height limit to avoid rendering
+ * artifacts where the conic slope approaches infinity. */
+export function computeElementShapes(L, zPos, sx, sy) {
+  return L.ES.map(([eid, s1, s2]) => {
+    const sd = Math.min(L.S[s1].sd, L.S[s2].sd);
+    const R1 = Math.abs(L.S[s1].R),
+      R2 = Math.abs(L.S[s2].R);
+    /* Conic-aware max height: surface slope → ∞ at h = |R|/√(1+K) when K > 0 */
+    const K1 = L.asphByIdx[s1]?.K || 0;
+    const K2 = L.asphByIdx[s2]?.K || 0;
+    const hMax1 = K1 > 0 && R1 < 1e10 ? (R1 / Math.sqrt(1 + K1)) * 0.98 : Infinity;
+    const hMax2 = K2 > 0 && R2 < 1e10 ? (R2 / Math.sqrt(1 + K2)) * 0.98 : Infinity;
+    let trim1 = R1 < 1e10 ? Math.min(sd, R1 * L.maxRimSin, hMax1) : Math.min(sd, hMax1);
+    let trim2 = R2 < 1e10 ? Math.min(sd, R2 * L.maxRimSin, hMax2) : Math.min(sd, hMax2);
+    /* Trim front surface if it curves backward into preceding air gap.
+     * Mirror of the TRIM2 logic: the preceding element's rear surface
+     * may curve backward (negative sag) widening the effective clearance,
+     * or forward (positive sag) narrowing it. */
+    if (s1 > 0 && L.gapSagFrac > 0 && renderSag(trim1, s1, L) < 0) {
+      const prevES = L.ES.findLast(([, , ps2]) => ps2 < s1 && L.S[ps2].nd === 1.0);
+      const gapBefore = prevES ? zPos[s1] - zPos[prevES[2]] : L.S[s1 - 1].d;
+      let effectiveGap = gapBefore;
+      if (prevES) {
+        const ps2 = prevES[2],
+          ps1 = prevES[1];
+        const prevSD = Math.min(L.S[ps1].sd, L.S[ps2].sd);
+        /* Negative renderSag on rear surface = curves backward = widens gap */
+        effectiveGap -= renderSag(Math.min(trim1, prevSD), ps2, L);
+      }
+      effectiveGap = Math.max(effectiveGap, 0);
+      if (Math.abs(renderSag(trim1, s1, L)) > effectiveGap * L.gapSagFrac)
+        trim1 = gapTrimHeight(s1, trim1, effectiveGap * L.gapSagFrac, L);
+    }
+    /* Trim rear surface if it actually overlaps with the following element.
+     * A rear surface with positive sag curves forward into the gap, but the
+     * next element's front surface may also curve forward (positive sag),
+     * widening the effective clearance; or backward (negative sag), narrowing
+     * it.  Account for both to avoid false trims on fast lenses. */
+    if (L.S[s2].nd === 1.0 && L.gapSagFrac > 0 && renderSag(trim2, s2, L) > 0) {
+      const nextES = L.ES.find(([, ns1]) => ns1 > s2);
+      const gapAfter = nextES ? zPos[nextES[1]] - zPos[s2] : L.S[s2].d;
+      let effectiveGap = gapAfter;
+      if (nextES) {
+        const ns1 = nextES[1],
+          ns2 = ns1 + 1;
+        const nextSD = Math.min(L.S[ns1].sd, ns2 < L.N ? L.S[ns2].sd : Infinity);
+        effectiveGap += renderSag(Math.min(trim2, nextSD), ns1, L);
+      }
+      effectiveGap = Math.max(effectiveGap, 0);
+      if (renderSag(trim2, s2, L) > effectiveGap * L.gapSagFrac)
+        trim2 = gapTrimHeight(s2, trim2, effectiveGap * L.gapSagFrac, L);
+    }
+    const z1 = zPos[s1],
+      z2 = zPos[s2],
+      NN = SVG_PATH_SUBDIVISIONS;
+    let d = "";
+    for (let i = 0; i <= NN; i++) {
+      const y = -sd + (2 * sd * i) / NN;
+      d += `${i ? "L" : "M"}${sx(z1 + renderSag(Math.min(Math.abs(y), trim1), s1, L))},${sy(y)} `;
+    }
+    for (let i = NN; i >= 0; i--) {
+      const y = -sd + (2 * sd * i) / NN;
+      d += `L${sx(z2 + renderSag(Math.min(Math.abs(y), trim2), s2, L))},${sy(y)} `;
+    }
+    /* Aspheric surface overlay paths + diamond half-fill paths */
+    const asphPaths = [];
+    const midX = sx((z1 + z2) / 2);
+    if (L.asphByIdx[s1]) {
+      let p = "";
+      for (let i = 0; i <= NN; i++) {
+        const y = -sd + (2 * sd * i) / NN;
+        p += `${i ? "L" : "M"}${sx(z1 + renderSag(Math.min(Math.abs(y), trim1), s1, L))},${sy(y)} `;
+      }
+      /* Half-path: front surface top-to-bottom, then straight line back at midpoint */
+      let hp = p + `L${midX},${sy(sd)} L${midX},${sy(-sd)} Z`;
+      asphPaths.push({
+        surfIdx: s1,
+        pathD: p,
+        halfPathD: hp,
+        labelX: sx(z1 + renderSag(Math.min(sd, trim1), s1, L)),
+        labelY: sy(-sd) - 4,
+      });
+    }
+    if (L.asphByIdx[s2]) {
+      let p = "";
+      for (let i = 0; i <= NN; i++) {
+        const y = -sd + (2 * sd * i) / NN;
+        p += `${i ? "L" : "M"}${sx(z2 + renderSag(Math.min(Math.abs(y), trim2), s2, L))},${sy(y)} `;
+      }
+      /* Half-path: straight line at midpoint top-to-bottom, then rear surface bottom-to-top */
+      let hp = `M${midX},${sy(-sd)} L${midX},${sy(sd)} `;
+      for (let i = NN; i >= 0; i--) {
+        const y = -sd + (2 * sd * i) / NN;
+        hp += `L${sx(z2 + renderSag(Math.min(Math.abs(y), trim2), s2, L))},${sy(y)} `;
+      }
+      hp += "Z";
+      asphPaths.push({
+        surfIdx: s2,
+        pathD: p,
+        halfPathD: hp,
+        labelX: sx(z2 + renderSag(Math.min(sd, trim2), s2, L)),
+        labelY: sy(-sd) - 4,
+      });
+    }
+    return { eid, d: d + "Z", z1, z2, asphPaths };
+  });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,12 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   base: "/",
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/optics/**"],
+      reporter: ["text", "html"],
+      reportsDirectory: "coverage",
+    },
+  },
 });


### PR DESCRIPTION
…e reporting

Extract computeElementShapes() and createCoordinateTransforms() from LensDiagramPanel.jsx useMemo/useCallback blocks into a new pure-function module (src/optics/diagramGeometry.js). This makes ~130 lines of complex geometry—conic height limits, gap trimming, SVG path generation, aspheric overlays, and coordinate transforms—independently testable without React.

Add 22 new tests in __tests__/diagramGeometry.test.js covering coordinate mapping, scale ratio, lens shift, viewport clamping, element shapes, conic limits, gap trimming, aspheric paths, and multi-element systems.

Configure @vitest/coverage-v8 with `npm run test:coverage` scoped to src/optics/ (93.4% statement, 96.4% line coverage).

Addresses #126.