### PR TITLE
Constrain LCA overlay to SVG diagram bounds

### DIFF
--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -252,7 +252,7 @@ export default function LensDiagramPanel({
           {/* ── SVG + controls body (side-by-side when overflowing) ── */}
           <div style={useSideLayout ? { display: "flex", minHeight: 0 } : undefined}>
             {/* ── SVG viewport ── */}
-            <div style={useSideLayout ? { flex: 1, minWidth: 0 } : undefined}>
+            <div style={useSideLayout ? { flex: 1, minWidth: 0, position: "relative" } : { position: "relative" }}>
               <DiagramSVG
                 L={L}
                 t={t}
@@ -289,6 +289,11 @@ export default function LensDiagramPanel({
                 flashFading={flashFading}
                 onLcaInsetClick={ENABLE_LCA_OVERLAY ? () => setShowLcaOverlay(true) : undefined}
               />
+              {ENABLE_LCA_OVERLAY && showLcaOverlay && showChromatic && chromSpread && (
+                <PanelOverlay onClose={() => setShowLcaOverlay(false)} theme={t}>
+                  <LCAOverlayContent chromSpread={chromSpread} effectiveSC={effectiveSC} IMG_MM={IMG_MM} t={t} />
+                </PanelOverlay>
+              )}
             </div>
             {/* end SVG wrapper */}
 
@@ -378,11 +383,6 @@ export default function LensDiagramPanel({
             )}
           </div>
           {/* end side-layout flex wrapper */}
-          {ENABLE_LCA_OVERLAY && showLcaOverlay && showChromatic && chromSpread && (
-            <PanelOverlay onClose={() => setShowLcaOverlay(false)} theme={t}>
-              <LCAOverlayContent chromSpread={chromSpread} effectiveSC={effectiveSC} IMG_MM={IMG_MM} t={t} />
-            </PanelOverlay>
-          )}
         </div>
       ) : null}
       {showAbbeDiagram && L && (


### PR DESCRIPTION
## Summary

- Moves `PanelOverlay` (LCA enlarged overlay) inside the SVG viewport `<div>` in `LensDiagramPanel`
- Adds `position: relative` to that wrapper div so it becomes the positioned ancestor for the overlay
- The overlay now covers only the lens diagram area — the header (title, subtitle, ray toggles) and sliders panel remain visible and interactive

## Root Cause

Previously, `PanelOverlay` rendered as a sibling of `DiagramHeader` and the controls panel, all inside the panel root div (`position: relative`). So `position: absolute; inset: 0` expanded to cover the entire panel including sliders and lens info.

## Test plan

- [ ] Enable chromatic rays on any lens with chromatic aberration data
- [ ] Click the LCA inset widget in the diagram
- [ ] Confirm the enlarged overlay appears only over the SVG diagram area
- [ ] Confirm title, subtitle, ray toggles, and sliders remain unobscured and interactive
- [ ] All 481 unit tests pass

Closes #209

https://claude.ai/code/session_016Qj6Ntza3tZYMCC62CpKoU