### PR TITLE
Add entrance and exit pupil toggle to lens diagram

### DIFF
--- a/src/components/controls/DiagramHeader.tsx
+++ b/src/components/controls/DiagramHeader.tsx
@@ -37,6 +37,8 @@ interface DiagramHeaderProps {
   onShowOnAxisChange?: (value: boolean) => void;
   showOffAxis: string;
   onShowOffAxisChange?: (value: string) => void;
+  showPupils: boolean;
+  onShowPupilsChange?: (value: boolean) => void;
   rayTracksF: boolean;
   onRayTracksFChange?: (value: boolean) => void;
   showChromatic: boolean;
@@ -71,6 +73,8 @@ const DiagramHeader = forwardRef<HTMLDivElement, DiagramHeaderProps>(function Di
     onShowOnAxisChange,
     showOffAxis,
     onShowOffAxisChange,
+    showPupils,
+    onShowPupilsChange,
     rayTracksF,
     onRayTracksFChange,
     showChromatic,
@@ -247,6 +251,8 @@ const DiagramHeader = forwardRef<HTMLDivElement, DiagramHeaderProps>(function Di
                   onShowOnAxisChange={onShowOnAxisChange}
                   showOffAxis={showOffAxis}
                   onShowOffAxisChange={onShowOffAxisChange}
+                  showPupils={showPupils}
+                  onShowPupilsChange={onShowPupilsChange}
                 />
                 {/* Ray mode */}
                 <div style={toggleGroup(t, { width: "100%" })}>

--- a/src/components/controls/RayToggles.tsx
+++ b/src/components/controls/RayToggles.tsx
@@ -14,6 +14,8 @@ interface RayTogglesProps {
   onShowOnAxisChange?: (value: boolean) => void;
   showOffAxis: string;
   onShowOffAxisChange?: (value: string) => void;
+  showPupils: boolean;
+  onShowPupilsChange?: (value: boolean) => void;
 }
 
 export default function RayToggles({
@@ -22,6 +24,8 @@ export default function RayToggles({
   onShowOnAxisChange,
   showOffAxis,
   onShowOffAxisChange,
+  showPupils,
+  onShowPupilsChange,
 }: RayTogglesProps) {
   const offAxisActive = showOffAxis !== "off";
   const offAxisCycle = ENABLE_EDGE_PROJECTION
@@ -40,26 +44,72 @@ export default function RayToggles({
       label: "ON-AXIS",
       active: showOnAxis,
       onClick: () => onShowOnAxisChange?.(!showOnAxis),
-      dotA: t.rayWarm,
-      dotB: t.rayCool,
+      icon: (active: boolean) => (
+        <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
+          <line x1="0" y1="4" x2="14" y2="4" stroke={active ? t.rayWarm : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
+          <line x1="0" y1="7" x2="14" y2="7" stroke={active ? t.rayCool : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
+        </svg>
+      ),
     },
     {
       label: offAxisLabel,
       active: offAxisActive,
       onClick: offAxisCycle,
-      dotA: t.rayOffWarm,
-      dotB: t.rayOffCool,
+      icon: (active: boolean) => (
+        <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
+          <line
+            x1="0"
+            y1="4"
+            x2="14"
+            y2="4"
+            stroke={active ? t.rayOffWarm : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.5"
+          />
+          <line
+            x1="0"
+            y1="7"
+            x2="14"
+            y2="7"
+            stroke={active ? t.rayOffCool : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.5"
+          />
+        </svg>
+      ),
+    },
+    {
+      label: "PUPILS",
+      active: showPupils,
+      onClick: () => onShowPupilsChange?.(!showPupils),
+      icon: (active: boolean) => (
+        <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
+          <line
+            x1="3"
+            y1="1"
+            x2="3"
+            y2="7"
+            stroke={active ? t.stopLabel : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <line
+            x1="11"
+            y1="1"
+            x2="11"
+            y2="7"
+            stroke={active ? t.stopLabel : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      ),
     },
   ];
 
   return (
     <div style={toggleGroup(t, { width: "100%" })}>
-      {buttons.map(({ label, active, onClick, dotA, dotB }, idx) => (
-        <button key={idx} onClick={onClick} style={toggleBtn(t, active, { hasRightBorder: idx === 0 })}>
-          <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
-            <line x1="0" y1="4" x2="14" y2="4" stroke={active ? dotA : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
-            <line x1="0" y1="7" x2="14" y2="7" stroke={active ? dotB : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
-          </svg>
+      {buttons.map(({ label, active, onClick, icon }, idx) => (
+        <button key={idx} onClick={onClick} style={toggleBtn(t, active, { hasRightBorder: idx < buttons.length - 1 })}>
+          {icon(active)}
           <span>{label}</span>
         </button>
       ))}

--- a/src/components/diagram/DiagramSVG.tsx
+++ b/src/components/diagram/DiagramSVG.tsx
@@ -49,6 +49,7 @@ interface DiagramSVGProps {
   showOnAxis: boolean;
   showOffAxis: string;
   showChromatic: boolean;
+  showPupils: boolean;
   act: number | null;
   onHover: (eid: number | null) => void;
   onSelect: (eid: number | null) => void;
@@ -84,6 +85,7 @@ export default function DiagramSVG({
   showOnAxis,
   showOffAxis,
   showChromatic,
+  showPupils,
   act,
   onHover,
   onSelect,
@@ -271,6 +273,111 @@ export default function DiagramSVG({
         lyStoPad={L.lyStoPad}
         t={t}
       />
+
+      {/* Entrance and exit pupil markers */}
+      {showPupils &&
+        (() => {
+          const epX = sx(zPos[L.stopIdx] + L.epZRelStop);
+          const xpX = sx(zPos[L.N - 1] + L.xpZRelLastSurf);
+          const epTopY = sy(-L.EP.epSD);
+          const epBotY = sy(L.EP.epSD);
+          const xpTopY = sy(-L.xpSD);
+          const xpBotY = sy(L.xpSD);
+          const midY = sy(0);
+          const tickLen = 4;
+          const color = t.stopLabel;
+          const labelStyle = {
+            pointerEvents: "none" as const,
+            letterSpacing: "0.1em",
+          };
+          return (
+            <>
+              {/* Entrance pupil */}
+              <line
+                x1={epX}
+                y1={epTopY}
+                x2={epX}
+                y2={epBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                strokeDasharray="3,2"
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={epX - tickLen}
+                y1={epTopY}
+                x2={epX + tickLen}
+                y2={epTopY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={epX - tickLen}
+                y1={epBotY}
+                x2={epX + tickLen}
+                y2={epBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <text
+                x={epX}
+                y={epTopY - L.lyStoPad}
+                textAnchor="middle"
+                fill={color}
+                fontSize={7.5}
+                fontFamily="inherit"
+                style={labelStyle}
+              >
+                EP
+              </text>
+              {/* Exit pupil */}
+              <line
+                x1={xpX}
+                y1={xpTopY}
+                x2={xpX}
+                y2={xpBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                strokeDasharray="3,2"
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={xpX - tickLen}
+                y1={xpTopY}
+                x2={xpX + tickLen}
+                y2={xpTopY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={xpX - tickLen}
+                y1={xpBotY}
+                x2={xpX + tickLen}
+                y2={xpBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <text
+                x={xpX}
+                y={xpTopY - L.lyStoPad}
+                textAnchor="middle"
+                fill={color}
+                fontSize={7.5}
+                fontFamily="inherit"
+                style={labelStyle}
+              >
+                XP
+              </text>
+              {/* Axis dots at pupil positions */}
+              <circle cx={epX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
+              <circle cx={xpX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
+            </>
+          );
+        })()}
 
       {/* Image plane */}
       <line

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -78,7 +78,7 @@ export default function LensDiagramPanel({
   const { state, theme: t, isWide, updateURLWithSliders } = useLensCtx();
   const dispatch = useLensDispatch();
   const { rays: raysState, display, panels, sliders } = state;
-  const { showOnAxis, showOffAxis, showChromatic, chromR, chromG, chromB, rayTracksF } = raysState;
+  const { showOnAxis, showOffAxis, showChromatic, chromR, chromG, chromB, rayTracksF, showPupils } = raysState;
   const { dark, highContrast } = display;
   const { focusExpanded, apertureExpanded, headerControlsExpanded, legendExpanded, headerInfoExpanded } = panels;
 
@@ -99,6 +99,7 @@ export default function LensDiagramPanel({
   const onChromRChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromR", value: v });
   const onChromGChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromG", value: v });
   const onChromBChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromB", value: v });
+  const onShowPupilsChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showPupils", value: v });
   const onDarkChange = (v: boolean) => dispatch({ type: SET_DARK, dark: v });
   const onHighContrastChange = (v: boolean) => dispatch({ type: SET_HIGH_CONTRAST, highContrast: v });
   const onFocusExpandedChange = (v: boolean) =>
@@ -215,6 +216,8 @@ export default function LensDiagramPanel({
             onShowOnAxisChange={onShowOnAxisChange}
             showOffAxis={showOffAxis}
             onShowOffAxisChange={onShowOffAxisChange}
+            showPupils={showPupils}
+            onShowPupilsChange={onShowPupilsChange}
             rayTracksF={rayTracksF}
             onRayTracksFChange={onRayTracksFChange}
             showChromatic={showChromatic}
@@ -260,6 +263,7 @@ export default function LensDiagramPanel({
                 showOnAxis={showOnAxis}
                 showOffAxis={showOffAxis}
                 showChromatic={showChromatic}
+                showPupils={showPupils}
                 act={act}
                 onHover={setHov}
                 onSelect={(eid) => setSel(sel === eid ? null : eid)}

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -177,6 +177,21 @@ export default function buildLens(data: LensData): RuntimeLens {
   /* B = chief ray height at stop (for vignetting computation below) */
   const B = paraxialTrace(S, 0, 1, { stopAt: stopIdx }).y;
 
+  /* Entrance pupil z-offset from the stop (mm, baseline layout).
+   * Back-projects the marginal ray arriving at the stop to find where it
+   * appears to originate — the entrance pupil position.  When u≈0 (no
+   * elements before the stop), the pupil is at the stop itself. */
+  const epZRelStop = Math.abs(epTrace.u) > 1e-9 ? -epTrace.y / epTrace.u : 0;
+
+  /* Exit pupil: trace the chief ray (y=0, u=1) through the full system.
+   * Back-projecting from the last surface finds the exit pupil position;
+   * the marginal ray height at that position gives the exit pupil SD.
+   * eflTrace (y=1, u=0, skipLastTransfer) already holds the marginal ray
+   * state at the last surface and is reused here. */
+  const chiefFull = paraxialTrace(S, 0, 1, { skipLastTransfer: true });
+  const xpZRelLastSurf = Math.abs(chiefFull.u) > 1e-9 ? -chiefFull.y / chiefFull.u : 0;
+  const xpSD = Math.abs(eflTrace.y + eflTrace.u * xpZRelLastSurf);
+
   const stopPhysSD = S[stopIdx].sd;
   const FOPEN = EFL / (2 * EP.epSD); /* wide-open f-number */
   if (!isFinite(FOPEN))
@@ -272,6 +287,9 @@ export default function buildLens(data: LensData): RuntimeLens {
     zoomHalfFields: number[] | null = null;
   let zoomYRatios: number[] | null = null,
     zoomBs: number[] | null = null;
+  let zoomEpZRelStops: number[] | null = null,
+    zoomXpZRelLastSurfs: number[] | null = null,
+    zoomXpSDs: number[] | null = null;
   if (isZoom) {
     const nz = data.zoomPositions!.length;
     zoomEFLs = [];
@@ -279,6 +297,9 @@ export default function buildLens(data: LensData): RuntimeLens {
     zoomHalfFields = [];
     zoomYRatios = [];
     zoomBs = [];
+    zoomEpZRelStops = [];
+    zoomXpZRelLastSurfs = [];
+    zoomXpSDs = [];
     for (let zi = 0; zi < nz; zi++) {
       const tmpS = S.map((s, i) => {
         const v = varByIdx[i];
@@ -286,8 +307,9 @@ export default function buildLens(data: LensData): RuntimeLens {
         return { ...s, d: (v as [number, number][])[zi][0] };
       });
 
-      /* EFL */
-      const { u: ue } = paraxialTrace(tmpS, 1, 0, { skipLastTransfer: true });
+      /* EFL — capture both y and u at last surface for exit pupil computation */
+      const zMargLast = paraxialTrace(tmpS, 1, 0, { skipLastTransfer: true });
+      const ue = zMargLast.u;
       zoomEFLs.push(-1.0 / ue);
 
       /* Entrance pupil and yRatio */
@@ -298,6 +320,14 @@ export default function buildLens(data: LensData): RuntimeLens {
 
       /* Chief ray height at stop */
       zoomBs.push(paraxialTrace(tmpS, 0, 1, { stopAt: stopIdx }).y);
+
+      /* Pupil positions at this zoom position */
+      const zEpRelStop = Math.abs(epT.u) > 1e-9 ? -epT.y / epT.u : 0;
+      zoomEpZRelStops.push(zEpRelStop);
+      const zChiefFull = paraxialTrace(tmpS, 0, 1, { skipLastTransfer: true });
+      const zXpRelLast = Math.abs(zChiefFull.u) > 1e-9 ? -zChiefFull.y / zChiefFull.u : 0;
+      zoomXpZRelLastSurfs.push(zXpRelLast);
+      zoomXpSDs.push(Math.abs(zMargLast.y + zMargLast.u * zXpRelLast));
 
       /* Half-field (vignetting-limited) */
       const zA = paraxialTrace(tmpS, 1, 0, { skipLastTransfer: true, recordHeights: true }).heights!;
@@ -333,6 +363,9 @@ export default function buildLens(data: LensData): RuntimeLens {
     EFL,
     EP,
     B,
+    epZRelStop,
+    xpZRelLastSurf,
+    xpSD,
     FOPEN,
     halfField,
     totalTrack,
@@ -375,6 +408,9 @@ export default function buildLens(data: LensData): RuntimeLens {
     zoomHalfFields,
     zoomYRatios,
     zoomBs,
+    zoomEpZRelStops,
+    zoomXpZRelLastSurfs,
+    zoomXpSDs,
     zoomStep: data.zoomStep || 0.004,
     zoomLabels: data.zoomLabels || null,
     labelIdx,

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -163,11 +163,17 @@ export interface RuntimeLens {
   readonly fstopSeries: number[];
   readonly isZoom: boolean;
   readonly zoomPositions: number[] | null;
+  readonly epZRelStop: number;
+  readonly xpZRelLastSurf: number;
+  readonly xpSD: number;
   readonly zoomEFLs: number[] | null;
   readonly zoomEPs: number[] | null;
   readonly zoomHalfFields: number[] | null;
   readonly zoomYRatios: number[] | null;
   readonly zoomBs: number[] | null;
+  readonly zoomEpZRelStops: number[] | null;
+  readonly zoomXpZRelLastSurfs: number[] | null;
+  readonly zoomXpSDs: number[] | null;
   readonly zoomStep: number;
   readonly zoomLabels: string[] | null;
   readonly labelIdx: Record<string, number>;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -18,7 +18,15 @@ export interface DisplaySlice {
   desktopView: string;
 }
 
-export type RayField = "showOnAxis" | "showOffAxis" | "rayTracksF" | "showChromatic" | "chromR" | "chromG" | "chromB";
+export type RayField =
+  | "showOnAxis"
+  | "showOffAxis"
+  | "rayTracksF"
+  | "showChromatic"
+  | "chromR"
+  | "chromG"
+  | "chromB"
+  | "showPupils";
 
 export interface RaysSlice {
   showOnAxis: boolean;
@@ -28,6 +36,7 @@ export interface RaysSlice {
   chromR: boolean;
   chromG: boolean;
   chromB: boolean;
+  showPupils: boolean;
 }
 
 export interface SlidersSlice {
@@ -116,6 +125,7 @@ export interface Preferences {
   chromR: boolean;
   chromG: boolean;
   chromB: boolean;
+  showPupils: boolean;
   focusExpanded: boolean;
   apertureExpanded: boolean;
   headerControlsExpanded: boolean;

--- a/src/utils/lensReducer.ts
+++ b/src/utils/lensReducer.ts
@@ -31,7 +31,16 @@ export const ENTER_COMPARE = "ENTER_COMPARE";
 export const EXIT_COMPARE = "EXIT_COMPARE";
 
 /* ── Valid fields for generic actions (runtime guards for JS consumers) ── */
-const RAY_FIELDS = new Set(["showOnAxis", "showOffAxis", "rayTracksF", "showChromatic", "chromR", "chromG", "chromB"]);
+const RAY_FIELDS = new Set([
+  "showOnAxis",
+  "showOffAxis",
+  "rayTracksF",
+  "showChromatic",
+  "chromR",
+  "chromG",
+  "chromB",
+  "showPupils",
+]);
 const PANEL_FIELDS = new Set([
   "focusExpanded",
   "apertureExpanded",
@@ -78,6 +87,7 @@ export function createInitialState(
       chromR: prefs.chromR ?? true,
       chromG: prefs.chromG ?? true,
       chromB: prefs.chromB ?? true,
+      showPupils: prefs.showPupils ?? false,
     },
     sliders: {
       focusT: urlState.focus ?? 0,

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -38,6 +38,7 @@ export function loadPrefs(catalogKeys: string[]): Partial<Preferences> {
     if (typeof p.chromR === "boolean") out.chromR = p.chromR;
     if (typeof p.chromG === "boolean") out.chromG = p.chromG;
     if (typeof p.chromB === "boolean") out.chromB = p.chromB;
+    if (typeof p.showPupils === "boolean") out.showPupils = p.showPupils;
     /* v1 compat: lensKey → lensKeyA */
     const key: unknown = p.lensKeyA || p.lensKey;
     if (typeof key === "string" && catalogKeys.includes(key)) out.lensKeyA = key;

--- a/src/utils/usePreferences.ts
+++ b/src/utils/usePreferences.ts
@@ -31,6 +31,7 @@ export default function usePreferences(state: LensState): void {
       chromR: rays.chromR,
       chromG: rays.chromG,
       chromB: rays.chromB,
+      showPupils: rays.showPupils,
       focusExpanded: panels.focusExpanded,
       apertureExpanded: panels.apertureExpanded,
       headerControlsExpanded: panels.headerControlsExpanded,


### PR DESCRIPTION
Adds a new PUPILS toggle button that overlays EP and XP markers on the lens cross-section diagram. Entrance and exit pupil positions and the exit pupil semi-diameter are computed via paraxial basis-ray traces in buildLens and stored on RuntimeLens (including per-zoom arrays for zoom lenses). The toggle state is persisted to localStorage and defaults off.

https://claude.ai/code/session_01KrAbMPi2ZSRLqzgvg4ZsC5