### PR TITLE
Improve deployment quality gates in CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Quality Checks"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -17,14 +19,20 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    # For workflow_run: only deploy when quality checks passed.
+    # For workflow_dispatch: always allow manual deploys.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out the exact commit that passed quality checks, not just HEAD.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "20.19.0"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,19 +3,63 @@ name: Quality Checks
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
-  quality:
+  lint-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "20.19.0"
           cache: npm
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: npm
+      - run: npm ci
       - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: npm
+      - run: npm ci
       - run: npm run test
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: npm
+      - run: npm ci
+      - run: npm audit --audit-level=high
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint-format, typecheck, test, audit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: npm
+      - run: npm ci
       - run: npm run build


### PR DESCRIPTION
- quality.yml: add push-to-main trigger so direct pushes are also checked
- quality.yml: split sequential steps into parallel jobs (lint-format, typecheck, test, audit) with build gated on all four passing
- quality.yml: add npm audit --audit-level=high for dependency security
- deploy.yml: switch trigger from push to workflow_run so deployment only fires after Quality Checks completes successfully on main
- deploy.yml: pin checkout ref to the exact commit that passed quality
- Both workflows: pin Node version to 20.19.0 for reproducibility

https://claude.ai/code/session_01PMiaSm4p6RbcX7vDpA958v