### PR TITLE
Fix lens selector scrollbar appearing behind other UI elements

### DIFF
--- a/src/components/controls/LensSelector.tsx
+++ b/src/components/controls/LensSelector.tsx
@@ -117,6 +117,7 @@ export default function LensSelector({ theme: t, isWide, value, options, onChang
               boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
               zIndex: 9999,
               fontFamily: "inherit",
+              willChange: "transform",
             }}
           >
             {options.map((o) => {


### PR DESCRIPTION
## Summary

- Fixes #212: lens selector dropdown scrollbar appearing behind other UI elements
- Root cause: elements using CSS `linear-gradient` for `backgroundImage` (e.g. `TopBar`, `DiagramHeader` in dark theme) can be promoted to GPU compositor layers by Chrome/Chromium, which can paint over native scrollbars even at `zIndex: 9999`
- Fix: add `willChange: "transform"` to the portal dropdown div in `LensSelector`, forcing it into its own compositor layer so its native scrollbar renders above all other composited content

## Test plan

- [ ] Open the app in the dark theme (which uses `linear-gradient` for header backgrounds)
- [ ] Click the lens selector dropdown — confirm the scrollbar on the right side of the list is fully visible and not obscured by the header/controls below
- [ ] Verify the same in comparison mode with two lens selectors
- [ ] Verify the dropdown still works correctly (opens, scrolls, selects, closes)
- [ ] Check light theme as well (no gradient, but should still work fine)

https://claude.ai/code/session_01GezETXXVWgYz8tJK4sQ83G