### PR TITLE
fix(CA inset): consistent scaling and partial-channel bar fix

### DIFF
--- a/__tests__/lcaScaling.test.ts
+++ b/__tests__/lcaScaling.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { computeLcaBarOffsets, REFERENCE_LCA_MM } from "../src/optics/lcaScaling.js";
+
+describe("computeLcaBarOffsets", () => {
+  const SC = 100; // 100 px/mm
+
+  it("produces proportionally wider offsets for larger LCA", () => {
+    const small = computeLcaBarOffsets({ R: 50.01, G: 50.0, B: 49.99 }, 50.0, 66, SC);
+    const large = computeLcaBarOffsets({ R: 50.1, G: 50.0, B: 49.9 }, 50.0, 66, SC);
+    // R offset should be 10× larger in the "large" case
+    expect(Math.abs(large.barOffsets.R!)).toBeGreaterThan(Math.abs(small.barOffsets.R!) * 5);
+  });
+
+  it("centers the G-line reference at zero offset", () => {
+    const result = computeLcaBarOffsets({ R: 50.05, G: 50.0, B: 49.95 }, 50.0, 66, SC);
+    expect(result.barOffsets.G).toBeCloseTo(0, 10);
+  });
+
+  it("clamps bars that exceed the half-width", () => {
+    // REFERENCE_LCA_MM = 0.15, so an offset of 1.0 mm is way beyond reference
+    const result = computeLcaBarOffsets({ R: 51.0, G: 50.0, B: 49.0 }, 50.0, 66, SC);
+    const halfWidth = 66 / 2;
+    expect(Math.abs(result.barOffsets.R!)).toBeLessThanOrEqual(halfWidth + 0.01);
+    expect(Math.abs(result.barOffsets.B!)).toBeLessThanOrEqual(halfWidth + 0.01);
+    expect(result.clamped).toBe(true);
+  });
+
+  it("does not clamp moderate LCA within reference range", () => {
+    // Offset of 0.05 mm is well within the 0.15 mm reference
+    const result = computeLcaBarOffsets({ R: 50.05, G: 50.0, B: 49.95 }, 50.0, 66, SC);
+    expect(result.clamped).toBe(false);
+  });
+
+  it("handles two-channel case (R+G only)", () => {
+    const result = computeLcaBarOffsets({ R: 50.05, G: 50.0 }, 50.0, 66, SC);
+    expect(result.barOffsets.R).toBeDefined();
+    expect(result.barOffsets.G).toBeCloseTo(0, 10);
+    expect(result.barOffsets.B).toBeUndefined();
+  });
+
+  it("scales proportionally with wider view width", () => {
+    const narrow = computeLcaBarOffsets({ R: 50.05, G: 50.0, B: 49.95 }, 50.0, 66, SC);
+    const wide = computeLcaBarOffsets({ R: 50.05, G: 50.0, B: 49.95 }, 50.0, 132, SC);
+    // Double the view width → double the pixel offsets (same LCA, unclamped)
+    expect(Math.abs(wide.barOffsets.R!)).toBeCloseTo(Math.abs(narrow.barOffsets.R!) * 2, 1);
+  });
+
+  it("returns zero offsets when all channels have the same intercept", () => {
+    const result = computeLcaBarOffsets({ R: 50.0, G: 50.0, B: 50.0 }, 50.0, 66, SC);
+    expect(result.barOffsets.R).toBeCloseTo(0, 10);
+    expect(result.barOffsets.G).toBeCloseTo(0, 10);
+    expect(result.barOffsets.B).toBeCloseTo(0, 10);
+    expect(result.clamped).toBe(false);
+  });
+
+  it("reports a positive magnification", () => {
+    const result = computeLcaBarOffsets({ R: 50.05, G: 50.0, B: 49.95 }, 50.0, 66, SC);
+    expect(result.mag).toBeGreaterThan(0);
+  });
+
+  it("uses REFERENCE_LCA_MM to set base magnification", () => {
+    // A channel exactly at REFERENCE_LCA_MM offset should fill ~70% of the half-width
+    const viewW = 66;
+    const result = computeLcaBarOffsets({ R: 50.0 + REFERENCE_LCA_MM, G: 50.0 }, 50.0, viewW, SC);
+    const expectedPx = (viewW / 2) * 0.7; // 70 % of the half-width
+    expect(Math.abs(result.barOffsets.R!)).toBeCloseTo(expectedPx, 1);
+  });
+});

--- a/__tests__/optics.test.ts
+++ b/__tests__/optics.test.ts
@@ -389,8 +389,32 @@ describe("computeChromaticSpread", () => {
       B: { y: 1.0, u: -0.06, clipped: false },
     };
     const result = computeChromaticSpread(marginalRays, 50, 40);
+    // R is clipped → only B+G fallback not available (no G), so lcaMm = 0
     expect(result.lcaMm).toBe(0);
     expect(result.intercepts.R).toBeUndefined();
+  });
+
+  it("falls back to R−G when B is missing", () => {
+    const marginalRays = {
+      R: { y: 1.0, u: -0.05, clipped: false },
+      G: { y: 1.0, u: -0.055, clipped: false },
+    };
+    const result = computeChromaticSpread(marginalRays, 65, 40);
+    // R intercept: 40 - 1/(-0.05) = 60, G intercept: 40 - 1/(-0.055) ≈ 58.18
+    expect(result.lcaMm).toBeCloseTo(60 - (40 + 1 / 0.055), 4);
+    expect(result.lcaMm).not.toBe(0);
+  });
+
+  it("falls back to G−B when R is missing", () => {
+    const marginalRays = {
+      G: { y: 1.0, u: -0.055, clipped: false },
+      B: { y: 1.0, u: -0.06, clipped: false },
+    };
+    const result = computeChromaticSpread(marginalRays, 65, 40);
+    const gIntercept = 40 - 1.0 / -0.055;
+    const bIntercept = 40 - 1.0 / -0.06;
+    expect(result.lcaMm).toBeCloseTo(gIntercept - bIntercept, 4);
+    expect(result.lcaMm).not.toBe(0);
   });
 });
 

--- a/src/components/diagram/DiagramSVG.tsx
+++ b/src/components/diagram/DiagramSVG.tsx
@@ -298,7 +298,7 @@ export default function DiagramSVG({
       </text>
 
       {/* LCA inset widget */}
-      {showChromatic && chromSpread && chromSpread.lcaMm !== 0 && (
+      {showChromatic && chromSpread && Object.keys(chromSpread.intercepts).length >= 2 && (
         <LCAInsetWidget
           chromSpread={chromSpread}
           effectiveSC={effectiveSC}

--- a/src/components/diagram/LCAInsetWidget.tsx
+++ b/src/components/diagram/LCAInsetWidget.tsx
@@ -2,11 +2,13 @@
  * LCAInsetWidget — Magnified inset showing longitudinal chromatic aberration.
  *
  * Displays where each wavelength's marginal ray crosses the axis relative to
- * the G/d-line reference. Magnification is auto-scaled and clamped at 5000x
- * to avoid pixel overflow for sub-micron LCA.
+ * the G/d-line reference. Uses a fixed reference scale (from lcaScaling) so
+ * lenses with worse CA show wider bars and well-corrected lenses show narrower
+ * bars.  Accepts optional width/height for reuse in a future larger overlay.
  */
 import type { ChromaticSpread, ChromaticChannel } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
+import { computeLcaBarOffsets } from "../../optics/lcaScaling.js";
 
 interface LCAInsetWidgetProps {
   chromSpread: ChromaticSpread;
@@ -16,17 +18,30 @@ interface LCAInsetWidgetProps {
   svgW: number;
   sy: (y: number) => number;
   t: Theme;
+  /** Override default 90px width — for a future larger overlay view. */
+  width?: number;
+  /** Override default 100px height — for a future larger overlay view. */
+  height?: number;
 }
 
-export default function LCAInsetWidget({ chromSpread, effectiveSC, IMG_MM, IX, svgW, sy, t }: LCAInsetWidgetProps) {
-  const insetW = 90;
-  const insetH = 100;
-  const gRef = chromSpread.intercepts.G || IMG_MM;
+export default function LCAInsetWidget({
+  chromSpread,
+  effectiveSC,
+  IMG_MM,
+  IX,
+  svgW,
+  sy,
+  t,
+  width,
+  height,
+}: LCAInsetWidgetProps) {
+  const insetW = width ?? 90;
+  const insetH = height ?? 100;
+  const gRef = chromSpread.intercepts.G ?? IMG_MM;
+  const viewWidthPx = insetW - 24;
+  const { barOffsets, mag } = computeLcaBarOffsets(chromSpread.intercepts, gRef, viewWidthPx, effectiveSC);
   const activeChans = (["R", "G", "B"] as ChromaticChannel[]).filter((ch) => chromSpread.intercepts[ch] !== undefined);
-  const offsets = activeChans.map((ch) => Math.abs((chromSpread.intercepts[ch] ?? 0) - gRef));
-  const maxOff = Math.max(...offsets, 1e-9);
-  const maxPixelSpan = (insetW - 24) / 2;
-  const mag = Math.min(maxPixelSpan / (maxOff * effectiveSC), 5000);
+
   let insetX = IX + 10;
   if (insetX + insetW > svgW - 4) insetX = IX - insetW - 10;
   const insetY = sy(0) - 55;
@@ -65,7 +80,7 @@ export default function LCAInsetWidget({ chromSpread, effectiveSC, IMG_MM, IX, s
         strokeWidth={0.5}
       />
       {activeChans.map((ch) => {
-        const offset = ((chromSpread.intercepts[ch] ?? 0) - gRef) * mag * effectiveSC;
+        const offset = barOffsets[ch] ?? 0;
         const color = ch === "R" ? t.rayChromR : ch === "G" ? t.rayChromG : t.rayChromB;
         return (
           <g key={ch}>

--- a/src/optics/lcaScaling.ts
+++ b/src/optics/lcaScaling.ts
@@ -1,0 +1,70 @@
+/**
+ * lcaScaling — Fixed-reference scaling for LCA bar visualisation.
+ *
+ * Provides a consistent magnification so that lenses with larger chromatic
+ * aberration display wider bars and well-corrected lenses display narrower
+ * bars.  The scale is anchored to REFERENCE_LCA_MM: a lens whose maximum
+ * channel offset equals that value will fill ~70 % of the available width.
+ *
+ * Extracted as a pure function so the same logic can drive both the small
+ * inset widget and a future full-size overlay.
+ */
+import type { ChromaticChannel } from "../types/optics.js";
+
+/** Typical moderate LCA in mm — sets the "full width" reference point. */
+export const REFERENCE_LCA_MM = 0.15;
+
+export interface LcaBarResult {
+  /** Pixel offset from centre for each active channel. */
+  barOffsets: Partial<Record<ChromaticChannel, number>>;
+  /** Effective magnification applied (for the readout label). */
+  mag: number;
+  /** True when bars were proportionally compressed to fit the view. */
+  clamped: boolean;
+}
+
+/**
+ * Compute pixel offsets for each wavelength bar relative to the G-line
+ * reference, using a fixed reference scale.
+ *
+ * @param intercepts       Per-channel axial intercept positions (mm).
+ * @param referenceIntercept  G-line intercept (or IMG_MM fallback).
+ * @param viewWidthPx      Total pixel width available for bars.
+ * @param effectiveSC      Horizontal scale factor (px / mm).
+ */
+export function computeLcaBarOffsets(
+  intercepts: Partial<Record<ChromaticChannel, number>>,
+  referenceIntercept: number,
+  viewWidthPx: number,
+  effectiveSC: number,
+): LcaBarResult {
+  const halfWidth = viewWidthPx / 2;
+
+  // Fixed magnification: REFERENCE_LCA_MM of offset fills 70 % of the half-width.
+  const baseMag = (halfWidth * 0.7) / (REFERENCE_LCA_MM * effectiveSC);
+
+  const barOffsets: Partial<Record<ChromaticChannel, number>> = {};
+  let maxAbsPx = 0;
+
+  for (const ch of ["R", "G", "B"] as ChromaticChannel[]) {
+    if (intercepts[ch] === undefined) continue;
+    const px = (intercepts[ch] - referenceIntercept) * baseMag * effectiveSC;
+    barOffsets[ch] = px;
+    maxAbsPx = Math.max(maxAbsPx, Math.abs(px));
+  }
+
+  let clamped = false;
+  let mag = baseMag;
+
+  if (maxAbsPx > halfWidth && maxAbsPx > 0) {
+    // Scale all bars proportionally so the widest just fits.
+    const scale = halfWidth / maxAbsPx;
+    for (const ch of Object.keys(barOffsets) as ChromaticChannel[]) {
+      barOffsets[ch] = barOffsets[ch]! * scale;
+    }
+    mag = baseMag * scale;
+    clamped = true;
+  }
+
+  return { barOffsets, mag, clamped };
+}

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -423,8 +423,10 @@ interface MarginalRayData {
 
 /**
  * Compute chromatic aberration metrics from marginal ray trace results.
- * marginalRays: { R?: {y,u,clipped}, G?: {y,u,clipped}, B?: {y,u,clipped} }
- * Returns { lcaMm, tcaMm, intercepts: {R?,G?,B?}, imgHeights: {R?,G?,B?} }
+ *
+ * lcaMm prefers the full R−B span; falls back to R−G or G−B when one channel
+ * is toggled off, so the widget remains visible with any 2-channel combination.
+ * lcaMm is 0 only when fewer than 2 channels have valid intercepts.
  */
 export function computeChromaticSpread(
   marginalRays: Partial<Record<ChromaticChannel, MarginalRayData>>,
@@ -442,8 +444,17 @@ export function computeChromaticSpread(
     const dz = imgZ - lastSurfZ;
     imgHeights[ch] = ray.y + dz * ray.u;
   }
-  const lcaMm = intercepts.R !== undefined && intercepts.B !== undefined ? intercepts.R - intercepts.B : 0;
-  const tcaMm = imgHeights.R !== undefined && imgHeights.B !== undefined ? imgHeights.R - imgHeights.B : 0;
+  // Prefer R−B; fall back to partial pairs so the widget stays visible
+  // when the user toggles individual wavelength channels off.
+  let lcaMm = 0;
+  if (intercepts.R !== undefined && intercepts.B !== undefined) lcaMm = intercepts.R - intercepts.B;
+  else if (intercepts.R !== undefined && intercepts.G !== undefined) lcaMm = intercepts.R - intercepts.G;
+  else if (intercepts.G !== undefined && intercepts.B !== undefined) lcaMm = intercepts.G - intercepts.B;
+
+  let tcaMm = 0;
+  if (imgHeights.R !== undefined && imgHeights.B !== undefined) tcaMm = imgHeights.R - imgHeights.B;
+  else if (imgHeights.R !== undefined && imgHeights.G !== undefined) tcaMm = imgHeights.R - imgHeights.G;
+  else if (imgHeights.G !== undefined && imgHeights.B !== undefined) tcaMm = imgHeights.G - imgHeights.B;
   return { lcaMm, tcaMm, intercepts, imgHeights };
 }
 


### PR DESCRIPTION
Replaces adaptive per-lens magnification with a fixed reference scale (REFERENCE_LCA_MM = 0.15 mm) so bars are proportional across lenses — worse CA shows wider bars, better-corrected lenses show narrower bars.

Extracted pure scaling logic into src/optics/lcaScaling.ts for reuse by a future full-size overlay view. LCAInsetWidget now accepts optional width/height props to support that future view.

Fixes disappearing color bars when wavelengths are toggled off:
- computeChromaticSpread now falls back to R−G or G−B pairs when the full R−B span is unavailable, keeping lcaMm nonzero for 2-channel use
- DiagramSVG rendering gate changed from `lcaMm !== 0` to an intercept count check so the widget stays visible for any 2-channel combination

Closes #202

https://claude.ai/code/session_01NUPoG9u6kzPzHbavhNNEHq