### PR TITLE
Add breadcrumb navigation bar above lens selector

### DIFF
--- a/src/components/layout/BreadcrumbBar.tsx
+++ b/src/components/layout/BreadcrumbBar.tsx
@@ -1,0 +1,62 @@
+/**
+ * Breadcrumb navigation bar — Home / Makers / {Maker} / {Lens Name}
+ *
+ * Renders above the TopBar in the LensViewer, matching the breadcrumb
+ * pattern used on the multipage layout pages (LensPage, MakerPage, etc.).
+ */
+
+import { Link } from "react-router";
+import type { Theme } from "../../types/theme.js";
+import { headerStrip } from "../../utils/styles.js";
+import { LENS_CATALOG } from "../../utils/lensCatalog.js";
+import { deriveMaker } from "../../utils/lensMetadata.js";
+
+interface BreadcrumbBarProps {
+  theme: Theme;
+  isWide: boolean;
+  lensKey: string;
+}
+
+export default function BreadcrumbBar({ theme: t, isWide, lensKey }: BreadcrumbBarProps) {
+  const lens = LENS_CATALOG[lensKey];
+  if (!lens) return null;
+
+  const maker = deriveMaker(lens.name, lens.maker);
+
+  const linkStyle: React.CSSProperties = {
+    color: t.descLinkColor,
+    textDecoration: "none",
+  };
+
+  const separatorStyle: React.CSSProperties = {
+    color: t.muted,
+    margin: "0 0.35em",
+  };
+
+  return (
+    <nav
+      style={{
+        ...headerStrip(t, { padding: isWide ? "6px 24px" : "6px 12px" }),
+        fontSize: isWide ? 11 : 10,
+        fontFamily: "inherit",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      }}
+    >
+      <Link to="/" style={linkStyle}>
+        Home
+      </Link>
+      <span style={separatorStyle}>/</span>
+      <Link to="/makers" style={linkStyle}>
+        Makers
+      </Link>
+      <span style={separatorStyle}>/</span>
+      <Link to={`/makers/${maker.slug}`} style={linkStyle}>
+        {maker.display}
+      </Link>
+      <span style={separatorStyle}>/</span>
+      <span style={{ color: t.body }}>{lens.name}</span>
+    </nav>
+  );
+}

--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -42,6 +42,7 @@ import { ErrorDisplay } from "../errors/ErrorBoundary.js";
 import OverlayModal from "./OverlayModal.js";
 import ControlsBar from "./ControlsBar.js";
 import TopBar from "./TopBar.js";
+import BreadcrumbBar from "./BreadcrumbBar.js";
 import ViewToggleBar from "./ViewToggleBar.js";
 import ComparisonLayout from "./ComparisonLayout.js";
 import ABOUT_ME_MD from "../../content/AboutMe.md?raw";
@@ -325,6 +326,9 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
             transition: "background 0.3s,color 0.3s",
           }}
         >
+          {/* ── Breadcrumb navigation ── */}
+          <BreadcrumbBar theme={t} isWide={isWide} lensKey={lensKeyA} />
+
           {/* ── Top bar: lens selector(s) + compare button ── */}
           <TopBar
             theme={t}


### PR DESCRIPTION
## Summary

- Adds a `BreadcrumbBar` component that displays **Home / Makers / {Maker} / {Lens Name}** breadcrumb links above the TopBar in the LensViewer
- Matches the navigation pattern already used on multipage layout pages (LensPage, MakerPage, etc.)
- Uses theme tokens (`descLinkColor`, `muted`, `headerBgColor`) for consistent styling across all 4 themes
- Uses react-router `<Link>` for client-side navigation and `deriveMaker()` to resolve maker info from lens data

## Test plan

- [x] TypeScript typecheck passes
- [x] All 481 unit tests pass
- [ ] Verify breadcrumbs render correctly on desktop and mobile widths
- [ ] Verify breadcrumb links navigate to correct pages (Home, Makers index, specific Maker page)
- [ ] Verify breadcrumb updates when switching lenses via the selector
- [ ] Verify appearance in all 4 themes (dark, light, darkHC, lightHC)

https://claude.ai/code/session_01DiynmyvRPBSZNGrwTNKVxW