### PR TITLE
Refactor inline styles to hoisted constants and memoized objects

### DIFF
--- a/src/components/DescriptionPanel.jsx
+++ b/src/components/DescriptionPanel.jsx
@@ -9,8 +9,12 @@
  * Used by LensViewer in the "analysis" pane (desktop right column / mobile tab).
  */
 
+import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+const WRAPPER_STYLE = { padding: "16px 24px 24px", fontSize: 12, lineHeight: 1.7 };
+const EMPTY_STATE_STYLE = { padding: 32, fontSize: 12, fontStyle: "italic" };
 
 /**
  * @param {Object}  props
@@ -18,130 +22,137 @@ import remarkGfm from "remark-gfm";
  * @param {Object}  props.theme    — active theme object from themes.js
  */
 export default function DescriptionPanel({ markdown, theme: t }) {
-  if (!markdown) {
-    return (
-      <div style={{ padding: 32, color: t.muted, fontSize: 12, fontStyle: "italic" }}>
-        No description available for this lens.
-      </div>
-    );
-  }
   /* Override every markdown element with theme-colored inline styles.
-   * react-markdown passes each tag through these custom renderers. */
-  const components = {
-    h1: ({ children }) => (
-      <h1
-        style={{
-          fontSize: 16,
-          fontWeight: 700,
-          color: t.descH1,
-          margin: "14px 0 6px",
-          fontFamily: "'DM Sans','Helvetica Neue',sans-serif",
-          letterSpacing: "0.02em",
-        }}
-      >
-        {children}
-      </h1>
-    ),
-    h2: ({ children }) => (
-      <h2 style={{ fontSize: 13, fontWeight: 600, color: t.descH2, margin: "14px 0 4px", letterSpacing: "0.06em" }}>
-        {children}
-      </h2>
-    ),
-    h3: ({ children }) => (
-      <h3 style={{ fontSize: 12, fontWeight: 600, color: t.descH2, margin: "10px 0 3px", letterSpacing: "0.04em" }}>
-        {children}
-      </h3>
-    ),
-    p: ({ children }) => (
-      <p style={{ margin: "6px 0", fontSize: 12, color: t.descText, lineHeight: 1.7 }}>{children}</p>
-    ),
-    strong: ({ children }) => <strong style={{ color: t.descH2, fontWeight: 600 }}>{children}</strong>,
-    a: ({ href, children }) => (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ color: t.descLinkColor, textDecoration: "none", borderBottom: `1px solid ${t.descLinkColor}40` }}
-      >
-        {children}
-      </a>
-    ),
-    /* Distinguish fenced code blocks (language-*) from inline `code` spans */
-    code: ({ className, children }) => {
-      const isBlock = className?.startsWith("language-");
-      if (isBlock) return <code style={{ fontSize: 11 }}>{children}</code>;
-      return (
-        <code
+   * react-markdown passes each tag through these custom renderers.
+   * Memoized on `t` so the 15 render functions aren't recreated every render.
+   * Hook must be called before any early return to satisfy rules-of-hooks. */
+  const components = useMemo(
+    () => ({
+      h1: ({ children }) => (
+        <h1
           style={{
-            background: t.descCodeBg,
-            padding: "1px 5px",
-            borderRadius: 3,
-            fontSize: 11,
-            color: t.descLinkColor,
+            fontSize: 16,
+            fontWeight: 700,
+            color: t.descH1,
+            margin: "14px 0 6px",
+            fontFamily: "'DM Sans','Helvetica Neue',sans-serif",
+            letterSpacing: "0.02em",
           }}
         >
           {children}
-        </code>
-      );
-    },
-    pre: ({ children }) => (
-      <pre
-        style={{
-          background: t.descCodeBg,
-          padding: 12,
-          borderRadius: 6,
-          overflow: "auto",
-          margin: "10px 0",
-          fontSize: 11,
-          lineHeight: 1.5,
-        }}
-      >
-        {children}
-      </pre>
-    ),
-    ul: ({ children }) => (
-      <ul style={{ paddingLeft: 20, margin: "6px 0", fontSize: 12, color: t.descText, lineHeight: 1.7 }}>{children}</ul>
-    ),
-    ol: ({ children }) => (
-      <ol style={{ paddingLeft: 20, margin: "6px 0", fontSize: 12, color: t.descText, lineHeight: 1.7 }}>{children}</ol>
-    ),
-    li: ({ children }) => <li style={{ marginBottom: 3 }}>{children}</li>,
-    blockquote: ({ children }) => (
-      <blockquote
-        style={{ borderLeft: `3px solid ${t.descLinkColor}`, paddingLeft: 14, margin: "10px 0", color: t.muted }}
-      >
-        {children}
-      </blockquote>
-    ),
-    table: ({ children }) => (
-      <div style={{ overflowX: "auto", margin: "10px 0" }}>
-        <table style={{ borderCollapse: "collapse", width: "100%", fontSize: 11 }}>{children}</table>
-      </div>
-    ),
-    thead: ({ children }) => <thead style={{ background: t.descTableHeaderBg }}>{children}</thead>,
-    th: ({ children }) => (
-      <th
-        style={{
-          border: `1px solid ${t.descTableBorder}`,
-          padding: "6px 10px",
-          textAlign: "left",
-          color: t.descH2,
-          fontWeight: 600,
-          fontSize: 10.5,
-        }}
-      >
-        {children}
-      </th>
-    ),
-    td: ({ children }) => (
-      <td style={{ border: `1px solid ${t.descTableBorder}`, padding: "5px 10px", color: t.descText, fontSize: 10.5 }}>
-        {children}
-      </td>
-    ),
-    hr: () => <hr style={{ border: "none", borderTop: `1px solid ${t.descBorder}`, margin: "16px 0" }} />,
-  };
+        </h1>
+      ),
+      h2: ({ children }) => (
+        <h2 style={{ fontSize: 13, fontWeight: 600, color: t.descH2, margin: "14px 0 4px", letterSpacing: "0.06em" }}>
+          {children}
+        </h2>
+      ),
+      h3: ({ children }) => (
+        <h3 style={{ fontSize: 12, fontWeight: 600, color: t.descH2, margin: "10px 0 3px", letterSpacing: "0.04em" }}>
+          {children}
+        </h3>
+      ),
+      p: ({ children }) => (
+        <p style={{ margin: "6px 0", fontSize: 12, color: t.descText, lineHeight: 1.7 }}>{children}</p>
+      ),
+      strong: ({ children }) => <strong style={{ color: t.descH2, fontWeight: 600 }}>{children}</strong>,
+      a: ({ href, children }) => (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: t.descLinkColor, textDecoration: "none", borderBottom: `1px solid ${t.descLinkColor}40` }}
+        >
+          {children}
+        </a>
+      ),
+      /* Distinguish fenced code blocks (language-*) from inline `code` spans */
+      code: ({ className, children }) => {
+        const isBlock = className?.startsWith("language-");
+        if (isBlock) return <code style={{ fontSize: 11 }}>{children}</code>;
+        return (
+          <code
+            style={{
+              background: t.descCodeBg,
+              padding: "1px 5px",
+              borderRadius: 3,
+              fontSize: 11,
+              color: t.descLinkColor,
+            }}
+          >
+            {children}
+          </code>
+        );
+      },
+      pre: ({ children }) => (
+        <pre
+          style={{
+            background: t.descCodeBg,
+            padding: 12,
+            borderRadius: 6,
+            overflow: "auto",
+            margin: "10px 0",
+            fontSize: 11,
+            lineHeight: 1.5,
+          }}
+        >
+          {children}
+        </pre>
+      ),
+      ul: ({ children }) => (
+        <ul style={{ paddingLeft: 20, margin: "6px 0", fontSize: 12, color: t.descText, lineHeight: 1.7 }}>
+          {children}
+        </ul>
+      ),
+      ol: ({ children }) => (
+        <ol style={{ paddingLeft: 20, margin: "6px 0", fontSize: 12, color: t.descText, lineHeight: 1.7 }}>
+          {children}
+        </ol>
+      ),
+      li: ({ children }) => <li style={{ marginBottom: 3 }}>{children}</li>,
+      blockquote: ({ children }) => (
+        <blockquote
+          style={{ borderLeft: `3px solid ${t.descLinkColor}`, paddingLeft: 14, margin: "10px 0", color: t.muted }}
+        >
+          {children}
+        </blockquote>
+      ),
+      table: ({ children }) => (
+        <div style={{ overflowX: "auto", margin: "10px 0" }}>
+          <table style={{ borderCollapse: "collapse", width: "100%", fontSize: 11 }}>{children}</table>
+        </div>
+      ),
+      thead: ({ children }) => <thead style={{ background: t.descTableHeaderBg }}>{children}</thead>,
+      th: ({ children }) => (
+        <th
+          style={{
+            border: `1px solid ${t.descTableBorder}`,
+            padding: "6px 10px",
+            textAlign: "left",
+            color: t.descH2,
+            fontWeight: 600,
+            fontSize: 10.5,
+          }}
+        >
+          {children}
+        </th>
+      ),
+      td: ({ children }) => (
+        <td
+          style={{ border: `1px solid ${t.descTableBorder}`, padding: "5px 10px", color: t.descText, fontSize: 10.5 }}
+        >
+          {children}
+        </td>
+      ),
+      hr: () => <hr style={{ border: "none", borderTop: `1px solid ${t.descBorder}`, margin: "16px 0" }} />,
+    }),
+    [t],
+  );
+  if (!markdown) {
+    return <div style={{ ...EMPTY_STATE_STYLE, color: t.muted }}>No description available for this lens.</div>;
+  }
   return (
-    <div style={{ padding: "16px 24px 24px", fontSize: 12, lineHeight: 1.7 }}>
+    <div style={WRAPPER_STYLE}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {markdown}
       </ReactMarkdown>

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -33,6 +33,62 @@ const FALLBACK = {
   mutedText: "#888",
 };
 
+/* ── Hoisted static styles (all reference FALLBACK, which is module-level) ── */
+const ERROR_DISPLAY_CONTAINER = {
+  maxWidth: 560,
+  padding: 24,
+  textAlign: "center",
+  fontFamily: "'JetBrains Mono','SF Mono','Fira Code',monospace",
+};
+
+const ERROR_PRE_BASE = {
+  background: FALLBACK.errorBg,
+  border: `1px solid ${FALLBACK.errorBorder}`,
+  borderRadius: 6,
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  textAlign: "left",
+  overflowY: "auto",
+};
+
+const ERROR_ACTIONS_ROW = { display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" };
+
+const RETRY_BTN_STYLE = {
+  background: FALLBACK.btnBg,
+  color: FALLBACK.btnText,
+  border: "none",
+  borderRadius: 4,
+  padding: "7px 18px",
+  cursor: "pointer",
+  fontSize: 12,
+  fontWeight: 600,
+  fontFamily: "inherit",
+};
+
+const REPORT_LINK_STYLE = {
+  display: "inline-block",
+  background: FALLBACK.linkBg,
+  border: `1.5px solid ${FALLBACK.linkBorder}`,
+  borderRadius: 4,
+  padding: "6px 16px",
+  fontSize: 12,
+  fontWeight: 600,
+  color: FALLBACK.linkText,
+  textDecoration: "none",
+  fontFamily: "inherit",
+  cursor: "pointer",
+};
+
+const BOUNDARY_WRAPPER = {
+  background: FALLBACK.bg,
+  color: FALLBACK.text,
+  minHeight: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontFamily: "'JetBrains Mono','SF Mono','Fira Code',monospace",
+};
+
 /**
  * ErrorDisplay — reusable error UI with "Report Issue" link.
  *
@@ -58,29 +114,16 @@ export function ErrorDisplay({ error, context, onRetry, title = "Rendering Error
   }
 
   return (
-    <div
-      style={{
-        maxWidth: 560,
-        padding: 24,
-        textAlign: "center",
-        fontFamily: "'JetBrains Mono','SF Mono','Fira Code',monospace",
-      }}
-    >
+    <div style={ERROR_DISPLAY_CONTAINER}>
       <h2 style={{ color: FALLBACK.errorTitle, fontSize: 16, marginBottom: 10 }}>{title}</h2>
       <pre
         style={{
-          background: FALLBACK.errorBg,
-          border: `1px solid ${FALLBACK.errorBorder}`,
-          borderRadius: 6,
+          ...ERROR_PRE_BASE,
           padding: 14,
-          whiteSpace: "pre-wrap",
-          wordBreak: "break-word",
           fontSize: 12,
           color: FALLBACK.errorText,
           marginBottom: 12,
-          textAlign: "left",
           maxHeight: 180,
-          overflowY: "auto",
         }}
       >
         {error?.message || String(error)}
@@ -91,62 +134,19 @@ export function ErrorDisplay({ error, context, onRetry, title = "Rendering Error
           <summary style={{ cursor: "pointer", fontSize: 11, color: FALLBACK.mutedText, marginBottom: 6 }}>
             Stack trace
           </summary>
-          <pre
-            style={{
-              background: FALLBACK.errorBg,
-              border: `1px solid ${FALLBACK.errorBorder}`,
-              borderRadius: 6,
-              padding: 10,
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-              fontSize: 10,
-              color: FALLBACK.mutedText,
-              maxHeight: 200,
-              overflowY: "auto",
-            }}
-          >
+          <pre style={{ ...ERROR_PRE_BASE, padding: 10, fontSize: 10, color: FALLBACK.mutedText, maxHeight: 200 }}>
             {error.stack}
           </pre>
         </details>
       )}
 
-      <div style={{ display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" }}>
+      <div style={ERROR_ACTIONS_ROW}>
         {onRetry && (
-          <button
-            onClick={onRetry}
-            style={{
-              background: FALLBACK.btnBg,
-              color: FALLBACK.btnText,
-              border: "none",
-              borderRadius: 4,
-              padding: "7px 18px",
-              cursor: "pointer",
-              fontSize: 12,
-              fontWeight: 600,
-              fontFamily: "inherit",
-            }}
-          >
+          <button onClick={onRetry} style={RETRY_BTN_STYLE}>
             Retry
           </button>
         )}
-        <a
-          href={issueURL}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{
-            display: "inline-block",
-            background: FALLBACK.linkBg,
-            border: `1.5px solid ${FALLBACK.linkBorder}`,
-            borderRadius: 4,
-            padding: "6px 16px",
-            fontSize: 12,
-            fontWeight: 600,
-            color: FALLBACK.linkText,
-            textDecoration: "none",
-            fontFamily: "inherit",
-            cursor: "pointer",
-          }}
-        >
+        <a href={issueURL} target="_blank" rel="noopener noreferrer" style={REPORT_LINK_STYLE}>
           Report Issue on GitHub
         </a>
       </div>
@@ -180,17 +180,7 @@ export default class ErrorBoundary extends Component {
   render() {
     if (!this.state.error) return this.props.children;
     return (
-      <div
-        style={{
-          background: FALLBACK.bg,
-          color: FALLBACK.text,
-          minHeight: "100vh",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontFamily: "'JetBrains Mono','SF Mono','Fira Code',monospace",
-        }}
-      >
+      <div style={BOUNDARY_WRAPPER}>
         <ErrorDisplay
           error={this.state.error}
           context={{ component: "ErrorBoundary (top-level)" }}

--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -52,6 +52,60 @@ import {
 } from "../utils/featureFlags.js";
 import { ErrorDisplay } from "./ErrorBoundary.jsx";
 
+/* ── Hoisted static / near-static styles ── */
+const SLIDER_LABEL = { fontSize: 9.5, letterSpacing: "0.1em", transition: "color 0.3s" };
+const SLIDER_VALUE_BASE = {
+  fontSize: 14,
+  fontWeight: 700,
+  fontVariantNumeric: "tabular-nums",
+  transition: "color 0.3s",
+};
+const SLIDER_INPUT_BASE = {
+  flex: 1,
+  height: 4,
+  appearance: "none",
+  borderRadius: 2,
+  outline: "none",
+  cursor: "pointer",
+};
+const COLLAPSE_BTN_BASE = {
+  borderRadius: 10,
+  cursor: "pointer",
+  padding: "3px 8px",
+  display: "flex",
+  alignItems: "center",
+  gap: 4,
+  fontSize: 8,
+  fontFamily: "inherit",
+  letterSpacing: "0.08em",
+  transition: "all 0.25s",
+};
+const INSPECTOR_GRID = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit,minmax(125px,1fr))",
+  gap: "3px 18px",
+  fontSize: 10.5,
+  lineHeight: 1.8,
+};
+const TOGGLE_GROUP_BASE = {
+  display: "flex",
+  gap: 0,
+  borderRadius: 5,
+  overflow: "hidden",
+  width: "100%",
+  transition: "border-color 0.3s",
+};
+const TOGGLE_BTN_BASE = {
+  border: "none",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontFamily: "inherit",
+  letterSpacing: "0.08em",
+  transition: "all 0.25s",
+};
+
 /* ── Panel-level error boundary — catches render errors within a single diagram ──
  * Separate from the app-wide ErrorBoundary so that one broken lens doesn't
  * crash the entire comparison view. Resets automatically when lensKey changes. */
@@ -598,19 +652,10 @@ export default function LensDiagramPanel({
                   <button
                     onClick={() => onHeaderInfoExpandedChange?.(!headerInfoExpanded)}
                     style={{
+                      ...COLLAPSE_BTN_BASE,
                       background: t.toggleBg,
                       border: `1px solid ${t.toggleBorder}`,
-                      borderRadius: 10,
-                      cursor: "pointer",
-                      padding: "3px 8px",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 4,
-                      fontSize: 8,
                       color: t.muted,
-                      fontFamily: "inherit",
-                      letterSpacing: "0.08em",
-                      transition: "all 0.25s",
                     }}
                   >
                     <span>{headerInfoExpanded ? "LESS" : "MORE"}</span>
@@ -704,35 +749,18 @@ export default function LensDiagramPanel({
                   {/* Theme controls */}
                   {(isWide || !ENABLE_COLLAPSIBLE_HEADER_CONTROLS || headerControlsExpanded) && (
                     <>
-                      <div
-                        style={{
-                          display: "flex",
-                          gap: 0,
-                          borderRadius: 5,
-                          overflow: "hidden",
-                          border: `1px solid ${t.toggleBorder}`,
-                          width: "100%",
-                          transition: "border-color 0.3s",
-                        }}
-                      >
+                      <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}` }}>
                         <button
                           onClick={() => onHighContrastChange?.(!highContrast)}
                           style={{
+                            ...TOGGLE_BTN_BASE,
                             flex: 1,
                             background: highContrast ? t.toggleActiveBg : t.toggleBg,
-                            border: "none",
                             borderRight: `1px solid ${t.toggleBorder}`,
                             padding: "5px 10px",
-                            cursor: "pointer",
                             fontSize: 10,
                             color: highContrast ? t.toggleActiveText : t.toggleInactiveText,
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
                             gap: 5,
-                            transition: "all 0.3s",
-                            fontFamily: "inherit",
-                            letterSpacing: "0.08em",
                           }}
                         >
                           <span style={{ fontSize: 12, lineHeight: 1, fontWeight: 700 }}>◐</span>
@@ -741,20 +769,13 @@ export default function LensDiagramPanel({
                         <button
                           onClick={() => onDarkChange?.(!dark)}
                           style={{
+                            ...TOGGLE_BTN_BASE,
                             flex: 1,
                             background: t.toggleBg,
-                            border: "none",
                             padding: "5px 10px",
-                            cursor: "pointer",
                             fontSize: 10,
                             color: t.toggleInactiveText,
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
                             gap: 5,
-                            transition: "all 0.3s",
-                            fontFamily: "inherit",
-                            letterSpacing: "0.08em",
                           }}
                         >
                           <span style={{ fontSize: 14, lineHeight: 1 }}>{t.toggleIcon}</span>
@@ -762,17 +783,7 @@ export default function LensDiagramPanel({
                         </button>
                       </div>
                       {/* Ray toggles */}
-                      <div
-                        style={{
-                          display: "flex",
-                          gap: 0,
-                          borderRadius: 5,
-                          overflow: "hidden",
-                          border: `1px solid ${t.toggleBorder}`,
-                          width: "100%",
-                          transition: "border-color 0.3s",
-                        }}
-                      >
+                      <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}` }}>
                         {(() => {
                           const offAxisActive = showOffAxis !== "off";
                           const offAxisCycle = ENABLE_EDGE_PROJECTION
@@ -808,21 +819,14 @@ export default function LensDiagramPanel({
                               key={idx}
                               onClick={onClick}
                               style={{
+                                ...TOGGLE_BTN_BASE,
                                 flex: 1,
                                 background: active ? t.toggleActiveBg : t.toggleBg,
-                                border: "none",
                                 borderRight: idx === 0 ? `1px solid ${t.toggleBorder}` : "none",
                                 padding: "5px 8px",
-                                cursor: "pointer",
                                 fontSize: 9,
                                 color: active ? t.toggleActiveText : t.toggleInactiveText,
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
                                 gap: 5,
-                                transition: "all 0.25s",
-                                fontFamily: "inherit",
-                                letterSpacing: "0.08em",
                               }}
                             >
                               <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
@@ -849,17 +853,7 @@ export default function LensDiagramPanel({
                         })()}
                       </div>
                       {/* Ray mode */}
-                      <div
-                        style={{
-                          display: "flex",
-                          gap: 0,
-                          borderRadius: 5,
-                          overflow: "hidden",
-                          border: `1px solid ${t.toggleBorder}`,
-                          width: "100%",
-                          transition: "border-color 0.3s",
-                        }}
-                      >
+                      <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}` }}>
                         {[
                           { label: "FROM \u221e", val: false, icon: "\u2225" },
                           { label: "TRACKS FOCUS", val: true, icon: "\u27e9" },
@@ -868,21 +862,14 @@ export default function LensDiagramPanel({
                             key={label}
                             onClick={() => onRayTracksFChange?.(val)}
                             style={{
+                              ...TOGGLE_BTN_BASE,
                               flex: 1,
                               background: rayTracksF === val ? t.toggleActiveBg : t.toggleBg,
-                              border: "none",
                               borderRight: !val ? `1px solid ${t.toggleBorder}` : "none",
                               padding: "5px 9px",
-                              cursor: "pointer",
                               fontSize: 9,
                               color: rayTracksF === val ? t.toggleActiveText : t.toggleInactiveText,
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
                               gap: 4,
-                              transition: "all 0.25s",
-                              fontFamily: "inherit",
-                              letterSpacing: "0.08em",
                             }}
                           >
                             <span
@@ -901,35 +888,18 @@ export default function LensDiagramPanel({
                       </div>
                       {/* Chromatic */}
                       {ENABLE_COLOR_TRACING && (
-                        <div
-                          style={{
-                            display: "flex",
-                            gap: 0,
-                            borderRadius: 5,
-                            overflow: "hidden",
-                            border: `1px solid ${t.toggleBorder}`,
-                            width: "100%",
-                            transition: "border-color 0.3s",
-                          }}
-                        >
+                        <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}` }}>
                           <button
                             onClick={() => onShowChromaticChange?.(!showChromatic)}
                             style={{
+                              ...TOGGLE_BTN_BASE,
                               flex: 1,
                               background: showChromatic ? t.toggleActiveBg : t.toggleBg,
-                              border: "none",
                               borderRight: showChromatic ? `1px solid ${t.toggleBorder}` : "none",
                               padding: "5px 8px",
-                              cursor: "pointer",
                               fontSize: 9,
                               color: showChromatic ? t.toggleActiveText : t.toggleInactiveText,
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
                               gap: 5,
-                              transition: "all 0.25s",
-                              fontFamily: "inherit",
-                              letterSpacing: "0.08em",
                             }}
                           >
                             <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
@@ -970,21 +940,14 @@ export default function LensDiagramPanel({
                                 key={ch}
                                 onClick={() => set?.(!active)}
                                 style={{
+                                  ...TOGGLE_BTN_BASE,
                                   flex: 0.6,
                                   background: active ? t.toggleActiveBg : t.toggleBg,
-                                  border: "none",
                                   borderRight: idx < 2 ? `1px solid ${t.toggleBorder}` : "none",
                                   padding: "5px 6px",
-                                  cursor: "pointer",
                                   fontSize: 9,
                                   color: active ? t.toggleActiveText : t.toggleInactiveText,
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
                                   gap: 3,
-                                  transition: "all 0.25s",
-                                  fontFamily: "inherit",
-                                  letterSpacing: "0.08em",
                                 }}
                               >
                                 <span
@@ -1522,26 +1485,8 @@ export default function LensDiagramPanel({
                     }
                   >
                     <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-                      <span
-                        style={{
-                          fontSize: 9.5,
-                          color: t.label,
-                          letterSpacing: "0.1em",
-                          minWidth: 55,
-                          transition: "color 0.3s",
-                        }}
-                      >
-                        ZOOM
-                      </span>
-                      <span
-                        style={{
-                          fontSize: 14,
-                          color: t.focusDist,
-                          fontWeight: 700,
-                          fontVariantNumeric: "tabular-nums",
-                          transition: "color 0.3s",
-                        }}
-                      >
+                      <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 55 }}>ZOOM</span>
+                      <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>
                         {eflAtZoom(zoomT, L).toFixed(0)} mm
                       </span>
                     </div>
@@ -1555,16 +1500,7 @@ export default function LensDiagramPanel({
                         value={zoomT}
                         onChange={(e) => onZoomChange?.(parseFloat(e.target.value))}
                         onPointerUp={onSliderPointerUp}
-                        style={{
-                          flex: 1,
-                          height: 4,
-                          appearance: "none",
-                          background: t.sliderTrack,
-                          borderRadius: 2,
-                          outline: "none",
-                          cursor: "pointer",
-                          accentColor: t.sliderAccent,
-                        }}
+                        style={{ ...SLIDER_INPUT_BASE, background: t.sliderTrack, accentColor: t.sliderAccent }}
                       />
                       <span style={{ fontSize: 9, color: t.focusEndpoint }}>
                         {L.zoomPositions[L.zoomPositions.length - 1]} mm
@@ -1586,46 +1522,17 @@ export default function LensDiagramPanel({
                     }
                   >
                     <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-                      <span
-                        style={{
-                          fontSize: 9.5,
-                          color: t.label,
-                          letterSpacing: "0.1em",
-                          minWidth: 85,
-                          transition: "color 0.3s",
-                        }}
-                      >
-                        FOCUS
-                      </span>
-                      <span
-                        style={{
-                          fontSize: 14,
-                          color: t.focusDist,
-                          fontWeight: 700,
-                          fontVariantNumeric: "tabular-nums",
-                          transition: "color 0.3s",
-                        }}
-                      >
-                        {formatDist(focusT, L)}
-                      </span>
+                      <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 85 }}>FOCUS</span>
+                      <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>{formatDist(focusT, L)}</span>
                       {ENABLE_COLLAPSIBLE_FOCUS && (
                         <button
                           onClick={() => onFocusExpandedChange?.(!focusExpanded)}
                           style={{
+                            ...COLLAPSE_BTN_BASE,
                             marginLeft: "auto",
                             background: t.toggleBg,
                             border: `1px solid ${t.toggleBorder}`,
-                            borderRadius: 10,
-                            cursor: "pointer",
-                            padding: "3px 8px",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 4,
-                            fontSize: 8,
                             color: t.muted,
-                            fontFamily: "inherit",
-                            letterSpacing: "0.08em",
-                            transition: "all 0.25s",
                           }}
                         >
                           <span>{focusExpanded ? "LESS" : "MORE"}</span>
@@ -1643,16 +1550,7 @@ export default function LensDiagramPanel({
                         value={focusT}
                         onChange={(e) => onFocusChange?.(parseFloat(e.target.value))}
                         onPointerUp={onSliderPointerUp}
-                        style={{
-                          flex: 1,
-                          height: 4,
-                          appearance: "none",
-                          background: t.sliderTrack,
-                          borderRadius: 2,
-                          outline: "none",
-                          cursor: "pointer",
-                          accentColor: t.sliderAccent,
-                        }}
+                        style={{ ...SLIDER_INPUT_BASE, background: t.sliderTrack, accentColor: t.sliderAccent }}
                       />
                       <span style={{ fontSize: 9, color: t.focusEndpoint }}>{L.closeFocusM} m</span>
                     </div>
@@ -1704,46 +1602,19 @@ export default function LensDiagramPanel({
                     }
                   >
                     <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-                      <span
-                        style={{
-                          fontSize: 9.5,
-                          color: t.label,
-                          letterSpacing: "0.1em",
-                          minWidth: 85,
-                          transition: "color 0.3s",
-                        }}
-                      >
-                        APERTURE
-                      </span>
-                      <span
-                        style={{
-                          fontSize: 14,
-                          color: t.focusDist,
-                          fontWeight: 700,
-                          fontVariantNumeric: "tabular-nums",
-                          transition: "color 0.3s",
-                        }}
-                      >
+                      <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 85 }}>APERTURE</span>
+                      <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>
                         f/{fNumber < 10 ? fNumber.toFixed(1) : Math.round(fNumber)}
                       </span>
                       {ENABLE_COLLAPSIBLE_APERTURE && (
                         <button
                           onClick={() => onApertureExpandedChange?.(!apertureExpanded)}
                           style={{
+                            ...COLLAPSE_BTN_BASE,
                             marginLeft: "auto",
                             background: t.toggleBg,
                             border: `1px solid ${t.toggleBorder}`,
-                            borderRadius: 10,
-                            cursor: "pointer",
-                            padding: "3px 8px",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 4,
-                            fontSize: 8,
                             color: t.muted,
-                            fontFamily: "inherit",
-                            letterSpacing: "0.08em",
-                            transition: "all 0.25s",
                           }}
                         >
                           <span>{apertureExpanded ? "LESS" : "MORE"}</span>
@@ -1761,16 +1632,7 @@ export default function LensDiagramPanel({
                         value={stopdownT}
                         onChange={(e) => onStopdownChange?.(parseFloat(e.target.value))}
                         onPointerUp={onSliderPointerUp}
-                        style={{
-                          flex: 1,
-                          height: 4,
-                          appearance: "none",
-                          background: t.sliderTrack,
-                          borderRadius: 2,
-                          outline: "none",
-                          cursor: "pointer",
-                          accentColor: t.sliderAccent,
-                        }}
+                        style={{ ...SLIDER_INPUT_BASE, background: t.sliderTrack, accentColor: t.sliderAccent }}
                       />
                       <span style={{ fontSize: 9, color: t.focusEndpoint }}>f/{L.maxFstop}</span>
                     </div>
@@ -1929,15 +1791,7 @@ export default function LensDiagramPanel({
                       <div style={{ fontSize: 10.5, color: t.elemType, marginBottom: 5, transition: "color 0.3s" }}>
                         {info.type}
                       </div>
-                      <div
-                        style={{
-                          display: "grid",
-                          gridTemplateColumns: "repeat(auto-fit,minmax(125px,1fr))",
-                          gap: "3px 18px",
-                          fontSize: 10.5,
-                          lineHeight: 1.8,
-                        }}
-                      >
+                      <div style={INSPECTOR_GRID}>
                         <div>
                           <span style={{ color: t.propLabel }}>nd = </span>
                           <span style={{ color: t.value }}>{info.nd}</span>
@@ -1978,16 +1832,7 @@ export default function LensDiagramPanel({
                         })()}
                       </div>
                       {showChromatic && info.vd && (
-                        <div
-                          style={{
-                            marginTop: 4,
-                            display: "grid",
-                            gridTemplateColumns: "repeat(auto-fit,minmax(125px,1fr))",
-                            gap: "3px 18px",
-                            fontSize: 10.5,
-                            lineHeight: 1.8,
-                          }}
-                        >
+                        <div style={{ ...INSPECTOR_GRID, marginTop: 4 }}>
                           <div>
                             <span style={{ color: t.propLabel }}>nF{"\u2212"}nC = </span>
                             <span style={{ color: t.value }}>{((info.nd - 1) / info.vd).toFixed(5)}</span>
@@ -2068,20 +1913,11 @@ export default function LensDiagramPanel({
                           <button
                             onClick={() => onLegendExpandedChange?.(!legendExpanded)}
                             style={{
+                              ...COLLAPSE_BTN_BASE,
                               marginLeft: "auto",
                               background: t.toggleBg,
                               border: `1px solid ${t.toggleBorder}`,
-                              borderRadius: 10,
-                              cursor: "pointer",
-                              padding: "3px 8px",
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 4,
-                              fontSize: 8,
                               color: t.muted,
-                              fontFamily: "inherit",
-                              letterSpacing: "0.08em",
-                              transition: "all 0.25s",
                             }}
                           >
                             LEGEND <span style={{ fontSize: 11, lineHeight: 1 }}>{legendExpanded ? "▴" : "▾"}</span>

--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -52,6 +52,51 @@ import { ErrorDisplay } from "./ErrorBoundary.jsx";
 import ABOUT_ME_MD from "../content/AboutMe.md?raw";
 import ABOUT_SITE_MD from "../content/AboutSite.md?raw";
 
+/* ── Hoisted static / near-static styles ── */
+const TOGGLE_GROUP_BASE = {
+  display: "flex",
+  gap: 0,
+  borderRadius: 5,
+  overflow: "hidden",
+};
+
+const OVERLAY_BACKDROP = {
+  position: "fixed",
+  inset: 0,
+  zIndex: 9999,
+  background: "rgba(0,0,0,0.5)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  transition: "background 0.2s",
+};
+
+const OVERLAY_MODAL_BASE = {
+  borderRadius: 10,
+  maxWidth: 480,
+  width: "90%",
+  maxHeight: "70vh",
+  overflowY: "auto",
+  position: "relative",
+  boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
+};
+
+const CLOSE_BTN_BASE = {
+  position: "sticky",
+  top: 0,
+  float: "right",
+  margin: "10px 10px 0 0",
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: 18,
+  fontFamily: "inherit",
+  lineHeight: 1,
+  padding: "2px 6px",
+  borderRadius: 4,
+  zIndex: 1,
+};
+
 /* =====================================================================
  * §6  RENDERER — React component
  * =====================================================================
@@ -604,10 +649,7 @@ export default function LensVisualization() {
       {/* Theme controls */}
       <div
         style={{
-          display: "flex",
-          gap: 0,
-          borderRadius: 5,
-          overflow: "hidden",
+          ...TOGGLE_GROUP_BASE,
           border: `1px solid ${t.toggleBorder}`,
           width: 120,
           transition: "border-color 0.3s",
@@ -626,10 +668,7 @@ export default function LensVisualization() {
       {/* Ray toggles */}
       <div
         style={{
-          display: "flex",
-          gap: 0,
-          borderRadius: 5,
-          overflow: "hidden",
+          ...TOGGLE_GROUP_BASE,
           border: `1px solid ${t.toggleBorder}`,
           width: 180,
           transition: "border-color 0.3s",
@@ -677,10 +716,7 @@ export default function LensVisualization() {
       {/* Ray mode */}
       <div
         style={{
-          display: "flex",
-          gap: 0,
-          borderRadius: 5,
-          overflow: "hidden",
+          ...TOGGLE_GROUP_BASE,
           border: `1px solid ${t.toggleBorder}`,
           width: 180,
           transition: "border-color 0.3s",
@@ -703,10 +739,7 @@ export default function LensVisualization() {
       {ENABLE_COLOR_TRACING && (
         <div
           style={{
-            display: "flex",
-            gap: 0,
-            borderRadius: 5,
-            overflow: "hidden",
+            ...TOGGLE_GROUP_BASE,
             border: `1px solid ${t.toggleBorder}`,
             width: showChromatic ? 220 : 90,
             transition: "border-color 0.3s, width 0.3s",
@@ -786,10 +819,7 @@ export default function LensVisualization() {
       {/* Scale mode toggle */}
       <div
         style={{
-          display: "flex",
-          gap: 0,
-          borderRadius: 5,
-          overflow: "hidden",
+          ...TOGGLE_GROUP_BASE,
           border: `1px solid ${t.toggleBorder}`,
           width: 190,
           transition: "border-color 0.3s",
@@ -894,16 +924,7 @@ export default function LensVisualization() {
         }}
       >
         {/* Theme controls */}
-        <div
-          style={{
-            display: "flex",
-            gap: 0,
-            borderRadius: 5,
-            overflow: "hidden",
-            border: `1px solid ${t.toggleBorder}`,
-            transition: "border-color 0.3s",
-          }}
-        >
+        <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}`, transition: "border-color 0.3s" }}>
           <button onClick={() => setHighContrast(!highContrast)} style={toggleBtnStyle(highContrast, true)}>
             <span style={{ fontSize: 12, lineHeight: 1, fontWeight: 700 }}>◐</span>
             <span>HC</span>
@@ -915,16 +936,7 @@ export default function LensVisualization() {
         </div>
 
         {/* Ray toggles */}
-        <div
-          style={{
-            display: "flex",
-            gap: 0,
-            borderRadius: 5,
-            overflow: "hidden",
-            border: `1px solid ${t.toggleBorder}`,
-            transition: "border-color 0.3s",
-          }}
-        >
+        <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}`, transition: "border-color 0.3s" }}>
           {(() => {
             const offAxisActive = showOffAxis !== "off";
             const offAxisCycle = ENABLE_EDGE_PROJECTION
@@ -979,16 +991,7 @@ export default function LensVisualization() {
         </div>
 
         {/* Ray mode */}
-        <div
-          style={{
-            display: "flex",
-            gap: 0,
-            borderRadius: 5,
-            overflow: "hidden",
-            border: `1px solid ${t.toggleBorder}`,
-            transition: "border-color 0.3s",
-          }}
-        >
+        <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}`, transition: "border-color 0.3s" }}>
           {[
             { label: "\u221e", val: false },
             { label: "\u27e9 F", val: true },
@@ -1005,16 +1008,7 @@ export default function LensVisualization() {
 
         {/* Chromatic */}
         {ENABLE_COLOR_TRACING && (
-          <div
-            style={{
-              display: "flex",
-              gap: 0,
-              borderRadius: 5,
-              overflow: "hidden",
-              border: `1px solid ${t.toggleBorder}`,
-              transition: "border-color 0.3s",
-            }}
-          >
+          <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}`, transition: "border-color 0.3s" }}>
             <button
               onClick={() => setShowChromatic(!showChromatic)}
               style={toggleBtnStyle(showChromatic, showChromatic)}
@@ -1267,16 +1261,7 @@ export default function LensVisualization() {
             transition: "background-color 0.3s,border-color 0.3s",
           }}
         >
-          <div
-            style={{
-              display: "flex",
-              gap: 0,
-              borderRadius: 5,
-              overflow: "hidden",
-              border: `1px solid ${t.toggleBorder}`,
-              width: 220,
-            }}
-          >
+          <div style={{ ...TOGGLE_GROUP_BASE, border: `1px solid ${t.toggleBorder}`, width: 220 }}>
             {[
               { label: "DIAGRAM", val: "diagram" },
               { label: "ANALYSIS", val: "description" },
@@ -1413,52 +1398,12 @@ export default function LensVisualization() {
 
       {/* ── About Site overlay ── */}
       {showAboutSite && (
-        <div
-          onClick={() => setShowAboutSite(false)}
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 9999,
-            background: "rgba(0,0,0,0.5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            transition: "background 0.2s",
-          }}
-        >
+        <div onClick={() => setShowAboutSite(false)} style={OVERLAY_BACKDROP}>
           <div
             onClick={(e) => e.stopPropagation()}
-            style={{
-              background: t.descBg,
-              borderRadius: 10,
-              maxWidth: 480,
-              width: "90%",
-              maxHeight: "70vh",
-              overflowY: "auto",
-              position: "relative",
-              boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
-              border: `1px solid ${t.descBorder}`,
-            }}
+            style={{ ...OVERLAY_MODAL_BASE, background: t.descBg, border: `1px solid ${t.descBorder}` }}
           >
-            <button
-              onClick={() => setShowAboutSite(false)}
-              style={{
-                position: "sticky",
-                top: 0,
-                float: "right",
-                margin: "10px 10px 0 0",
-                background: "none",
-                border: "none",
-                color: t.muted,
-                cursor: "pointer",
-                fontSize: 18,
-                fontFamily: "inherit",
-                lineHeight: 1,
-                padding: "2px 6px",
-                borderRadius: 4,
-                zIndex: 1,
-              }}
-            >
+            <button onClick={() => setShowAboutSite(false)} style={{ ...CLOSE_BTN_BASE, color: t.muted }}>
               ×
             </button>
             <DescriptionPanel markdown={ABOUT_SITE_MD} theme={t} />
@@ -1468,52 +1413,12 @@ export default function LensVisualization() {
 
       {/* ── About Me overlay ── */}
       {showAbout && (
-        <div
-          onClick={() => setShowAbout(false)}
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 9999,
-            background: "rgba(0,0,0,0.5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            transition: "background 0.2s",
-          }}
-        >
+        <div onClick={() => setShowAbout(false)} style={OVERLAY_BACKDROP}>
           <div
             onClick={(e) => e.stopPropagation()}
-            style={{
-              background: t.descBg,
-              borderRadius: 10,
-              maxWidth: 480,
-              width: "90%",
-              maxHeight: "70vh",
-              overflowY: "auto",
-              position: "relative",
-              boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
-              border: `1px solid ${t.descBorder}`,
-            }}
+            style={{ ...OVERLAY_MODAL_BASE, background: t.descBg, border: `1px solid ${t.descBorder}` }}
           >
-            <button
-              onClick={() => setShowAbout(false)}
-              style={{
-                position: "sticky",
-                top: 0,
-                float: "right",
-                margin: "10px 10px 0 0",
-                background: "none",
-                border: "none",
-                color: t.muted,
-                cursor: "pointer",
-                fontSize: 18,
-                fontFamily: "inherit",
-                lineHeight: 1,
-                padding: "2px 6px",
-                borderRadius: 4,
-                zIndex: 1,
-              }}
-            >
+            <button onClick={() => setShowAbout(false)} style={{ ...CLOSE_BTN_BASE, color: t.muted }}>
               ×
             </button>
             <DescriptionPanel markdown={ABOUT_ME_MD} theme={t} />

--- a/src/components/SharedSlidersBar.jsx
+++ b/src/components/SharedSlidersBar.jsx
@@ -31,6 +31,21 @@
 import { formatSharedFocusDist, sharedFNumber } from "../utils/comparisonSliders.js";
 import { formatDist, eflAtZoom } from "../optics/optics.js";
 
+/* ── Hoisted static styles ── */
+const SLIDER_INPUT_BASE = {
+  width: "100%",
+  height: 4,
+  appearance: "none",
+  borderRadius: 2,
+  outline: "none",
+  cursor: "pointer",
+};
+const SLIDER_LABEL = { fontSize: 9.5, letterSpacing: "0.1em" };
+const SLIDER_VALUE_BASE = { fontSize: 14, fontWeight: 700, fontVariantNumeric: "tabular-nums" };
+const SLIDER_ROW = { display: "flex", alignItems: "center", gap: 8 };
+const READOUT_ROW = { marginTop: 6, display: "flex", gap: 16, fontSize: 9, fontVariantNumeric: "tabular-nums" };
+const LABEL_ROW = { display: "flex", alignItems: "center", gap: 10, marginBottom: 8 };
+
 export default function SharedSlidersBar({
   LA,
   LB,
@@ -125,13 +140,11 @@ export default function SharedSlidersBar({
         {/* Zoom slider (only when at least one lens is a zoom) */}
         {showZoom && (
           <div style={{ flex: 1 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-              <span style={{ fontSize: 9.5, color: t.label, letterSpacing: "0.1em", minWidth: 55 }}>ZOOM</span>
-              <span style={{ fontSize: 14, color: t.focusDist, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
-                {zoomEfl} mm
-              </span>
+            <div style={LABEL_ROW}>
+              <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 55 }}>ZOOM</span>
+              <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>{zoomEfl} mm</span>
             </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div style={SLIDER_ROW}>
               <span style={{ fontSize: 9, color: t.focusEndpoint }}>{zoomMinLabel}</span>
               <div style={sliderWrap}>
                 {showZoomCPLow && <div style={markerStyle(zoomPair.commonPointLow)} />}
@@ -146,30 +159,12 @@ export default function SharedSlidersBar({
                   value={sharedZoomT}
                   onChange={(e) => onSharedZoomChange(parseFloat(e.target.value))}
                   onPointerUp={onSliderPointerUp}
-                  style={{
-                    width: "100%",
-                    height: 4,
-                    appearance: "none",
-                    background: t.sliderTrack,
-                    borderRadius: 2,
-                    outline: "none",
-                    cursor: "pointer",
-                    accentColor: t.sliderAccent,
-                  }}
+                  style={{ ...SLIDER_INPUT_BASE, background: t.sliderTrack, accentColor: t.sliderAccent }}
                 />
               </div>
               <span style={{ fontSize: 9, color: t.focusEndpoint }}>{zoomMaxLabel}</span>
             </div>
-            <div
-              style={{
-                marginTop: 6,
-                display: "flex",
-                gap: 16,
-                fontSize: 9,
-                color: t.spacingVal,
-                fontVariantNumeric: "tabular-nums",
-              }}
-            >
+            <div style={{ ...READOUT_ROW, color: t.spacingVal }}>
               <span>A: {zoomReadoutA}</span>
               <span>B: {zoomReadoutB}</span>
             </div>
@@ -178,13 +173,11 @@ export default function SharedSlidersBar({
 
         {/* Focus slider */}
         <div style={{ flex: 1 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-            <span style={{ fontSize: 9.5, color: t.label, letterSpacing: "0.1em", minWidth: 55 }}>FOCUS</span>
-            <span style={{ fontSize: 14, color: t.focusDist, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
-              {focusDistStr}
-            </span>
+          <div style={LABEL_ROW}>
+            <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 55 }}>FOCUS</span>
+            <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>{focusDistStr}</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={SLIDER_ROW}>
             <span style={{ fontSize: 9, color: t.focusEndpoint }}>{"\u221e"}</span>
             <div style={sliderWrap}>
               {showFocusCP && <div style={markerStyle(focusCP)} />}
@@ -213,16 +206,7 @@ export default function SharedSlidersBar({
             <span style={{ fontSize: 9, color: t.focusEndpoint }}>{minCloseFocus} m</span>
           </div>
           {/* Per-lens readouts */}
-          <div
-            style={{
-              marginTop: 6,
-              display: "flex",
-              gap: 16,
-              fontSize: 9,
-              color: t.spacingVal,
-              fontVariantNumeric: "tabular-nums",
-            }}
-          >
+          <div style={{ ...READOUT_ROW, color: t.spacingVal }}>
             <span>A: {formatDist(focusPair.focusA, LA)}</span>
             <span>B: {formatDist(focusPair.focusB, LB)}</span>
           </div>
@@ -230,13 +214,13 @@ export default function SharedSlidersBar({
 
         {/* Aperture slider */}
         <div style={{ flex: 1 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-            <span style={{ fontSize: 9.5, color: t.label, letterSpacing: "0.1em", minWidth: 75 }}>APERTURE</span>
-            <span style={{ fontSize: 14, color: t.focusDist, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+          <div style={LABEL_ROW}>
+            <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 75 }}>APERTURE</span>
+            <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>
               f/{fNum < 10 ? fNum.toFixed(1) : Math.round(fNum)}
             </span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={SLIDER_ROW}>
             <span style={{ fontSize: 9, color: t.focusEndpoint }}>f/{widerFOPEN.toFixed(1)}</span>
             <div style={sliderWrap}>
               {showApertureCP && <div style={markerStyle(apertureCP)} />}
@@ -265,17 +249,7 @@ export default function SharedSlidersBar({
             <span style={{ fontSize: 9, color: t.focusEndpoint }}>f/{sharedMaxFstop}</span>
           </div>
           {/* f-stop quick-select (union of both series) */}
-          <div
-            style={{
-              marginTop: 6,
-              display: "flex",
-              gap: 14,
-              flexWrap: "wrap",
-              fontSize: 9,
-              color: t.spacingVal,
-              fontVariantNumeric: "tabular-nums",
-            }}
-          >
+          <div style={{ ...READOUT_ROW, gap: 14, flexWrap: "wrap", color: t.spacingVal }}>
             {/* Merge both lenses' f-stop series into a sorted union, filter to the
               valid shared range, then compute each f-number's slider position.
               stopT = log(f/fOpen) / log(fMax/fOpen) maps f-number → [0..1] via


### PR DESCRIPTION
Extract repeated inline style objects to module-level constants across all 5 components, reducing duplication and improving readability. Key changes: useMemo for DescriptionPanel markdown renderers, TOGGLE_GROUP_BASE/TOGGLE_BTN_BASE/COLLAPSE_BTN_BASE/SLIDER_INPUT_BASE constants, and OVERLAY_BACKDROP/OVERLAY_MODAL_BASE for modal styles.