### PR TITLE
Add Tier 1 test coverage: zoom optics helpers and React hooks

### DIFF
--- a/__tests__/useLensState.test.ts
+++ b/__tests__/useLensState.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useLensState from "../src/utils/useLensState.js";
+import { PREFS_KEY } from "../src/utils/preferences.js";
+import { CATALOG_KEYS } from "../src/utils/lensCatalog.js";
+
+/* ── Mock window.matchMedia (not implemented in jsdom) ── */
+
+beforeEach(() => {
+  // Reset URL to bare path before each test
+  window.history.replaceState({}, "", "/");
+  localStorage.clear();
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("900px"),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  });
+});
+
+/* ── Default state initialization ── */
+
+describe("useLensState — defaults", () => {
+  it("returns [state, dispatch, isWide] tuple", () => {
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    const [state, dispatch, isWide] = result.current;
+    expect(typeof state).toBe("object");
+    expect(typeof dispatch).toBe("function");
+    expect(typeof isWide).toBe("boolean");
+  });
+
+  it("defaults lensKeyA to first catalog key when no URL or prefs", () => {
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.lensKeyA).toBe(CATALOG_KEYS[0]);
+  });
+
+  it("defaults lensKeyB to second catalog key when no URL or prefs", () => {
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.lensKeyB).toBe(CATALOG_KEYS[1]);
+  });
+
+  it("defaults comparing to false", () => {
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.comparing).toBe(false);
+  });
+
+  it("defaults sliders to zero", () => {
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    const { focusT, zoomT, stopdownT } = result.current[0].sliders;
+    expect(focusT).toBe(0);
+    expect(zoomT).toBe(0);
+    expect(stopdownT).toBe(0);
+  });
+});
+
+/* ── URL param initialization ── */
+
+describe("useLensState — URL params override defaults", () => {
+  it("uses ?lens= to set lensKeyA when key is valid", () => {
+    window.history.replaceState({}, "", `?lens=${CATALOG_KEYS[1]}`);
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.lensKeyA).toBe(CATALOG_KEYS[1]);
+  });
+
+  it("applies ?focus= slider to focusT", () => {
+    window.history.replaceState({}, "", "?focus=0.6");
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].sliders.focusT).toBeCloseTo(0.6, 5);
+  });
+
+  it("applies ?aperture= slider to stopdownT", () => {
+    window.history.replaceState({}, "", "?aperture=0.4");
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].sliders.stopdownT).toBeCloseTo(0.4, 5);
+  });
+
+  it("ignores ?lens= value not in catalog", () => {
+    window.history.replaceState({}, "", "?lens=totally_fake_lens_xyz");
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    // Falls back to default (first key)
+    expect(result.current[0].lens.lensKeyA).toBe(CATALOG_KEYS[0]);
+  });
+});
+
+/* ── Preferences initialization ── */
+
+describe("useLensState — localStorage prefs override defaults", () => {
+  it("uses saved lensKeyA from prefs", () => {
+    const targetKey = CATALOG_KEYS[Math.min(2, CATALOG_KEYS.length - 1)];
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ v: 2, lensKeyA: targetKey }));
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.lensKeyA).toBe(targetKey);
+  });
+
+  it("applies dark=true from prefs", () => {
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ v: 2, dark: true }));
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].display.dark).toBe(true);
+  });
+
+  it("applies dark=false from prefs", () => {
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ v: 2, dark: false }));
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].display.dark).toBe(false);
+  });
+
+  it("applies comparing=true from prefs", () => {
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ v: 2, comparing: true }));
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.comparing).toBe(true);
+  });
+
+  it("ignores saved lensKeyA that is not in catalog", () => {
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ v: 2, lensKeyA: "deleted_lens_xyz" }));
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    // Falls back to catalog default
+    expect(CATALOG_KEYS).toContain(result.current[0].lens.lensKeyA);
+  });
+
+  it("ignores corrupted prefs JSON and uses defaults", () => {
+    localStorage.setItem(PREFS_KEY, "not valid json {{{");
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.lensKeyA).toBe(CATALOG_KEYS[0]);
+  });
+});
+
+/* ── URL > prefs precedence ── */
+
+describe("useLensState — URL params take precedence over prefs", () => {
+  it("URL ?lens= overrides saved lensKeyA in prefs", () => {
+    const prefKey = CATALOG_KEYS[1];
+    const urlKey = CATALOG_KEYS[2] ?? CATALOG_KEYS[0];
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ v: 2, lensKeyA: prefKey }));
+    window.history.replaceState({}, "", `?lens=${urlKey}`);
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    expect(result.current[0].lens.lensKeyA).toBe(urlKey);
+  });
+});
+
+/* ── Dispatch works ── */
+
+describe("useLensState — dispatch", () => {
+  it("dispatching SET_DARK updates display.dark", () => {
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    const [initialState, dispatch] = result.current;
+    const initialDark = initialState.display.dark;
+
+    act(() => {
+      dispatch({ type: "SET_DARK", dark: !initialDark });
+    });
+
+    expect(result.current[0].display.dark).toBe(!initialDark);
+  });
+
+  it("dispatching SET_LENS_A updates lensKeyA", () => {
+    const { result } = renderHook(() => useLensState(CATALOG_KEYS));
+    const newKey = CATALOG_KEYS[1];
+
+    act(() => {
+      result.current[1]({ type: "SET_LENS_A", key: newKey });
+    });
+
+    expect(result.current[0].lens.lensKeyA).toBe(newKey);
+  });
+});

--- a/__tests__/usePreferences.test.ts
+++ b/__tests__/usePreferences.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import usePreferences from "../src/utils/usePreferences.js";
+import { createInitialState } from "../src/utils/lensReducer.js";
+import { PREFS_KEY } from "../src/utils/preferences.js";
+import type { LensState } from "../src/types/state.js";
+
+const CATALOG_KEYS = ["nikon_58", "canon_50", "zeiss_35"];
+
+function makeState(overrides: Partial<LensState> = {}): LensState {
+  return { ...createInitialState({}, {}, true, CATALOG_KEYS), ...overrides };
+}
+
+/* ── Environment setup ── */
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+
+  // createInitialState reads window.matchMedia for dark/contrast defaults when prefs are absent
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi
+      .fn()
+      .mockImplementation(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+  });
+});
+
+/* ── Basic write-on-mount ── */
+
+describe("usePreferences — initial write", () => {
+  it("writes to localStorage on mount", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    expect(localStorage.getItem(PREFS_KEY)).not.toBeNull();
+  });
+
+  it("persisted JSON is valid and has version field", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    const raw = localStorage.getItem(PREFS_KEY)!;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed.v).toBe(2);
+  });
+});
+
+/* ── Field inclusion ── */
+
+describe("usePreferences — persisted fields", () => {
+  it("persists dark and highContrast display flags", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(typeof parsed.dark).toBe("boolean");
+    expect(typeof parsed.highContrast).toBe("boolean");
+  });
+
+  it("persists lens selection keys", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(parsed.lensKeyA).toBe(CATALOG_KEYS[0]);
+    expect(parsed.lensKeyB).toBe(CATALOG_KEYS[1]);
+  });
+
+  it("persists ray toggle flags", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(typeof parsed.showOnAxis).toBe("boolean");
+    expect(typeof parsed.showOffAxis).toBe("string");
+    expect(typeof parsed.rayTracksF).toBe("boolean");
+    expect(typeof parsed.showChromatic).toBe("boolean");
+    expect(typeof parsed.chromR).toBe("boolean");
+    expect(typeof parsed.chromG).toBe("boolean");
+    expect(typeof parsed.chromB).toBe("boolean");
+  });
+
+  it("persists panel expand states", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(typeof parsed.focusExpanded).toBe("boolean");
+    expect(typeof parsed.apertureExpanded).toBe("boolean");
+    expect(typeof parsed.headerControlsExpanded).toBe("boolean");
+    expect(typeof parsed.legendExpanded).toBe("boolean");
+    expect(typeof parsed.headerInfoExpanded).toBe("boolean");
+  });
+
+  it("does NOT persist slider positions", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(parsed.focusT).toBeUndefined();
+    expect(parsed.zoomT).toBeUndefined();
+    expect(parsed.stopdownT).toBeUndefined();
+    expect(parsed.sharedFocusT).toBeUndefined();
+    expect(parsed.sharedStopdownT).toBeUndefined();
+    expect(parsed.sharedZoomT).toBeUndefined();
+  });
+
+  it("does NOT persist overlay visibility", () => {
+    const state = makeState();
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(parsed.showAbout).toBeUndefined();
+    expect(parsed.showAboutSite).toBeUndefined();
+    expect(parsed.showOpticsPrimer).toBeUndefined();
+  });
+});
+
+/* ── Change detection ── */
+
+describe("usePreferences — change detection", () => {
+  it("writes again when relevant state changes", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    const state1 = makeState();
+    const { rerender } = renderHook(({ s }: { s: LensState }) => usePreferences(s), {
+      initialProps: { s: state1 },
+    });
+
+    const callsAfterMount = spy.mock.calls.length;
+
+    // Change a persisted field (display.dark) in the lens slice
+    const state2: LensState = {
+      ...state1,
+      display: { ...state1.display, dark: !state1.display.dark },
+    };
+    act(() => {
+      rerender({ s: state2 });
+    });
+
+    expect(spy.mock.calls.length).toBeGreaterThan(callsAfterMount);
+  });
+
+  it("does NOT re-write when only sliders change", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    const state1 = makeState();
+    const { rerender } = renderHook(({ s }: { s: LensState }) => usePreferences(s), {
+      initialProps: { s: state1 },
+    });
+
+    const callsAfterMount = spy.mock.calls.length;
+
+    // Change only slider positions (not persisted)
+    const state2: LensState = {
+      ...state1,
+      sliders: { focusT: 0.5, zoomT: 0.3, stopdownT: 0.2 },
+    };
+    act(() => {
+      rerender({ s: state2 });
+    });
+
+    // setItem count should not increase — slider changes don't trigger the effect
+    expect(spy.mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it("does NOT re-write when state is structurally identical", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    const state = makeState();
+    const { rerender } = renderHook(({ s }: { s: LensState }) => usePreferences(s), {
+      initialProps: { s: state },
+    });
+
+    const callsAfterMount = spy.mock.calls.length;
+
+    // Rerender with the exact same object
+    act(() => {
+      rerender({ s: state });
+    });
+
+    expect(spy.mock.calls.length).toBe(callsAfterMount);
+  });
+});
+
+/* ── localStorage error handling ── */
+
+describe("usePreferences — error handling", () => {
+  it("does not throw when localStorage.setItem throws (e.g. quota exceeded)", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+
+    const state = makeState();
+    // Should not throw
+    expect(() => renderHook(() => usePreferences(state))).not.toThrow();
+  });
+});
+
+/* ── Value accuracy ── */
+
+describe("usePreferences — value accuracy", () => {
+  it("persists the actual lensKeyA value", () => {
+    const state: LensState = {
+      ...makeState(),
+      lens: { ...makeState().lens, lensKeyA: "zeiss_35" },
+    };
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(parsed.lensKeyA).toBe("zeiss_35");
+  });
+
+  it("persists comparing=true correctly", () => {
+    const state: LensState = {
+      ...makeState(),
+      lens: { ...makeState().lens, comparing: true },
+    };
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(parsed.comparing).toBe(true);
+  });
+
+  it("persists showOffAxis string value", () => {
+    const state: LensState = {
+      ...makeState(),
+      rays: { ...makeState().rays, showOffAxis: "trueAngle" },
+    };
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(parsed.showOffAxis).toBe("trueAngle");
+  });
+
+  it("persists scaleMode correctly", () => {
+    const state: LensState = {
+      ...makeState(),
+      lens: { ...makeState().lens, scaleMode: "normalized" },
+    };
+    renderHook(() => usePreferences(state));
+    const parsed = JSON.parse(localStorage.getItem(PREFS_KEY)!) as Record<string, unknown>;
+    expect(parsed.scaleMode).toBe("normalized");
+  });
+});

--- a/__tests__/useURLSync.test.ts
+++ b/__tests__/useURLSync.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useURLSync from "../src/utils/useURLSync.js";
+import { createInitialState } from "../src/utils/lensReducer.js";
+import { CATALOG_KEYS } from "../src/utils/lensCatalog.js";
+import type { Dispatch } from "react";
+import type { LensState, LensAction } from "../src/types/state.js";
+
+function makeState(overrides: Partial<LensState> = {}): LensState {
+  return { ...createInitialState({}, {}, true, CATALOG_KEYS), ...overrides };
+}
+
+/* ── Setup / teardown ── */
+
+let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  window.history.replaceState({}, "", "/");
+  replaceStateSpy = vi.spyOn(history, "replaceState");
+  vi.useFakeTimers();
+
+  // createInitialState reads window.matchMedia for dark/contrast defaults when prefs are absent
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi
+      .fn()
+      .mockImplementation(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+/* ── Return value shape ── */
+
+describe("useURLSync — return value", () => {
+  it("returns an object with updateURLWithSliders function", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state = makeState();
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+    expect(typeof result.current.updateURLWithSliders).toBe("function");
+  });
+});
+
+/* ── Immediate URL update on lens selection change ── */
+
+describe("useURLSync — immediate URL update on lens change", () => {
+  it("calls history.replaceState on mount for single-lens mode", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state = makeState();
+    renderHook(() => useURLSync(state, dispatch, null));
+    // Effect fires on mount — replaceState should have been called
+    expect(replaceStateSpy).toHaveBeenCalled();
+  });
+
+  it("updates URL when lensKeyA changes", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state1 = makeState();
+    const { rerender } = renderHook(({ s }: { s: LensState }) => useURLSync(s, dispatch, null), {
+      initialProps: { s: state1 },
+    });
+
+    const callsBefore = replaceStateSpy.mock.calls.length;
+
+    const state2: LensState = {
+      ...state1,
+      lens: { ...state1.lens, lensKeyA: CATALOG_KEYS[1] },
+    };
+    act(() => {
+      rerender({ s: state2 });
+    });
+
+    expect(replaceStateSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it("updates URL when entering comparison mode", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state1 = makeState();
+    const { rerender } = renderHook(({ s }: { s: LensState }) => useURLSync(s, dispatch, null), {
+      initialProps: { s: state1 },
+    });
+
+    const callsBefore = replaceStateSpy.mock.calls.length;
+
+    const state2: LensState = {
+      ...state1,
+      lens: { ...state1.lens, comparing: true },
+    };
+    act(() => {
+      rerender({ s: state2 });
+    });
+
+    expect(replaceStateSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+});
+
+/* ── Debounced slider URL update ── */
+
+describe("useURLSync — updateURLWithSliders (debounced)", () => {
+  it("does not call replaceState immediately when invoked", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state = makeState();
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+
+    const callsBefore = replaceStateSpy.mock.calls.length;
+    act(() => {
+      result.current.updateURLWithSliders();
+    });
+
+    // No immediate call — debounce pending
+    expect(replaceStateSpy.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("calls replaceState after 300ms debounce", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    // Non-zero focusT so the debounced URL (with focus param) differs from the lens-only URL
+    const state: LensState = { ...makeState(), sliders: { focusT: 0.5, zoomT: 0, stopdownT: 0 } };
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+
+    act(() => {
+      result.current.updateURLWithSliders();
+    });
+
+    const callsBefore = replaceStateSpy.mock.calls.length;
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(replaceStateSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it("coalesces multiple rapid calls into a single replaceState", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    // Non-zero focusT so the debounced URL (with focus param) differs from the lens-only URL
+    const state: LensState = { ...makeState(), sliders: { focusT: 0.5, zoomT: 0, stopdownT: 0 } };
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+
+    act(() => {
+      result.current.updateURLWithSliders();
+      result.current.updateURLWithSliders();
+      result.current.updateURLWithSliders();
+    });
+
+    const callsBefore = replaceStateSpy.mock.calls.length;
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // Only one replaceState despite three rapid calls
+    expect(replaceStateSpy.mock.calls.length).toBe(callsBefore + 1);
+  });
+
+  it("encodes non-zero focusT in the URL after debounce", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state: LensState = {
+      ...makeState(),
+      sliders: { focusT: 0.6, zoomT: 0, stopdownT: 0 },
+    };
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+
+    act(() => {
+      result.current.updateURLWithSliders();
+      vi.advanceTimersByTime(300);
+    });
+
+    // Check that the URL passed to replaceState contains focus param
+    const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1];
+    const urlArg = lastCall[2] as string;
+    expect(urlArg).toContain("focus=");
+  });
+
+  it("encodes non-zero stopdownT as aperture in the URL after debounce", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state: LensState = {
+      ...makeState(),
+      sliders: { focusT: 0, zoomT: 0, stopdownT: 0.5 },
+    };
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+
+    act(() => {
+      result.current.updateURLWithSliders();
+      vi.advanceTimersByTime(300);
+    });
+
+    const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1];
+    const urlArg = lastCall[2] as string;
+    expect(urlArg).toContain("aperture=");
+  });
+
+  it("omits focus from URL when focusT is 0 (infinity focus)", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state: LensState = {
+      ...makeState(),
+      sliders: { focusT: 0, zoomT: 0, stopdownT: 0 },
+    };
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+
+    act(() => {
+      result.current.updateURLWithSliders();
+      vi.advanceTimersByTime(300);
+    });
+
+    const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1];
+    const urlArg = lastCall[2] as string;
+    // At zero sliders the URL should be the plain lens param, no focus/aperture
+    expect(urlArg).not.toContain("focus=");
+    expect(urlArg).not.toContain("aperture=");
+  });
+});
+
+/* ── Comparison mode slider URL update ── */
+
+describe("useURLSync — comparison mode slider URL", () => {
+  it("encodes sharedFocusT when comparing and sharedFocusT > 0", () => {
+    const dispatch = vi.fn() as unknown as Dispatch<LensAction>;
+    const state: LensState = {
+      ...makeState(),
+      lens: { ...makeState().lens, comparing: true },
+      sharedSliders: { sharedFocusT: 0.4, sharedStopdownT: 0, sharedZoomT: 0 },
+    };
+    const { result } = renderHook(() => useURLSync(state, dispatch, null));
+
+    act(() => {
+      result.current.updateURLWithSliders();
+      vi.advanceTimersByTime(300);
+    });
+
+    const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1];
+    const urlArg = lastCall[2] as string;
+    expect(urlArg).toContain("focus=");
+  });
+});

--- a/__tests__/zoomOptics.test.ts
+++ b/__tests__/zoomOptics.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import { yRatioAtZoom, bAtZoom } from "../src/optics/optics.js";
+import buildLens from "../src/optics/buildLens.js";
+import LENS_DEFAULTS from "../src/lens-data/defaults.js";
+import NikkorZ70200Raw from "../src/lens-data/NikonNikkorZ70200f28.data.js";
+import type { RuntimeLens, LensData } from "../src/types/optics.js";
+
+/* ── Minimal mock helpers ── */
+
+function makeNonZoomLens(yRatio = 0.75, B = 8.5): RuntimeLens {
+  return { isZoom: false, EP: { yRatio, epSD: 12 }, B } as unknown as RuntimeLens;
+}
+
+function makeZoomLens(yRatios: number[], bs: number[]): RuntimeLens {
+  return { isZoom: true, zoomYRatios: yRatios, zoomBs: bs } as unknown as RuntimeLens;
+}
+
+/* ── yRatioAtZoom ── */
+
+describe("yRatioAtZoom — non-zoom lens", () => {
+  it("returns EP.yRatio regardless of zoomT", () => {
+    const L = makeNonZoomLens(0.75);
+    expect(yRatioAtZoom(0, L)).toBe(0.75);
+    expect(yRatioAtZoom(0.5, L)).toBe(0.75);
+    expect(yRatioAtZoom(1, L)).toBe(0.75);
+  });
+
+  it("returns exact EP.yRatio value from lens object", () => {
+    const L = makeNonZoomLens(1.23456);
+    expect(yRatioAtZoom(0.99, L)).toBe(1.23456);
+  });
+});
+
+describe("yRatioAtZoom — zoom lens, single position", () => {
+  it("returns the single array value regardless of zoomT", () => {
+    const L = makeZoomLens([0.6], [5.0]);
+    expect(yRatioAtZoom(0, L)).toBe(0.6);
+    expect(yRatioAtZoom(0.5, L)).toBe(0.6);
+    expect(yRatioAtZoom(1, L)).toBe(0.6);
+  });
+});
+
+describe("yRatioAtZoom — zoom lens, two positions", () => {
+  it("returns first value at zoomT = 0", () => {
+    const L = makeZoomLens([0.4, 0.9], [3, 9]);
+    expect(yRatioAtZoom(0, L)).toBeCloseTo(0.4, 10);
+  });
+
+  it("returns last value at zoomT = 1", () => {
+    const L = makeZoomLens([0.4, 0.9], [3, 9]);
+    expect(yRatioAtZoom(1, L)).toBeCloseTo(0.9, 10);
+  });
+
+  it("interpolates linearly at zoomT = 0.5", () => {
+    const L = makeZoomLens([0.4, 0.9], [3, 9]);
+    expect(yRatioAtZoom(0.5, L)).toBeCloseTo(0.65, 10);
+  });
+
+  it("interpolates correctly at zoomT = 0.25", () => {
+    const L = makeZoomLens([0.4, 0.9], [3, 9]);
+    // 0.4 + 0.25 * (0.9 - 0.4) = 0.525
+    expect(yRatioAtZoom(0.25, L)).toBeCloseTo(0.525, 10);
+  });
+});
+
+describe("yRatioAtZoom — zoom lens, three positions", () => {
+  it("returns first value at zoomT = 0", () => {
+    const L = makeZoomLens([0.3, 0.6, 0.9], [2, 5, 8]);
+    expect(yRatioAtZoom(0, L)).toBeCloseTo(0.3, 10);
+  });
+
+  it("returns middle value at zoomT = 0.5", () => {
+    const L = makeZoomLens([0.3, 0.6, 0.9], [2, 5, 8]);
+    expect(yRatioAtZoom(0.5, L)).toBeCloseTo(0.6, 10);
+  });
+
+  it("returns last value at zoomT = 1", () => {
+    const L = makeZoomLens([0.3, 0.6, 0.9], [2, 5, 8]);
+    expect(yRatioAtZoom(1, L)).toBeCloseTo(0.9, 10);
+  });
+
+  it("interpolates in the first half at zoomT = 0.25", () => {
+    const L = makeZoomLens([0.3, 0.6, 0.9], [2, 5, 8]);
+    // pos = 0.25 * 2 = 0.5, idx = 0, frac = 0.5 → 0.3 + 0.5*(0.6-0.3) = 0.45
+    expect(yRatioAtZoom(0.25, L)).toBeCloseTo(0.45, 10);
+  });
+
+  it("interpolates in the second half at zoomT = 0.75", () => {
+    const L = makeZoomLens([0.3, 0.6, 0.9], [2, 5, 8]);
+    // pos = 0.75 * 2 = 1.5, idx = 1, frac = 0.5 → 0.6 + 0.5*(0.9-0.6) = 0.75
+    expect(yRatioAtZoom(0.75, L)).toBeCloseTo(0.75, 10);
+  });
+});
+
+/* ── bAtZoom ── */
+
+describe("bAtZoom — non-zoom lens", () => {
+  it("returns L.B regardless of zoomT", () => {
+    const L = makeNonZoomLens(0.75, 10.5);
+    expect(bAtZoom(0, L)).toBe(10.5);
+    expect(bAtZoom(0.5, L)).toBe(10.5);
+    expect(bAtZoom(1, L)).toBe(10.5);
+  });
+
+  it("handles negative B (telephoto-type lenses)", () => {
+    const L = makeNonZoomLens(0.75, -3.2);
+    expect(bAtZoom(0.5, L)).toBe(-3.2);
+  });
+});
+
+describe("bAtZoom — zoom lens, single position", () => {
+  it("returns the single array value regardless of zoomT", () => {
+    const L = makeZoomLens([0.5], [7.0]);
+    expect(bAtZoom(0, L)).toBe(7.0);
+    expect(bAtZoom(0.5, L)).toBe(7.0);
+    expect(bAtZoom(1, L)).toBe(7.0);
+  });
+});
+
+describe("bAtZoom — zoom lens, two positions", () => {
+  it("returns first value at zoomT = 0", () => {
+    const L = makeZoomLens([0.4, 0.9], [3.0, 12.0]);
+    expect(bAtZoom(0, L)).toBeCloseTo(3.0, 10);
+  });
+
+  it("returns last value at zoomT = 1", () => {
+    const L = makeZoomLens([0.4, 0.9], [3.0, 12.0]);
+    expect(bAtZoom(1, L)).toBeCloseTo(12.0, 10);
+  });
+
+  it("interpolates linearly at zoomT = 0.5", () => {
+    const L = makeZoomLens([0.4, 0.9], [3.0, 12.0]);
+    expect(bAtZoom(0.5, L)).toBeCloseTo(7.5, 10);
+  });
+});
+
+describe("bAtZoom — zoom lens, three positions", () => {
+  it("interpolates symmetrically across all three segments", () => {
+    const L = makeZoomLens([0.3, 0.6, 0.9], [2.0, 6.0, 10.0]);
+    expect(bAtZoom(0, L)).toBeCloseTo(2.0, 10);
+    // pos=0.5*2=1, idx=min(1,1)=1, frac=0 → arr[1] = 6.0
+    expect(bAtZoom(0.5, L)).toBeCloseTo(6.0, 10);
+    expect(bAtZoom(1, L)).toBeCloseTo(10.0, 10);
+    // zoomT=0.25: pos=0.5, idx=0, frac=0.5 → 2 + 0.5*(6-2) = 4
+    expect(bAtZoom(0.25, L)).toBeCloseTo(4.0, 10);
+    // zoomT=0.75: pos=1.5, idx=1, frac=0.5 → 6 + 0.5*(10-6) = 8
+    expect(bAtZoom(0.75, L)).toBeCloseTo(8.0, 10);
+  });
+});
+
+/* ── Production zoom lens sanity checks ── */
+
+describe("yRatioAtZoom / bAtZoom — production zoom lens (Nikkor Z 70-200mm f/2.8)", () => {
+  const NikkorZ70200 = { ...LENS_DEFAULTS, ...NikkorZ70200Raw } as LensData;
+  const L = buildLens(NikkorZ70200);
+
+  it("L.isZoom is true", () => {
+    expect(L.isZoom).toBe(true);
+  });
+
+  it("yRatioAtZoom returns finite values across zoom range", () => {
+    for (const t of [0, 0.25, 0.5, 0.75, 1]) {
+      const val = yRatioAtZoom(t, L);
+      expect(isFinite(val), `yRatioAtZoom(${t}) must be finite`).toBe(true);
+    }
+  });
+
+  it("bAtZoom returns finite values across zoom range", () => {
+    for (const t of [0, 0.25, 0.5, 0.75, 1]) {
+      const val = bAtZoom(t, L);
+      expect(isFinite(val), `bAtZoom(${t}) must be finite`).toBe(true);
+    }
+  });
+
+  it("yRatioAtZoom is monotone across the zoom range", () => {
+    // yRatio may increase or decrease monotonically; verify it changes between endpoints
+    const wide = yRatioAtZoom(0, L);
+    const tele = yRatioAtZoom(1, L);
+    expect(wide).not.toBeCloseTo(tele, 3); // should differ meaningfully
+  });
+
+  it("yRatioAtZoom matches L.zoomYRatios endpoints exactly", () => {
+    expect(yRatioAtZoom(0, L)).toBeCloseTo(L.zoomYRatios![0], 10);
+    expect(yRatioAtZoom(1, L)).toBeCloseTo(L.zoomYRatios![L.zoomYRatios!.length - 1], 10);
+  });
+
+  it("bAtZoom matches L.zoomBs endpoints exactly", () => {
+    expect(bAtZoom(0, L)).toBeCloseTo(L.zoomBs![0], 10);
+    expect(bAtZoom(1, L)).toBeCloseTo(L.zoomBs![L.zoomBs!.length - 1], 10);
+  });
+
+  it("mid-zoom yRatioAtZoom is between wide and tele values", () => {
+    const wide = yRatioAtZoom(0, L);
+    const tele = yRatioAtZoom(1, L);
+    const mid = yRatioAtZoom(0.5, L);
+    const lo = Math.min(wide, tele);
+    const hi = Math.max(wide, tele);
+    expect(mid).toBeGreaterThanOrEqual(lo);
+    expect(mid).toBeLessThanOrEqual(hi);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.3.4",
@@ -24,12 +25,74 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "globals": "^17.4.0",
+        "jsdom": "^29.0.1",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.2",
         "vite": "^6.0.0",
         "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -265,6 +328,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -321,6 +394,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -922,6 +1148,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1387,6 +1631,63 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2037,6 +2338,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2059,6 +2371,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2281,6 +2604,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2545,11 +2878,39 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2621,6 +2982,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -2713,6 +3081,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2734,6 +3110,19 @@
       "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -3702,6 +4091,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4070,6 +4472,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4305,6 +4714,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4445,6 +4905,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -4787,6 +5258,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -5647,6 +6125,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5765,6 +6256,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5977,6 +6506,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
@@ -6109,6 +6648,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -6502,6 +7054,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6544,6 +7103,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -6725,6 +7330,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {
@@ -7040,6 +7655,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7171,6 +7834,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
@@ -32,6 +33,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^17.4.0",
+    "jsdom": "^29.0.1",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.2",


### PR DESCRIPTION
- __tests__/zoomOptics.test.ts: unit tests for yRatioAtZoom and bAtZoom, covering non-zoom lenses, single/two/three-position zoom arrays, interpolation math at boundary and mid-range positions, and production Nikkor Z 70-200mm regression checks
- __tests__/usePreferences.test.ts: hook tests verifying localStorage is written on mount, correct fields are included/excluded (sliders and overlays omitted), change detection skips writes for unchanged state, and localStorage errors are swallowed gracefully
- __tests__/useLensState.test.ts: hook integration tests covering default state, URL param initialization (?lens=, ?focus=, ?aperture=), localStorage prefs loading, URL > prefs precedence, and dispatch round-trips
- __tests__/useURLSync.test.ts: hook tests for immediate URL update on lens change, 300ms debounce behavior, coalescing of rapid calls, focus/aperture encoding, and comparison-mode shared slider URL encoding

Adds @testing-library/react and jsdom as dev dependencies to enable renderHook-based hook testing.

https://claude.ai/code/session_01L8ahKujmMasuDF2M74kfVp