### PR TITLE
Exclude entire src/lens-data/ directory from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
 dist/
 node_modules/
 *.md
-*.data.js
+src/lens-data/


### PR DESCRIPTION
Replaces the *.data.js glob with src/lens-data/ to cover all files in the directory (defaults.js, template, etc.), not just .data.js files.

https://claude.ai/code/session_017Zr8wZCkjVA1USn8RsKPXy