### PR TITLE
Fix mobile focus mode button text wrapping

### DIFF
--- a/src/components/LensViewer.jsx
+++ b/src/components/LensViewer.jsx
@@ -617,6 +617,7 @@ export default function LensVisualization() {
     justifyContent: "center",
     gap: 5,
     transition: "all 0.25s",
+    whiteSpace: "nowrap",
     fontFamily: "inherit",
     letterSpacing: "0.08em",
     minHeight: 28,


### PR DESCRIPTION
Add whiteSpace: "nowrap" to toggle button style to prevent the "⟩ F" label from splitting the arrow and letter onto separate lines on narrow screens.

https://claude.ai/code/session_01J7kU5oD9vD7pWFtNW13qbV