### PR TITLE
Fix aperture slider container contracting at stopped-down values

### DIFF
--- a/src/components/DiagramControls.jsx
+++ b/src/components/DiagramControls.jsx
@@ -158,7 +158,7 @@ export default function DiagramControls({
         >
           <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
             <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 85 }}>APERTURE</span>
-            <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>
+            <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist, minWidth: "3.5em" }}>
               f/{fNumber < 10 ? fNumber.toFixed(1) : Math.round(fNumber)}
             </span>
             {ENABLE_COLLAPSIBLE_APERTURE && (

--- a/src/components/SharedSlidersBar.jsx
+++ b/src/components/SharedSlidersBar.jsx
@@ -198,7 +198,7 @@ export default function SharedSlidersBar({
         <div style={{ flex: 1 }}>
           <div style={LABEL_ROW}>
             <span style={{ ...SLIDER_LABEL, color: t.label, minWidth: 75 }}>APERTURE</span>
-            <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist }}>
+            <span style={{ ...SLIDER_VALUE_BASE, color: t.focusDist, minWidth: "3.5em" }}>
               f/{fNum < 10 ? fNum.toFixed(1) : Math.round(fNum)}
             </span>
           </div>


### PR DESCRIPTION
The aperture header row (no-wrap flex) contains an APERTURE label, a dynamic f-number readout, and a collapse button. The f-number display switches format at f/10: values below 10 use toFixed(1) ("f/9.9", 5 chars ~38px) while values ≥ 10 use Math.round ("f/10", 4 chars ~34px). This ~4px width change causes the header row's min-content-size to fluctuate around the 220px flex-basis threshold of the aperture section. At viewport widths where the focus+aperture sections plus the legend section total just over 840px, this triggers the legend to jump between "below the sliders" and "alongside" as the user adjusts the aperture slider past the f/10 boundary.

Fix: add minWidth: "3.5em" (49px) to the f-number readout span so its contribution to the header row min-content is always a stable value above the widest f-number string width (~38px at 14px bold monospace). Apply the same fix in SharedSlidersBar for consistency.

Closes #169

https://claude.ai/code/session_018wQ9xKDVCTDLfuySCYEGYy