### PR TITLE
Add swap lenses button between A/B selectors in comparison mode

### DIFF
--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -53,6 +53,7 @@ import useLensState from "../../utils/useLensState.js";
 import {
   SET_LENS_A,
   SET_LENS_B,
+  SWAP_LENSES,
   SET_MOBILE_VIEW,
   SET_DESKTOP_VIEW,
   SET_SHARED_STOPDOWN_T,
@@ -162,6 +163,10 @@ export default function LensVisualization() {
     },
     [dispatch],
   );
+
+  const swapLenses = useCallback(() => {
+    dispatch({ type: SWAP_LENSES });
+  }, [dispatch]);
 
   /* ── Build both lenses for comparison computations ──
    * Built eagerly when comparison mode is active so we can compute
@@ -325,6 +330,7 @@ export default function LensVisualization() {
             showCompareBtn={showCompareBtn}
             onSwitchLensA={switchLensA}
             onSwitchLensB={switchLensB}
+            onSwapLenses={swapLenses}
             onToggleCompare={toggleCompare}
             onOpenAboutSite={() => dispatch({ type: SET_OVERLAY, overlay: "showAboutSite", visible: true })}
             onOpenAboutAuthor={() => dispatch({ type: SET_OVERLAY, overlay: "showAbout", visible: true })}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -17,6 +17,7 @@ interface TopBarProps {
   showCompareBtn: boolean;
   onSwitchLensA: (key: string) => void;
   onSwitchLensB: (key: string) => void;
+  onSwapLenses: () => void;
   onToggleCompare: () => void;
   onOpenAboutSite: () => void;
   onOpenAboutAuthor: () => void;
@@ -34,6 +35,7 @@ export default function TopBar({
   showCompareBtn,
   onSwitchLensA,
   onSwitchLensB,
+  onSwapLenses,
   onToggleCompare,
   onOpenAboutSite,
   onOpenAboutAuthor,
@@ -69,6 +71,28 @@ export default function TopBar({
           </option>
         ))}
       </select>
+
+      {comparing && (
+        <button
+          onClick={onSwapLenses}
+          title="Swap lenses"
+          style={{
+            background: "none",
+            border: `1.5px solid ${t.sliderAccent}40`,
+            borderRadius: 6,
+            padding: "4px 8px",
+            cursor: "pointer",
+            color: t.muted,
+            fontFamily: "inherit",
+            fontSize: 14,
+            lineHeight: 1,
+            flexShrink: 0,
+            outline: "none",
+          }}
+        >
+          ⇄
+        </button>
+      )}
 
       {comparing && (
         <>

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -106,7 +106,8 @@ export type LensAction =
   | { type: "SET_OVERLAY"; overlay: OverlayField; visible: boolean }
   | { type: "CLOSE_ALL_OVERLAYS" }
   | { type: "ENTER_COMPARE"; catalogKeys?: string[] }
-  | { type: "EXIT_COMPARE"; focusA?: number; stopdownA?: number };
+  | { type: "EXIT_COMPARE"; focusA?: number; stopdownA?: number }
+  | { type: "SWAP_LENSES" };
 
 /* ── Preferences (from localStorage) ── */
 

--- a/src/utils/lensReducer.ts
+++ b/src/utils/lensReducer.ts
@@ -11,6 +11,7 @@ import type { LensState, LensAction, Preferences, URLState } from "../types/stat
 /* ── Action type constants ── */
 export const SET_LENS_A = "SET_LENS_A";
 export const SET_LENS_B = "SET_LENS_B";
+export const SWAP_LENSES = "SWAP_LENSES";
 export const SET_SCALE_MODE = "SET_SCALE_MODE";
 export const SET_DARK = "SET_DARK";
 export const SET_HIGH_CONTRAST = "SET_HIGH_CONTRAST";
@@ -130,6 +131,8 @@ export default function lensReducer(state: LensState, action: LensAction): LensS
     }
     case SET_LENS_B:
       return { ...state, lens: { ...state.lens, lensKeyB: action.key } };
+    case SWAP_LENSES:
+      return { ...state, lens: { ...state.lens, lensKeyA: state.lens.lensKeyB, lensKeyB: state.lens.lensKeyA } };
     case SET_SCALE_MODE:
       return { ...state, lens: { ...state.lens, scaleMode: action.scaleMode } };
 


### PR DESCRIPTION
Adds a ⇄ button between the Lens A and Lens B dropdowns in the TopBar that instantly swaps lensKeyA ↔ lensKeyB when clicked. Implements a new SWAP_LENSES action through the state/reducer/callback/UI stack.

Closes #171

https://claude.ai/code/session_01EowZy2o1bn6wLiyg3q4hUh