### PR TITLE
Fix entrance and exit pupil position and size formulas

### DIFF
--- a/src/components/controls/DiagramHeader.tsx
+++ b/src/components/controls/DiagramHeader.tsx
@@ -17,6 +17,7 @@ import {
   ENABLE_COLLAPSIBLE_HEADER_CONTROLS,
   ENABLE_COLLAPSIBLE_HEADER_INFO,
   ENABLE_MOBILE_CONTROLS_STRIP,
+  ENABLE_PUPIL_TOGGLE,
 } from "../../utils/featureFlags.js";
 import { toggleGroup, toggleBtn, collapseBtn, headerStrip } from "../../utils/styles.js";
 import RayToggles from "./RayToggles.js";
@@ -47,6 +48,8 @@ interface DiagramHeaderProps {
   onChromRChange?: (value: boolean) => void;
   onChromGChange?: (value: boolean) => void;
   onChromBChange?: (value: boolean) => void;
+  showPupils: boolean;
+  onShowPupilsChange?: (value: boolean) => void;
   onDarkChange?: (value: boolean) => void;
   onHighContrastChange?: (value: boolean) => void;
   highContrast: boolean;
@@ -81,6 +84,8 @@ const DiagramHeader = forwardRef<HTMLDivElement, DiagramHeaderProps>(function Di
     onChromRChange,
     onChromGChange,
     onChromBChange,
+    showPupils,
+    onShowPupilsChange,
     onDarkChange,
     onHighContrastChange,
     highContrast,
@@ -247,6 +252,8 @@ const DiagramHeader = forwardRef<HTMLDivElement, DiagramHeaderProps>(function Di
                   onShowOnAxisChange={onShowOnAxisChange}
                   showOffAxis={showOffAxis}
                   onShowOffAxisChange={onShowOffAxisChange}
+                  showPupils={showPupils}
+                  onShowPupilsChange={ENABLE_PUPIL_TOGGLE ? onShowPupilsChange : undefined}
                 />
                 {/* Ray mode */}
                 <div style={toggleGroup(t, { width: "100%" })}>

--- a/src/components/controls/RayToggles.tsx
+++ b/src/components/controls/RayToggles.tsx
@@ -1,10 +1,11 @@
 /**
- * RayToggles — On-axis and off-axis ray toggle buttons.
+ * RayToggles — On-axis, off-axis, and pupil overlay toggle buttons.
  *
  * Handles the off-axis cycling logic (off → trueAngle → edge → off)
  * with feature flag awareness for edge projection mode.
  */
-import { ENABLE_EDGE_PROJECTION } from "../../utils/featureFlags.js";
+import type { ReactNode } from "react";
+import { ENABLE_EDGE_PROJECTION, ENABLE_PUPIL_TOGGLE } from "../../utils/featureFlags.js";
 import { toggleGroup, toggleBtn } from "../../utils/styles.js";
 import type { Theme } from "../../types/theme.js";
 
@@ -14,6 +15,8 @@ interface RayTogglesProps {
   onShowOnAxisChange?: (value: boolean) => void;
   showOffAxis: string;
   onShowOffAxisChange?: (value: string) => void;
+  showPupils: boolean;
+  onShowPupilsChange?: (value: boolean) => void;
 }
 
 export default function RayToggles({
@@ -22,6 +25,8 @@ export default function RayToggles({
   onShowOnAxisChange,
   showOffAxis,
   onShowOffAxisChange,
+  showPupils,
+  onShowPupilsChange,
 }: RayTogglesProps) {
   const offAxisActive = showOffAxis !== "off";
   const offAxisCycle = ENABLE_EDGE_PROJECTION
@@ -35,31 +40,94 @@ export default function RayToggles({
         : "OFF-AXIS"
     : "OFF-AXIS";
 
-  const buttons = [
+  type ButtonDef = {
+    label: string;
+    active: boolean;
+    onClick: () => void;
+    icon: (active: boolean) => ReactNode;
+  };
+
+  const buttons: ButtonDef[] = [
     {
       label: "ON-AXIS",
       active: showOnAxis,
       onClick: () => onShowOnAxisChange?.(!showOnAxis),
-      dotA: t.rayWarm,
-      dotB: t.rayCool,
+      icon: (active: boolean) => (
+        <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
+          <line x1="0" y1="4" x2="14" y2="4" stroke={active ? t.rayWarm : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
+          <line x1="0" y1="7" x2="14" y2="7" stroke={active ? t.rayCool : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
+        </svg>
+      ),
     },
     {
       label: offAxisLabel,
       active: offAxisActive,
       onClick: offAxisCycle,
-      dotA: t.rayOffWarm,
-      dotB: t.rayOffCool,
+      icon: (active: boolean) => (
+        <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
+          <line
+            x1="0"
+            y1="4"
+            x2="14"
+            y2="4"
+            stroke={active ? t.rayOffWarm : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.5"
+          />
+          <line
+            x1="0"
+            y1="7"
+            x2="14"
+            y2="7"
+            stroke={active ? t.rayOffCool : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.5"
+          />
+        </svg>
+      ),
     },
   ];
 
+  if (ENABLE_PUPIL_TOGGLE) {
+    buttons.push({
+      label: "PUPILS",
+      active: showPupils,
+      onClick: () => onShowPupilsChange?.(!showPupils),
+      icon: (active: boolean) => (
+        <svg width="14" height="10" viewBox="0 0 14 10" style={{ flexShrink: 0 }}>
+          <line
+            x1="7"
+            y1="0"
+            x2="7"
+            y2="10"
+            stroke={active ? t.stopLabel : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.2"
+            strokeDasharray="2,1.5"
+          />
+          <line
+            x1="4"
+            y1="0"
+            x2="10"
+            y2="0"
+            stroke={active ? t.stopLabel : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.2"
+          />
+          <line
+            x1="4"
+            y1="10"
+            x2="10"
+            y2="10"
+            stroke={active ? t.stopLabel : "rgba(128,128,128,0.3)"}
+            strokeWidth="1.2"
+          />
+        </svg>
+      ),
+    });
+  }
+
   return (
     <div style={toggleGroup(t, { width: "100%" })}>
-      {buttons.map(({ label, active, onClick, dotA, dotB }, idx) => (
-        <button key={idx} onClick={onClick} style={toggleBtn(t, active, { hasRightBorder: idx === 0 })}>
-          <svg width="14" height="8" viewBox="0 0 14 8" style={{ flexShrink: 0 }}>
-            <line x1="0" y1="4" x2="14" y2="4" stroke={active ? dotA : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
-            <line x1="0" y1="7" x2="14" y2="7" stroke={active ? dotB : "rgba(128,128,128,0.3)"} strokeWidth="1.5" />
-          </svg>
+      {buttons.map(({ label, active, onClick, icon }, idx) => (
+        <button key={idx} onClick={onClick} style={toggleBtn(t, active, { hasRightBorder: idx < buttons.length - 1 })}>
+          {icon(active)}
           <span>{label}</span>
         </button>
       ))}

--- a/src/components/diagram/DiagramSVG.tsx
+++ b/src/components/diagram/DiagramSVG.tsx
@@ -10,7 +10,7 @@
  * state or side effects. Interaction callbacks (onHover, onSelect) are passed
  * through from the parent LensDiagramPanel.
  */
-import { ENABLE_ASPH_DIAMOND_FILL } from "../../utils/featureFlags.js";
+import { ENABLE_ASPH_DIAMOND_FILL, ENABLE_PUPIL_TOGGLE } from "../../utils/featureFlags.js";
 import RayPolylines from "./RayPolylines.js";
 import ApertureStop from "./ApertureStop.js";
 import ElementAnnotations from "./ElementAnnotations.js";
@@ -50,6 +50,7 @@ interface DiagramSVGProps {
   showOnAxis: boolean;
   showOffAxis: string;
   showChromatic: boolean;
+  showPupils: boolean;
   act: number | null;
   onHover: (eid: number | null) => void;
   onSelect: (eid: number | null) => void;
@@ -85,6 +86,7 @@ export default function DiagramSVG({
   showOnAxis,
   showOffAxis,
   showChromatic,
+  showPupils,
   act,
   onHover,
   onSelect,
@@ -319,6 +321,110 @@ export default function DiagramSVG({
         act={act}
         showChromatic={showChromatic}
       />
+
+      {/* Entrance and exit pupil markers */}
+      {ENABLE_PUPIL_TOGGLE &&
+        showPupils &&
+        (() => {
+          const epX = sx(zPos[L.stopIdx] + L.epZRelStop);
+          const xpX = sx(zPos[L.N - 1] + L.xpZRelLastSurf);
+          const epTopY = sy(-L.EP.epSD);
+          const epBotY = sy(L.EP.epSD);
+          const xpTopY = sy(-L.xpSD);
+          const xpBotY = sy(L.xpSD);
+          const midY = sy(0);
+          const tickLen = 4;
+          const color = t.stopLabel;
+          const labelStyle = {
+            pointerEvents: "none" as const,
+            letterSpacing: "0.1em",
+          };
+          return (
+            <>
+              {/* Entrance pupil */}
+              <line
+                x1={epX}
+                y1={epTopY}
+                x2={epX}
+                y2={epBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                strokeDasharray="3,2"
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={epX - tickLen}
+                y1={epTopY}
+                x2={epX + tickLen}
+                y2={epTopY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={epX - tickLen}
+                y1={epBotY}
+                x2={epX + tickLen}
+                y2={epBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <text
+                x={epX}
+                y={epTopY - L.lyStoPad}
+                textAnchor="middle"
+                fontSize={L.lyStoPad * 1.4}
+                fill={color}
+                style={labelStyle}
+              >
+                EP
+              </text>
+              {/* Exit pupil */}
+              <line
+                x1={xpX}
+                y1={xpTopY}
+                x2={xpX}
+                y2={xpBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                strokeDasharray="3,2"
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={xpX - tickLen}
+                y1={xpTopY}
+                x2={xpX + tickLen}
+                y2={xpTopY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <line
+                x1={xpX - tickLen}
+                y1={xpBotY}
+                x2={xpX + tickLen}
+                y2={xpBotY}
+                stroke={color}
+                strokeWidth={1.2}
+                style={{ pointerEvents: "none" }}
+              />
+              <text
+                x={xpX}
+                y={xpTopY - L.lyStoPad}
+                textAnchor="middle"
+                fontSize={L.lyStoPad * 1.4}
+                fill={color}
+                style={labelStyle}
+              >
+                XP
+              </text>
+              {/* Axis dots at pupil positions */}
+              <circle cx={epX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
+              <circle cx={xpX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
+            </>
+          );
+        })()}
 
       {/* Petzval sum badge — upper-left corner */}
       <PetzvalSumBadge L={L} t={t} />

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -80,7 +80,7 @@ export default function LensDiagramPanel({
   const { state, theme: t, isWide, updateURLWithSliders } = useLensCtx();
   const dispatch = useLensDispatch();
   const { rays: raysState, display, panels, sliders } = state;
-  const { showOnAxis, showOffAxis, showChromatic, chromR, chromG, chromB, rayTracksF } = raysState;
+  const { showOnAxis, showOffAxis, showChromatic, chromR, chromG, chromB, rayTracksF, showPupils } = raysState;
   const { dark, highContrast } = display;
   const { focusExpanded, apertureExpanded, headerControlsExpanded, legendExpanded, headerInfoExpanded } = panels;
 
@@ -101,6 +101,7 @@ export default function LensDiagramPanel({
   const onChromRChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromR", value: v });
   const onChromGChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromG", value: v });
   const onChromBChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromB", value: v });
+  const onShowPupilsChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showPupils", value: v });
   const onDarkChange = (v: boolean) => dispatch({ type: SET_DARK, dark: v });
   const onHighContrastChange = (v: boolean) => dispatch({ type: SET_HIGH_CONTRAST, highContrast: v });
   const onFocusExpandedChange = (v: boolean) =>
@@ -229,6 +230,8 @@ export default function LensDiagramPanel({
             onChromRChange={onChromRChange}
             onChromGChange={onChromGChange}
             onChromBChange={onChromBChange}
+            showPupils={showPupils}
+            onShowPupilsChange={onShowPupilsChange}
             onDarkChange={onDarkChange}
             onHighContrastChange={onHighContrastChange}
             highContrast={highContrast}
@@ -264,6 +267,7 @@ export default function LensDiagramPanel({
                 showOnAxis={showOnAxis}
                 showOffAxis={showOffAxis}
                 showChromatic={showChromatic}
+                showPupils={showPupils}
                 act={act}
                 onHover={setHov}
                 onSelect={(eid) => setSel(sel === eid ? null : eid)}

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -177,6 +177,27 @@ export default function buildLens(data: LensData): RuntimeLens {
   /* B = chief ray height at stop (for vignetting computation below) */
   const B = paraxialTrace(S, 0, 1, { stopAt: stopIdx }).y;
 
+  /* Entrance pupil z-position (absolute from z=0) = B / yRatio, derived from
+   * the two-ray decomposition: a chief ray through the stop center (y_stop=0)
+   * satisfies y_in = -(B/yRatio)·u_in, which crosses the axis at z = B/yRatio.
+   * epZRelStop is the offset from the stop's baseline z-position. */
+  let zStopBaseline = 0;
+  for (let i = 0; i < stopIdx; i++) zStopBaseline += S[i].d;
+  const epZRelStop = Math.abs(epTrace.y) > 1e-9 ? B / epTrace.y - zStopBaseline : 0;
+
+  /* Exit pupil: construct the chief ray that actually passes through the stop
+   * center (y=0 at stop) by combining the two full-system basis rays.
+   * The basis chief ray (y=0, u=1) hits the stop at y=B ≠ 0, so we use the
+   * two-ray decomposition: the stop-center chief ray at z=0 is (y=−B, u=yRatio).
+   * At the last surface this gives y_last = yRatio·chiefFull.y − eflTrace.y·B
+   * and u_last = yRatio·chiefFull.u − eflTrace.u·B.  Back-projecting finds XP.
+   * xpSD scales the unit marginal ray height to physical mm via EP.epSD. */
+  const chiefFull = paraxialTrace(S, 0, 1, { skipLastTransfer: true });
+  const xpNumer = -(epTrace.y * chiefFull.y - eflTrace.y * B);
+  const xpDenom = epTrace.y * chiefFull.u - eflTrace.u * B;
+  const xpZRelLastSurf = Math.abs(xpDenom) > 1e-9 ? xpNumer / xpDenom : 0;
+  const xpSD = Math.abs(eflTrace.y + eflTrace.u * xpZRelLastSurf) * EP.epSD;
+
   const stopPhysSD = S[stopIdx].sd;
   const FOPEN = EFL / (2 * EP.epSD); /* wide-open f-number */
   if (!isFinite(FOPEN))
@@ -286,6 +307,9 @@ export default function buildLens(data: LensData): RuntimeLens {
     zoomHalfFields: number[] | null = null;
   let zoomYRatios: number[] | null = null,
     zoomBs: number[] | null = null;
+  let zoomEpZRelStops: number[] | null = null,
+    zoomXpZRelLastSurfs: number[] | null = null,
+    zoomXpSDs: number[] | null = null;
   if (isZoom) {
     const nz = data.zoomPositions!.length;
     zoomEFLs = [];
@@ -293,6 +317,9 @@ export default function buildLens(data: LensData): RuntimeLens {
     zoomHalfFields = [];
     zoomYRatios = [];
     zoomBs = [];
+    zoomEpZRelStops = [];
+    zoomXpZRelLastSurfs = [];
+    zoomXpSDs = [];
     for (let zi = 0; zi < nz; zi++) {
       const tmpS = S.map((s, i) => {
         const v = varByIdx[i];
@@ -300,9 +327,9 @@ export default function buildLens(data: LensData): RuntimeLens {
         return { ...s, d: (v as [number, number][])[zi][0] };
       });
 
-      /* EFL */
-      const { u: ue } = paraxialTrace(tmpS, 1, 0, { skipLastTransfer: true });
-      zoomEFLs.push(-1.0 / ue);
+      /* EFL — capture y and u at last surface for exit pupil computation */
+      const zMargLast = paraxialTrace(tmpS, 1, 0, { skipLastTransfer: true });
+      zoomEFLs.push(-1.0 / zMargLast.u);
 
       /* Entrance pupil and yRatio */
       const epT = paraxialTrace(tmpS, 1, 0, { stopAt: stopIdx });
@@ -311,7 +338,20 @@ export default function buildLens(data: LensData): RuntimeLens {
       zoomYRatios.push(epT.y);
 
       /* Chief ray height at stop */
-      zoomBs.push(paraxialTrace(tmpS, 0, 1, { stopAt: stopIdx }).y);
+      const zBValue = paraxialTrace(tmpS, 0, 1, { stopAt: stopIdx }).y;
+      zoomBs.push(zBValue);
+
+      /* Pupil positions at this zoom position (same derivation as baseline) */
+      let zStopBaselineZ = 0;
+      for (let i = 0; i < stopIdx; i++) zStopBaselineZ += tmpS[i].d;
+      const zEpRelStop = Math.abs(epT.y) > 1e-9 ? zBValue / epT.y - zStopBaselineZ : 0;
+      zoomEpZRelStops.push(zEpRelStop);
+      const zChiefFull = paraxialTrace(tmpS, 0, 1, { skipLastTransfer: true });
+      const zXpNumer = -(epT.y * zChiefFull.y - zMargLast.y * zBValue);
+      const zXpDenom = epT.y * zChiefFull.u - zMargLast.u * zBValue;
+      const zXpRelLast = Math.abs(zXpDenom) > 1e-9 ? zXpNumer / zXpDenom : 0;
+      zoomXpZRelLastSurfs.push(zXpRelLast);
+      zoomXpSDs.push(Math.abs(zMargLast.y + zMargLast.u * zXpRelLast) * epSD);
 
       /* Half-field (vignetting-limited) */
       const zA = paraxialTrace(tmpS, 1, 0, { skipLastTransfer: true, recordHeights: true }).heights!;
@@ -390,6 +430,12 @@ export default function buildLens(data: LensData): RuntimeLens {
     zoomHalfFields,
     zoomYRatios,
     zoomBs,
+    epZRelStop,
+    xpZRelLastSurf,
+    xpSD,
+    zoomEpZRelStops,
+    zoomXpZRelLastSurfs,
+    zoomXpSDs,
     zoomStep: data.zoomStep || 0.004,
     zoomLabels: data.zoomLabels || null,
     labelIdx,

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -169,6 +169,12 @@ export interface RuntimeLens {
   readonly zoomHalfFields: number[] | null;
   readonly zoomYRatios: number[] | null;
   readonly zoomBs: number[] | null;
+  readonly epZRelStop: number;
+  readonly xpZRelLastSurf: number;
+  readonly xpSD: number;
+  readonly zoomEpZRelStops: number[] | null;
+  readonly zoomXpZRelLastSurfs: number[] | null;
+  readonly zoomXpSDs: number[] | null;
   readonly zoomStep: number;
   readonly zoomLabels: string[] | null;
   readonly labelIdx: Record<string, number>;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -18,7 +18,15 @@ export interface DisplaySlice {
   desktopView: string;
 }
 
-export type RayField = "showOnAxis" | "showOffAxis" | "rayTracksF" | "showChromatic" | "chromR" | "chromG" | "chromB";
+export type RayField =
+  | "showOnAxis"
+  | "showOffAxis"
+  | "rayTracksF"
+  | "showChromatic"
+  | "chromR"
+  | "chromG"
+  | "chromB"
+  | "showPupils";
 
 export interface RaysSlice {
   showOnAxis: boolean;
@@ -28,6 +36,7 @@ export interface RaysSlice {
   chromR: boolean;
   chromG: boolean;
   chromB: boolean;
+  showPupils: boolean;
 }
 
 export interface SlidersSlice {
@@ -116,6 +125,7 @@ export interface Preferences {
   chromR: boolean;
   chromG: boolean;
   chromB: boolean;
+  showPupils: boolean;
   focusExpanded: boolean;
   apertureExpanded: boolean;
   headerControlsExpanded: boolean;

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -37,3 +37,5 @@ export const ENABLE_COLLAPSIBLE_HEADER_INFO = true;
 export const ENABLE_MOBILE_CONTROLS_STRIP = true;
 
 export const ENABLE_ABOUT_BUTTONS_IN_TOPBAR = false;
+
+export const ENABLE_PUPIL_TOGGLE = true;

--- a/src/utils/lensReducer.ts
+++ b/src/utils/lensReducer.ts
@@ -31,7 +31,16 @@ export const ENTER_COMPARE = "ENTER_COMPARE";
 export const EXIT_COMPARE = "EXIT_COMPARE";
 
 /* ── Valid fields for generic actions (runtime guards for JS consumers) ── */
-const RAY_FIELDS = new Set(["showOnAxis", "showOffAxis", "rayTracksF", "showChromatic", "chromR", "chromG", "chromB"]);
+const RAY_FIELDS = new Set([
+  "showOnAxis",
+  "showOffAxis",
+  "rayTracksF",
+  "showChromatic",
+  "chromR",
+  "chromG",
+  "chromB",
+  "showPupils",
+]);
 const PANEL_FIELDS = new Set([
   "focusExpanded",
   "apertureExpanded",
@@ -78,6 +87,7 @@ export function createInitialState(
       chromR: prefs.chromR ?? true,
       chromG: prefs.chromG ?? true,
       chromB: prefs.chromB ?? true,
+      showPupils: prefs.showPupils ?? false,
     },
     sliders: {
       focusT: urlState.focus ?? 0,

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -38,6 +38,7 @@ export function loadPrefs(catalogKeys: string[]): Partial<Preferences> {
     if (typeof p.chromR === "boolean") out.chromR = p.chromR;
     if (typeof p.chromG === "boolean") out.chromG = p.chromG;
     if (typeof p.chromB === "boolean") out.chromB = p.chromB;
+    if (typeof p.showPupils === "boolean") out.showPupils = p.showPupils;
     /* v1 compat: lensKey → lensKeyA */
     const key: unknown = p.lensKeyA || p.lensKey;
     if (typeof key === "string" && catalogKeys.includes(key)) out.lensKeyA = key;

--- a/src/utils/usePreferences.ts
+++ b/src/utils/usePreferences.ts
@@ -31,6 +31,7 @@ export default function usePreferences(state: LensState): void {
       chromR: rays.chromR,
       chromG: rays.chromG,
       chromB: rays.chromB,
+      showPupils: rays.showPupils,
       focusExpanded: panels.focusExpanded,
       apertureExpanded: panels.apertureExpanded,
       headerControlsExpanded: panels.headerControlsExpanded,


### PR DESCRIPTION
Both EP and XP formulas were computing wrong positions:

EP: was back-projecting the marginal ray from the stop (-epTrace.y/epTrace.u), which gives the back focal point of the front subsystem, not the entrance pupil. Correct formula uses the two-ray decomposition: z_EP = B/yRatio (absolute from z=0), so epZRelStop = B/yRatio − zStopBaseline.

XP: was back-projecting the basis chief ray (y=0,u=1), which hits the stop at y=B≠0. XP requires the ray through the stop center. Constructing it via two-ray decomposition: at z=0 use (y=−B, u=yRatio), giving y_last=yRatio·chiefFull.y−eflTrace.y·B and u_last=yRatio·chiefFull.u−eflTrace.u·B, then back-project.

xpSD: was missing EP.epSD scaling — result was in unit-marginal-ray space, not physical mm. Multiplied by EP.epSD to correct.

All three fixes applied to both the baseline and zoom loop paths.

https://claude.ai/code/session_01KrAbMPi2ZSRLqzgvg4ZsC5