### PR TITLE
refactor: consolidate client and SSR routes into shared manifest

### DIFF
--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -2,7 +2,8 @@
  * Server entry point for static prerendering.
  *
  * Renders a given URL path to an HTML string using StaticRouter and
- * react-helmet-async for head extraction.
+ * react-helmet-async for head extraction. Route definitions come from
+ * `src/routes/routeManifest.tsx` — the shared source of truth.
  */
 
 import { renderToString } from "react-dom/server";
@@ -10,12 +11,7 @@ import { StaticRouter } from "react-router";
 import { HelmetProvider, HelmetData } from "react-helmet-async";
 import type { HelmetServerState } from "react-helmet-async";
 import ErrorBoundary from "./components/errors/ErrorBoundary.js";
-import HomePage from "./pages/HomePage.js";
-import LensPage from "./pages/LensPage.js";
-import LensIndexPage from "./pages/LensIndexPage.js";
-import MakersIndexPage from "./pages/MakersIndexPage.js";
-import MakerPage from "./pages/MakerPage.js";
-import NotFoundPage from "./pages/NotFoundPage.js";
+import routeManifest from "./routes/routeManifest.js";
 import { Routes, Route } from "react-router";
 
 export interface RenderResult {
@@ -31,12 +27,9 @@ export function render(url: string): RenderResult {
       <HelmetProvider context={helmetData.context}>
         <StaticRouter location={url}>
           <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/lenses" element={<LensIndexPage />} />
-            <Route path="/lens/:slug" element={<LensPage />} />
-            <Route path="/makers" element={<MakersIndexPage />} />
-            <Route path="/makers/:maker" element={<MakerPage />} />
-            <Route path="*" element={<NotFoundPage />} />
+            {routeManifest.map(({ path, element }) => (
+              <Route key={path} path={path} element={element} />
+            ))}
           </Routes>
         </StaticRouter>
       </HelmetProvider>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,25 +1,13 @@
 /**
- * Application route definitions.
+ * Client-side browser router.
  *
- * Path-based routing for SEO-friendly URLs. The home page at / renders the
- * full interactive visualizer; /lens/:slug pre-selects a specific lens.
+ * Route definitions live in `src/routes/routeManifest.tsx` — the shared
+ * source of truth used by both the client router and SSR renderer.
  */
 
 import { createBrowserRouter } from "react-router";
-import HomePage from "./pages/HomePage.js";
-import LensPage from "./pages/LensPage.js";
-import LensIndexPage from "./pages/LensIndexPage.js";
-import MakersIndexPage from "./pages/MakersIndexPage.js";
-import MakerPage from "./pages/MakerPage.js";
-import NotFoundPage from "./pages/NotFoundPage.js";
+import routeManifest from "./routes/routeManifest.js";
 
-const router = createBrowserRouter([
-  { path: "/", element: <HomePage /> },
-  { path: "/lenses", element: <LensIndexPage /> },
-  { path: "/lens/:slug", element: <LensPage /> },
-  { path: "/makers", element: <MakersIndexPage /> },
-  { path: "/makers/:maker", element: <MakerPage /> },
-  { path: "*", element: <NotFoundPage /> },
-]);
+const router = createBrowserRouter(routeManifest);
 
 export default router;

--- a/src/routes/routeManifest.tsx
+++ b/src/routes/routeManifest.tsx
@@ -1,0 +1,30 @@
+/**
+ * Shared route manifest — single source of truth for all app routes.
+ *
+ * Consumed by both the client-side browser router (`src/router.tsx`) and the
+ * SSR static renderer (`src/entry-server.tsx`) so route definitions stay in sync.
+ */
+
+import type { ReactNode } from "react";
+import HomePage from "../pages/HomePage.js";
+import LensPage from "../pages/LensPage.js";
+import LensIndexPage from "../pages/LensIndexPage.js";
+import MakersIndexPage from "../pages/MakersIndexPage.js";
+import MakerPage from "../pages/MakerPage.js";
+import NotFoundPage from "../pages/NotFoundPage.js";
+
+export interface RouteManifestEntry {
+  path: string;
+  element: ReactNode;
+}
+
+const routeManifest: RouteManifestEntry[] = [
+  { path: "/", element: <HomePage /> },
+  { path: "/lenses", element: <LensIndexPage /> },
+  { path: "/lens/:slug", element: <LensPage /> },
+  { path: "/makers", element: <MakersIndexPage /> },
+  { path: "/makers/:maker", element: <MakerPage /> },
+  { path: "*", element: <NotFoundPage /> },
+];
+
+export default routeManifest;


### PR DESCRIPTION
## Summary\n\n- Extracts route definitions from `src/router.tsx` and `src/entry-server.tsx` into a new `src/routes/routeManifest.tsx` module\n- Both the client-side browser router and SSR static renderer now derive routes from this single source of truth\n- Eliminates the drift hazard of maintaining two identical route lists\n\nCloses #225\n\n## Test plan\n\n- [x] `npm run typecheck` — passes\n- [x] `npm run lint` — passes\n- [x] `npm run test` — all 558 tests pass\n- [x] `npm run build` — full build succeeds, all 31 routes prerendered\n- [ ] Verify all routes work in browser: `/`, `/lenses`, `/lens/:slug`, `/makers`, `/makers/:maker`, and a 404 path\n\nhttps://claude.ai/code/session_01GSfWAnL3LzLtTe2RK3pnU7