### PR TITLE
fix(nikon85f14g): prevent outer off-axis ray from clipping at front e…

### DIFF
--- a/src/lens-data/NikonNikkor85f14G.data.js
+++ b/src/lens-data/NikonNikkor85f14G.data.js
@@ -212,6 +212,14 @@ const LENS_DATA = {
   nominalFno: 1.4,
   fstopSeries: [1.4, 2, 2.8, 4, 5.6, 8, 11, 16],
 
+  /* ── Off-axis ray tuning ──
+   *  Default offAxisFractions (±0.75) places the upper marginal ray at
+   *  yChief + 0.75×epSD ≈ 11.4 + 22.8 = 34.1 mm, which exceeds the front
+   *  element SD of 32 mm and causes an immediate ghost that traverses the
+   *  entire lens.  Cap at ±0.6 (→ y0_max ≈ 29.6 mm) for a clean trace.
+   */
+  offAxisFractions: [-0.6, -0.3, 0, 0.3, 0.6],
+
   /* ── Layout tuning ── */
   scFill: 0.52,
   yScFill: 0.38,

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -301,17 +301,27 @@ export function traceRay(
        *   I  = angle of incidence = ray angle − normal tilt
        *   I' = angle of refraction via n·sin(I) = n'·sin(I')
        *   U' = α + I'  (new ray angle after refraction)
-       * |sin(I')| > 1 means total internal reflection → clip the ray. */
+       * |sin(I')| > 1 means total internal reflection → clip the ray.
+       *
+       * Guard: if the ray is a ghost and |y| exceeds the sphere's geometric
+       * extent (|y| > |R|, so the sag discriminant would go negative), the
+       * surface normal is undefined.  Skip refraction and propagate straight
+       * rather than letting the 1e-12 clamp in sagSlope produce a garbage angle. */
       const absY = Math.abs(y);
-      const slope = sagSlope(absY, i, L);
-      const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
-      const I = U - alpha;
-      const sinIp = (n / nn) * Math.sin(I);
-      if (Math.abs(sinIp) > 1.0) {
-        if (!ghost) break;
-        clipped = true;
+      const R = L.S[i].R;
+      if (clipped && Math.abs(R) < FLAT_R_THRESHOLD && absY * absY > R * R) {
+        /* ghost ray beyond sphere extent — propagate straight, no refraction */
       } else {
-        U = alpha + Math.asin(sinIp);
+        const slope = sagSlope(absY, i, L);
+        const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
+        const I = U - alpha;
+        const sinIp = (n / nn) * Math.sin(I);
+        if (Math.abs(sinIp) > 1.0) {
+          if (!ghost) break;
+          clipped = true;
+        } else {
+          U = alpha + Math.asin(sinIp);
+        }
       }
     }
     n = nn;
@@ -382,15 +392,20 @@ export function traceRayChromatic(
     const nn = wavelengthNd(nd, L.vdByIdx[i], channel);
     if (nn !== n) {
       const absY = Math.abs(y);
-      const slope = sagSlope(absY, i, L);
-      const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
-      const I = U - alpha;
-      const sinIp = (n / nn) * Math.sin(I);
-      if (Math.abs(sinIp) > 1.0) {
-        if (!ghost) break;
-        clipped = true;
+      const R = L.S[i].R;
+      if (clipped && Math.abs(R) < FLAT_R_THRESHOLD && absY * absY > R * R) {
+        /* ghost ray beyond sphere extent — propagate straight, no refraction */
       } else {
-        U = alpha + Math.asin(sinIp);
+        const slope = sagSlope(absY, i, L);
+        const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
+        const I = U - alpha;
+        const sinIp = (n / nn) * Math.sin(I);
+        if (Math.abs(sinIp) > 1.0) {
+          if (!ghost) break;
+          clipped = true;
+        } else {
+          U = alpha + Math.asin(sinIp);
+        }
       }
     }
     n = nn;


### PR DESCRIPTION
…lement

The upper marginal off-axis ray (f=+0.75) entered at y₀ ≈ 34.1 mm, exceeding the front element SD of 32 mm (yChief ≈ 11.4 mm at 60% field plus 0.75 × epSD ≈ 22.8 mm).  This caused an immediate ghost that propagated through the entire lens producing a spurious diagonal dashed line far from the expected image convergence.

Two-part fix:
- NikonNikkor85f14G.data.js: override offAxisFractions to [-0.6, …, 0.6], keeping y₀_max ≈ 29.6 mm safely inside the 32 mm front aperture.
- optics.ts: add a defensive guard in traceRay and traceRayChromatic that skips Snell's law refraction for ghost rays at surfaces where |y| > |R| (sphere doesn't extend that far geometrically).  The 1e-12 clamp in sagSlope would otherwise produce near-vertical surface normals and unpredictable deflection angles for any ghost ray in this regime.

https://claude.ai/code/session_01TFFwcnyDpuQAy6xMBdD6uR