### PR TITLE
Update lens-data docs: fix scFill default, add zoom lens instructions

### DIFF
--- a/agent_docs/adding_a_lens.md
+++ b/agent_docs/adding_a_lens.md
@@ -38,4 +38,30 @@ Surface `sd` values are the most common source of rendering bugs. If validation 
 
 ### Validation
 
-`buildLens()` calls `validateLensData()` internally. Malformed data throws descriptive errors listing all issues. The validator checks: required fields, surface label uniqueness, element ID references, STO surface presence, edge thickness, SD consistency, sd/|R| ratio (max 0.90), cross-gap overlap, and conic height limits (K > 0).
+`buildLens()` calls `validateLensData()` internally. Malformed data throws descriptive errors listing all issues. The validator checks: required fields, surface label uniqueness, element ID references, STO surface presence, edge thickness, SD consistency, sd/|R| ratio (max 0.90), cross-gap overlap (at all zoom positions for zoom lenses), and conic height limits (K > 0).
+
+### Zoom Lenses
+
+If the patent describes a variable focal-length lens with spacing tables at multiple focal lengths, add zoom fields:
+
+**Required zoom fields:**
+- `zoomPositions`: Array of focal lengths in mm (at least 2, monotonically increasing) from the patent's variable spacing table column headers — e.g., `[71.5, 135, 196]`
+- `var` format change: Each value becomes an array of `[d_inf, d_close]` pairs, one per zoom position (instead of a single pair for primes)
+
+**Optional zoom fields:**
+- `zoomStep`: Zoom slider step size (default `0.004`)
+- `zoomLabels`: Endpoint labels — e.g., `["Wide", "Tele"]`
+
+**Zoom-only vs zoom+focus gaps:**
+- Gaps that only change with zoom (no focus variation): use identical inf/close values — e.g., `[[1.0, 1.0], [3.0, 3.0]]`
+- Gaps that change with both zoom and focus: use different inf/close values at each position
+
+**File header:** Document which gaps are zoom-only vs zoom+focus, and note any non-monotonic (reversing) groups. See the header in `src/lens-data/NikonNikkorZ70200f28.data.js` for an example.
+
+**Zoom-specific validation:**
+- `zoomPositions` must be monotonically increasing finite numbers
+- `var` pair count must match `zoomPositions.length`
+- Surface `d` must match `var[label][0][0]` (first zoom position, infinity focus)
+- Cross-gap overlap is checked at every zoom position
+
+**References:** Zoom Lens Fields section in `src/lens-data/LENS_DATA_SPEC.md`, zoom fields section in the template, and `src/lens-data/NikonNikkorZ70200f28.data.js` as a working example.

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -4,7 +4,7 @@ Reference for creating new `*.data.js` files in `lens-data/`.
 
 ## Quick Start
 
-1. Copy `TEMPLATE.data.js` to `YourLens.data.js`
+1. Copy `TEMPLATE.data.js.template` to `YourLens.data.js`
 2. Fill in all fields following this spec
 3. Optionally add `YourLens.analysis.md` for the description panel
 4. Auto-registration picks it up — no imports or catalog edits needed
@@ -47,6 +47,7 @@ These are merged automatically. Override only when needed.
 | `lensShiftFrac` | `0.08` | Horizontal lens shift (fraction of SVG width) |
 | `offAxisFieldFrac` | `0.60` | Off-axis field angle (fraction of max half-field) |
 | `offAxisFractions` | `[-0.75, -0.375, 0, 0.375, 0.75]` | Off-axis ray fan heights |
+| `scFill` | `0.55` | Horizontal fill fraction (0–1) — layout tuning |
 
 ### Required (per-lens, no defaults)
 
@@ -54,7 +55,6 @@ These must be specified in every lens file — they have no defaults.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `scFill` | `number` | Horizontal fill fraction (0–1) — layout tuning |
 | `yScFill` | `number` | Vertical fill fraction (0–1) — layout tuning |
 
 ### Optional
@@ -364,6 +364,13 @@ When transcribing from an optical patent:
 10. **EFL verification** — After transcribing all surfaces, verify the computed EFL (from `buildLens()` or tests) matches the patent's stated focal length (scaled if applicable). A mismatch usually indicates a sign error in R or a wrong nd value
 11. **Cross-reference patent text** — Compare the patent's prose element descriptions (e.g., "plano-convex", "biconcave") against your transcribed R values. Older patents sometimes use approximate language — "plane" may mean "very weakly curved" if the numerical example has a finite but large R
 
+### Zoom-Specific Sourcing (additional steps for zoom lenses)
+
+12. **Variable spacing tables at multiple focal lengths** — Look for tables giving air gap values at 3–5 focal length positions (wide/mid/tele). The column header focal lengths become `zoomPositions`; each gap row provides the per-position `var` pairs
+13. **Zoom-only vs zoom+focus gaps** — Identify which variable gaps change only with zoom (the patent's infinity-focus spacing varies across focal lengths, but the close-focus table shows the same change pattern) vs gaps that change with both zoom and focus (different infinity/close values at each position). Document which is which in the file header
+14. **Non-monotonic (reversing) groups** — Check whether any gap's spacing goes up then down (or vice versa) across zoom positions — e.g., `[28.12, 22.59, 27.71]`. This is handled automatically by piecewise-linear interpolation, but include enough zoom positions to bracket any reversals. Note reversals in the file header
+15. **EFL verification at each zoom position** — After transcribing all surfaces and variable gaps, verify the computed EFL at each zoom position (from `buildLens()` → `zoomEFLs`) against the patent's stated focal lengths. Mismatches usually indicate a transcription error in the variable gap table
+
 ---
 
 ## Example: Minimal All-Spherical Singlet
@@ -393,3 +400,33 @@ const LENS_DATA = {
 };
 export default LENS_DATA;
 ```
+
+---
+
+## Example: Zoom Lens Variable-Gap Structure
+
+The zoom-specific fields added alongside normal lens fields. For a complete working example, see `NikonNikkorZ70200f28.data.js`.
+
+```javascript
+// Zoom positions — focal lengths in mm (≥2, monotonically increasing)
+zoomPositions: [24, 50, 70],
+zoomStep: 0.004,
+zoomLabels: ["Wide", "Tele"],
+
+// Variable air spacings — one [d_inf, d_close] pair per zoom position
+var: {
+  // Zoom-only gap: identical inf/close values at each position
+  "5":  [[2.0, 2.0], [5.0, 5.0], [3.5, 3.5]],
+  // Zoom + focus gap: different inf/close values
+  "10": [[8.0, 6.5], [5.0, 3.2], [6.5, 5.0]],
+  // Another zoom + focus gap
+  "15": [[12.0, 14.5], [15.0, 17.8], [13.5, 16.0]],
+},
+varLabels: [
+  ["5",  "D5"],
+  ["10", "D10"],
+  ["15", "BF"],
+],
+```
+
+Each surface's `d` field must equal its first zoom position's infinity value — e.g., surface `"5"` has `d: 2.0` (matching `var["5"][0][0]`).

--- a/src/lens-data/TEMPLATE.data.js.template
+++ b/src/lens-data/TEMPLATE.data.js.template
@@ -7,6 +7,12 @@
  * ║  [N] elements / [N] groups, [N] aspherical surfaces.              ║
  * ║  Focus: [focus mechanism description].                             ║
  * ║                                                                    ║
+ * ║  FOR ZOOM LENSES, also document:                                   ║
+ * ║    Internal zoom (constant overall length N mm).  [if applicable] ║
+ * ║    Zoom variable gaps: D5, D13 (zoom only).                       ║
+ * ║    Focus variable gaps: D30, D34 (zoom + focus).                  ║
+ * ║    Reversing groups: D34 (non-monotonic).         [if applicable] ║
+ * ║                                                                    ║
  * ║  NOTE ON SCALING (if applicable):                                   ║
  * ║    [If patent data is at a different focal length, note the scale  ║
  * ║    factor applied to R, d, and sd values here.  E.g.:             ║
@@ -233,8 +239,8 @@ const LENS_DATA = {
   /* ── Layout tuning (overrides defaults from defaults.js) ──
    *  Only include if the defaults don't work well for this lens.
    *
-   *  scFill   (0–1)  Horizontal fill fraction for the lens diagram
-   *  yScFill  (0–1)  Vertical fill fraction for the lens diagram
+   *  scFill   (0–1)  Horizontal fill fraction (default: 0.55 from defaults.js)
+   *  yScFill  (0–1)  Vertical fill fraction (no default — must be specified per lens)
    *
    *  Other overridable defaults (usually fine as-is):
    *    svgW: 1080, svgH: 490, clipMargin: 1.0, maxRimAngleDeg: 40,
@@ -244,7 +250,7 @@ const LENS_DATA = {
    *    rayLeadFrac: 0.35, lensShiftFrac: 0.08, offAxisFieldFrac: 0.60,
    *    offAxisFractions: [-0.75, -0.375, 0, 0.375, 0.75]
    */
-  scFill:           0.50,
+  scFill:           0.50,   // override default 0.55 if needed
   yScFill:          0.30,
 };
 


### PR DESCRIPTION
- Fix scFill incorrectly listed as "no default" when defaults.js has 0.55
- Fix template filename typo in Quick Start
- Add zoom-specific items to Data Sourcing Checklist
- Add zoom lens variable-gap structure example to spec
- Add zoom header documentation example to template
- Add Zoom Lenses section to adding_a_lens.md guide

https://claude.ai/code/session_01YP9UC5Ayn5j6VMbsJBVUD7