### PR TITLE
feat: Petzval sum badge opens expanded overlay (issue #197)

### DIFF
--- a/src/components/diagram/DiagramSVG.tsx
+++ b/src/components/diagram/DiagramSVG.tsx
@@ -10,7 +10,7 @@
  * state or side effects. Interaction callbacks (onHover, onSelect) are passed
  * through from the parent LensDiagramPanel.
  */
-import { ENABLE_ASPH_DIAMOND_FILL, ENABLE_PUPIL_TOGGLE } from "../../utils/featureFlags.js";
+import { ENABLE_ASPH_DIAMOND_FILL, ENABLE_PUPIL_TOGGLE, ENABLE_PETZVAL_OVERLAY } from "../../utils/featureFlags.js";
 import RayPolylines from "./RayPolylines.js";
 import ApertureStop from "./ApertureStop.js";
 import ElementAnnotations from "./ElementAnnotations.js";
@@ -63,6 +63,7 @@ interface DiagramSVGProps {
   flashKey: number;
   flashFading: boolean;
   onLcaInsetClick?: () => void;
+  onPetzvalBadgeClick?: () => void;
 }
 
 export default function DiagramSVG({
@@ -100,6 +101,7 @@ export default function DiagramSVG({
   flashKey,
   flashFading,
   onLcaInsetClick,
+  onPetzvalBadgeClick,
 }: DiagramSVGProps) {
   return (
     <svg
@@ -430,7 +432,7 @@ export default function DiagramSVG({
         })()}
 
       {/* Petzval sum badge — upper-left corner */}
-      <PetzvalSumBadge L={L} t={t} />
+      <PetzvalSumBadge L={L} t={t} onClick={ENABLE_PETZVAL_OVERLAY ? onPetzvalBadgeClick : undefined} />
 
       {/* Flash overlay — brief highlight when slider sticks at common point */}
       {flashVisible && (

--- a/src/components/diagram/PetzvalOverlayContent.tsx
+++ b/src/components/diagram/PetzvalOverlayContent.tsx
@@ -1,0 +1,90 @@
+/**
+ * PetzvalOverlayContent — Enlarged Petzval sum visualization.
+ *
+ * Renders a standalone SVG with the Petzval sum and field radius at a larger
+ * scale, plus a short description explaining what the Petzval sum represents.
+ * Used inside PanelOverlay.
+ */
+
+import type { RuntimeLens } from "../../types/optics.js";
+import type { Theme } from "../../types/theme.js";
+
+interface PetzvalOverlayContentProps {
+  L: RuntimeLens;
+  t: Theme;
+}
+
+const SVG_W = 340;
+const SVG_H = 180;
+
+function formatPetzvalRadius(P: number): string {
+  if (Math.abs(P) < 1e-6) return "R = \u221e";
+  const R = 1 / P;
+  const absR = Math.abs(R);
+  const formatted = absR < 10 ? absR.toFixed(1) : Math.round(absR).toString();
+  return `R\u209a\u209c\u2093 = ${R < 0 ? "\u2212" : ""}${formatted} mm`;
+}
+
+export default function PetzvalOverlayContent({ L, t }: PetzvalOverlayContentProps) {
+  const P = L.petzvalSum;
+  const sign = P >= 0 ? "+" : "\u2212";
+  const pStr = `P = ${sign}${Math.abs(P).toFixed(4)} mm\u207b\u00b9`;
+  const rStr = formatPetzvalRadius(P);
+
+  const cx = SVG_W / 2;
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: "8px 20px 20px" }}>
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", minHeight: 0 }}>
+        <svg
+          viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+          style={{ width: "100%", maxWidth: SVG_W, maxHeight: "100%", display: "block" }}
+        >
+          <rect
+            x={12}
+            y={12}
+            width={SVG_W - 24}
+            height={SVG_H - 24}
+            rx={6}
+            fill={t.panelBg}
+            stroke={t.panelBorder}
+            strokeWidth={0.8}
+            opacity={0.97}
+          />
+          <text
+            x={cx}
+            y={52}
+            textAnchor="middle"
+            fill={t.muted}
+            fontSize={16}
+            fontFamily="inherit"
+            style={{ letterSpacing: "0.12em" }}
+          >
+            PETZVAL
+          </text>
+          <text x={cx} y={100} textAnchor="middle" fill={t.value} fontSize={26} fontFamily="inherit" fontWeight={700}>
+            {pStr}
+          </text>
+          <text x={cx} y={140} textAnchor="middle" fill={t.muted} fontSize={20} fontFamily="inherit">
+            {rStr}
+          </text>
+        </svg>
+      </div>
+      <p
+        style={{
+          margin: "12px 0 0",
+          fontSize: 13,
+          lineHeight: 1.55,
+          color: t.value,
+          fontFamily: "inherit",
+        }}
+      >
+        The <strong>Petzval sum</strong> P&nbsp;=&nbsp;&Sigma;(n&prime;&minus;n)/(n&prime;&middot;n&middot;R) quantifies
+        the inherent field curvature of a lens system. A non-zero Petzval sum means the sharpest focus lies on a curved
+        surface rather than a flat image plane. The <strong>Petzval field radius</strong> R&nbsp;=&nbsp;1/P gives the
+        radius of that curved focal surface &mdash; a larger magnitude means a flatter field. Well-corrected
+        photographic lenses use element combinations that partially cancel the Petzval sum.
+      </p>
+    </div>
+  );
+}

--- a/src/components/diagram/PetzvalSumBadge.tsx
+++ b/src/components/diagram/PetzvalSumBadge.tsx
@@ -11,6 +11,7 @@ import type { Theme } from "../../types/theme.js";
 interface PetzvalSumBadgeProps {
   L: RuntimeLens;
   t: Theme;
+  onClick?: () => void;
 }
 
 function formatPetzvalRadius(P: number): string {
@@ -21,7 +22,7 @@ function formatPetzvalRadius(P: number): string {
   return `R = ${R < 0 ? "\u2212" : ""}${formatted} mm`;
 }
 
-export default function PetzvalSumBadge({ L, t }: PetzvalSumBadgeProps) {
+export default function PetzvalSumBadge({ L, t, onClick }: PetzvalSumBadgeProps) {
   const P = L.petzvalSum;
   const sign = P >= 0 ? "+" : "\u2212";
   const pStr = `${sign}${Math.abs(P).toFixed(4)} mm\u207b\u00b9`;
@@ -33,7 +34,7 @@ export default function PetzvalSumBadge({ L, t }: PetzvalSumBadgeProps) {
   const h = 52;
 
   return (
-    <g style={{ pointerEvents: "none" }}>
+    <g onClick={onClick} style={onClick ? { cursor: "pointer" } : { pointerEvents: "none" }}>
       <rect
         x={x}
         y={y}

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -32,10 +32,12 @@ import OverlayModal from "./OverlayModal.js";
 import PanelOverlay from "./PanelOverlay.js";
 import AbbeDiagram from "../display/AbbeDiagram.js";
 import LCAOverlayContent from "../diagram/LCAOverlayContent.js";
+import PetzvalOverlayContent from "../diagram/PetzvalOverlayContent.js";
 import {
   ENABLE_DYNAMIC_DIAGRAM_HEIGHT,
   ENABLE_COLLAPSIBLE_LEGEND,
   ENABLE_LCA_OVERLAY,
+  ENABLE_PETZVAL_OVERLAY,
 } from "../../utils/featureFlags.js";
 import { ErrorDisplay } from "../errors/ErrorBoundary.js";
 import { useLensCtx, useLensDispatch } from "../../utils/LensContext.js";
@@ -124,6 +126,7 @@ export default function LensDiagramPanel({
   const [sel, setSel] = useState<number | null>(null);
   const [showAbbeDiagram, setShowAbbeDiagram] = useState(false);
   const [showLcaOverlay, setShowLcaOverlay] = useState(false);
+  const [showPetzvalOverlay, setShowPetzvalOverlay] = useState(false);
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -131,6 +134,7 @@ export default function LensDiagramPanel({
     setSel(null);
     setShowAbbeDiagram(false);
     setShowLcaOverlay(false);
+    setShowPetzvalOverlay(false);
   }, [lensKey]);
 
   /* ── Flash overlay animation ── */
@@ -288,10 +292,16 @@ export default function LensDiagramPanel({
                 flashKey={flashKey}
                 flashFading={flashFading}
                 onLcaInsetClick={ENABLE_LCA_OVERLAY ? () => setShowLcaOverlay(true) : undefined}
+                onPetzvalBadgeClick={ENABLE_PETZVAL_OVERLAY ? () => setShowPetzvalOverlay(true) : undefined}
               />
               {ENABLE_LCA_OVERLAY && showLcaOverlay && showChromatic && chromSpread && (
                 <PanelOverlay onClose={() => setShowLcaOverlay(false)} theme={t}>
                   <LCAOverlayContent chromSpread={chromSpread} effectiveSC={effectiveSC} IMG_MM={IMG_MM} t={t} />
+                </PanelOverlay>
+              )}
+              {ENABLE_PETZVAL_OVERLAY && showPetzvalOverlay && L && (
+                <PanelOverlay onClose={() => setShowPetzvalOverlay(false)} theme={t}>
+                  <PetzvalOverlayContent L={L} t={t} />
                 </PanelOverlay>
               )}
             </div>

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -41,3 +41,5 @@ export const ENABLE_ABOUT_BUTTONS_IN_TOPBAR = false;
 export const ENABLE_PUPIL_TOGGLE = true;
 
 export const ENABLE_LCA_OVERLAY = true;
+
+export const ENABLE_PETZVAL_OVERLAY = true;


### PR DESCRIPTION
Clicking the Petzval Sum badge in the lens diagram now opens a panel-scoped overlay (90% of the diagram area) showing the P value and Petzval field radius at a larger scale, along with a description of what the Petzval sum represents.

Reuses PanelOverlay (closes on outside click or × button) and follows the same pattern as the existing LCA overlay. A new ENABLE_PETZVAL_OVERLAY feature flag gates the behaviour; the badge remains non-interactive when the flag is off.

https://claude.ai/code/session_01E3eLjzRXqvh4xbpfE4jhBJ