### PR TITLE
refactor: split LensViewer.tsx into smaller orchestration units

### DIFF
--- a/__tests__/useComparisonMode.test.ts
+++ b/__tests__/useComparisonMode.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useComparisonMode, {
+  isComparisonOk,
+  type ComparisonLensesResult,
+} from "../src/components/hooks/useComparisonMode.js";
+import { CATALOG_KEYS } from "../src/utils/lensCatalog.js";
+
+/* Pick two valid catalog keys for testing */
+const keyA = CATALOG_KEYS[0];
+const keyB = CATALOG_KEYS.length > 1 ? CATALOG_KEYS[1] : CATALOG_KEYS[0];
+
+function makeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    comparing: false,
+    lensKeyA: keyA,
+    lensKeyB: keyB,
+    scaleMode: "independent",
+    sharedFocusT: 0,
+    sharedStopdownT: 0,
+    sharedZoomT: 0,
+    ...overrides,
+  };
+}
+
+describe("useComparisonMode", () => {
+  it("returns expected interface shape", () => {
+    const { result } = renderHook(() => useComparisonMode(makeParams()));
+    expect(result.current.comparisonLenses).toBeNull();
+    expect(result.current.scaleRatios).toBeNull();
+    expect(result.current.focusPair).toBeNull();
+    expect(result.current.aperturePair).toBeNull();
+    expect(result.current.zoomPair).toBeNull();
+    expect(typeof result.current.handleHeaderHeight).toBe("function");
+    expect(typeof result.current.maxHeaderHeight).toBe("number");
+  });
+
+  it("returns null for all fields when not comparing", () => {
+    const { result } = renderHook(() => useComparisonMode(makeParams({ comparing: false })));
+    expect(result.current.comparisonLenses).toBeNull();
+    expect(result.current.focusPair).toBeNull();
+    expect(result.current.aperturePair).toBeNull();
+    expect(result.current.zoomPair).toBeNull();
+    expect(result.current.scaleRatios).toBeNull();
+  });
+
+  it("builds both lenses when comparing", () => {
+    const { result } = renderHook(() => useComparisonMode(makeParams({ comparing: true })));
+    const cl = result.current.comparisonLenses;
+    expect(isComparisonOk(cl)).toBe(true);
+    if (isComparisonOk(cl)) {
+      expect(cl.LA).toBeDefined();
+      expect(cl.LB).toBeDefined();
+      expect(typeof cl.LA.SC).toBe("number");
+      expect(typeof cl.LB.SC).toBe("number");
+    }
+  });
+
+  it("returns error result for invalid lens key", () => {
+    const { result } = renderHook(() => useComparisonMode(makeParams({ comparing: true, lensKeyA: "__INVALID__" })));
+    const cl = result.current.comparisonLenses;
+    expect(cl).not.toBeNull();
+    expect(isComparisonOk(cl)).toBe(false);
+    expect(cl!.error).toBeDefined();
+  });
+
+  it("computes focusPair, aperturePair, zoomPair when comparison is valid", () => {
+    const { result } = renderHook(() =>
+      useComparisonMode(makeParams({ comparing: true, sharedFocusT: 0.3, sharedStopdownT: 0.2 })),
+    );
+    expect(result.current.focusPair).not.toBeNull();
+    expect(typeof result.current.focusPair!.focusA).toBe("number");
+    expect(typeof result.current.focusPair!.focusB).toBe("number");
+    expect(result.current.aperturePair).not.toBeNull();
+    expect(typeof result.current.aperturePair!.stopdownA).toBe("number");
+    expect(result.current.zoomPair).not.toBeNull();
+  });
+
+  it("returns null scaleRatios in independent mode", () => {
+    const { result } = renderHook(() => useComparisonMode(makeParams({ comparing: true, scaleMode: "independent" })));
+    expect(result.current.scaleRatios).toBeNull();
+  });
+
+  it("computes scaleRatios in normalized mode", () => {
+    const { result } = renderHook(() => useComparisonMode(makeParams({ comparing: true, scaleMode: "normalized" })));
+    const sr = result.current.scaleRatios;
+    expect(sr).not.toBeNull();
+    if (sr) {
+      expect(typeof sr.a).toBe("number");
+      expect(typeof sr.b).toBe("number");
+      /* The smaller SC lens gets ratio 1.0, the larger gets minSC/SC < 1 */
+      expect(Math.max(sr.a, sr.b)).toBeCloseTo(1.0);
+    }
+  });
+
+  it("handleHeaderHeight tracks max height across panels", () => {
+    const { result } = renderHook(() => useComparisonMode(makeParams()));
+    expect(result.current.maxHeaderHeight).toBe(0);
+
+    act(() => result.current.handleHeaderHeight("a", 40));
+    expect(result.current.maxHeaderHeight).toBe(40);
+
+    act(() => result.current.handleHeaderHeight("b", 60));
+    expect(result.current.maxHeaderHeight).toBe(60);
+
+    act(() => result.current.handleHeaderHeight("a", 80));
+    expect(result.current.maxHeaderHeight).toBe(80);
+  });
+
+  it("handleHeaderHeight is referentially stable", () => {
+    const { result, rerender } = renderHook(() => useComparisonMode(makeParams()));
+    const ref1 = result.current.handleHeaderHeight;
+    rerender();
+    expect(result.current.handleHeaderHeight).toBe(ref1);
+  });
+});
+
+describe("isComparisonOk", () => {
+  it("returns false for null", () => {
+    expect(isComparisonOk(null)).toBe(false);
+  });
+
+  it("returns false for error result", () => {
+    const err: ComparisonLensesResult = { error: new Error("test"), failedKeys: "a vs b" };
+    expect(isComparisonOk(err)).toBe(false);
+  });
+});

--- a/__tests__/useOverlays.test.ts
+++ b/__tests__/useOverlays.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useOverlays from "../src/components/hooks/useOverlays.js";
+import { SET_OVERLAY, CLOSE_ALL_OVERLAYS } from "../src/utils/lensReducer.js";
+import type { LensAction } from "../src/types/state.js";
+import type { Dispatch } from "react";
+
+function makeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    showAbout: false,
+    showAboutSite: false,
+    showOpticsPrimer: false,
+    dispatch: vi.fn() as unknown as Dispatch<LensAction>,
+    ...overrides,
+  };
+}
+
+describe("useOverlays", () => {
+  it("returns expected interface shape", () => {
+    const { result } = renderHook(() => useOverlays(makeParams()));
+    expect(result.current.primerLevel).toBe("simple");
+    expect(typeof result.current.togglePrimerLevel).toBe("function");
+    expect(typeof result.current.openAboutSite).toBe("function");
+    expect(typeof result.current.openAboutAuthor).toBe("function");
+    expect(typeof result.current.openOpticsPrimer).toBe("function");
+    expect(typeof result.current.closeAboutSite).toBe("function");
+    expect(typeof result.current.closeAboutAuthor).toBe("function");
+    expect(typeof result.current.closeOpticsPrimer).toBe("function");
+  });
+
+  it("togglePrimerLevel cycles between simple and intermediate", () => {
+    const { result } = renderHook(() => useOverlays(makeParams()));
+    expect(result.current.primerLevel).toBe("simple");
+
+    act(() => result.current.togglePrimerLevel());
+    expect(result.current.primerLevel).toBe("intermediate");
+
+    act(() => result.current.togglePrimerLevel());
+    expect(result.current.primerLevel).toBe("simple");
+  });
+
+  it("openAboutSite dispatches SET_OVERLAY with showAboutSite", () => {
+    const dispatch = vi.fn();
+    const { result } = renderHook(() => useOverlays(makeParams({ dispatch })));
+    act(() => result.current.openAboutSite());
+    expect(dispatch).toHaveBeenCalledWith({ type: SET_OVERLAY, overlay: "showAboutSite", visible: true });
+  });
+
+  it("openAboutAuthor dispatches SET_OVERLAY with showAbout", () => {
+    const dispatch = vi.fn();
+    const { result } = renderHook(() => useOverlays(makeParams({ dispatch })));
+    act(() => result.current.openAboutAuthor());
+    expect(dispatch).toHaveBeenCalledWith({ type: SET_OVERLAY, overlay: "showAbout", visible: true });
+  });
+
+  it("openOpticsPrimer dispatches SET_OVERLAY with showOpticsPrimer", () => {
+    const dispatch = vi.fn();
+    const { result } = renderHook(() => useOverlays(makeParams({ dispatch })));
+    act(() => result.current.openOpticsPrimer());
+    expect(dispatch).toHaveBeenCalledWith({ type: SET_OVERLAY, overlay: "showOpticsPrimer", visible: true });
+  });
+
+  it("closeAboutSite dispatches SET_OVERLAY with visible false", () => {
+    const dispatch = vi.fn();
+    const { result } = renderHook(() => useOverlays(makeParams({ dispatch })));
+    act(() => result.current.closeAboutSite());
+    expect(dispatch).toHaveBeenCalledWith({ type: SET_OVERLAY, overlay: "showAboutSite", visible: false });
+  });
+
+  it("closeOpticsPrimer dispatches and resets primerLevel", () => {
+    const dispatch = vi.fn();
+    const { result } = renderHook(() => useOverlays(makeParams({ dispatch, showOpticsPrimer: true })));
+
+    /* Set primer to intermediate first */
+    act(() => result.current.togglePrimerLevel());
+    expect(result.current.primerLevel).toBe("intermediate");
+
+    /* Close should reset to simple */
+    act(() => result.current.closeOpticsPrimer());
+    expect(dispatch).toHaveBeenCalledWith({ type: SET_OVERLAY, overlay: "showOpticsPrimer", visible: false });
+    expect(result.current.primerLevel).toBe("simple");
+  });
+
+  describe("Escape key handler", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("dispatches CLOSE_ALL_OVERLAYS on Escape when overlay is open", () => {
+      const dispatch = vi.fn();
+      renderHook(() => useOverlays(makeParams({ dispatch, showAboutSite: true })));
+
+      const event = new KeyboardEvent("keydown", { key: "Escape" });
+      window.dispatchEvent(event);
+
+      expect(dispatch).toHaveBeenCalledWith({ type: CLOSE_ALL_OVERLAYS });
+    });
+
+    it("resets primerLevel to simple on Escape", () => {
+      const dispatch = vi.fn();
+      const { result } = renderHook(() => useOverlays(makeParams({ dispatch, showOpticsPrimer: true })));
+
+      act(() => result.current.togglePrimerLevel());
+      expect(result.current.primerLevel).toBe("intermediate");
+
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(result.current.primerLevel).toBe("simple");
+    });
+
+    it("does not add listener when no overlay is open", () => {
+      const dispatch = vi.fn();
+      renderHook(() => useOverlays(makeParams({ dispatch })));
+
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/hooks/useComparisonMode.ts
+++ b/src/components/hooks/useComparisonMode.ts
@@ -1,0 +1,128 @@
+/**
+ * useComparisonMode — Comparison-mode lens building, slider mapping, and header alignment.
+ *
+ * Consolidates the pure-computation side of comparison mode:
+ *   • Building both lenses (with error handling)
+ *   • Computing per-lens focus/aperture/zoom from shared slider positions
+ *   • Normalized scale ratios for visual comparison
+ *   • Header height alignment across panels
+ *
+ * The toggle/entry-effect logic stays in LensViewer because it depends on
+ * useStickySliders outputs (circular dependency).
+ */
+
+import { useMemo, useState, useCallback } from "react";
+import buildLens from "../../optics/buildLens.js";
+import { LENS_CATALOG } from "../../utils/lensCatalog.js";
+import { computeFocusPair, computeAperturePair, computeZoomPair } from "../../utils/comparisonSliders.js";
+import type { FocusPairResult, AperturePairResult, ZoomPairResult } from "../../utils/comparisonSliders.js";
+import type { RuntimeLens } from "../../types/optics.js";
+
+/* ── Comparison result types ── */
+
+export interface ComparisonLensesOk {
+  LA: RuntimeLens;
+  LB: RuntimeLens;
+  error?: undefined;
+  failedKeys?: undefined;
+}
+
+interface ComparisonLensesErr {
+  error: unknown;
+  failedKeys: string;
+  LA?: undefined;
+  LB?: undefined;
+}
+
+export type ComparisonLensesResult = ComparisonLensesOk | ComparisonLensesErr | null;
+
+export function isComparisonOk(cl: ComparisonLensesResult): cl is ComparisonLensesOk {
+  return cl !== null && !cl.error;
+}
+
+/* ── Hook interface ── */
+
+interface UseComparisonModeParams {
+  comparing: boolean;
+  lensKeyA: string;
+  lensKeyB: string;
+  scaleMode: string;
+  sharedFocusT: number;
+  sharedStopdownT: number;
+  sharedZoomT: number;
+}
+
+interface UseComparisonModeResult {
+  comparisonLenses: ComparisonLensesResult;
+  scaleRatios: { a: number; b: number } | null;
+  focusPair: FocusPairResult | null;
+  aperturePair: AperturePairResult | null;
+  zoomPair: ZoomPairResult | null;
+  handleHeaderHeight: (panelId: string, height: number) => void;
+  maxHeaderHeight: number;
+}
+
+/* ── Hook implementation ── */
+
+export default function useComparisonMode({
+  comparing,
+  lensKeyA,
+  lensKeyB,
+  scaleMode,
+  sharedFocusT,
+  sharedStopdownT,
+  sharedZoomT,
+}: UseComparisonModeParams): UseComparisonModeResult {
+  /* ── Build both lenses when comparison mode is active ── */
+  const comparisonLenses: ComparisonLensesResult = useMemo(() => {
+    if (!comparing) return null;
+    try {
+      return { LA: buildLens(LENS_CATALOG[lensKeyA]), LB: buildLens(LENS_CATALOG[lensKeyB]) } as ComparisonLensesOk;
+    } catch (e) {
+      return { error: e, failedKeys: `${lensKeyA} vs ${lensKeyB}` } as ComparisonLensesErr;
+    }
+  }, [comparing, lensKeyA, lensKeyB]);
+
+  /* ── Normalized scale ratios ── */
+  const scaleRatios = useMemo(() => {
+    if (!isComparisonOk(comparisonLenses) || scaleMode !== "normalized") return null;
+    const { LA, LB } = comparisonLenses;
+    const minSC = Math.min(LA.SC, LB.SC);
+    return { a: minSC / LA.SC, b: minSC / LB.SC };
+  }, [comparisonLenses, scaleMode]);
+
+  /* ── Per-lens slider values from shared positions ── */
+  const focusPair = useMemo(() => {
+    if (!isComparisonOk(comparisonLenses)) return null;
+    return computeFocusPair(sharedFocusT, comparisonLenses.LA, comparisonLenses.LB);
+  }, [sharedFocusT, comparisonLenses]);
+
+  const aperturePair = useMemo(() => {
+    if (!isComparisonOk(comparisonLenses)) return null;
+    return computeAperturePair(sharedStopdownT, comparisonLenses.LA, comparisonLenses.LB);
+  }, [sharedStopdownT, comparisonLenses]);
+
+  const zoomPair = useMemo(() => {
+    if (!isComparisonOk(comparisonLenses)) return null;
+    return computeZoomPair(sharedZoomT, comparisonLenses.LA, comparisonLenses.LB);
+  }, [sharedZoomT, comparisonLenses]);
+
+  /* ── Header height alignment for comparison panels ── */
+  const [headerHeights, setHeaderHeights] = useState<Record<string, number>>({ a: 0, b: 0 });
+
+  const handleHeaderHeight = useCallback((panelId: string, height: number) => {
+    setHeaderHeights((prev) => (prev[panelId] === height ? prev : { ...prev, [panelId]: height }));
+  }, []);
+
+  const maxHeaderHeight = Math.max(headerHeights.a, headerHeights.b);
+
+  return {
+    comparisonLenses,
+    scaleRatios,
+    focusPair,
+    aperturePair,
+    zoomPair,
+    handleHeaderHeight,
+    maxHeaderHeight,
+  };
+}

--- a/src/components/hooks/useOverlays.ts
+++ b/src/components/hooks/useOverlays.ts
@@ -1,0 +1,93 @@
+/**
+ * useOverlays — Overlay open/close management and primer level state.
+ *
+ * Consolidates:
+ *   • Named open/close callbacks for all three overlays (About Site, About Author, Optics Primer)
+ *   • Primer level toggle (simple ↔ intermediate)
+ *   • Escape key handler that closes all overlays and resets primer level
+ */
+
+import { useState, useCallback, useEffect, type Dispatch } from "react";
+import { SET_OVERLAY, CLOSE_ALL_OVERLAYS } from "../../utils/lensReducer.js";
+import type { LensAction } from "../../types/state.js";
+
+interface UseOverlaysParams {
+  showAbout: boolean;
+  showAboutSite: boolean;
+  showOpticsPrimer: boolean;
+  dispatch: Dispatch<LensAction>;
+}
+
+interface UseOverlaysResult {
+  primerLevel: "simple" | "intermediate";
+  togglePrimerLevel: () => void;
+  openAboutSite: () => void;
+  openAboutAuthor: () => void;
+  openOpticsPrimer: () => void;
+  closeAboutSite: () => void;
+  closeAboutAuthor: () => void;
+  closeOpticsPrimer: () => void;
+}
+
+export default function useOverlays({
+  showAbout,
+  showAboutSite,
+  showOpticsPrimer,
+  dispatch,
+}: UseOverlaysParams): UseOverlaysResult {
+  const [primerLevel, setPrimerLevel] = useState<"simple" | "intermediate">("simple");
+
+  /* ── Escape key closes all overlays ── */
+  useEffect(() => {
+    if (!showAbout && !showAboutSite && !showOpticsPrimer) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        dispatch({ type: CLOSE_ALL_OVERLAYS });
+        setPrimerLevel("simple");
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [showAbout, showAboutSite, showOpticsPrimer, dispatch]);
+
+  /* ── Named callbacks ── */
+  const togglePrimerLevel = useCallback(() => {
+    setPrimerLevel((prev) => (prev === "simple" ? "intermediate" : "simple"));
+  }, []);
+
+  const openAboutSite = useCallback(() => {
+    dispatch({ type: SET_OVERLAY, overlay: "showAboutSite", visible: true });
+  }, [dispatch]);
+
+  const openAboutAuthor = useCallback(() => {
+    dispatch({ type: SET_OVERLAY, overlay: "showAbout", visible: true });
+  }, [dispatch]);
+
+  const openOpticsPrimer = useCallback(() => {
+    dispatch({ type: SET_OVERLAY, overlay: "showOpticsPrimer", visible: true });
+  }, [dispatch]);
+
+  const closeAboutSite = useCallback(() => {
+    dispatch({ type: SET_OVERLAY, overlay: "showAboutSite", visible: false });
+  }, [dispatch]);
+
+  const closeAboutAuthor = useCallback(() => {
+    dispatch({ type: SET_OVERLAY, overlay: "showAbout", visible: false });
+  }, [dispatch]);
+
+  const closeOpticsPrimer = useCallback(() => {
+    dispatch({ type: SET_OVERLAY, overlay: "showOpticsPrimer", visible: false });
+    setPrimerLevel("simple");
+  }, [dispatch]);
+
+  return {
+    primerLevel,
+    togglePrimerLevel,
+    openAboutSite,
+    openAboutAuthor,
+    openOpticsPrimer,
+    closeAboutSite,
+    closeAboutAuthor,
+    closeOpticsPrimer,
+  };
+}

--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -9,20 +9,18 @@
  * ║    • ControlsBar — theme/ray/chromatic/scale toggles              ║
  * ║    • ViewToggleBar — desktop/mobile view mode switching           ║
  * ║    • ComparisonLayout — side-by-side/stacked lens panels          ║
+ * ║    • SingleLensContent — desktop/mobile single-lens layout        ║
  * ║    • AboutFooter — mobile-only page-bottom about buttons          ║
  * ║    • OverlayModal — about site/author/optics primer modals        ║
  * ║  Diagram rendering lives in LensDiagramPanel.                     ║
  * ╚══════════════════════════════════════════════════════════════════════╝
  */
 
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useMemo, useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 
 import T from "../../utils/themes.js";
-import buildLens from "../../optics/buildLens.js";
 import { LENS_CATALOG, CATALOG_KEYS, mdForKey } from "../../utils/lensCatalog.js";
-import LensDiagramPanel from "./LensDiagramPanel.js";
-import DescriptionPanel from "./DescriptionPanel.js";
 import SharedSlidersBar from "./SharedSlidersBar.js";
 import usePreferences from "../../utils/usePreferences.js";
 import useURLSync from "../../utils/useURLSync.js";
@@ -34,10 +32,8 @@ import {
   ENABLE_ANALYSIS_ONLY,
   ENABLE_COMPARISON,
   ENABLE_COMPARISON_MOBILE,
-  ENABLE_SIDE_PANEL_LAYOUT,
   ENABLE_MOBILE_CONTROLS_STRIP,
 } from "../../utils/featureFlags.js";
-import { computeFocusPair, computeAperturePair, computeZoomPair } from "../../utils/comparisonSliders.js";
 import useStickySliders from "../../utils/useStickySliders.js";
 import { ErrorDisplay } from "../errors/ErrorBoundary.js";
 import OverlayModal from "./OverlayModal.js";
@@ -46,6 +42,8 @@ import TopBar from "./TopBar.js";
 import BreadcrumbBar from "./BreadcrumbBar.js";
 import ViewToggleBar from "./ViewToggleBar.js";
 import ComparisonLayout from "./ComparisonLayout.js";
+import SingleLensContent from "./SingleLensContent.js";
+import DescriptionPanel from "./DescriptionPanel.js";
 import ABOUT_ME_MD from "../../content/AboutMe.md?raw";
 import ABOUT_SITE_MD from "../../content/AboutSite.md?raw";
 import OPTICS_PRIMER_SIMPLE_MD from "../../content/OpticsPrimerSimple.md?raw";
@@ -60,30 +58,11 @@ import {
   SET_DESKTOP_VIEW,
   SET_SHARED_STOPDOWN_T,
   SET_SHARED_ZOOM_T,
-  SET_OVERLAY,
-  CLOSE_ALL_OVERLAYS,
   ENTER_COMPARE,
   EXIT_COMPARE,
 } from "../../utils/lensReducer.js";
-import type { RuntimeLens } from "../../types/optics.js";
-
-interface ComparisonLensesOk {
-  LA: RuntimeLens;
-  LB: RuntimeLens;
-  error?: undefined;
-  failedKeys?: undefined;
-}
-interface ComparisonLensesErr {
-  error: unknown;
-  failedKeys: string;
-  LA?: undefined;
-  LB?: undefined;
-}
-type ComparisonLensesResult = ComparisonLensesOk | ComparisonLensesErr | null;
-
-function isComparisonOk(cl: ComparisonLensesResult): cl is ComparisonLensesOk {
-  return cl !== null && !cl.error;
-}
+import useComparisonMode, { isComparisonOk } from "../hooks/useComparisonMode.js";
+import useOverlays from "../hooks/useOverlays.js";
 
 /* =====================================================================
  * §2  COMPONENT — State, effects, and orchestration logic
@@ -110,32 +89,75 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
   const { sharedFocusT, sharedStopdownT, sharedZoomT } = sharedSliders;
   const { showAbout, showAboutSite, showOpticsPrimer } = overlays;
 
-  /* ── Local transient state for primer level (resets when overlay closes) ── */
-  const [primerLevel, setPrimerLevel] = useState<"simple" | "intermediate">("simple");
+  /* ── Comparison mode: lens building, slider pairs, scale ratios, header alignment ── */
+  const { comparisonLenses, scaleRatios, focusPair, aperturePair, zoomPair, handleHeaderHeight, maxHeaderHeight } =
+    useComparisonMode({ comparing, lensKeyA, lensKeyB, scaleMode, sharedFocusT, sharedStopdownT, sharedZoomT });
 
-  /* ── Comparison mode header height alignment ── */
-  const [headerHeights, setHeaderHeights] = useState<Record<string, number>>({ a: 0, b: 0 });
-  const justEnteredCompare = useRef(false);
-
-  /* ── Sticky slider state machine (see useStickySliders for docs) ── */
+  /* ── Overlay management: primer level, escape key, open/close callbacks ── */
+  const {
+    primerLevel,
+    togglePrimerLevel,
+    openAboutSite,
+    openAboutAuthor,
+    openOpticsPrimer,
+    closeAboutSite,
+    closeAboutAuthor,
+    closeOpticsPrimer,
+  } = useOverlays({ showAbout, showAboutSite, showOpticsPrimer, dispatch });
 
   /* ── Persist preferences to localStorage ── */
   usePreferences(state);
 
   /* ── URL synchronization (lens selection, slider deep links, zoom init) ── */
+  const { updateURLWithSliders } = useURLSync(
+    state,
+    dispatch,
+    comparisonLenses as Parameters<typeof useURLSync>[2],
+    isLensPage,
+  );
 
-  /* ── Escape key closes overlays ── */
+  /* ── Sticky slider state machine ── */
+  const justEnteredCompare = useRef(false);
+  const {
+    handleSharedFocusChange,
+    handleSharedStopdownChange,
+    handleFocusPointerDown,
+    handleAperturePointerDown,
+    flashPanel,
+    resetSticky,
+    prevStopdownT,
+  } = useStickySliders(dispatch, focusPair, aperturePair, comparisonLenses as Parameters<typeof useStickySliders>[3]);
+
+  /* ── Set default aperture to slowest lens wide-open when entering comparison ── */
   useEffect(() => {
-    if (!showAbout && !showAboutSite && !showOpticsPrimer) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        dispatch({ type: CLOSE_ALL_OVERLAYS });
-        setPrimerLevel("simple");
-      }
-    };
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [showAbout, showAboutSite, showOpticsPrimer, dispatch]);
+    if (!justEnteredCompare.current || !isComparisonOk(comparisonLenses)) return;
+    justEnteredCompare.current = false;
+    const { LA, LB } = comparisonLenses;
+    const widerFOPEN = Math.min(LA.FOPEN, LB.FOPEN);
+    const narrowerFOPEN = Math.max(LA.FOPEN, LB.FOPEN);
+    const sharedMaxFstop = Math.max(LA.maxFstop, LB.maxFstop);
+    const cp =
+      Math.abs(widerFOPEN - narrowerFOPEN) < 0.01
+        ? 0
+        : Math.log(narrowerFOPEN / widerFOPEN) / Math.log(sharedMaxFstop / widerFOPEN);
+    prevStopdownT.current = cp;
+    dispatch({ type: SET_SHARED_STOPDOWN_T, value: cp });
+  }, [comparisonLenses, dispatch, prevStopdownT]);
+
+  /* ── Enter/exit comparison mode ── */
+  const toggleCompare = useCallback(() => {
+    if (!comparing) {
+      dispatch({ type: ENTER_COMPARE, catalogKeys: CATALOG_KEYS });
+      resetSticky();
+      justEnteredCompare.current = true;
+    } else {
+      dispatch({
+        type: EXIT_COMPARE,
+        focusA: focusPair?.focusA,
+        stopdownA: aperturePair?.stopdownA,
+      });
+    }
+  }, [comparing, focusPair, aperturePair, dispatch, resetSticky]);
 
   const markdown = useMemo(() => mdForKey(lensKeyA), [lensKeyA]);
 
@@ -179,101 +201,6 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
     dispatch({ type: SWAP_LENSES });
   }, [dispatch]);
 
-  /* ── Build both lenses for comparison computations ──
-   * Built eagerly when comparison mode is active so we can compute
-   * shared slider mappings (focus/aperture/zoom pairs). Both lenses
-   * are also needed for normalized scale ratios. */
-  const comparisonLenses: ComparisonLensesResult = useMemo(() => {
-    if (!comparing) return null;
-    try {
-      return { LA: buildLens(LENS_CATALOG[lensKeyA]), LB: buildLens(LENS_CATALOG[lensKeyB]) } as ComparisonLensesOk;
-    } catch (e) {
-      return { error: e, failedKeys: `${lensKeyA} vs ${lensKeyB}` } as ComparisonLensesErr;
-    }
-  }, [comparing, lensKeyA, lensKeyB]);
-
-  const { updateURLWithSliders } = useURLSync(
-    state,
-    dispatch,
-    comparisonLenses as Parameters<typeof useURLSync>[2],
-    isLensPage,
-  );
-
-  /* ── Normalized scale computation ──
-   * In normalized mode, both panels use the same mm-per-pixel ratio so lens
-   * sizes are visually comparable. Each panel's SC is scaled down to match
-   * whichever lens has the smaller (more zoomed-out) SC value. */
-  const scaleRatios = useMemo(() => {
-    if (!isComparisonOk(comparisonLenses) || scaleMode !== "normalized") return null;
-    const { LA, LB } = comparisonLenses;
-    const minSC = Math.min(LA.SC, LB.SC);
-    return { a: minSC / LA.SC, b: minSC / LB.SC };
-  }, [comparisonLenses, scaleMode]);
-
-  /* ── Per-lens focus/aperture from shared sliders ── */
-  const focusPair = useMemo(() => {
-    if (!isComparisonOk(comparisonLenses)) return null;
-    return computeFocusPair(sharedFocusT, comparisonLenses.LA, comparisonLenses.LB);
-  }, [sharedFocusT, comparisonLenses]);
-
-  const aperturePair = useMemo(() => {
-    if (!isComparisonOk(comparisonLenses)) return null;
-    return computeAperturePair(sharedStopdownT, comparisonLenses.LA, comparisonLenses.LB);
-  }, [sharedStopdownT, comparisonLenses]);
-
-  const zoomPair = useMemo(() => {
-    if (!isComparisonOk(comparisonLenses)) return null;
-    return computeZoomPair(sharedZoomT, comparisonLenses.LA, comparisonLenses.LB);
-  }, [sharedZoomT, comparisonLenses]);
-
-  /* ── Sticky slider state machine ── */
-  const {
-    handleSharedFocusChange,
-    handleSharedStopdownChange,
-    handleFocusPointerDown,
-    handleAperturePointerDown,
-    flashPanel,
-    resetSticky,
-    prevStopdownT,
-  } = useStickySliders(dispatch, focusPair, aperturePair, comparisonLenses as Parameters<typeof useStickySliders>[3]);
-
-  /* ── Set default aperture to slowest lens wide-open when entering comparison ── */
-  useEffect(() => {
-    if (!justEnteredCompare.current || !isComparisonOk(comparisonLenses)) return;
-    justEnteredCompare.current = false;
-    const { LA, LB } = comparisonLenses;
-    const widerFOPEN = Math.min(LA.FOPEN, LB.FOPEN);
-    const narrowerFOPEN = Math.max(LA.FOPEN, LB.FOPEN);
-    const sharedMaxFstop = Math.max(LA.maxFstop, LB.maxFstop);
-    const cp =
-      Math.abs(widerFOPEN - narrowerFOPEN) < 0.01
-        ? 0
-        : Math.log(narrowerFOPEN / widerFOPEN) / Math.log(sharedMaxFstop / widerFOPEN);
-    prevStopdownT.current = cp;
-    dispatch({ type: SET_SHARED_STOPDOWN_T, value: cp });
-  }, [comparisonLenses, dispatch, prevStopdownT]);
-
-  /* ── Enter/exit comparison mode ── */
-  const toggleCompare = useCallback(() => {
-    if (!comparing) {
-      dispatch({ type: ENTER_COMPARE, catalogKeys: CATALOG_KEYS });
-      resetSticky();
-      justEnteredCompare.current = true;
-    } else {
-      dispatch({
-        type: EXIT_COMPARE,
-        focusA: focusPair?.focusA,
-        stopdownA: aperturePair?.stopdownA,
-      });
-    }
-  }, [comparing, focusPair, aperturePair, dispatch, resetSticky]);
-
-  /* ── Header height alignment callback ── */
-  const handleHeaderHeight = useCallback((panelId: string, height: number) => {
-    setHeaderHeights((prev) => (prev[panelId] === height ? prev : { ...prev, [panelId]: height }));
-  }, []);
-  const maxHeaderHeight = Math.max(headerHeights.a, headerHeights.b);
-
   /* ── Context value (replaces sharedProps prop drilling) ── */
   const ctxValue = useMemo(
     () => ({ state, theme: t, isWide, updateURLWithSliders }),
@@ -285,13 +212,6 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
    * ===================================================================== */
 
   const showCompareBtn = ENABLE_COMPARISON && (isWide || ENABLE_COMPARISON_MOBILE);
-
-  /* ── Description content (only in single-lens mode) ── */
-  const descriptionContent = (
-    <div style={{ background: t.descBg, overflowY: "auto", transition: "background 0.3s" }}>
-      <DescriptionPanel markdown={markdown} theme={t} />
-    </div>
-  );
 
   /* ── Controls bar props (shared between comparison and mobile instances) ── */
   const controlsBarProps = {
@@ -309,18 +229,6 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
     scaleMode,
     dispatch,
   } as const;
-
-  /* ── Single-lens diagram content ── */
-  const singleDiagramContent = !comparing ? (
-    <LensDiagramPanel
-      lensKey={lensKeyA}
-      scaleRatio={null}
-      panelId="main"
-      compact={false}
-      showControls={true}
-      sideLayoutEnabled={ENABLE_SIDE_PANEL_LAYOUT && isWide && effectiveDesktopView === "diagram"}
-    />
-  ) : null;
 
   /* =====================================================================
    * §4  JSX — Top bar, comparison chrome, diagram panels, overlays
@@ -352,9 +260,9 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
             onSwitchLensB={switchLensB}
             onSwapLenses={swapLenses}
             onToggleCompare={toggleCompare}
-            onOpenAboutSite={() => dispatch({ type: SET_OVERLAY, overlay: "showAboutSite", visible: true })}
-            onOpenAboutAuthor={() => dispatch({ type: SET_OVERLAY, overlay: "showAbout", visible: true })}
-            onOpenOpticsPrimer={() => dispatch({ type: SET_OVERLAY, overlay: "showOpticsPrimer", visible: true })}
+            onOpenAboutSite={openAboutSite}
+            onOpenAboutAuthor={openAboutAuthor}
+            onOpenOpticsPrimer={openOpticsPrimer}
             catalogKeys={CATALOG_KEYS}
             catalogNames={catalogNames}
           />
@@ -447,82 +355,51 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
                 />
               )}
             </>
-          ) : isWide ? (
-            effectiveDesktopView === "diagram" ? (
-              <div style={{ minHeight: `calc(100vh - ${showDesktopToggle ? 82 : 45}px)` }}>{singleDiagramContent}</div>
-            ) : effectiveDesktopView === "analysis" ? (
-              <div style={{ overflowY: "auto", maxHeight: `calc(100vh - ${showDesktopToggle ? 82 : 45}px)` }}>
-                {descriptionContent}
-              </div>
-            ) : (
-              /* Both — side-by-side */
-              <div style={{ display: "flex", minHeight: `calc(100vh - ${showDesktopToggle ? 82 : 45}px)` }}>
-                <div style={{ flex: "0 0 65%", minWidth: 0, overflow: "hidden" }}>{singleDiagramContent}</div>
-                <div
-                  style={{
-                    flex: "0 0 35%",
-                    borderLeft: `1px solid ${t.descBorder}`,
-                    overflowY: "auto",
-                    maxHeight: `calc(100vh - ${showDesktopToggle ? 82 : 45}px)`,
-                  }}
-                >
-                  {descriptionContent}
-                </div>
-              </div>
-            )
-          ) : /* Mobile: toggle between views */
-          !ENABLE_ANALYSIS_VIEW || mobileView === "diagram" ? (
-            singleDiagramContent
           ) : (
-            descriptionContent
+            <SingleLensContent
+              theme={t}
+              isWide={isWide}
+              effectiveDesktopView={effectiveDesktopView}
+              showDesktopToggle={showDesktopToggle}
+              mobileView={mobileView}
+              lensKeyA={lensKeyA}
+              markdown={markdown}
+            />
           )}
 
           {/* ── About buttons footer (mobile only) ── */}
           <AboutFooter
             theme={t}
             isWide={isWide}
-            onOpenOpticsPrimer={() => dispatch({ type: SET_OVERLAY, overlay: "showOpticsPrimer", visible: true })}
-            onOpenAboutSite={() => dispatch({ type: SET_OVERLAY, overlay: "showAboutSite", visible: true })}
-            onOpenAboutAuthor={() => dispatch({ type: SET_OVERLAY, overlay: "showAbout", visible: true })}
+            onOpenOpticsPrimer={openOpticsPrimer}
+            onOpenAboutSite={openAboutSite}
+            onOpenAboutAuthor={openAboutAuthor}
           />
 
           {/* ── About Site overlay ── */}
           {showAboutSite && (
-            <OverlayModal
-              onClose={() => dispatch({ type: SET_OVERLAY, overlay: "showAboutSite", visible: false })}
-              theme={t}
-            >
+            <OverlayModal onClose={closeAboutSite} theme={t}>
               <DescriptionPanel markdown={ABOUT_SITE_MD} theme={t} />
             </OverlayModal>
           )}
 
           {/* ── About Me overlay ── */}
           {showAbout && (
-            <OverlayModal
-              onClose={() => dispatch({ type: SET_OVERLAY, overlay: "showAbout", visible: false })}
-              theme={t}
-            >
+            <OverlayModal onClose={closeAboutAuthor} theme={t}>
               <DescriptionPanel markdown={ABOUT_ME_MD} theme={t} />
             </OverlayModal>
           )}
 
           {/* ── Optics Primer overlay ── */}
           {showOpticsPrimer && (
-            <OverlayModal
-              onClose={() => {
-                dispatch({ type: SET_OVERLAY, overlay: "showOpticsPrimer", visible: false });
-                setPrimerLevel("simple");
-              }}
-              theme={t}
-              maxWidth={isWide ? 640 : 480}
-            >
+            <OverlayModal onClose={closeOpticsPrimer} theme={t} maxWidth={isWide ? 640 : 480}>
               <DescriptionPanel
                 markdown={primerLevel === "simple" ? OPTICS_PRIMER_SIMPLE_MD : OPTICS_PRIMER_INTERMEDIATE_MD}
                 theme={t}
               />
               <div style={{ padding: "0 24px 20px", textAlign: "center" }}>
                 <button
-                  onClick={() => setPrimerLevel(primerLevel === "simple" ? "intermediate" : "simple")}
+                  onClick={togglePrimerLevel}
                   style={{
                     background: "none",
                     border: "none",

--- a/src/components/layout/SingleLensContent.tsx
+++ b/src/components/layout/SingleLensContent.tsx
@@ -1,0 +1,81 @@
+/**
+ * SingleLensContent — Desktop/mobile single-lens view layout branching.
+ *
+ * Handles the three desktop views (diagram-only, analysis-only, side-by-side)
+ * and the mobile toggle between diagram and description.
+ */
+
+import LensDiagramPanel from "./LensDiagramPanel.js";
+import DescriptionPanel from "./DescriptionPanel.js";
+import { ENABLE_ANALYSIS_VIEW, ENABLE_SIDE_PANEL_LAYOUT } from "../../utils/featureFlags.js";
+import type { Theme } from "../../types/theme.js";
+
+interface SingleLensContentProps {
+  theme: Theme;
+  isWide: boolean;
+  effectiveDesktopView: string;
+  showDesktopToggle: boolean;
+  mobileView: string;
+  lensKeyA: string;
+  markdown: string | null | undefined;
+}
+
+export default function SingleLensContent({
+  theme: t,
+  isWide,
+  effectiveDesktopView,
+  showDesktopToggle,
+  mobileView,
+  lensKeyA,
+  markdown,
+}: SingleLensContentProps) {
+  const singleDiagramContent = (
+    <LensDiagramPanel
+      lensKey={lensKeyA}
+      scaleRatio={null}
+      panelId="main"
+      compact={false}
+      showControls={true}
+      sideLayoutEnabled={ENABLE_SIDE_PANEL_LAYOUT && isWide && effectiveDesktopView === "diagram"}
+    />
+  );
+
+  const descriptionContent = (
+    <div style={{ background: t.descBg, overflowY: "auto", transition: "background 0.3s" }}>
+      <DescriptionPanel markdown={markdown} theme={t} />
+    </div>
+  );
+
+  const topOffset = showDesktopToggle ? 82 : 45;
+
+  if (isWide) {
+    if (effectiveDesktopView === "diagram") {
+      return <div style={{ minHeight: `calc(100vh - ${topOffset}px)` }}>{singleDiagramContent}</div>;
+    }
+    if (effectiveDesktopView === "analysis") {
+      return <div style={{ overflowY: "auto", maxHeight: `calc(100vh - ${topOffset}px)` }}>{descriptionContent}</div>;
+    }
+    /* Both — side-by-side */
+    return (
+      <div style={{ display: "flex", minHeight: `calc(100vh - ${topOffset}px)` }}>
+        <div style={{ flex: "0 0 65%", minWidth: 0, overflow: "hidden" }}>{singleDiagramContent}</div>
+        <div
+          style={{
+            flex: "0 0 35%",
+            borderLeft: `1px solid ${t.descBorder}`,
+            overflowY: "auto",
+            maxHeight: `calc(100vh - ${topOffset}px)`,
+          }}
+        >
+          {descriptionContent}
+        </div>
+      </div>
+    );
+  }
+
+  /* Mobile: toggle between views */
+  if (!ENABLE_ANALYSIS_VIEW || mobileView === "diagram") {
+    return singleDiagramContent;
+  }
+  return descriptionContent;
+}


### PR DESCRIPTION
## Summary

- Extract `useComparisonMode` hook: consolidates comparison lens building, shared slider pair computation (focus/aperture/zoom), normalized scale ratios, and header height alignment
- Extract `useOverlays` hook: consolidates primer level state, Escape key handler, and named open/close callbacks for all three overlay modals
- Extract `SingleLensContent` component: moves desktop/mobile single-lens view layout branching (diagram-only, analysis-only, side-by-side, mobile toggle) into its own component
- LensViewer.tsx remains the top-level composition shell — now focused on state setup, context provision, and comparison entry/exit bridge logic

## Test plan

- [x] `npm run typecheck` — no type errors
- [x] `npm run test` — all 579 tests pass (including 22 new tests for `useComparisonMode` and `useOverlays`)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — production build succeeds with prerender + sitemap
- [ ] Manual smoke test: single lens view, comparison mode entry/exit, overlay open/close/Escape, primer level toggle, desktop/mobile view switching, URL deep links

Closes #226

https://claude.ai/code/session_013WC7YAx2DNPR12X6zFbm1e