### PR TITLE
Fix inconsistent button heights in comparison and mobile views

### DIFF
--- a/src/components/LensDiagramPanel.jsx
+++ b/src/components/LensDiagramPanel.jsx
@@ -104,6 +104,8 @@ const TOGGLE_BTN_BASE = {
   fontFamily: "inherit",
   letterSpacing: "0.08em",
   transition: "all 0.25s",
+  minHeight: 28,
+  fontSize: 9,
 };
 
 /* ── Panel-level error boundary — catches render errors within a single diagram ──
@@ -757,8 +759,7 @@ export default function LensDiagramPanel({
                             flex: 1,
                             background: highContrast ? t.toggleActiveBg : t.toggleBg,
                             borderRight: `1px solid ${t.toggleBorder}`,
-                            padding: "5px 10px",
-                            fontSize: 10,
+                            padding: "5px 8px",
                             color: highContrast ? t.toggleActiveText : t.toggleInactiveText,
                             gap: 5,
                           }}
@@ -772,8 +773,7 @@ export default function LensDiagramPanel({
                             ...TOGGLE_BTN_BASE,
                             flex: 1,
                             background: t.toggleBg,
-                            padding: "5px 10px",
-                            fontSize: 10,
+                            padding: "5px 8px",
                             color: t.toggleInactiveText,
                             gap: 5,
                           }}
@@ -824,7 +824,6 @@ export default function LensDiagramPanel({
                                 background: active ? t.toggleActiveBg : t.toggleBg,
                                 borderRight: idx === 0 ? `1px solid ${t.toggleBorder}` : "none",
                                 padding: "5px 8px",
-                                fontSize: 9,
                                 color: active ? t.toggleActiveText : t.toggleInactiveText,
                                 gap: 5,
                               }}
@@ -866,8 +865,7 @@ export default function LensDiagramPanel({
                               flex: 1,
                               background: rayTracksF === val ? t.toggleActiveBg : t.toggleBg,
                               borderRight: !val ? `1px solid ${t.toggleBorder}` : "none",
-                              padding: "5px 9px",
-                              fontSize: 9,
+                              padding: "5px 8px",
                               color: rayTracksF === val ? t.toggleActiveText : t.toggleInactiveText,
                               gap: 4,
                             }}
@@ -897,7 +895,6 @@ export default function LensDiagramPanel({
                               background: showChromatic ? t.toggleActiveBg : t.toggleBg,
                               borderRight: showChromatic ? `1px solid ${t.toggleBorder}` : "none",
                               padding: "5px 8px",
-                              fontSize: 9,
                               color: showChromatic ? t.toggleActiveText : t.toggleInactiveText,
                               gap: 5,
                             }}
@@ -945,7 +942,6 @@ export default function LensDiagramPanel({
                                   background: active ? t.toggleActiveBg : t.toggleBg,
                                   borderRight: idx < 2 ? `1px solid ${t.toggleBorder}` : "none",
                                   padding: "5px 6px",
-                                  fontSize: 9,
                                   color: active ? t.toggleActiveText : t.toggleInactiveText,
                                   gap: 3,
                                 }}

--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -619,6 +619,7 @@ export default function LensVisualization() {
     transition: "all 0.25s",
     fontFamily: "inherit",
     letterSpacing: "0.08em",
+    minHeight: 28,
   });
 
   const showCompareBtn = ENABLE_COMPARISON && (isWide || ENABLE_COMPARISON_MOBILE);
@@ -795,6 +796,7 @@ export default function LensVisualization() {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
+                  minHeight: 28,
                   gap: 3,
                   transition: "all 0.25s",
                   fontFamily: "inherit",
@@ -1062,6 +1064,7 @@ export default function LensVisualization() {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
+                    minHeight: 28,
                     gap: 3,
                     transition: "all 0.25s",
                     fontFamily: "inherit",
@@ -1274,13 +1277,14 @@ export default function LensVisualization() {
                   background: mobileView === val ? t.toggleActiveBg : t.toggleBg,
                   border: "none",
                   borderRight: val === "diagram" ? `1px solid ${t.toggleBorder}` : "none",
-                  padding: "6px 0",
+                  padding: "5px 0",
                   cursor: "pointer",
-                  fontSize: 10,
+                  fontSize: 9,
                   color: mobileView === val ? t.toggleActiveText : t.toggleInactiveText,
                   fontFamily: "inherit",
                   letterSpacing: "0.08em",
                   transition: "all 0.25s",
+                  minHeight: 28,
                 }}
               >
                 {label}
@@ -1322,13 +1326,14 @@ export default function LensVisualization() {
                   background: effectiveDesktopView === val ? t.toggleActiveBg : t.toggleBg,
                   border: "none",
                   borderRight: i < desktopViewOptions.length - 1 ? `1px solid ${t.toggleBorder}` : "none",
-                  padding: "6px 0",
+                  padding: "5px 0",
                   cursor: "pointer",
-                  fontSize: 10,
+                  fontSize: 9,
                   color: effectiveDesktopView === val ? t.toggleActiveText : t.toggleInactiveText,
                   fontFamily: "inherit",
                   letterSpacing: "0.08em",
                   transition: "all 0.25s",
+                  minHeight: 28,
                 }}
               >
                 {label}


### PR DESCRIPTION
Add minHeight: 28 to all toggle buttons and standardize fontSize/padding so control buttons (appearance, rays, focus, color rays) render at a consistent height across comparison mode, mobile view, and desktop view.

https://claude.ai/code/session_019MEuxkuu3gxQv9jxo5GTeq