### PR TITLE
Fix lens selector to update URL path on /lens/ pages

### DIFF
--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useNavigate } from "react-router";
 
 import T from "../../utils/themes.js";
 import buildLens from "../../optics/buildLens.js";
@@ -97,6 +98,8 @@ interface LensVisualizationProps {
 }
 
 export default function LensVisualization({ initialLensKey }: LensVisualizationProps) {
+  const navigate = useNavigate();
+  const isLensPage = !!initialLensKey;
   const [state, dispatch, isWide] = useLensState(CATALOG_KEYS, initialLensKey);
 
   /* ── Destructure state slices for convenient access ── */
@@ -158,8 +161,11 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
   const switchLensA = useCallback(
     (key: string) => {
       dispatch({ type: SET_LENS_A, key });
+      if (isLensPage && !state.lens.comparing) {
+        void navigate(`/lens/${key}`, { replace: true });
+      }
     },
-    [dispatch],
+    [dispatch, isLensPage, state.lens.comparing, navigate],
   );
 
   const switchLensB = useCallback(
@@ -186,7 +192,12 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
     }
   }, [comparing, lensKeyA, lensKeyB]);
 
-  const { updateURLWithSliders } = useURLSync(state, dispatch, comparisonLenses as Parameters<typeof useURLSync>[2]);
+  const { updateURLWithSliders } = useURLSync(
+    state,
+    dispatch,
+    comparisonLenses as Parameters<typeof useURLSync>[2],
+    isLensPage,
+  );
 
   /* ── Normalized scale computation ──
    * In normalized mode, both panels use the same mm-per-pixel ratio so lens

--- a/src/utils/useURLSync.ts
+++ b/src/utils/useURLSync.ts
@@ -34,6 +34,7 @@ export default function useURLSync(
   state: LensState,
   dispatch: Dispatch<LensAction>,
   comparisonLenses: ComparisonLensesParam,
+  isLensPage?: boolean,
 ): UseURLSyncResult {
   const { lens, sliders, sharedSliders } = state;
   const { comparing, lensKeyA, lensKeyB } = lens;
@@ -53,12 +54,14 @@ export default function useURLSync(
 
   /* ── 1. Immediate URL update on lens selection change ── */
   useEffect(() => {
+    // On lens pages in single-lens mode, navigation is handled by LensViewer via React Router
+    if (isLensPage && !comparing) return;
     const url = buildComparisonURL(comparing, lensKeyA, lensKeyB);
     const current = window.location.search;
     if (url !== current) {
       history.replaceState(null, "", url || window.location.pathname);
     }
-  }, [comparing, lensKeyA, lensKeyB]);
+  }, [comparing, lensKeyA, lensKeyB, isLensPage]);
 
   /* ── 3a. Zoom init — comparison mode ── */
   useEffect(() => {
@@ -121,10 +124,23 @@ export default function useURLSync(
           /* ignore */
         }
       }
-      const url = buildComparisonURL(comparing, lensKeyA, lensKeyB, sliderState);
-      const current = window.location.search;
-      if (url !== current) {
-        history.replaceState(null, "", url || window.location.pathname);
+      if (isLensPage && !comparing) {
+        // On lens pages, only encode slider params — the pathname already has the lens key
+        const params = new URLSearchParams();
+        if (sliderState.zoom != null && sliderState.zoom > 0) params.set("zoom", String(sliderState.zoom));
+        if (sliderState.focus != null && sliderState.focus > 0) params.set("focus", sliderState.focus.toFixed(3));
+        if (sliderState.aperture != null && sliderState.aperture > 0)
+          params.set("aperture", sliderState.aperture.toFixed(3));
+        const search = params.toString() ? `?${params.toString()}` : "";
+        if (search !== window.location.search) {
+          history.replaceState(null, "", window.location.pathname + search);
+        }
+      } else {
+        const url = buildComparisonURL(comparing, lensKeyA, lensKeyB, sliderState);
+        const current = window.location.search;
+        if (url !== current) {
+          history.replaceState(null, "", url || window.location.pathname);
+        }
       }
     }, 300);
   }, [
@@ -138,6 +154,7 @@ export default function useURLSync(
     sharedStopdownT,
     sharedZoomT,
     comparisonLenses,
+    isLensPage,
   ]);
 
   return { updateURLWithSliders };


### PR DESCRIPTION
## Summary

- **Fix stale SEO content**: When changing lenses via the selector on a `/lens/:slug` page, the SEO details (specs, elements, analysis) at the bottom of the page now update to reflect the newly selected lens
- **Fix reload regression**: Reloading the page after changing lenses via the selector now correctly loads the selected lens instead of reverting to the first lens visited
- **Preserve existing behavior**: HomePage query-param-based URL sync and comparison mode are unaffected

## What changed

**`LensViewer.tsx`**: When on a lens page (`initialLensKey` is set) in single-lens mode, `switchLensA` now calls `navigate(`/lens/${key}`, { replace: true })` via React Router in addition to dispatching `SET_LENS_A`. This updates the URL path so `LensPage` re-renders with the correct `slug`.

**`useURLSync.ts`**: Accepts an `isLensPage` flag. On lens pages in single-lens mode, skips writing `?lens=KEY` to query params (since the pathname already encodes the lens key) and only writes slider params (focus, aperture, zoom).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 558 tests pass (31 files)
- [x] `npm run lint` — clean
- [ ] Manual: navigate from maker index → lens page → change lens via selector → verify URL path updates, SEO content updates, reload preserves selection
- [ ] Manual: verify HomePage lens selector still works with query params
- [ ] Manual: verify comparison mode on lens pages still works

https://claude.ai/code/session_01VfRHzXX5zZoM6CytjacELa