### PR TITLE
Update Nikkor Z 70-200mm f/2.8 VR S lens data with improved prescription

### DIFF
--- a/src/lens-data/NikonNikkorZ70200f28.analysis.md
+++ b/src/lens-data/NikonNikkorZ70200f28.analysis.md
@@ -1,0 +1,20 @@
+## Patent-to-Production Match
+
+The optical design derives from **WO2020/105104 A1**, filed by Nikon inventor Ken Uehara in November 2018. Example 1 describes a variable-magnification system with 21 elements across 9 zoom groups, matching the production NIKKOR Z 70-200mm f/2.8 VR S released August 2020. The minor differences between patent specifications (71.5–196 mm, f/2.88) and production (70–200 mm, f/2.8) fall within the normal tolerances between patent numerical examples and production-tuned designs.
+
+## Key Glass Technologies
+
+The lens employs four specialty glass strategies:
+
+1. **Six ED elements** (S-FPL52 equivalent: nd=1.498, νd=82.57) distributed across multiple groups for consistent chromatic correction during zoom
+2. **One fluorite element** (CaF₂, nd=1.434, νd=95.25) positioned in the first group where it maximizes contribution to longitudinal chromatic aberration correction
+3. **One SR (Short-wavelength Refractive) element** with anomalous partial dispersion properties for secondary spectrum correction
+4. **Two aspherical surfaces** (on elements L62 and L91) for spherical aberration and field flattening
+
+## Focus Architecture
+
+The lens employs dual-group internal focusing with G7 and G8 moving in opposite directions during autofocus. This design maintains constant track length and suppresses focus breathing—critical for video work. The movement ratio satisfies the patent's condition requiring balanced focus group powers (0.80 < ratio < 5.00), minimizing aberration variation at close focus distances.
+
+## Design Innovation
+
+The variator group (G2) is internally achromatized using ED and SR elements together, ensuring chromatic correction remains balanced as groups move during zooming. This distributed specialty-glass approach prevents color shifts across the zoom range.

--- a/src/lens-data/NikonNikkorZ70200f28.data.js
+++ b/src/lens-data/NikonNikkorZ70200f28.data.js
@@ -1,405 +1,446 @@
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
- * ║  LENS DATA — NIKON NIKKOR Z 70-200mm f/2.8 VR S                   ║
+ * ║           LENS DATA — NIKON NIKKOR Z 70-200mm f/2.8 VR S          ║
  * ╠══════════════════════════════════════════════════════════════════════╣
- * ║  Data source: WO 2020/105104 A1 (JPWO2020105104A1), Example 1     ║
- * ║  (Nikon / Internal zoom telephoto for Z-mount).                   ║
- * ║  21 elements / 9 groups, 2 aspherical surfaces.                   ║
- * ║  Internal zoom (constant overall length 199.89 mm).               ║
- * ║  Focus: Two inner-focus groups (F1, F2) within the rear section.  ║
+ * ║  Data source: WO2020/105104 A1, Example 1 (Nikon / Ken Uehara).   ║
+ * ║  Positive-lead internal-zoom telephoto with dual-group focus.      ║
+ * ║  21 elements / 9 groups (18 marketing groups), 2 aspherical sfc.  ║
+ * ║  Focus: dual-group inner focus (G7−, G8+) — opposite directions.  ║
+ * ║                                                                    ║
+ * ║  Internal zoom (constant overall length).                          ║
  * ║  Zoom variable gaps: D5, D13, D15, D19, D23 (zoom only).         ║
- * ║  Focus variable gaps: D30, D34, D36 (zoom + focus).               ║
- * ║  Back focus (BF) is constant at 32.5469 mm.                       ║
+ * ║  Focus variable gaps: D30, D34, D36, D40/BF (zoom + focus).      ║
+ * ║  D36 close-focus: non-monotonic (15.67 → 11.66 → 15.44).        ║
  * ║                                                                    ║
  * ║  NOTE ON SEMI-DIAMETERS:                                           ║
- * ║    Not listed in the patent. Estimated from paraxial marginal     ║
- * ║    ray trace at wide end (EP SD ≈ 12.4 mm at f/2.88) with 10%   ║
- * ║    mechanical clearance. Front elements sized for full 70mm       ║
- * ║    field coverage. STO SD from patent half-angle + geometry.      ║
- * ║                                                                    ║
- * ║  NOTE ON VARIABLE GAP D34 (REVERSING GROUP):                      ║
- * ║    D34 exhibits non-monotonic zoom behavior:                      ║
- * ║    W=28.12 → M=22.59 → T=27.71 (decreases then increases).      ║
- * ║    This is correctly handled by piecewise-linear interpolation.   ║
+ * ║    SDs estimated via paraxial marginal ray trace at tele/infinity  ║
+ * ║    with 10% mechanical clearance.  G9 SDs enlarged for off-axis   ║
+ * ║    field coverage (image half-height Y = 21.7 mm).  Not patent-   ║
+ * ║    listed — these are engineering estimates for rendering only.    ║
  * ╚══════════════════════════════════════════════════════════════════════╝
  */
 
 const LENS_DATA = {
   /* ── Identity ── */
-  key: "nikkor-z70-200f28",
+  key: "nikkor-z-70-200f28",
   name: "NIKON NIKKOR Z 70-200mm f/2.8 VR S",
-  subtitle: "WO 2020/105104 A1 EXAMPLE 1 — NIKON",
-  visible: true,
-  specs: ["21 ELEMENTS / 9 GROUPS", "f = 71.5–196 mm", "F/2.88", "2ω = 33.8°–12.3°", "2 ASPHERICAL SURFACES"],
+  subtitle: "WO2020/105104 EXAMPLE 1 — NIKON / KEN UEHARA",
+  specs: [
+    "21 ELEMENTS / 18 GROUPS",
+    "f = 71.5–196 mm",
+    "F/2.88",
+    "2ω = 33.8°–12.3°",
+    "2 ASPHERICAL SURFACES",
+  ],
 
-  /* ── Elements ──
-   *  21 optical elements, front to rear.
-   *  Group architecture: G1(+), G2(-), G3(+), G4(+), G5(-), G6(+), G7(-), G8(+), G9(-)
-   */
+  /* ── Elements ── */
   elements: [
     {
       id: 1,
-      name: "L1",
+      name: "L11",
       label: "Element 1",
       type: "Negative Meniscus",
       nd: 2.001,
       vd: 29.12,
-      fl: -315.0,
-      glass: "S-NPH7 equiv (nd=2.001, νd=29.1)",
-      cemented: "C1",
+      fl: -317.0,
+      glass: "S-LAH99 / TAFD55 (001-291)",
+      apd: false,
+      role: "Achromatic partner for L12; ultra-high nd minimizes surface curvatures",
+      cemented: "D1",
     },
     {
       id: 2,
-      name: "L2",
+      name: "L12",
       label: "Element 2",
-      type: "Positive Meniscus",
+      type: "Plano-Convex Positive",
       nd: 1.49782,
       vd: 82.57,
-      fl: 233.0,
-      glass: "S-FPL51 equiv (nd=1.498, νd=82.6)",
+      fl: 171.0,
+      glass: "S-FPL52 — ED (498-826)",
       apd: "inferred",
-      apdNote: "Fluorite-equivalent, νd=82.6",
-      cemented: "C1",
+      apdNote: "Fluorophosphate crown, +ΔPgF",
+      role: "Primary positive power for G1; ED glass corrects LoCA",
+      cemented: "D1",
     },
     {
       id: 3,
-      name: "L3",
+      name: "L13",
       label: "Element 3",
       type: "Positive Meniscus",
       nd: 1.43385,
       vd: 95.25,
-      fl: 211.0,
-      glass: "S-FPL55 equiv (nd=1.434, νd=95.3)",
+      fl: 244.3,
+      glass: "CaF₂ Fluorite (434-952)",
       apd: "inferred",
-      apdNote: "Fluorite crown, νd=95.3",
+      apdNote: "Fluorite, strong +ΔPgF",
+      role: "Positive power with minimal chromatic contribution; lightweight",
     },
     {
       id: 4,
-      name: "L4",
+      name: "L21",
       label: "Element 4",
       type: "Negative Meniscus",
       nd: 1.603,
       vd: 65.44,
-      fl: -69.3,
-      glass: "S-BSL7 equiv (nd=1.603, νd=65.4)",
+      fl: -115.5,
+      glass: "S-PHM53 or equiv. (603-654)",
+      apd: false,
+      role: "First negative element of variator; Petzval sum control",
     },
     {
       id: 5,
-      name: "L5",
+      name: "L22",
       label: "Element 5",
       type: "Biconcave Negative",
       nd: 1.49782,
       vd: 82.57,
-      fl: -133.0,
-      glass: "S-FPL51 equiv (nd=1.498, νd=82.6)",
+      fl: -135.2,
+      glass: "S-FPL52 — ED (498-826)",
       apd: "inferred",
-      apdNote: "Fluorite-equivalent ED",
+      apdNote: "Fluorophosphate crown, +ΔPgF",
+      role: "Strong negative power with low dispersion; LoCA correction in variator",
     },
     {
       id: 6,
-      name: "L6",
+      name: "L23",
       label: "Element 6",
-      type: "Biconvex Positive",
+      type: "Positive Meniscus",
       nd: 1.66382,
       vd: 27.35,
-      fl: 65.0,
-      glass: "S-TIH53 equiv (nd=1.664, νd=27.4)",
+      fl: 172.8,
+      glass: "Nikon SR glass (proprietary)",
+      apd: "patent",
+      apdNote: "θgF=0.6319; extreme +ΔPgF for secondary spectrum correction",
+      role: "SR element — anomalous dispersion corrects secondary spectrum across zoom range",
     },
     {
       id: 7,
-      name: "L7",
+      name: "L24",
       label: "Element 7",
       type: "Biconcave Negative",
       nd: 1.49782,
       vd: 82.57,
-      fl: -56.0,
-      glass: "S-FPL51 equiv (nd=1.498, νd=82.6)",
+      fl: -79.6,
+      glass: "S-FPL52 — ED (498-826)",
       apd: "inferred",
-      apdNote: "Fluorite-equivalent ED",
+      apdNote: "Fluorophosphate crown, +ΔPgF",
+      role: "Additional variator negative power; chromatic balance with SR element",
     },
     {
       id: 8,
-      name: "L8",
+      name: "L31",
       label: "Element 8",
-      type: "Biconvex Positive",
+      type: "Positive Meniscus",
       nd: 1.94595,
       vd: 17.98,
-      fl: 111.0,
-      glass: "S-NPH53 equiv (nd=1.946, νd=18.0)",
+      fl: 112.0,
+      glass: "FDS18 (HOYA) / H-ZF88 (946-180)",
+      apd: false,
+      role: "Zoom compensator; ultra-high nd minimizes SA from moving group",
     },
     {
       id: 9,
-      name: "L9",
+      name: "L41",
       label: "Element 9",
       type: "Biconvex Positive",
       nd: 1.49782,
       vd: 82.57,
-      fl: 63.1,
-      glass: "S-FPL51 equiv (nd=1.498, νd=82.6)",
+      fl: 126.8,
+      glass: "S-FPL52 — ED (498-826)",
       apd: "inferred",
-      apdNote: "Fluorite-equivalent ED",
+      apdNote: "Fluorophosphate crown, +ΔPgF",
+      role: "Relay positive power with minimal color contribution",
     },
     {
       id: 10,
-      name: "L10",
+      name: "L42",
       label: "Element 10",
       type: "Positive Meniscus",
       nd: 1.49782,
       vd: 82.57,
-      fl: 121.0,
-      glass: "S-FPL51 equiv (nd=1.498, νd=82.6)",
+      fl: 156.4,
+      glass: "S-FPL52 — ED (498-826)",
       apd: "inferred",
-      apdNote: "Fluorite-equivalent ED",
+      apdNote: "Fluorophosphate crown, +ΔPgF",
+      role: "Additional relay power; all-ED pair minimizes G4 LoCA",
     },
     {
       id: 11,
-      name: "L11",
+      name: "L51",
       label: "Element 11",
-      type: "Negative Meniscus",
+      type: "Biconcave Negative",
       nd: 1.92286,
       vd: 20.88,
-      fl: -31.3,
-      glass: "S-NPH4 equiv (nd=1.923, νd=20.9)",
-      cemented: "D1",
+      fl: -35.0,
+      glass: "N-SF66 / E-FDS1 (923-209)",
+      apd: false,
+      role: "Strong negative power; Petzval correction at stop",
+      cemented: "D2",
     },
     {
       id: 12,
-      name: "L12",
+      name: "L52",
       label: "Element 12",
       type: "Biconvex Positive",
       nd: 1.49782,
       vd: 82.57,
-      fl: 53.0,
-      glass: "S-FPL51 equiv (nd=1.498, νd=82.6)",
+      fl: 80.3,
+      glass: "S-FPL52 — ED (498-826)",
       apd: "inferred",
-      apdNote: "Fluorite-equivalent ED",
-      cemented: "D1",
+      apdNote: "Fluorophosphate crown, +ΔPgF",
+      role: "Achromatic partner for L51",
+      cemented: "D2",
     },
     {
       id: 13,
-      name: "L13",
+      name: "L61",
       label: "Element 13",
       type: "Negative Meniscus",
       nd: 1.85026,
       vd: 32.35,
-      fl: -133.0,
-      glass: "S-NBH51 equiv (nd=1.850, νd=32.4)",
+      fl: -155.6,
+      glass: "Dense flint (850-324, no exact match)",
+      apd: false,
+      role: "Aberration correction; high-index field corrector",
     },
     {
       id: 14,
-      name: "L14",
+      name: "L62",
       label: "Element 14",
-      type: "Biconvex Pos. (1× Asph)",
+      type: "Biconvex Positive (1× Asph)",
       nd: 1.59306,
       vd: 66.97,
-      fl: 28.8,
-      glass: "S-FPM2 equiv (nd=1.593, νd=67.0)",
-      apd: "inferred",
-      apdNote: "Phosphate crown, νd=67.0",
+      fl: 48.2,
+      glass: "PCD51 (HOYA) / J-PSKH4 (593-670)",
+      apd: false,
+      role: "Primary SA/coma correction via aspherical surface; PGM-moldable glass",
+      cemented: "D3",
     },
     {
       id: 15,
-      name: "L15",
+      name: "L63",
       label: "Element 15",
       type: "Negative Meniscus",
       nd: 1.62004,
       vd: 36.4,
-      fl: -182.0,
-      glass: "S-TIM25 equiv (nd=1.620, νd=36.4)",
-      cemented: "D2",
+      fl: -215.7,
+      glass: "S-TIM2 / N-F2 (620-364)",
+      apd: false,
+      role: "Achromatic correction partner for L62",
+      cemented: "D3",
     },
     {
       id: 16,
-      name: "L16",
+      name: "L64",
       label: "Element 16",
-      type: "Biconvex Positive",
+      type: "Positive Meniscus",
       nd: 1.801,
       vd: 34.92,
-      fl: 87.0,
-      glass: "S-LAH65VS equiv (nd=1.801, νd=34.9)",
+      fl: 126.9,
+      glass: "Dense flint (801-349, no exact match)",
+      apd: false,
+      role: "Additional positive power; coma correction",
     },
     {
       id: 17,
-      name: "L17",
+      name: "L71",
       label: "Element 17",
-      type: "Negative Meniscus",
+      type: "Positive Meniscus",
       nd: 1.94595,
       vd: 17.98,
-      fl: -87.0,
-      glass: "S-NPH53 equiv (nd=1.946, νd=18.0)",
+      fl: 142.3,
+      glass: "FDS18 (HOYA) / H-ZF88 (946-180)",
+      apd: false,
+      role: "Positive element within negative focus group; SA balance during focus",
     },
     {
       id: 18,
-      name: "L18",
+      name: "L72",
       label: "Element 18",
-      type: "Biconvex Positive",
+      type: "Negative Meniscus",
       nd: 1.713,
       vd: 53.96,
-      fl: -102.0,
-      glass: "S-LAL61 equiv (nd=1.713, νd=54.0)",
+      fl: -53.6,
+      glass: "S-LAL8 / N-LAK8 (713-540)",
+      apd: false,
+      role: "Dominant negative power for G7; lanthanum crown for Petzval control",
     },
     {
       id: 19,
-      name: "L19",
+      name: "L81",
       label: "Element 19",
       type: "Biconvex Positive",
       nd: 1.90265,
       vd: 35.77,
-      fl: 63.1,
-      glass: "S-LAH79 equiv (nd=1.903, νd=35.8)",
+      fl: 66.1,
+      glass: "J-LASFH9A / ~S-LAH93 (903-358)",
+      apd: false,
+      role: "Sole element of G8; symmetric form minimizes coma; high-nd for compact focus group",
     },
     {
       id: 20,
-      name: "L20",
+      name: "L91",
       label: "Element 20",
       type: "Neg. Meniscus (1× Asph)",
       nd: 1.51696,
       vd: 64.14,
-      fl: -104.0,
-      glass: "S-BSL7 equiv (nd=1.517, νd=64.1)",
+      fl: -214.2,
+      glass: "S-BSL7 / N-BK7 (517-641)",
+      apd: false,
+      role: "Aspherical field flattener; corrects astigmatism and field curvature",
     },
     {
       id: 21,
-      name: "L21",
+      name: "L92",
       label: "Element 21",
       type: "Negative Meniscus",
       nd: 1.56384,
       vd: 60.71,
-      fl: -103.0,
-      glass: "S-BAL41 equiv (nd=1.564, νd=60.7)",
+      fl: -121.0,
+      glass: "S-BAL41 / N-SK11 (564-607)",
+      apd: false,
+      role: "Final Petzval correction for 43.4 mm image circle",
     },
   ],
 
-  /* ── Surface prescription ──
-   *  40 patent surfaces → 40 data file surfaces.
-   *  Surface 20 is the aperture stop (STO).
-   *
-   *  elemId assignment:
-   *    - Front (entry) surface of each element → elemId = element's id
-   *    - Rear surface to air → elemId = 0
-   *    - Cemented junction → elemId = second element's id
-   *    - STO and all air interfaces → elemId = 0
-   */
+  /* ── Surface prescription ── */
   surfaces: [
-    //                                                                          Patent
-    // label    R              d         nd         elemId  sd      // surf   Description
-    { label: "1", R: 116.34563, d: 2.8, nd: 2.001, elemId: 1, sd: 35.5 }, // 1   L1 front (G1)
-    { label: "2", R: 85.133, d: 9.7, nd: 1.49782, elemId: 2, sd: 34.0 }, // 2   L1→L2 cemented junction
-    { label: "3", R: 1e15, d: 0.1, nd: 1.0, elemId: 0, sd: 34.0 }, // 3   L2 rear → air (flat)
-    { label: "4", R: 92.01324, d: 7.7, nd: 1.43385, elemId: 3, sd: 34.0 }, // 4   L3 front
-    { label: "5", R: 696.98757, d: 1.597, nd: 1.0, elemId: 0, sd: 33.5 }, // 5   L3 rear → air (variable: zoom)
-    { label: "6", R: 58.77, d: 1.9, nd: 1.603, elemId: 4, sd: 22.0 }, // 6   L4 front (G2)
-    { label: "7", R: 31.87745, d: 10.3, nd: 1.0, elemId: 0, sd: 19.5 }, // 7   L4 rear → air
-    { label: "8", R: -186.53352, d: 1.6, nd: 1.49782, elemId: 5, sd: 19.0 }, // 8   L5 front
-    { label: "9", R: 105.34866, d: 0.8, nd: 1.0, elemId: 0, sd: 18.5 }, // 9   L5 rear → air
-    { label: "10", R: 41.08366, d: 3.7, nd: 1.66382, elemId: 6, sd: 18.0 }, // 10  L6 front
-    { label: "11", R: 64.00891, d: 5.5, nd: 1.0, elemId: 0, sd: 17.0 }, // 11  L6 rear → air
-    { label: "12", R: -71.62319, d: 1.9, nd: 1.49782, elemId: 7, sd: 17.0 }, // 12  L7 front
-    { label: "13", R: 88.67881, d: 37.803, nd: 1.0, elemId: 0, sd: 17.0 }, // 13  L7 rear → air (variable: zoom)
-    { label: "14", R: 69.46271, d: 3.2, nd: 1.94595, elemId: 8, sd: 16.0 }, // 14  L8 front (G3)
-    { label: "15", R: 201.8299, d: 14.1, nd: 1.0, elemId: 0, sd: 16.0 }, // 15  L8 rear → air (variable: zoom)
-    { label: "16", R: 126.26563, d: 4.7, nd: 1.49782, elemId: 9, sd: 17.0 }, // 16  L9 front (G4)
-    { label: "17", R: -126.26563, d: 0.1, nd: 1.0, elemId: 0, sd: 17.0 }, // 17  L9 rear → air
-    { label: "18", R: 47.66354, d: 3.85, nd: 1.49782, elemId: 10, sd: 16.5 }, // 18  L10 front
-    { label: "19", R: 122.86616, d: 4.25, nd: 1.0, elemId: 0, sd: 16.0 }, // 19  L10 rear → air (variable: zoom)
-    { label: "STO", R: 1e15, d: 3.5, nd: 1.0, elemId: 0, sd: 12.4 }, // 20  Aperture stop (G5)
-    { label: "21", R: -84.82141, d: 1.8, nd: 1.92286, elemId: 11, sd: 12.5 }, // 21  L11 front — cemented D1
-    { label: "22", R: 52.171, d: 5.0, nd: 1.49782, elemId: 12, sd: 13.0 }, // 22  L11→L12 junction — cemented D1
-    { label: "23", R: -170.93248, d: 5.357, nd: 1.0, elemId: 0, sd: 13.0 }, // 23  L12 rear → air (variable: zoom)
-    { label: "24", R: 111.64091, d: 1.7, nd: 1.85026, elemId: 13, sd: 14.0 }, // 24  L13 front (G6)
-    { label: "25", R: 60.55636, d: 2.0, nd: 1.0, elemId: 0, sd: 14.0 }, // 25  L13 rear → air
-    { label: "26A", R: 58.68256, d: 7.7, nd: 1.59306, elemId: 14, sd: 14.5 }, // 26* L14 front (ASPH)
-    { label: "27", R: -55.839, d: 1.7, nd: 1.62004, elemId: 15, sd: 14.5 }, // 27  L14→L15 junction — cemented D2
-    { label: "28", R: -95.85894, d: 1.3, nd: 1.0, elemId: 0, sd: 14.0 }, // 28  L15 rear → air
-    { label: "29", R: 58.0393, d: 2.7, nd: 1.801, elemId: 16, sd: 14.0 }, // 29  L16 front
-    { label: "30", R: 135.30037, d: 3.816, nd: 1.0, elemId: 0, sd: 13.5 }, // 30  L16 rear → air (variable: zoom+focus)
-    { label: "31", R: -369.28597, d: 2.0, nd: 1.94595, elemId: 17, sd: 12.0 }, // 31  L17 front (G7 — focus F1)
-    { label: "32", R: -98.65201, d: 0.8, nd: 1.0, elemId: 0, sd: 12.0 }, // 32  L17 rear → air
-    { label: "33", R: 1344.92022, d: 1.25, nd: 1.713, elemId: 18, sd: 12.0 }, // 33  L18 front
-    { label: "34", R: 37.13115, d: 28.124, nd: 1.0, elemId: 0, sd: 11.5 }, // 34  L18 rear → air (variable: zoom+focus) — REVERSING
-    { label: "35", R: 119.39985, d: 3.85, nd: 1.90265, elemId: 19, sd: 14.0 }, // 35  L19 front (G8 — focus F2)
-    { label: "36", R: -119.39985, d: 3.79, nd: 1.0, elemId: 0, sd: 14.0 }, // 36  L19 rear → air (variable: zoom+focus)
-    { label: "37A", R: -83.23047, d: 1.9, nd: 1.51696, elemId: 20, sd: 14.5 }, // 37* L20 front (ASPH) (G9)
-    { label: "38", R: -335.27926, d: 4.1, nd: 1.0, elemId: 0, sd: 15.0 }, // 38  L20 rear → air
-    { label: "39", R: -54.71091, d: 1.9, nd: 1.56384, elemId: 21, sd: 15.0 }, // 39  L21 front
-    { label: "40", R: -276.64763, d: 32.547, nd: 1.0, elemId: 0, sd: 15.5 }, // 40  L21 rear → image (BF, constant)
+    // ── G1: Fixed front group (positive, f = +148.0 mm) ──
+    { label: "1", R: 116.34563, d: 2.8, nd: 2.001, elemId: 1, sd: 37.5 }, // L11 front
+    { label: "2", R: 85.133, d: 9.7, nd: 1.49782, elemId: 2, sd: 37.0 }, // L11→L12 junction
+    { label: "3", R: 1e15, d: 0.1, nd: 1.0, elemId: 0, sd: 36.5 }, // L12 rear → air
+    { label: "4", R: 92.01324, d: 7.7, nd: 1.43385, elemId: 3, sd: 36.0 }, // L13 front (fluorite)
+    { label: "5", R: 696.98757, d: 1.59716, nd: 1.0, elemId: 0, sd: 35.0 }, // L13 rear → air [VAR zoom]
+
+    // ── G2: Variator (negative, f = −40.6 mm) — moves during zoom ──
+    { label: "6", R: 58.77, d: 1.9, nd: 1.603, elemId: 4, sd: 24.0 }, // L21 front
+    { label: "7", R: 31.87745, d: 10.3, nd: 1.0, elemId: 0, sd: 23.0 }, // L21 rear → air
+    { label: "8", R: -186.53352, d: 1.6, nd: 1.49782, elemId: 5, sd: 22.0 }, // L22 front (ED)
+    { label: "9", R: 105.34866, d: 0.8, nd: 1.0, elemId: 0, sd: 21.5 }, // L22 rear → air
+    { label: "10", R: 41.08366, d: 3.7, nd: 1.66382, elemId: 6, sd: 21.0 }, // L23 front (SR)
+    { label: "11", R: 64.00891, d: 5.5, nd: 1.0, elemId: 0, sd: 20.5 }, // L23 rear → air
+    { label: "12", R: -71.62319, d: 1.9, nd: 1.49782, elemId: 7, sd: 20.0 }, // L24 front (ED)
+    { label: "13", R: 88.67881, d: 37.80321, nd: 1.0, elemId: 0, sd: 19.5 }, // L24 rear → air [VAR zoom]
+
+    // ── G3: Compensator (positive, f = +110.7 mm) — moves during zoom ──
+    { label: "14", R: 69.46271, d: 3.2, nd: 1.94595, elemId: 8, sd: 19.5 }, // L31 front
+    { label: "15", R: 201.8299, d: 14.1, nd: 1.0, elemId: 0, sd: 19.0 }, // L31 rear → air [VAR zoom]
+
+    // ── G4: Fixed relay (positive, f = +69.8 mm) ──
+    { label: "16", R: 126.26563, d: 4.7, nd: 1.49782, elemId: 9, sd: 19.5 }, // L41 front (ED)
+    { label: "17", R: -126.26563, d: 0.1, nd: 1.0, elemId: 0, sd: 19.5 }, // L41 rear → air
+    { label: "18", R: 47.66354, d: 3.85, nd: 1.49782, elemId: 10, sd: 19.0 }, // L42 front (ED)
+    { label: "19", R: 122.86616, d: 4.25, nd: 1.0, elemId: 0, sd: 18.5 }, // L42 rear → air [VAR zoom]
+
+    // ── G5: Moving group with aperture stop (negative, f = −62.6 mm) ──
+    { label: "STO", R: 1e15, d: 3.5, nd: 1.0, elemId: 0, sd: 13.0 }, // Aperture stop
+    { label: "21", R: -84.82141, d: 1.8, nd: 1.92286, elemId: 11, sd: 14.0 }, // L51 front
+    { label: "22", R: 52.171, d: 5.0, nd: 1.49782, elemId: 12, sd: 14.0 }, // L51→L52 junction
+    { label: "23", R: -170.93248, d: 5.35665, nd: 1.0, elemId: 0, sd: 14.0 }, // L52 rear → air [VAR zoom]
+
+    // ── G6: Fixed relay (positive, f = +56.9 mm) ──
+    { label: "24", R: 111.64091, d: 1.7, nd: 1.85026, elemId: 13, sd: 15.5 }, // L61 front
+    { label: "25", R: 60.55636, d: 2.0, nd: 1.0, elemId: 0, sd: 15.5 }, // L61 rear → air
+    { label: "26A", R: 58.68256, d: 7.7, nd: 1.59306, elemId: 14, sd: 15.5 }, // L62 front [ASPH]
+    { label: "27", R: -55.839, d: 1.7, nd: 1.62004, elemId: 15, sd: 15.5 }, // L62→L63 junction
+    { label: "28", R: -95.85894, d: 1.3, nd: 1.0, elemId: 0, sd: 15.0 }, // L63 rear → air
+    { label: "29", R: 58.0393, d: 2.7, nd: 1.801, elemId: 16, sd: 15.0 }, // L64 front
+    { label: "30", R: 135.30037, d: 11.66041, nd: 1.0, elemId: 0, sd: 14.5 }, // L64 rear → air [VAR zoom+focus]
+
+    // ── G7: Focus group 1 (negative, f = −87.3 mm) — moves toward image ──
+    { label: "31", R: -369.28597, d: 2.0, nd: 1.94595, elemId: 17, sd: 14.0 }, // L71 front
+    { label: "32", R: -98.65201, d: 0.8, nd: 1.0, elemId: 0, sd: 14.0 }, // L71 rear → air
+    { label: "33", R: 1344.92022, d: 1.25, nd: 1.713, elemId: 18, sd: 13.5 }, // L72 front
+    { label: "34", R: 37.13115, d: 15.00085, nd: 1.0, elemId: 0, sd: 13.0 }, // L72 rear → air [VAR zoom+focus]
+
+    // ── G8: Focus group 2 (positive, f = +66.6 mm) — moves toward object ──
+    { label: "35", R: 119.39985, d: 3.85, nd: 1.90265, elemId: 19, sd: 12.5 }, // L81 front
+    { label: "36", R: -119.39985, d: 9.06837, nd: 1.0, elemId: 0, sd: 12.5 }, // L81 rear → air [VAR zoom+focus]
+
+    // ── G9: Fixed field corrector (negative, f = −76.3 mm) ──
+    { label: "37A", R: -83.23047, d: 1.9, nd: 1.51696, elemId: 20, sd: 18.0 }, // L91 front [ASPH]
+    { label: "38", R: -335.27926, d: 4.1, nd: 1.0, elemId: 0, sd: 18.5 }, // L91 rear → air
+    { label: "39", R: -54.71091, d: 1.9, nd: 1.56384, elemId: 21, sd: 19.0 }, // L92 front
+    { label: "40", R: -276.64763, d: 16.24001, nd: 1.0, elemId: 0, sd: 19.5 }, // L92 rear → BF [VAR zoom+focus]
   ],
 
-  /* ── Aspherical coefficients ──
-   *  Patent uses sag equation with conic κ and even-order polynomial A4–A12.
-   */
+  /* ── Aspherical coefficients ── */
   asph: {
     "26A": {
-      K: 0.0,
-      A4: -2.0e-6,
-      A6: 8.31e-10,
-      A8: -6.83e-12,
-      A10: 2.63e-14,
-      A12: -3.55e-17,
+      K: 0,
+      A4: -2.0038e-6,
+      A6: 8.31219e-10,
+      A8: -6.83049e-12,
+      A10: 2.63176e-14,
+      A12: -3.55064e-17,
       A14: 0,
     },
     "37A": {
-      K: 0.0,
-      A4: 1.18e-6,
-      A6: 1.63e-9,
-      A8: -7.32e-12,
-      A10: 2.41e-14,
-      A12: -2.65e-17,
+      K: 0,
+      A4: 1.17932e-6,
+      A6: 1.62709e-9,
+      A8: -7.32279e-12,
+      A10: 2.40767e-14,
+      A12: -2.65267e-17,
       A14: 0,
     },
   },
 
   /* ── Variable air spacings (zoom + focus) ──
-   *  Zoom lens format: each value is an array of [d_inf, d_close] pairs,
-   *  one per zoom position (W=71.5mm, M=135mm, T=196mm).
+   *  Zoom format: each value is an array of [d_infinity, d_close] pairs,
+   *  one per zoom position (wide / mid / tele).
    *
-   *  D5, D13, D15, D19, D23: zoom-only (identical inf/close values).
-   *  D30, D34, D36: zoom + focus (different inf/close values).
-   *
-   *  D34 exhibits non-monotonic (reversing) zoom behavior:
-   *    W=28.12 → M=22.59 → T=27.71
+   *  D5, D13, D15, D19, D23: zoom only (identical inf/close values).
+   *  D30, D34, D36, D40: zoom + focus (different inf/close values).
    */
   var: {
-    5: [
-      [1.597, 1.597],
-      [33.499, 33.499],
-      [49.531, 49.531],
-    ],
-    13: [
-      [37.803, 37.803],
-      [11.652, 11.652],
-      [1.605, 1.605],
-    ],
-    15: [
+    // ── Zoom-only gaps ──
+    "5": [
+      [1.59716, 1.59716],
+      [33.49886, 33.49886],
+      [49.53103, 49.53103],
+    ], // G1→G2
+    "13": [
+      [37.80321, 37.80321],
+      [11.65165, 11.65165],
+      [1.60507, 1.60507],
+    ], // G2→G3
+    "15": [
       [14.1, 14.1],
-      [8.349, 8.349],
-      [2.364, 2.364],
-    ],
-    19: [
+      [8.3487, 8.3487],
+      [2.36438, 2.36438],
+    ], // G3→G4
+    "19": [
       [4.25, 4.25],
-      [7.08, 7.08],
-      [8.123, 8.123],
-    ],
-    23: [
-      [5.357, 5.357],
-      [2.527, 2.527],
-      [1.483, 1.483],
-    ],
-    30: [
-      [3.816, 5.101],
-      [6.229, 11.895],
-      [4.107, 15.633],
-    ],
-    34: [
-      [28.124, 24.59],
-      [22.593, 10.978],
-      [27.71, 4.659],
-    ],
-    36: [
-      [3.79, 6.038],
-      [6.908, 12.857],
-      [3.913, 15.438],
-    ],
+      [7.0803, 7.0803],
+      [8.12302, 8.12302],
+    ], // G4→STO/G5
+    "23": [
+      [5.35665, 5.35665],
+      [2.52658, 2.52658],
+      [1.48301, 1.48301],
+    ], // G5→G6
+    // ── Zoom + focus gaps ──
+    "30": [
+      [11.66041, 18.32549],
+      [8.48543, 20.01086],
+      [4.10722, 15.63265],
+    ], // G6→G7
+    "34": [
+      [15.00085, 1.73284],
+      [21.85684, 4.06023],
+      [27.70989, 4.65903],
+    ], // G7→G8
+    "36": [
+      [9.06837, 15.6713],
+      [5.38736, 11.65854],
+      [3.91252, 15.43795],
+    ], // G8→G9
+    "40": [
+      [16.24001, 9.57493],
+      [18.15175, 6.62649],
+      [18.15175, 6.62649],
+    ], // BF
   },
 
   varLabels: [
@@ -411,9 +452,10 @@ const LENS_DATA = {
     ["30", "D30"],
     ["34", "D34"],
     ["36", "D36"],
+    ["40", "BF"],
   ],
 
-  /* ── Zoom lens fields ── */
+  /* ── Zoom fields ── */
   zoomPositions: [71.5, 135, 196],
   zoomStep: 0.004,
   zoomLabels: ["Wide", "Tele"],
@@ -432,22 +474,23 @@ const LENS_DATA = {
   ],
 
   doublets: [
-    { text: "D1", fromSurface: "21", toSurface: "23" },
-    { text: "D2", fromSurface: "26A", toSurface: "28" },
+    { text: "D1", fromSurface: "1", toSurface: "3" }, // L11+L12 cemented
+    { text: "D2", fromSurface: "21", toSurface: "23" }, // L51+L52 cemented
+    { text: "D3", fromSurface: "26A", toSurface: "28" }, // L62+L63 cemented
   ],
 
   /* ── Focus configuration ── */
-  closeFocusM: 1.0,
-  focusDescription: "Dual inner-focus: F1 (G7, negative) moves toward image; F2 (G8, positive) moves toward object.",
+  closeFocusM: 0.5,
+  focusDescription:
+    "Dual-group inner focus: G7 (neg.) moves toward image, G8 (pos.) moves toward object. Equal ±11.5 mm travel at tele. Multi-focusing via two STM motors.",
 
   /* ── Aperture configuration ── */
   nominalFno: 2.88,
-  fstopSeries: [2.8, 3.2, 3.5, 4, 4.5, 5.6, 6.3, 8, 11, 16, 22],
+  fstopSeries: [2.8, 3.2, 3.5, 4, 4.5, 5, 5.6, 6.3, 8, 11, 16, 22],
 
   /* ── Layout tuning ── */
-  scFill: 0.52,
-  yScFill: 0.38,
-  maxAspectRatio: 3.0,
+  scFill: 0.65,
+  yScFill: 0.42,
 };
 
 export default LENS_DATA;


### PR DESCRIPTION
Replaces the existing lens data with an updated version from issue #135:
- More precise surface thicknesses and semi-diameters
- Enriched element metadata (roles, APD glass info, specific glass names)
- Added variable back focus (D40/BF) gap
- Updated close-focus values (0.5m vs 1.0m)
- Added D1 cemented doublet annotation
- Added analysis markdown for the description panel

Closes #135

https://claude.ai/code/session_01JqigPAd2qhHqBFDgcTF31R