### PR TITLE
fix: show PUPILS button in mobile controls strip

### DIFF
--- a/src/components/layout/ControlsBar.tsx
+++ b/src/components/layout/ControlsBar.tsx
@@ -6,7 +6,7 @@
  * Props control presentation differences; logic is identical in both modes.
  */
 
-import { ENABLE_COLOR_TRACING, ENABLE_EDGE_PROJECTION } from "../../utils/featureFlags.js";
+import { ENABLE_COLOR_TRACING, ENABLE_EDGE_PROJECTION, ENABLE_PUPIL_TOGGLE } from "../../utils/featureFlags.js";
 import { SET_HIGH_CONTRAST, SET_DARK, SET_RAY_TOGGLE, SET_SCALE_MODE } from "../../utils/lensReducer.js";
 import { toggleGroup, toggleBtn, chromChannelBtn, headerStrip } from "../../utils/styles.js";
 import type { Theme } from "../../types/theme.js";
@@ -24,6 +24,7 @@ interface ControlsBarProps {
   chromR: boolean;
   chromG: boolean;
   chromB: boolean;
+  showPupils: boolean;
   dark: boolean;
   highContrast: boolean;
   scaleMode: "independent" | "normalized";
@@ -41,6 +42,7 @@ export default function ControlsBar({
   chromR,
   chromG,
   chromB,
+  showPupils,
   dark,
   highContrast,
   scaleMode,
@@ -94,6 +96,16 @@ export default function ControlsBar({
       dotB: t.rayOffCool,
     },
   ];
+
+  if (ENABLE_PUPIL_TOGGLE) {
+    rayToggles.push({
+      label: "PUPILS",
+      active: showPupils,
+      onClick: () => dispatch({ type: SET_RAY_TOGGLE, field: "showPupils" as RayField, value: !showPupils }),
+      dotA: t.stopLabel,
+      dotB: t.stopLabel,
+    });
+  }
 
   /* ── Ray mode descriptors ── */
   const rayModes = compact

--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -97,7 +97,7 @@ export default function LensVisualization() {
   const { lens, display, rays, sharedSliders, overlays } = state;
   const { lensKeyA, lensKeyB, comparing, scaleMode } = lens;
   const { dark, highContrast, mobileView, desktopView } = display;
-  const { showOnAxis, showOffAxis, rayTracksF, showChromatic, chromR, chromG, chromB } = rays;
+  const { showOnAxis, showOffAxis, rayTracksF, showChromatic, chromR, chromG, chromB, showPupils } = rays;
   const { sharedFocusT, sharedStopdownT, sharedZoomT } = sharedSliders;
   const { showAbout, showAboutSite, showOpticsPrimer } = overlays;
 
@@ -282,6 +282,7 @@ export default function LensVisualization() {
     chromR,
     chromG,
     chromB,
+    showPupils,
     dark,
     highContrast,
     scaleMode,


### PR DESCRIPTION
ControlsBar was missing the PUPILS toggle that appears on desktop via DiagramHeader/RayToggles. Added showPupils prop to ControlsBar and wired it through controlsBarProps in LensViewer, guarded by the existing ENABLE_PUPIL_TOGGLE feature flag.

Fixes #199

https://claude.ai/code/session_015hG5GENAo2a7bcdPeFye91