### PR TITLE
refactor: reduce LensDiagramPanel to panel composition only

### DIFF
--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -30,6 +30,7 @@
 | `SharedSlidersBar.tsx` | `src/components/layout/` | Comparison mode shared focus/aperture/zoom controls |
 | `BreadcrumbBar.tsx` | `src/components/layout/` | Breadcrumb navigation (Home / Makers / {Maker} / {Lens Name}) for lens pages |
 | `PanelOverlay.tsx` | `src/components/layout/` | Panel-scoped overlay (position:absolute) for diagram-level LCA/Petzval overlays |
+| `DiagramControlPanel.tsx` | `src/components/layout/` | Sliders, inspector, and legend panel extracted from LensDiagramPanel |
 
 ### Hooks
 
@@ -42,6 +43,9 @@
 | `useChromaticRays.ts` | `src/components/hooks/` | Hook: chromatic tracing + spread computation |
 | `useFlashOverlay.ts` | `src/components/hooks/` | Hook: flash animation state machine for sticky slider feedback |
 | `useSideLayoutDetection.ts` | `src/components/hooks/` | Hook: ResizeObserver overflow detection with hysteresis |
+| `useDispatchAdapters.ts` | `src/components/hooks/` | Hook: context dispatch callback wiring for LensDiagramPanel children |
+| `useOverlayState.ts` | `src/components/hooks/` | Hook: Abbe/LCA/Petzval overlay open/close state with lensKey reset |
+| `useHeaderHeight.ts` | `src/components/hooks/` | Hook: header ResizeObserver height tracking for multi-panel alignment |
 
 ### Controls
 
@@ -152,7 +156,7 @@ State is provided to children via `LensStateContext` (state + theme + isWide) an
 
 ## LensDiagramPanel.tsx — Diagram Composition Layer
 
-Orchestrates sub-components and custom hooks. Owns only hover/selection state, header height reporting, and structural layout wiring.
+Orchestrates sub-components and custom hooks. Owns only hover/selection state and structural layout wiring.
 
 Extracted hooks (all in `src/components/hooks/`):
 - **`useLensComputation.ts`** — Hook: lens building, layout, coordinate transforms, element shapes, aperture calculations
@@ -162,6 +166,9 @@ Extracted hooks (all in `src/components/hooks/`):
 - **`useChromaticRays.ts`** — Hook: chromatic tracing across R/G/B channels + LCA/TCA spread computation
 - **`useFlashOverlay.ts`** — Hook: two-phase flash animation state machine for sticky slider feedback
 - **`useSideLayoutDetection.ts`** — Hook: ResizeObserver-based overflow detection with hysteresis for side-by-side layout
+- **`useDispatchAdapters.ts`** — Hook: reads context dispatch and returns named callback adapters for child components
+- **`useOverlayState.ts`** — Hook: Abbe/LCA/Petzval overlay open/close state with lensKey reset
+- **`useHeaderHeight.ts`** — Hook: header ResizeObserver height tracking for multi-panel alignment
 
 Sub-components:
 - **`PanelErrorBoundary.tsx`** (`src/components/errors/`) — Panel-level error boundary that resets automatically on lens change
@@ -177,6 +184,7 @@ Sub-components:
   - **`PetzvalOverlayContent.tsx`** — Enlarged Petzval sum visualization with description, rendered inside PanelOverlay on click
 - **`PetzvalSumBadge.tsx`** — SVG overlay badge showing Petzval sum (P) and field radius (R_ptz) in diagram upper-left
 - **`PanelOverlay.tsx`** (`src/components/layout/`) — Panel-scoped overlay (position:absolute, not fixed) for diagram-level measure overlays
+- **`DiagramControlPanel.tsx`** (`src/components/layout/`) — Sliders, inspector, and legend section extracted from LensDiagramPanel; composes DiagramControls, ElementInspector, and DiagramLegend
 - **`DiagramControls.tsx`** (`src/components/controls/`) — Zoom, focus, aperture sliders (composes SliderControl)
   - **`SliderControl.tsx`** — Reusable slider with label, value display, endpoints, optional collapsible content
 - **`ElementInspector.tsx`** (`src/components/display/`) — Selected element property display (nd, νd, FL, glass, aspheric coefficients, chromatic data)

--- a/src/components/hooks/useDispatchAdapters.ts
+++ b/src/components/hooks/useDispatchAdapters.ts
@@ -1,0 +1,78 @@
+/**
+ * useDispatchAdapters — Bridges context dispatch to named callback props
+ * for LensDiagramPanel's child components.
+ *
+ * Reads useLensDispatch() and useLensCtx() internally. Returns a stable
+ * object of 18 dispatch adapter callbacks for sliders, ray toggles,
+ * display toggles, and panel-expanded toggles.
+ */
+
+import { useMemo } from "react";
+import { useLensCtx, useLensDispatch } from "../../utils/LensContext.js";
+import {
+  SET_FOCUS_T,
+  SET_ZOOM_T,
+  SET_STOPDOWN_T,
+  SET_RAY_TOGGLE,
+  SET_DARK,
+  SET_HIGH_CONTRAST,
+  SET_PANEL_EXPANDED,
+} from "../../utils/lensReducer.js";
+
+export interface DispatchAdapters {
+  onFocusChange: (v: number) => void;
+  onZoomChange: (v: number) => void;
+  onStopdownChange: (v: number) => void;
+  onSliderPointerUp: () => void;
+  onShowOnAxisChange: (v: boolean) => void;
+  onShowOffAxisChange: (v: string) => void;
+  onRayTracksFChange: (v: boolean) => void;
+  onShowChromaticChange: (v: boolean) => void;
+  onChromRChange: (v: boolean) => void;
+  onChromGChange: (v: boolean) => void;
+  onChromBChange: (v: boolean) => void;
+  onShowPupilsChange: (v: boolean) => void;
+  onDarkChange: (v: boolean) => void;
+  onHighContrastChange: (v: boolean) => void;
+  onFocusExpandedChange: (v: boolean) => void;
+  onApertureExpandedChange: (v: boolean) => void;
+  onHeaderControlsExpandedChange: (v: boolean) => void;
+  onLegendExpandedChange: (v: boolean) => void;
+  onHeaderInfoExpandedChange: (v: boolean) => void;
+}
+
+export default function useDispatchAdapters(): DispatchAdapters {
+  const { updateURLWithSliders } = useLensCtx();
+  const dispatch = useLensDispatch();
+
+  /* dispatch and updateURLWithSliders are stable refs, so the memo never recomputes */
+  return useMemo(
+    () => ({
+      onFocusChange: (v: number) => dispatch({ type: SET_FOCUS_T, value: v }),
+      onZoomChange: (v: number) => dispatch({ type: SET_ZOOM_T, value: v }),
+      onStopdownChange: (v: number) => dispatch({ type: SET_STOPDOWN_T, value: v }),
+      onSliderPointerUp: updateURLWithSliders,
+      onShowOnAxisChange: (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showOnAxis", value: v }),
+      onShowOffAxisChange: (v: string) => dispatch({ type: SET_RAY_TOGGLE, field: "showOffAxis", value: v }),
+      onRayTracksFChange: (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "rayTracksF", value: v }),
+      onShowChromaticChange: (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showChromatic", value: v }),
+      onChromRChange: (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromR", value: v }),
+      onChromGChange: (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromG", value: v }),
+      onChromBChange: (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromB", value: v }),
+      onShowPupilsChange: (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showPupils", value: v }),
+      onDarkChange: (v: boolean) => dispatch({ type: SET_DARK, dark: v }),
+      onHighContrastChange: (v: boolean) => dispatch({ type: SET_HIGH_CONTRAST, highContrast: v }),
+      onFocusExpandedChange: (v: boolean) =>
+        dispatch({ type: SET_PANEL_EXPANDED, panel: "focusExpanded", expanded: v }),
+      onApertureExpandedChange: (v: boolean) =>
+        dispatch({ type: SET_PANEL_EXPANDED, panel: "apertureExpanded", expanded: v }),
+      onHeaderControlsExpandedChange: (v: boolean) =>
+        dispatch({ type: SET_PANEL_EXPANDED, panel: "headerControlsExpanded", expanded: v }),
+      onLegendExpandedChange: (v: boolean) =>
+        dispatch({ type: SET_PANEL_EXPANDED, panel: "legendExpanded", expanded: v }),
+      onHeaderInfoExpandedChange: (v: boolean) =>
+        dispatch({ type: SET_PANEL_EXPANDED, panel: "headerInfoExpanded", expanded: v }),
+    }),
+    [dispatch, updateURLWithSliders],
+  );
+}

--- a/src/components/hooks/useHeaderHeight.ts
+++ b/src/components/hooks/useHeaderHeight.ts
@@ -1,0 +1,47 @@
+/**
+ * useHeaderHeight — Tracks header element height via ResizeObserver
+ * and reports it to a parent callback for multi-panel alignment.
+ *
+ * Returns a ref to attach to the header element and the current
+ * measured height (avoids stale ref reads in render).
+ */
+
+import { useRef, useState, useLayoutEffect } from "react";
+import type { RefObject } from "react";
+
+interface UseHeaderHeightParams {
+  panelId: string;
+  lensKey: string;
+  onHeaderHeight?: (panelId: string, height: number) => void;
+}
+
+interface UseHeaderHeightResult {
+  headerRef: RefObject<HTMLDivElement | null>;
+  headerHeight: number;
+}
+
+export default function useHeaderHeight({
+  panelId,
+  lensKey,
+  onHeaderHeight,
+}: UseHeaderHeightParams): UseHeaderHeightResult {
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const [headerHeight, setHeaderHeight] = useState(80);
+
+  useLayoutEffect(() => {
+    if (!headerRef.current) return;
+    const el = headerRef.current;
+    const report = () => {
+      const h = el.scrollHeight;
+      setHeaderHeight(h);
+      onHeaderHeight?.(panelId, h);
+    };
+    report();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(report);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [onHeaderHeight, panelId, lensKey]);
+
+  return { headerRef, headerHeight };
+}

--- a/src/components/hooks/useOverlayState.ts
+++ b/src/components/hooks/useOverlayState.ts
@@ -1,0 +1,51 @@
+/**
+ * useOverlayState — Manages open/close state for diagram panel overlays
+ * (Abbe diagram, LCA overlay, Petzval overlay).
+ *
+ * Resets all overlays when lensKey changes.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface OverlayState {
+  showAbbeDiagram: boolean;
+  openAbbeDiagram: () => void;
+  closeAbbeDiagram: () => void;
+  showLcaOverlay: boolean;
+  openLcaOverlay: () => void;
+  closeLcaOverlay: () => void;
+  showPetzvalOverlay: boolean;
+  openPetzvalOverlay: () => void;
+  closePetzvalOverlay: () => void;
+}
+
+export default function useOverlayState(lensKey: string): OverlayState {
+  const [showAbbeDiagram, setShowAbbeDiagram] = useState(false);
+  const [showLcaOverlay, setShowLcaOverlay] = useState(false);
+  const [showPetzvalOverlay, setShowPetzvalOverlay] = useState(false);
+
+  useEffect(() => {
+    setShowAbbeDiagram(false);
+    setShowLcaOverlay(false);
+    setShowPetzvalOverlay(false);
+  }, [lensKey]);
+
+  const openAbbeDiagram = useCallback(() => setShowAbbeDiagram(true), []);
+  const closeAbbeDiagram = useCallback(() => setShowAbbeDiagram(false), []);
+  const openLcaOverlay = useCallback(() => setShowLcaOverlay(true), []);
+  const closeLcaOverlay = useCallback(() => setShowLcaOverlay(false), []);
+  const openPetzvalOverlay = useCallback(() => setShowPetzvalOverlay(true), []);
+  const closePetzvalOverlay = useCallback(() => setShowPetzvalOverlay(false), []);
+
+  return {
+    showAbbeDiagram,
+    openAbbeDiagram,
+    closeAbbeDiagram,
+    showLcaOverlay,
+    openLcaOverlay,
+    closeLcaOverlay,
+    showPetzvalOverlay,
+    openPetzvalOverlay,
+    closePetzvalOverlay,
+  };
+}

--- a/src/components/layout/DiagramControlPanel.tsx
+++ b/src/components/layout/DiagramControlPanel.tsx
@@ -1,0 +1,172 @@
+/**
+ * DiagramControlPanel — Renders the control panel section of LensDiagramPanel:
+ * slider controls (DiagramControls) and inspector/legend display.
+ *
+ * Handles responsive layout switching between side-by-side and stacked modes.
+ */
+
+import DiagramControls from "../controls/DiagramControls.js";
+import ElementInspector from "../display/ElementInspector.js";
+import DiagramLegend from "../display/DiagramLegend.js";
+import { ENABLE_COLLAPSIBLE_LEGEND } from "../../utils/featureFlags.js";
+import type { RuntimeLens, ElementData, ChromaticSpread } from "../../types/optics.js";
+import type { Theme } from "../../types/theme.js";
+
+interface VarReadout {
+  label: string;
+  val: string;
+}
+
+interface DiagramControlPanelProps {
+  L: RuntimeLens;
+  t: Theme;
+  compact: boolean;
+  isWide: boolean;
+  useSideLayout: boolean;
+  headerHeight: number;
+  showSliders: boolean;
+  zoomT: number;
+  focusT: number;
+  stopdownT: number;
+  fNumber: number;
+  currentPhysStopSD: number;
+  baseEPSD: number;
+  varReadouts: VarReadout[];
+  focusExpanded: boolean;
+  apertureExpanded: boolean;
+  legendExpanded: boolean;
+  onZoomChange: (v: number) => void;
+  onFocusChange: (v: number) => void;
+  onStopdownChange: (v: number) => void;
+  onFocusExpandedChange: (v: boolean) => void;
+  onApertureExpandedChange: (v: boolean) => void;
+  onLegendExpandedChange: (v: boolean) => void;
+  onSliderPointerUp: () => void;
+  info: ElementData | null;
+  showOnAxis: boolean;
+  showOffAxis: string;
+  showChromatic: boolean;
+  chromR: boolean;
+  chromG: boolean;
+  chromB: boolean;
+  chromSpread: ChromaticSpread | null;
+  rayTracksF: boolean;
+  onOpenAbbeDiagram: () => void;
+}
+
+export default function DiagramControlPanel({
+  L,
+  t,
+  compact,
+  isWide,
+  useSideLayout,
+  headerHeight,
+  showSliders,
+  zoomT,
+  focusT,
+  stopdownT,
+  fNumber,
+  currentPhysStopSD,
+  baseEPSD,
+  varReadouts,
+  focusExpanded,
+  apertureExpanded,
+  legendExpanded,
+  onZoomChange,
+  onFocusChange,
+  onStopdownChange,
+  onFocusExpandedChange,
+  onApertureExpandedChange,
+  onLegendExpandedChange,
+  onSliderPointerUp,
+  info,
+  showOnAxis,
+  showOffAxis,
+  showChromatic,
+  chromR,
+  chromG,
+  chromB,
+  chromSpread,
+  rayTracksF,
+  onOpenAbbeDiagram,
+}: DiagramControlPanelProps) {
+  return (
+    <div
+      style={
+        useSideLayout
+          ? {
+              flex: "0 0 340px",
+              borderLeft: `1px solid ${t.panelBorder}`,
+              overflowY: "auto",
+              maxHeight: `calc(100vh - ${headerHeight}px - 20px)`,
+              display: "flex",
+              flexDirection: "column",
+              background: t.panelBg,
+              transition: "background 0.3s,border-color 0.3s",
+            }
+          : {
+              display: "flex",
+              borderTop: `1px solid ${t.panelBorder}`,
+              background: t.panelBg,
+              flexWrap: "wrap",
+              transition: "background 0.3s,border-color 0.3s",
+            }
+      }
+    >
+      <DiagramControls
+        L={L}
+        t={t}
+        compact={compact}
+        useSideLayout={useSideLayout}
+        zoomT={zoomT}
+        onZoomChange={onZoomChange}
+        focusT={focusT}
+        onFocusChange={onFocusChange}
+        focusExpanded={focusExpanded}
+        onFocusExpandedChange={onFocusExpandedChange}
+        varReadouts={varReadouts}
+        stopdownT={stopdownT}
+        onStopdownChange={onStopdownChange}
+        fNumber={fNumber}
+        currentPhysStopSD={currentPhysStopSD}
+        baseEPSD={baseEPSD}
+        apertureExpanded={apertureExpanded}
+        onApertureExpandedChange={onApertureExpandedChange}
+        onSliderPointerUp={onSliderPointerUp}
+        showSliders={showSliders}
+      />
+
+      <div
+        style={{
+          flex: useSideLayout ? 1 : "1 1 360px",
+          padding: compact ? "10px 14px" : "14px 22px",
+          minHeight: compact ? 100 : ENABLE_COLLAPSIBLE_LEGEND && !isWide && !info && !legendExpanded ? 40 : 125,
+          transition: "background 0.2s",
+          background: info ? t.infoBgActive : t.infoBgIdle,
+        }}
+      >
+        {info ? (
+          <ElementInspector info={info} L={L} t={t} showChromatic={showChromatic} />
+        ) : (
+          <DiagramLegend
+            L={L}
+            t={t}
+            isWide={isWide}
+            zoomT={zoomT}
+            showOnAxis={showOnAxis}
+            showOffAxis={showOffAxis}
+            showChromatic={showChromatic}
+            chromR={chromR}
+            chromG={chromG}
+            chromB={chromB}
+            chromSpread={chromSpread}
+            rayTracksF={rayTracksF}
+            legendExpanded={legendExpanded}
+            onLegendExpandedChange={onLegendExpandedChange}
+            onOpenAbbeDiagram={onOpenAbbeDiagram}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -4,52 +4,40 @@
  * Orchestrates sub-components and custom hooks:
  *   useLensComputation  → lens building, layout, transforms, shapes, aperture
  *   useRayTracing       → on-axis, off-axis, chromatic ray fans
+ *   useDispatchAdapters → context dispatch callback wiring
+ *   useOverlayState     → Abbe/LCA/Petzval overlay open/close state
+ *   useHeaderHeight     → header ResizeObserver + height reporting
  *   useFlashOverlay     → flash animation state machine
  *   useSideLayoutDetection → overflow-based side layout switching
  *   DiagramHeader       → title, specs, theme/ray toggle controls
  *   DiagramSVG          → full SVG rendering of the optical system
- *   DiagramControls     → zoom, focus, aperture sliders
- *   ElementInspector    → selected element property display
- *   DiagramLegend       → legend with color swatches and ray descriptions
+ *   DiagramControlPanel → sliders, inspector, legend
  *   PanelErrorBoundary  → panel-level error boundary
  *
- * Owns only: hover/selection state, header height reporting, and the
- * structural layout that wires sub-components.
+ * Owns only: hover/selection state and the structural layout that
+ * wires sub-components.
  */
 
-import { useState, useEffect, useLayoutEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import useLensComputation from "../hooks/useLensComputation.js";
 import useRayTracing from "../hooks/useRayTracing.js";
+import useDispatchAdapters from "../hooks/useDispatchAdapters.js";
+import useOverlayState from "../hooks/useOverlayState.js";
+import useHeaderHeight from "../hooks/useHeaderHeight.js";
 import useFlashOverlay from "../hooks/useFlashOverlay.js";
 import useSideLayoutDetection from "../hooks/useSideLayoutDetection.js";
-import DiagramControls from "../controls/DiagramControls.js";
-import ElementInspector from "../display/ElementInspector.js";
-import DiagramLegend from "../display/DiagramLegend.js";
 import DiagramSVG from "../diagram/DiagramSVG.js";
 import DiagramHeader from "../controls/DiagramHeader.js";
+import DiagramControlPanel from "./DiagramControlPanel.js";
 import PanelErrorBoundary from "../errors/PanelErrorBoundary.js";
 import OverlayModal from "./OverlayModal.js";
 import PanelOverlay from "./PanelOverlay.js";
 import AbbeDiagram from "../display/AbbeDiagram.js";
 import LCAOverlayContent from "../diagram/LCAOverlayContent.js";
 import PetzvalOverlayContent from "../diagram/PetzvalOverlayContent.js";
-import {
-  ENABLE_DYNAMIC_DIAGRAM_HEIGHT,
-  ENABLE_COLLAPSIBLE_LEGEND,
-  ENABLE_LCA_OVERLAY,
-  ENABLE_PETZVAL_OVERLAY,
-} from "../../utils/featureFlags.js";
+import { ENABLE_DYNAMIC_DIAGRAM_HEIGHT, ENABLE_LCA_OVERLAY, ENABLE_PETZVAL_OVERLAY } from "../../utils/featureFlags.js";
 import { ErrorDisplay } from "../errors/ErrorBoundary.js";
-import { useLensCtx, useLensDispatch } from "../../utils/LensContext.js";
-import {
-  SET_FOCUS_T,
-  SET_ZOOM_T,
-  SET_STOPDOWN_T,
-  SET_RAY_TOGGLE,
-  SET_DARK,
-  SET_HIGH_CONTRAST,
-  SET_PANEL_EXPANDED,
-} from "../../utils/lensReducer.js";
+import { useLensCtx } from "../../utils/LensContext.js";
 
 interface LensDiagramPanelProps {
   lensKey: string;
@@ -85,8 +73,7 @@ export default function LensDiagramPanel({
   sideLayoutEnabled = false,
 }: LensDiagramPanelProps) {
   /* ── Read shared state from context ── */
-  const { state, theme: t, isWide, updateURLWithSliders } = useLensCtx();
-  const dispatch = useLensDispatch();
+  const { state, theme: t, isWide } = useLensCtx();
   const { rays: raysState, display, panels, sliders } = state;
   const { showOnAxis, showOffAxis, showChromatic, chromR, chromG, chromB, rayTracksF, showPupils } = raysState;
   const { dark, highContrast } = display;
@@ -97,61 +84,21 @@ export default function LensDiagramPanel({
   const zoomT = zoomTProp ?? sliders.zoomT;
   const stopdownT = stopdownTProp ?? sliders.stopdownT;
 
-  /* Callback adapters: dispatch actions instead of calling prop callbacks */
-  const onFocusChange = (v: number) => dispatch({ type: SET_FOCUS_T, value: v });
-  const onZoomChange = (v: number) => dispatch({ type: SET_ZOOM_T, value: v });
-  const onStopdownChange = (v: number) => dispatch({ type: SET_STOPDOWN_T, value: v });
-  const onSliderPointerUp = updateURLWithSliders;
-  const onShowOnAxisChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showOnAxis", value: v });
-  const onShowOffAxisChange = (v: string) => dispatch({ type: SET_RAY_TOGGLE, field: "showOffAxis", value: v });
-  const onRayTracksFChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "rayTracksF", value: v });
-  const onShowChromaticChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showChromatic", value: v });
-  const onChromRChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromR", value: v });
-  const onChromGChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromG", value: v });
-  const onChromBChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "chromB", value: v });
-  const onShowPupilsChange = (v: boolean) => dispatch({ type: SET_RAY_TOGGLE, field: "showPupils", value: v });
-  const onDarkChange = (v: boolean) => dispatch({ type: SET_DARK, dark: v });
-  const onHighContrastChange = (v: boolean) => dispatch({ type: SET_HIGH_CONTRAST, highContrast: v });
-  const onFocusExpandedChange = (v: boolean) =>
-    dispatch({ type: SET_PANEL_EXPANDED, panel: "focusExpanded", expanded: v });
-  const onApertureExpandedChange = (v: boolean) =>
-    dispatch({ type: SET_PANEL_EXPANDED, panel: "apertureExpanded", expanded: v });
-  const onHeaderControlsExpandedChange = (v: boolean) =>
-    dispatch({ type: SET_PANEL_EXPANDED, panel: "headerControlsExpanded", expanded: v });
-  const onLegendExpandedChange = (v: boolean) =>
-    dispatch({ type: SET_PANEL_EXPANDED, panel: "legendExpanded", expanded: v });
-  const onHeaderInfoExpandedChange = (v: boolean) =>
-    dispatch({ type: SET_PANEL_EXPANDED, panel: "headerInfoExpanded", expanded: v });
+  /* ── Extracted hooks ── */
+  const adapters = useDispatchAdapters();
+  const overlays = useOverlayState(lensKey);
+  const { headerRef, headerHeight } = useHeaderHeight({ panelId, lensKey, onHeaderHeight });
+  const { flashKey, flashVisible, flashFading } = useFlashOverlay(flashOverlay);
+
+  /* ── Hover/selection state ── */
   const [hov, setHov] = useState<number | null>(null);
   const [sel, setSel] = useState<number | null>(null);
-  const [showAbbeDiagram, setShowAbbeDiagram] = useState(false);
-  const [showLcaOverlay, setShowLcaOverlay] = useState(false);
-  const [showPetzvalOverlay, setShowPetzvalOverlay] = useState(false);
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     setHov(null);
     setSel(null);
-    setShowAbbeDiagram(false);
-    setShowLcaOverlay(false);
-    setShowPetzvalOverlay(false);
   }, [lensKey]);
-
-  /* ── Flash overlay animation ── */
-  const { flashKey, flashVisible, flashFading } = useFlashOverlay(flashOverlay);
-
-  /* ── Header height reporting for alignment ── */
-  const headerRef = useRef<HTMLDivElement | null>(null);
-  useLayoutEffect(() => {
-    if (!onHeaderHeight || !headerRef.current) return;
-    const el = headerRef.current;
-    const report = () => onHeaderHeight(panelId, el.scrollHeight);
-    report();
-    if (typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(report);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [onHeaderHeight, panelId, lensKey]);
 
   /* ── Side-panel overflow detection ── */
   const useSideLayout = useSideLayoutDetection({
@@ -184,6 +131,7 @@ export default function LensDiagramPanel({
 
   const act = L ? sel || hov : null;
   const info = act && L ? L.elements.find((e) => e.id === act) : null;
+
   /* ── Ray tracing (on-axis, off-axis, chromatic) ── */
   const { rays, offAxisRays, chromaticRays, chromSpread } = useRayTracing({
     L,
@@ -229,28 +177,28 @@ export default function LensDiagramPanel({
             zoomT={zoomT}
             fNumber={fNumber}
             showOnAxis={showOnAxis}
-            onShowOnAxisChange={onShowOnAxisChange}
+            onShowOnAxisChange={adapters.onShowOnAxisChange}
             showOffAxis={showOffAxis}
-            onShowOffAxisChange={onShowOffAxisChange}
+            onShowOffAxisChange={adapters.onShowOffAxisChange}
             rayTracksF={rayTracksF}
-            onRayTracksFChange={onRayTracksFChange}
+            onRayTracksFChange={adapters.onRayTracksFChange}
             showChromatic={showChromatic}
-            onShowChromaticChange={onShowChromaticChange}
+            onShowChromaticChange={adapters.onShowChromaticChange}
             chromR={chromR}
             chromG={chromG}
             chromB={chromB}
-            onChromRChange={onChromRChange}
-            onChromGChange={onChromGChange}
-            onChromBChange={onChromBChange}
+            onChromRChange={adapters.onChromRChange}
+            onChromGChange={adapters.onChromGChange}
+            onChromBChange={adapters.onChromBChange}
             showPupils={showPupils}
-            onShowPupilsChange={onShowPupilsChange}
-            onDarkChange={onDarkChange}
-            onHighContrastChange={onHighContrastChange}
+            onShowPupilsChange={adapters.onShowPupilsChange}
+            onDarkChange={adapters.onDarkChange}
+            onHighContrastChange={adapters.onHighContrastChange}
             highContrast={highContrast}
             headerControlsExpanded={headerControlsExpanded}
-            onHeaderControlsExpandedChange={onHeaderControlsExpandedChange}
+            onHeaderControlsExpandedChange={adapters.onHeaderControlsExpandedChange}
             headerInfoExpanded={headerInfoExpanded}
-            onHeaderInfoExpandedChange={onHeaderInfoExpandedChange}
+            onHeaderInfoExpandedChange={adapters.onHeaderInfoExpandedChange}
             minHeaderHeight={minHeaderHeight}
           />
           {/* ── SVG + controls body (side-by-side when overflowing) ── */}
@@ -286,21 +234,21 @@ export default function LensDiagramPanel({
                 sel={sel}
                 maxSvgHeight={maxSvgHeight}
                 useSideLayout={useSideLayout}
-                headerHeight={headerRef.current?.offsetHeight || 80}
+                headerHeight={headerHeight}
                 compact={compact}
                 flashVisible={flashVisible}
                 flashKey={flashKey}
                 flashFading={flashFading}
-                onLcaInsetClick={ENABLE_LCA_OVERLAY ? () => setShowLcaOverlay(true) : undefined}
-                onPetzvalBadgeClick={ENABLE_PETZVAL_OVERLAY ? () => setShowPetzvalOverlay(true) : undefined}
+                onLcaInsetClick={ENABLE_LCA_OVERLAY ? overlays.openLcaOverlay : undefined}
+                onPetzvalBadgeClick={ENABLE_PETZVAL_OVERLAY ? overlays.openPetzvalOverlay : undefined}
               />
-              {ENABLE_LCA_OVERLAY && showLcaOverlay && showChromatic && chromSpread && (
-                <PanelOverlay onClose={() => setShowLcaOverlay(false)} theme={t}>
+              {ENABLE_LCA_OVERLAY && overlays.showLcaOverlay && showChromatic && chromSpread && (
+                <PanelOverlay onClose={overlays.closeLcaOverlay} theme={t}>
                   <LCAOverlayContent chromSpread={chromSpread} effectiveSC={effectiveSC} IMG_MM={IMG_MM} t={t} />
                 </PanelOverlay>
               )}
-              {ENABLE_PETZVAL_OVERLAY && showPetzvalOverlay && L && (
-                <PanelOverlay onClose={() => setShowPetzvalOverlay(false)} theme={t}>
+              {ENABLE_PETZVAL_OVERLAY && overlays.showPetzvalOverlay && L && (
+                <PanelOverlay onClose={overlays.closePetzvalOverlay} theme={t}>
                   <PetzvalOverlayContent L={L} t={t} />
                 </PanelOverlay>
               )}
@@ -309,94 +257,49 @@ export default function LensDiagramPanel({
 
             {/* ── Control panel ── */}
             {showControls && (
-              <div
-                style={
-                  useSideLayout
-                    ? {
-                        flex: "0 0 340px",
-                        borderLeft: `1px solid ${t.panelBorder}`,
-                        overflowY: "auto",
-                        maxHeight: `calc(100vh - ${headerRef.current?.offsetHeight || 80}px - 20px)`,
-                        display: "flex",
-                        flexDirection: "column",
-                        background: t.panelBg,
-                        transition: "background 0.3s,border-color 0.3s",
-                      }
-                    : {
-                        display: "flex",
-                        borderTop: `1px solid ${t.panelBorder}`,
-                        background: t.panelBg,
-                        flexWrap: "wrap",
-                        transition: "background 0.3s,border-color 0.3s",
-                      }
-                }
-              >
-                <DiagramControls
-                  L={L}
-                  t={t}
-                  compact={compact}
-                  useSideLayout={useSideLayout}
-                  zoomT={zoomT}
-                  onZoomChange={onZoomChange}
-                  focusT={focusT}
-                  onFocusChange={onFocusChange}
-                  focusExpanded={focusExpanded}
-                  onFocusExpandedChange={onFocusExpandedChange}
-                  varReadouts={varReadouts}
-                  stopdownT={stopdownT}
-                  onStopdownChange={onStopdownChange}
-                  fNumber={fNumber}
-                  currentPhysStopSD={currentPhysStopSD}
-                  baseEPSD={baseEPSD}
-                  apertureExpanded={apertureExpanded}
-                  onApertureExpandedChange={onApertureExpandedChange}
-                  onSliderPointerUp={onSliderPointerUp}
-                  showSliders={showSliders}
-                />
-
-                <div
-                  style={{
-                    flex: useSideLayout ? 1 : "1 1 360px",
-                    padding: compact ? "10px 14px" : "14px 22px",
-                    minHeight: compact
-                      ? 100
-                      : ENABLE_COLLAPSIBLE_LEGEND && !isWide && !info && !legendExpanded
-                        ? 40
-                        : 125,
-                    transition: "background 0.2s",
-                    background: info ? t.infoBgActive : t.infoBgIdle,
-                  }}
-                >
-                  {info ? (
-                    <ElementInspector info={info} L={L} t={t} showChromatic={showChromatic} />
-                  ) : (
-                    <DiagramLegend
-                      L={L}
-                      t={t}
-                      isWide={isWide}
-                      zoomT={zoomT}
-                      showOnAxis={showOnAxis}
-                      showOffAxis={showOffAxis}
-                      showChromatic={showChromatic}
-                      chromR={chromR}
-                      chromG={chromG}
-                      chromB={chromB}
-                      chromSpread={chromSpread}
-                      rayTracksF={rayTracksF}
-                      legendExpanded={legendExpanded}
-                      onLegendExpandedChange={onLegendExpandedChange}
-                      onOpenAbbeDiagram={() => setShowAbbeDiagram(true)}
-                    />
-                  )}
-                </div>
-              </div>
+              <DiagramControlPanel
+                L={L}
+                t={t}
+                compact={compact}
+                isWide={isWide}
+                useSideLayout={useSideLayout}
+                headerHeight={headerHeight}
+                showSliders={showSliders}
+                zoomT={zoomT}
+                focusT={focusT}
+                stopdownT={stopdownT}
+                fNumber={fNumber}
+                currentPhysStopSD={currentPhysStopSD}
+                baseEPSD={baseEPSD}
+                varReadouts={varReadouts}
+                focusExpanded={focusExpanded}
+                apertureExpanded={apertureExpanded}
+                legendExpanded={legendExpanded}
+                onZoomChange={adapters.onZoomChange}
+                onFocusChange={adapters.onFocusChange}
+                onStopdownChange={adapters.onStopdownChange}
+                onFocusExpandedChange={adapters.onFocusExpandedChange}
+                onApertureExpandedChange={adapters.onApertureExpandedChange}
+                onLegendExpandedChange={adapters.onLegendExpandedChange}
+                onSliderPointerUp={adapters.onSliderPointerUp}
+                info={info ?? null}
+                showOnAxis={showOnAxis}
+                showOffAxis={showOffAxis}
+                showChromatic={showChromatic}
+                chromR={chromR}
+                chromG={chromG}
+                chromB={chromB}
+                chromSpread={chromSpread ?? null}
+                rayTracksF={rayTracksF}
+                onOpenAbbeDiagram={overlays.openAbbeDiagram}
+              />
             )}
           </div>
           {/* end side-layout flex wrapper */}
         </div>
       ) : null}
-      {showAbbeDiagram && L && (
-        <OverlayModal onClose={() => setShowAbbeDiagram(false)} theme={t} maxWidth={580}>
+      {overlays.showAbbeDiagram && L && (
+        <OverlayModal onClose={overlays.closeAbbeDiagram} theme={t} maxWidth={580}>
           <AbbeDiagram L={L} t={t} />
         </OverlayModal>
       )}


### PR DESCRIPTION
## Summary

Closes #227. Reduces `LensDiagramPanel.tsx` from 406 to ~300 lines by extracting four concerns into dedicated hooks and a child component:

- **`useDispatchAdapters`** — Moves 18 inline dispatch callback adapters into a hook that reads context internally and returns a stable memoized object
- **`useOverlayState`** — Extracts Abbe/LCA/Petzval overlay open/close state + lensKey reset effect
- **`useHeaderHeight`** — Extracts header ResizeObserver height tracking (also fixes stale `headerRef.current?.offsetHeight` reads by returning a reactive `headerHeight` value)
- **`DiagramControlPanel`** — Extracts the 84-line control panel JSX block (sliders, inspector/legend conditional) into a dedicated child component

`LensDiagramPanel` is now a declarative composition layer that wires hook outputs to child component props.

## Test plan

- [x] `npm run typecheck` — no type errors
- [x] `npm run lint` — no lint errors
- [x] `npm run format:check` — all files formatted
- [x] `npm run test` — all 558 tests pass (31 test files)
- [ ] Manual: single lens view — hover, select, controls, sliders all work
- [ ] Manual: Abbe diagram opens from legend and closes
- [ ] Manual: LCA/Petzval overlays open and close
- [ ] Manual: comparison mode — both panels work independently
- [ ] Manual: responsive side-layout triggers on overflow

https://claude.ai/code/session_016Qd4YddVx715AM5gmd8kqT