### PR TITLE
docs: update documentation to reflect current codebase structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,35 @@ Interactive web-based optical lens cross-section visualizer and ray-tracing tool
 src/types/                — Shared TypeScript type definitions (optics, state, theme)
 src/components/           — React UI components and hooks
   components/layout/      — Top-level layout and orchestration components
+                            (LensViewer, TopBar, ControlsBar, ViewToggleBar,
+                             ComparisonLayout, OverlayModal, LensDiagramPanel,
+                             DescriptionPanel, SharedSlidersBar)
   components/diagram/     — SVG rendering components
+                            (DiagramSVG, RayPolylines, ApertureStop,
+                             ElementAnnotations, LCAInsetWidget)
   components/controls/    — Sliders, toggles, and header controls
+                            (DiagramControls, DiagramHeader, SliderControl,
+                             RayToggles, ChromaticControls)
   components/display/     — Data display (inspector, legend, about)
+                            (ElementInspector, DiagramLegend,
+                             AboutButtonRow, AboutFooter)
   components/errors/      — Error boundary components
+                            (ErrorBoundary, PanelErrorBoundary)
   components/hooks/       — Custom React hooks for computation and state
+                            (useLensComputation, useRayTracing, useOnAxisRays,
+                             useOffAxisRays, useChromaticRays, useFlashOverlay,
+                             useSideLayoutDetection)
 src/optics/               — Pure-function optical engine (.ts, no React deps)
-src/utils/                — Themes, feature flags, catalog, hooks (.ts)
+src/utils/                — Themes, styles, feature flags, catalog, state hooks (.ts)
+                            (themes, styles, featureFlags, lensCatalog,
+                             lensReducer, useLensState, LensContext,
+                             useURLSync, useStickySliders, comparisonSliders,
+                             parseComparisonParams, usePreferences, preferences,
+                             errorReporting, useMediaQuery)
 src/lens-data/            — Lens prescription data (auto-registered *.data.js)
 src/content/              — Static markdown content
+                            (AboutMe.md, AboutSite.md,
+                             OpticsPrimerSimple.md, OpticsPrimerIntermediate.md)
 __tests__/                — Vitest unit tests (.ts, type-checked by tsc)
 agent_docs/               — Detailed architecture and task guides
 ```
@@ -34,16 +54,17 @@ agent_docs/               — Detailed architecture and task guides
 ## Commands
 
 ```bash
-npm install        # Install dependencies
-npm run dev        # Start dev server (http://localhost:5173)
-npm run build      # Production build → dist/
-npm run preview    # Preview production build
-npm run test         # Run Vitest unit tests
-npm run typecheck    # Run TypeScript type checking (tsc --noEmit)
-npm run lint         # Run ESLint
-npm run lint:fix     # Run ESLint with auto-fix
-npm run format       # Format code with Prettier
-npm run format:check # Check formatting (CI uses this)
+npm install           # Install dependencies
+npm run dev           # Start dev server (http://localhost:5173)
+npm run build         # Production build → dist/
+npm run preview       # Preview production build
+npm run test          # Run Vitest unit tests
+npm run test:coverage # Run Vitest with v8 coverage report
+npm run typecheck     # Run TypeScript type checking (tsc --noEmit)
+npm run lint          # Run ESLint
+npm run lint:fix      # Run ESLint with auto-fix
+npm run format        # Format code with Prettier
+npm run format:check  # Check formatting (CI uses this)
 ```
 
 ## Deployment
@@ -85,7 +106,7 @@ See `agent_docs/adding_a_lens.md` for details on defaults merging, naming conven
 
 ## Testing
 
-Run `npm run test`. Tests in `__tests__/` cover the optics engine, lens building, validation, catalog loading, comparison sliders, URL parsing, and extracted UI component module contracts. Full DOM-based component rendering is not tested.
+Run `npm run test`. Tests in `__tests__/` cover the optics engine, lens building, validation, catalog loading, comparison sliders, URL parsing, themes, styles, state management (reducer, preferences, URL sync, sticky sliders), zoom optics helpers, error reporting, and extracted UI component module contracts. Full DOM-based component rendering is not tested. Run `npm run test:coverage` for a v8 coverage report (coverage scope is `src/optics/**`).
 
 Test files are TypeScript (`.ts`) and included in `tsconfig.json` so `npm run typecheck` validates them alongside `src/`. Intentionally partial mock objects use `as unknown as RuntimeLens` (or the relevant type) to satisfy strict mode while keeping fixtures minimal. Lens data files (`.data.js`) are declared in `__tests__/globals.d.ts` via a wildcard module so tsc can resolve those imports.
 

--- a/README.md
+++ b/README.md
@@ -46,19 +46,21 @@ Created by **Ron Buening** — see [About This Site](src/content/AboutSite.md) f
 | RICOH GR IV 18.3mm f/2.8 | 7 | Compact retrofocus; JP2025-069516A |
 | NIKON NIKKOR Z 24-70mm f/2.8 S | 17 | Internal zoom; 4 aspherics; 4 APD elements; WO 2020/136749 A1 |
 | NIKON NIKKOR Z 70-200mm f/2.8 VR S | 21 | Internal zoom; 2 aspherics; 7 APD elements; WO 2020/105104 A1 |
+| NIKON NIKKOR 85mm f/1.4G | 10 | All-spherical; US 7,760,444 B2 |
 
 New lenses are auto-registered — just add a `.data.js` file to `src/lens-data/`. See [Adding a New Lens](#adding-a-new-lens) below.
 
 ## Getting Started
 
 ```bash
-npm install        # Install dependencies
-npm run dev        # Start dev server at http://localhost:5173
-npm run build      # Production build → dist/
-npm run preview    # Preview production build
-npm run test       # Run Vitest unit tests
-npm run lint       # Run ESLint
-npm run format     # Format code with Prettier
+npm install           # Install dependencies
+npm run dev           # Start dev server at http://localhost:5173
+npm run build         # Production build → dist/
+npm run preview       # Preview production build
+npm run test          # Run Vitest unit tests
+npm run test:coverage # Run Vitest with v8 coverage report
+npm run lint          # Run ESLint
+npm run format        # Format code with Prettier
 ```
 
 Requires Node.js 18+.
@@ -94,43 +96,51 @@ LensVisualizer/
 │   ├── main.tsx                        # React root mount
 │   ├── types/                          # Shared TypeScript type definitions
 │   ├── components/
-│   │   ├── LensViewer.tsx              # Orchestration: state, context, layout
-│   │   ├── TopBar.tsx                  # Lens selectors, compare/about buttons
-│   │   ├── ControlsBar.tsx             # Theme/ray/chromatic/scale toggles
-│   │   ├── ViewToggleBar.tsx           # View-mode toggle (mobile + desktop)
-│   │   ├── ComparisonLayout.tsx        # Side-by-side / stacked comparison panels
-│   │   ├── OverlayModal.tsx            # Generic backdrop + modal overlay
-│   │   ├── LensDiagramPanel.tsx        # Diagram composition layer
-│   │   ├── PanelErrorBoundary.tsx      # Panel-level error boundary
-│   │   ├── DiagramHeader.tsx           # Title, specs, controls header
-│   │   ├── RayToggles.tsx              # On-axis/off-axis toggle buttons
-│   │   ├── ChromaticControls.tsx       # COLOR toggle + R/G/B channels
-│   │   ├── DiagramSVG.tsx              # Full SVG rendering
-│   │   ├── RayPolylines.tsx            # Consolidated ray segment rendering
-│   │   ├── ApertureStop.tsx            # Aperture stop blades + STO label
-│   │   ├── ElementAnnotations.tsx      # Element numbers, Abbe badges, labels
-│   │   ├── LCAInsetWidget.tsx          # Magnified LCA inset
-│   │   ├── DiagramControls.tsx         # Zoom, focus, aperture sliders
-│   │   ├── SliderControl.tsx           # Reusable slider component
-│   │   ├── ElementInspector.tsx        # Selected element property display
-│   │   ├── DiagramLegend.tsx           # Legend with aberration readouts
-│   │   ├── DescriptionPanel.tsx        # Themed markdown renderer
-│   │   ├── SharedSlidersBar.tsx        # Comparison mode shared controls
-│   │   ├── ErrorBoundary.tsx           # Error boundary with retry UI
-│   │   ├── useLensComputation.ts       # Hook: lens building, layout, shapes
-│   │   ├── useRayTracing.ts            # Hook: ray tracing orchestrator
-│   │   ├── useOnAxisRays.ts            # Hook: on-axis ray fan
-│   │   ├── useOffAxisRays.ts           # Hook: off-axis field rays
-│   │   ├── useChromaticRays.ts         # Hook: chromatic tracing + spread
-│   │   ├── useFlashOverlay.ts          # Hook: flash animation state machine
-│   │   └── useSideLayoutDetection.ts   # Hook: overflow-based side layout
+│   │   ├── layout/                     # Orchestration + top-level layout
+│   │   │   ├── LensViewer.tsx          # State, context, layout composition
+│   │   │   ├── TopBar.tsx              # Lens selectors, compare/about buttons
+│   │   │   ├── ControlsBar.tsx         # Theme/ray/chromatic/scale toggles
+│   │   │   ├── ViewToggleBar.tsx       # View-mode toggle (mobile + desktop)
+│   │   │   ├── ComparisonLayout.tsx    # Side-by-side / stacked comparison panels
+│   │   │   ├── OverlayModal.tsx        # Generic backdrop + modal overlay
+│   │   │   ├── LensDiagramPanel.tsx    # Diagram composition layer
+│   │   │   ├── DescriptionPanel.tsx    # Themed markdown renderer
+│   │   │   └── SharedSlidersBar.tsx    # Comparison mode shared controls
+│   │   ├── diagram/                    # SVG rendering
+│   │   │   ├── DiagramSVG.tsx          # Full SVG rendering
+│   │   │   ├── RayPolylines.tsx        # Consolidated ray segment rendering
+│   │   │   ├── ApertureStop.tsx        # Aperture stop blades + STO label
+│   │   │   ├── ElementAnnotations.tsx  # Element numbers, Abbe badges, labels
+│   │   │   └── LCAInsetWidget.tsx      # Magnified LCA inset
+│   │   ├── controls/                   # Sliders, toggles, header controls
+│   │   │   ├── DiagramControls.tsx     # Zoom, focus, aperture sliders
+│   │   │   ├── DiagramHeader.tsx       # Title, specs, controls header
+│   │   │   ├── SliderControl.tsx       # Reusable slider component
+│   │   │   ├── RayToggles.tsx          # On-axis/off-axis toggle buttons
+│   │   │   └── ChromaticControls.tsx   # COLOR toggle + R/G/B channels
+│   │   ├── display/                    # Data display
+│   │   │   ├── ElementInspector.tsx    # Selected element property display
+│   │   │   ├── DiagramLegend.tsx       # Legend with aberration readouts
+│   │   │   ├── AboutButtonRow.tsx      # Shared about button group
+│   │   │   └── AboutFooter.tsx         # Mobile-only footer about buttons
+│   │   ├── errors/                     # Error boundaries
+│   │   │   ├── ErrorBoundary.tsx       # App-level error boundary
+│   │   │   └── PanelErrorBoundary.tsx  # Panel-level error boundary
+│   │   └── hooks/                      # Custom React hooks
+│   │       ├── useLensComputation.ts   # Lens building, layout, shapes
+│   │       ├── useRayTracing.ts        # Ray tracing orchestrator
+│   │       ├── useOnAxisRays.ts        # On-axis ray fan
+│   │       ├── useOffAxisRays.ts       # Off-axis field rays
+│   │       ├── useChromaticRays.ts     # Chromatic tracing + spread
+│   │       ├── useFlashOverlay.ts      # Flash animation state machine
+│   │       └── useSideLayoutDetection.ts # Overflow-based side layout
 │   ├── optics/
 │   │   ├── optics.ts                   # Ray tracing, sag curves, layout math
 │   │   ├── buildLens.ts                # Lens construction, EFL/pupil/field
 │   │   ├── validateLensData.ts         # Schema validation
 │   │   └── diagramGeometry.ts          # Coordinate transforms, element shapes
-│   ├── utils/                          # Themes, feature flags, catalog, hooks
-│   ├── content/                        # AboutMe.md, AboutSite.md
+│   ├── utils/                          # Themes, styles, feature flags, catalog, state hooks
+│   ├── content/                        # AboutMe.md, AboutSite.md, OpticsPrimer*.md
 │   └── lens-data/                      # Lens prescriptions + analyses
 ├── agent_docs/                         # Documentation for AI coding assistants
 └── __tests__/                          # Vitest unit tests (TypeScript)

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -4,38 +4,38 @@
 
 | Module | Location | Purpose |
 |--------|----------|---------|
-| `LensViewer.tsx` | `src/components/` | Orchestration: state management, context provision, layout composition |
-| `TopBar.tsx` | `src/components/` | Lens selectors, compare button, about buttons |
-| `ControlsBar.tsx` | `src/components/` | Theme/ray/chromatic/scale toggles (compact + full modes) |
-| `ViewToggleBar.tsx` | `src/components/` | Generic view-mode toggle (mobile + desktop) |
-| `ComparisonLayout.tsx` | `src/components/` | Side-by-side (desktop) / stacked (mobile) comparison panels |
-| `OverlayModal.tsx` | `src/components/` | Generic backdrop + modal + close button |
-| `LensDiagramPanel.tsx` | `src/components/` | Diagram composition: wires hooks + sub-components |
-| `PanelErrorBoundary.tsx` | `src/components/` | Panel-level error boundary, resets on lens change |
-| `useLensComputation.ts` | `src/components/` | Hook: lens building, layout, transforms, shapes, aperture |
-| `useRayTracing.ts` | `src/components/` | Hook: orchestrates on-axis, off-axis, chromatic ray sub-hooks |
-| `useOnAxisRays.ts` | `src/components/` | Hook: on-axis ray fan computation |
-| `useOffAxisRays.ts` | `src/components/` | Hook: off-axis field ray computation |
-| `useChromaticRays.ts` | `src/components/` | Hook: chromatic tracing + spread computation |
-| `useFlashOverlay.ts` | `src/components/` | Hook: flash animation state machine for sticky slider feedback |
-| `useSideLayoutDetection.ts` | `src/components/` | Hook: ResizeObserver overflow detection with hysteresis |
-| `DiagramHeader.tsx` | `src/components/` | Header: title, specs, composes RayToggles + ChromaticControls |
-| `RayToggles.tsx` | `src/components/` | On-axis/off-axis toggle buttons with cycling logic |
-| `ChromaticControls.tsx` | `src/components/` | COLOR master toggle + R/G/B channel buttons |
-| `DiagramSVG.tsx` | `src/components/` | SVG rendering: composes RayPolylines, ApertureStop, ElementAnnotations, LCAInsetWidget |
-| `RayPolylines.tsx` | `src/components/` | Consolidated ray segment polyline rendering |
-| `ApertureStop.tsx` | `src/components/` | Aperture stop blades + STO label |
-| `ElementAnnotations.tsx` | `src/components/` | Element numbers, Abbe νd badges, group/doublet labels |
-| `LCAInsetWidget.tsx` | `src/components/` | Magnified LCA inset with auto-scaled wavelength offsets |
-| `DiagramControls.tsx` | `src/components/` | Zoom, focus, aperture sliders (composes SliderControl) |
-| `SliderControl.tsx` | `src/components/` | Reusable slider with label, endpoints, collapsible content |
-| `ElementInspector.tsx` | `src/components/` | Selected element property display |
-| `DiagramLegend.tsx` | `src/components/` | Legend with swatches, ray descriptions, aberration readouts |
-| `AboutButtonRow.tsx` | `src/components/` | Shared about button group (Optics, Site, Author) |
-| `AboutFooter.tsx` | `src/components/` | Mobile-only footer rendering about buttons at page bottom |
-| `DescriptionPanel.tsx` | `src/components/` | Markdown panel with themed styling |
-| `SharedSlidersBar.tsx` | `src/components/` | Comparison mode shared focus/aperture/zoom controls |
-| `ErrorBoundary.tsx` | `src/components/` | Error boundary + reusable ErrorDisplay |
+| `LensViewer.tsx` | `src/components/layout/` | Orchestration: state management, context provision, layout composition |
+| `TopBar.tsx` | `src/components/layout/` | Lens selectors, compare button, about buttons |
+| `ControlsBar.tsx` | `src/components/layout/` | Theme/ray/chromatic/scale toggles (compact + full modes) |
+| `ViewToggleBar.tsx` | `src/components/layout/` | Generic view-mode toggle (mobile + desktop) |
+| `ComparisonLayout.tsx` | `src/components/layout/` | Side-by-side (desktop) / stacked (mobile) comparison panels |
+| `OverlayModal.tsx` | `src/components/layout/` | Generic backdrop + modal + close button |
+| `LensDiagramPanel.tsx` | `src/components/layout/` | Diagram composition: wires hooks + sub-components |
+| `DescriptionPanel.tsx` | `src/components/layout/` | Markdown panel with themed styling |
+| `SharedSlidersBar.tsx` | `src/components/layout/` | Comparison mode shared focus/aperture/zoom controls |
+| `useLensComputation.ts` | `src/components/hooks/` | Hook: lens building, layout, transforms, shapes, aperture |
+| `useRayTracing.ts` | `src/components/hooks/` | Hook: orchestrates on-axis, off-axis, chromatic ray sub-hooks |
+| `useOnAxisRays.ts` | `src/components/hooks/` | Hook: on-axis ray fan computation |
+| `useOffAxisRays.ts` | `src/components/hooks/` | Hook: off-axis field ray computation |
+| `useChromaticRays.ts` | `src/components/hooks/` | Hook: chromatic tracing + spread computation |
+| `useFlashOverlay.ts` | `src/components/hooks/` | Hook: flash animation state machine for sticky slider feedback |
+| `useSideLayoutDetection.ts` | `src/components/hooks/` | Hook: ResizeObserver overflow detection with hysteresis |
+| `DiagramHeader.tsx` | `src/components/controls/` | Header: title, specs, composes RayToggles + ChromaticControls |
+| `RayToggles.tsx` | `src/components/controls/` | On-axis/off-axis toggle buttons with cycling logic |
+| `ChromaticControls.tsx` | `src/components/controls/` | COLOR master toggle + R/G/B channel buttons |
+| `DiagramControls.tsx` | `src/components/controls/` | Zoom, focus, aperture sliders (composes SliderControl) |
+| `SliderControl.tsx` | `src/components/controls/` | Reusable slider with label, endpoints, collapsible content |
+| `DiagramSVG.tsx` | `src/components/diagram/` | SVG rendering: composes RayPolylines, ApertureStop, ElementAnnotations, LCAInsetWidget |
+| `RayPolylines.tsx` | `src/components/diagram/` | Consolidated ray segment polyline rendering |
+| `ApertureStop.tsx` | `src/components/diagram/` | Aperture stop blades + STO label |
+| `ElementAnnotations.tsx` | `src/components/diagram/` | Element numbers, Abbe νd badges, group/doublet labels |
+| `LCAInsetWidget.tsx` | `src/components/diagram/` | Magnified LCA inset with auto-scaled wavelength offsets |
+| `ElementInspector.tsx` | `src/components/display/` | Selected element property display |
+| `DiagramLegend.tsx` | `src/components/display/` | Legend with swatches, ray descriptions, aberration readouts |
+| `AboutButtonRow.tsx` | `src/components/display/` | Shared about button group (Optics, Site, Author) |
+| `AboutFooter.tsx` | `src/components/display/` | Mobile-only footer rendering about buttons at page bottom |
+| `ErrorBoundary.tsx` | `src/components/errors/` | Error boundary + reusable ErrorDisplay |
+| `PanelErrorBoundary.tsx` | `src/components/errors/` | Panel-level error boundary, resets on lens change |
 | `optics.ts` | `src/optics/` | Ray tracing, sag curves, chromatic, layout geometry |
 | `buildLens.ts` | `src/optics/` | Lens construction, EFL/pupil/field computation |
 | `validateLensData.ts` | `src/optics/` | Schema validation for lens data |
@@ -79,7 +79,7 @@ State is provided to children via `LensStateContext` (state + theme + isWide) an
 
 Orchestrates sub-components and custom hooks. Owns only hover/selection state, header height reporting, and structural layout wiring.
 
-Extracted hooks (all in `src/components/`):
+Extracted hooks (all in `src/components/hooks/`):
 - **`useLensComputation.ts`** — Hook: lens building, layout, coordinate transforms, element shapes, aperture calculations
 - **`useRayTracing.ts`** — Hook: orchestrates ray sub-hooks (useOnAxisRays, useOffAxisRays, useChromaticRays)
 - **`useOnAxisRays.ts`** — Hook: on-axis ray fan computation + coordinate transform
@@ -88,20 +88,20 @@ Extracted hooks (all in `src/components/`):
 - **`useFlashOverlay.ts`** — Hook: two-phase flash animation state machine for sticky slider feedback
 - **`useSideLayoutDetection.ts`** — Hook: ResizeObserver-based overflow detection with hysteresis for side-by-side layout
 
-Sub-components (all in `src/components/`):
-- **`PanelErrorBoundary.tsx`** — Panel-level error boundary that resets automatically on lens change
-- **`DiagramHeader.tsx`** — Title, specs, composes RayToggles + ChromaticControls (uses `forwardRef` for height measurement)
+Sub-components:
+- **`PanelErrorBoundary.tsx`** (`src/components/errors/`) — Panel-level error boundary that resets automatically on lens change
+- **`DiagramHeader.tsx`** (`src/components/controls/`) — Title, specs, composes RayToggles + ChromaticControls (uses `forwardRef` for height measurement)
   - **`RayToggles.tsx`** — On-axis/off-axis toggle buttons with off-axis cycling logic and feature flag awareness
   - **`ChromaticControls.tsx`** — COLOR master toggle + individual R/G/B channel buttons
-- **`DiagramSVG.tsx`** — SVG rendering: defs, grid, composes RayPolylines, element shapes, aspheric overlays, ApertureStop, image plane, LCAInsetWidget, ElementAnnotations, flash overlay
+- **`DiagramSVG.tsx`** (`src/components/diagram/`) — SVG rendering: defs, grid, composes RayPolylines, element shapes, aspheric overlays, ApertureStop, image plane, LCAInsetWidget, ElementAnnotations, flash overlay
   - **`RayPolylines.tsx`** — Consolidated ray segment polyline rendering (solid + ghost paths)
   - **`ApertureStop.tsx`** — Aperture stop blades + STO label
   - **`ElementAnnotations.tsx`** — Element number labels, Abbe νd badges, group/doublet labels
   - **`LCAInsetWidget.tsx`** — Magnified LCA inset with auto-scaled wavelength offsets (clamped at 5000×)
-- **`DiagramControls.tsx`** — Zoom, focus, aperture sliders (composes SliderControl)
+- **`DiagramControls.tsx`** (`src/components/controls/`) — Zoom, focus, aperture sliders (composes SliderControl)
   - **`SliderControl.tsx`** — Reusable slider with label, value display, endpoints, optional collapsible content
-- **`ElementInspector.tsx`** — Selected element property display (nd, νd, FL, glass, aspheric coefficients, chromatic data)
-- **`DiagramLegend.tsx`** — Legend with color swatches, ray mode descriptions, chromatic aberration readouts
+- **`ElementInspector.tsx`** (`src/components/display/`) — Selected element property display (nd, νd, FL, glass, aspheric coefficients, chromatic data)
+- **`DiagramLegend.tsx`** (`src/components/display/`) — Legend with color swatches, ray mode descriptions, chromatic aberration readouts
 
 Reads shared state (rays, display, panels) from `LensContext`. Per-instance props (lensKey, per-lens slider values, scaleRatio, panelId, compact, flashOverlay) are passed as explicit props. Sub-components remain context-unaware.
 


### PR DESCRIPTION
- CLAUDE.md: expand component subdirectory listing with file names, expand utils/ listing with all 15 modules, add OpticsPrimer content files, add test:coverage command, broaden Testing section description
- README.md: update project structure tree to show component subdirectories (layout/diagram/controls/display/errors/hooks), add NIKKOR 85mm f/1.4G to Available Lenses table, add test:coverage command, update content/ description
- agent_docs/architecture.md: update all component module paths from flat src/components/ to their correct subdirectories (layout/, hooks/, controls/, diagram/, display/, errors/)

https://claude.ai/code/session_01GpARezWEVhfNjHJCAYsApd