### PR TITLE
Migrate lens data files from .data.js to .data.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ src/utils/                — Themes, styles, feature flags, catalog, state hook
                              useURLSync, useStickySliders, comparisonSliders,
                              parseComparisonParams, usePreferences, preferences,
                              errorReporting, useMediaQuery)
-src/lens-data/            — Lens prescription data (auto-registered *.data.js)
+src/lens-data/            — Lens prescription data (auto-registered *.data.ts)
 src/content/              — Static markdown content
                             (AboutMe.md, AboutSite.md,
                              OpticsPrimerSimple.md, OpticsPrimerIntermediate.md)
@@ -103,7 +103,7 @@ Read the relevant file before starting work on that area:
 - **`agent_docs/architecture.md`** — Module responsibilities, component data flow, API surface
 - **`agent_docs/adding_a_lens.md`** — Lens data creation workflow and troubleshooting
 - **`src/lens-data/LENS_DATA_SPEC.md`** — Complete lens data format specification
-- **`src/lens-data/TEMPLATE.data.js.template`** — Annotated template with SD guidelines
+- **`src/lens-data/TEMPLATE.data.ts.template`** — Annotated template with SD guidelines
 - **`agent_docs/commenting_guide.md`** — Code commenting standards and best practices
 
 ## Key Design Patterns
@@ -122,10 +122,10 @@ Read the relevant file before starting work on that area:
 
 ## Adding a New Lens
 
-1. Copy `src/lens-data/TEMPLATE.data.js.template` to `src/lens-data/YourLens.data.js`
+1. Copy `src/lens-data/TEMPLATE.data.ts.template` to `src/lens-data/YourLens.data.ts`
 2. Fill in the lens data following the template's field documentation
 3. Optionally add `src/lens-data/YourLens.analysis.md` for the description panel
-4. Run `npm run test` to verify validation passes
+4. Run `npm run typecheck && npm run test` to verify types and validation pass
 
 See `agent_docs/adding_a_lens.md` for details on defaults merging, naming conventions, and SD troubleshooting.
 
@@ -133,7 +133,7 @@ See `agent_docs/adding_a_lens.md` for details on defaults merging, naming conven
 
 Run `npm run test`. Tests in `__tests__/` (31 test files) cover the optics engine, lens building, validation, catalog loading, comparison sliders, URL parsing, themes, styles, state management (reducer, preferences, URL sync, sticky sliders), zoom optics helpers, error reporting, diagram geometry, LCA scaling, lens metadata, media queries, feature flags, and extracted UI component module contracts. Full DOM-based component rendering is not tested. Run `npm run test:coverage` for a v8 coverage report (coverage scope is `src/optics/**` and `src/utils/**`).
 
-Test files are TypeScript (`.ts`) and included in `tsconfig.json` so `npm run typecheck` validates them alongside `src/`. Intentionally partial mock objects use `as unknown as RuntimeLens` (or the relevant type) to satisfy strict mode while keeping fixtures minimal. Lens data files (`.data.js`) are declared in `__tests__/globals.d.ts` via a wildcard module so tsc can resolve those imports.
+Test files are TypeScript (`.ts`) and included in `tsconfig.json` so `npm run typecheck` validates them alongside `src/`. Intentionally partial mock objects use `as unknown as RuntimeLens` (or the relevant type) to satisfy strict mode while keeping fixtures minimal. Lens data files (`.data.ts`) are type-checked by tsc directly — each file uses `satisfies LensDataInput` for compile-time validation.
 
 ## Code Conventions
 
@@ -157,12 +157,12 @@ Test files are TypeScript (`.ts`) and included in `tsconfig.json` so `npm run ty
 - `buildLens()` calls `validateLensData()` internally; malformed data throws descriptive errors with all issues listed
 - Theme colors use semantic names (`rayWarm`, `rayCool`, `apdPatentBg`) — update all 4 themes when changing colors
 - `vite.config.js` sets `base: '/'` — GitHub Actions deploy workflow handles the Pages base path
-- Lens data globs match `*.data.js`; analysis globs match `*.analysis.md` — naming convention matters for auto-registration
-- `src/lens-data/defaults.ts` values are merged under each lens — per-lens values in `.data.js` take precedence
+- Lens data globs match `*.data.ts`; analysis globs match `*.analysis.md` — naming convention matters for auto-registration
+- `src/lens-data/defaults.ts` values are merged under each lens — per-lens values in `.data.ts` take precedence
 - Glob paths in `lensCatalog.ts` are relative to the file's location (`../lens-data/`)
-- Lens data files stay as `.data.js` (not TypeScript) for glob pattern compatibility — validated at runtime by `validateLensData()`
+- Lens data files are TypeScript (`.data.ts`) with `satisfies LensDataInput` for compile-time type checking — also validated at runtime by `validateLensData()`
 - Test files are `.ts` — both Vitest and tsc process them; Vitest resolves `.js` import extensions to `.ts` sources automatically
-- `tsconfig.json` uses `strict: true` with `allowJs: false`; `__tests__/` is included but lens data `.data.js` files are excluded via `__tests__/globals.d.ts` wildcard module declaration
+- `tsconfig.json` uses `strict: true` with `allowJs: false`; lens data `.data.ts` files are included in tsc via the `"src"` include
 - `.git-blame-ignore-revs` lists the initial Prettier commit — GitHub respects it automatically; for local blame run `git config blame.ignoreRevsFile .git-blame-ignore-revs`
 
 ## Compaction Instructions

--- a/__tests__/globals.d.ts
+++ b/__tests__/globals.d.ts
@@ -1,6 +1,0 @@
-// Wildcard declaration for raw lens data files (plain JS, excluded from tsc).
-// These are partial LensData objects; defaults are merged before use in tests.
-declare module "*.data.js" {
-  const data: Record<string, unknown>;
-  export default data;
-}

--- a/__tests__/lensDataTyping.test.ts
+++ b/__tests__/lensDataTyping.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { LENS_CATALOG, CATALOG_KEYS } from "../src/utils/lensCatalog.js";
+import type { LensData } from "../src/types/optics.js";
+
+/**
+ * Tests that verify the TypeScript migration of lens data files:
+ * - All catalog lenses have complete LensData shape after defaults merge
+ * - Key field types are correct at runtime (regression guard)
+ */
+
+/** Required LensData fields that must be present after defaults merge */
+const REQUIRED_POST_MERGE: (keyof LensData)[] = [
+  "key",
+  "name",
+  "closeFocusM",
+  "fstopSeries",
+  "elements",
+  "surfaces",
+  "yScFill",
+  "svgW",
+  "svgH",
+  "scFill",
+  "clipMargin",
+  "maxRimAngleDeg",
+  "gapSagFrac",
+  "maxAspectRatio",
+  "focusStep",
+  "apertureStep",
+  "maxFstop",
+  "rayFractions",
+  "rayLeadFrac",
+  "offAxisFieldFrac",
+  "offAxisFractions",
+];
+
+describe("lensDataTyping — post-merge completeness", () => {
+  it("every catalog lens has all required LensData fields after defaults merge", () => {
+    for (const key of CATALOG_KEYS) {
+      const entry = LENS_CATALOG[key];
+      for (const field of REQUIRED_POST_MERGE) {
+        expect(entry[field], `${key}: missing required field "${field}"`).toBeDefined();
+      }
+    }
+  });
+});
+
+describe("lensDataTyping — runtime field types", () => {
+  it("elements[].id is number for all lenses", () => {
+    for (const key of CATALOG_KEYS) {
+      for (const el of LENS_CATALOG[key].elements) {
+        expect(typeof el.id, `${key}/${el.name}: id must be number`).toBe("number");
+      }
+    }
+  });
+
+  it("surfaces[].R is number for all lenses", () => {
+    for (const key of CATALOG_KEYS) {
+      for (const s of LENS_CATALOG[key].surfaces) {
+        expect(typeof s.R, `${key}/${s.label}: R must be number`).toBe("number");
+      }
+    }
+  });
+
+  it("surfaces[].sd is a positive number for all lenses", () => {
+    for (const key of CATALOG_KEYS) {
+      for (const s of LENS_CATALOG[key].surfaces) {
+        expect(typeof s.sd, `${key}/${s.label}: sd must be number`).toBe("number");
+        expect(s.sd, `${key}/${s.label}: sd must be positive`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("asph keys (when present) are strings matching surface labels", () => {
+    for (const key of CATALOG_KEYS) {
+      const entry = LENS_CATALOG[key];
+      if (!entry.asph) continue;
+      const surfaceLabels = new Set(entry.surfaces.map((s) => s.label));
+      for (const asphKey of Object.keys(entry.asph)) {
+        expect(surfaceLabels.has(asphKey), `${key}: asph key "${asphKey}" not in surface labels`).toBe(true);
+      }
+    }
+  });
+
+  it("fstopSeries is an array of numbers for all lenses", () => {
+    for (const key of CATALOG_KEYS) {
+      const series = LENS_CATALOG[key].fstopSeries;
+      expect(Array.isArray(series), `${key}: fstopSeries must be array`).toBe(true);
+      for (const f of series) {
+        expect(typeof f, `${key}: fstopSeries values must be number`).toBe("number");
+      }
+    }
+  });
+
+  it("elements[].apd is 'patent', 'inferred', false, or undefined", () => {
+    const valid = new Set(["patent", "inferred", false, undefined]);
+    for (const key of CATALOG_KEYS) {
+      for (const el of LENS_CATALOG[key].elements) {
+        expect(valid.has(el.apd), `${key}/${el.name}: invalid apd value "${el.apd}"`).toBe(true);
+      }
+    }
+  });
+
+  it("elements[].cemented is string or undefined", () => {
+    for (const key of CATALOG_KEYS) {
+      for (const el of LENS_CATALOG[key].elements) {
+        if (el.cemented !== undefined) {
+          expect(typeof el.cemented, `${key}/${el.name}: cemented must be string`).toBe("string");
+        }
+      }
+    }
+  });
+});

--- a/agent_docs/adding_a_lens.md
+++ b/agent_docs/adding_a_lens.md
@@ -2,29 +2,29 @@
 
 ## Quick Steps
 
-1. Copy `src/lens-data/TEMPLATE.data.js.template` to `src/lens-data/YourLens.data.js`
+1. Copy `src/lens-data/TEMPLATE.data.ts.template` to `src/lens-data/YourLens.data.ts`
 2. Fill in the lens data following the template's inline field documentation
 3. Optionally add `src/lens-data/YourLens.analysis.md` for the description panel
 4. Run `npm run test` to verify validation passes
-5. Done — `import.meta.glob` auto-registers all `src/lens-data/*.data.js` files
+5. Done — `import.meta.glob` auto-registers all `src/lens-data/*.data.ts` files
 
 No manual imports or catalog edits required.
 
 ## Reference Documents
 
 - **Full format specification:** `src/lens-data/LENS_DATA_SPEC.md`
-- **Annotated template:** `src/lens-data/TEMPLATE.data.js.template`
+- **Annotated template:** `src/lens-data/TEMPLATE.data.ts.template`
 - **Shared defaults:** `src/lens-data/defaults.ts`
 
 ## Key Details
 
 ### Auto-Registration
 
-`src/utils/lensCatalog.ts` uses `import.meta.glob` to discover all `*.data.js` files in `src/lens-data/`. Each file must default-export a `LENS_DATA` object with a unique `key` field. Analysis files are matched by `*.analysis.md` glob.
+`src/utils/lensCatalog.ts` uses `import.meta.glob` to discover all `*.data.ts` files in `src/lens-data/`. Each file must default-export a `LENS_DATA` object with a unique `key` field and use `satisfies LensDataInput` for compile-time type checking. Analysis files are matched by `*.analysis.md` glob.
 
 ### Defaults Merge
 
-Shared defaults from `src/lens-data/defaults.ts` are merged automatically under each lens. Only override values in your `.data.js` that differ from defaults (e.g., `svgW`, `svgH`, `maxRimAngleDeg`).
+Shared defaults from `src/lens-data/defaults.ts` are merged automatically under each lens. Only override values in your `.data.ts` that differ from defaults (e.g., `svgW`, `svgH`, `maxRimAngleDeg`).
 
 ### Maker Field
 
@@ -32,13 +32,13 @@ Set `maker` to the manufacturer name (e.g. `"Nikon"`, `"Voigtländer"`, `"Carl Z
 
 ### Naming Conventions
 
-- Lens data: `*.data.js` (required for auto-registration)
+- Lens data: `*.data.ts` (required for auto-registration, typed with `satisfies LensDataInput`)
 - Analysis: `*.analysis.md` (optional, matched by name prefix)
 - Set `visible: false` in the data object to hide a lens from the UI
 
 ### Semi-Diameter Troubleshooting
 
-Surface `sd` values are the most common source of rendering bugs. If validation fails on SD-related checks (edge thickness, SD consistency, sd/|R| ratio, cross-gap overlap, conic height limits), see the Semi-Diameter Guidelines section in `src/lens-data/TEMPLATE.data.js.template` for detailed constraints and examples.
+Surface `sd` values are the most common source of rendering bugs. If validation fails on SD-related checks (edge thickness, SD consistency, sd/|R| ratio, cross-gap overlap, conic height limits), see the Semi-Diameter Guidelines section in `src/lens-data/TEMPLATE.data.ts.template` for detailed constraints and examples.
 
 ### Validation
 
@@ -60,7 +60,7 @@ If the patent describes a variable focal-length lens with spacing tables at mult
 - Gaps that only change with zoom (no focus variation): use identical inf/close values — e.g., `[[1.0, 1.0], [3.0, 3.0]]`
 - Gaps that change with both zoom and focus: use different inf/close values at each position
 
-**File header:** Document which gaps are zoom-only vs zoom+focus, and note any non-monotonic (reversing) groups. See the header in `src/lens-data/NikonNikkorZ70200f28.data.js` for an example.
+**File header:** Document which gaps are zoom-only vs zoom+focus, and note any non-monotonic (reversing) groups. See the header in `src/lens-data/NikonNikkorZ70200f28.data.ts` for an example.
 
 **Zoom-specific validation:**
 - `zoomPositions` must be monotonically increasing finite numbers
@@ -68,4 +68,4 @@ If the patent describes a variable focal-length lens with spacing tables at mult
 - Surface `d` must match `var[label][0][0]` (first zoom position, infinity focus)
 - Cross-gap overlap is checked at every zoom position
 
-**References:** Zoom Lens Fields section in `src/lens-data/LENS_DATA_SPEC.md`, zoom fields section in the template, and `src/lens-data/NikonNikkorZ70200f28.data.js` as a working example.
+**References:** Zoom Lens Fields section in `src/lens-data/LENS_DATA_SPEC.md`, zoom fields section in the template, and `src/lens-data/NikonNikkorZ70200f28.data.ts` as a working example.

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -50,7 +50,7 @@ function generateSitemap() {
     process.exit(1);
   }
 
-  const dataFiles = readdirSync(LENS_DATA_DIR).filter((f) => f.endsWith(".data.js"));
+  const dataFiles = readdirSync(LENS_DATA_DIR).filter((f) => f.endsWith(".data.ts"));
   const lensKeys = [];
   const makers = new Set();
 

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -43,7 +43,7 @@ function extractLensInfo(filePath) {
 
 /** Collect all routes to prerender. */
 function collectRoutes() {
-  const dataFiles = readdirSync(LENS_DATA_DIR).filter((f) => f.endsWith(".data.js"));
+  const dataFiles = readdirSync(LENS_DATA_DIR).filter((f) => f.endsWith(".data.ts"));
   const routes = ["/", "/lenses", "/makers"];
   const makers = new Set();
 

--- a/scripts/seo-audit.mjs
+++ b/scripts/seo-audit.mjs
@@ -38,7 +38,7 @@ function ok(msg) {
 
 /** Extract all lens keys from data files. */
 function getLensKeys() {
-  const files = readdirSync(LENS_DATA_DIR).filter((f) => f.endsWith(".data.js"));
+  const files = readdirSync(LENS_DATA_DIR).filter((f) => f.endsWith(".data.ts"));
   const keys = [];
   for (const file of files) {
     const content = readFileSync(join(LENS_DATA_DIR, file), "utf-8");

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -1,15 +1,15 @@
 # Lens Data Specification
 
-Reference for creating new `*.data.js` files in `lens-data/`.
+Reference for creating new `*.data.ts` files in `lens-data/`.
 
 ## Quick Start
 
-1. Copy `TEMPLATE.data.js.template` to `YourLens.data.js`
+1. Copy `TEMPLATE.data.ts.template` to `YourLens.data.ts`
 2. Fill in all fields following this spec
 3. Optionally add `YourLens.analysis.md` for the description panel
 4. Auto-registration picks it up — no imports or catalog edits needed
 
-File naming: `lens-data/*.data.js` (glob pattern used for auto-discovery).
+File naming: `lens-data/*.data.ts` (glob pattern used for auto-discovery). Each file imports and uses `satisfies LensDataInput` for compile-time type checking.
 
 ---
 
@@ -406,7 +406,7 @@ export default LENS_DATA;
 
 ## Example: Zoom Lens Variable-Gap Structure
 
-The zoom-specific fields added alongside normal lens fields. For a complete working example, see `NikonNikkorZ70200f28.data.js`.
+The zoom-specific fields added alongside normal lens fields. For a complete working example, see `NikonNikkorZ70200f28.data.ts`.
 
 ```javascript
 // Zoom positions — focal lengths in mm (≥2, monotonically increasing)

--- a/src/lens-data/Nikon58f14GDesignCandidate.data.ts
+++ b/src/lens-data/Nikon58f14GDesignCandidate.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║  LENS DATA — NIKON AF-S NIKKOR 58mm f/1.4G (Design Candidate)     ║
@@ -252,6 +254,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.5,
   yScFill: 0.32,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/Nikon85f14AIS.data.ts
+++ b/src/lens-data/Nikon85f14AIS.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON AI NIKKOR 85mm f/1.4S                  ║
@@ -194,6 +196,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.5,
   yScFill: 0.35,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/Nikon85f14D.data.ts
+++ b/src/lens-data/Nikon85f14D.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON AF NIKKOR 85mm f/1.4D IF              ║
@@ -221,6 +223,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.5,
   yScFill: 0.32,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonAFSMicroNikkor60f28G.data.ts
+++ b/src/lens-data/NikonAFSMicroNikkor60f28G.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON AF-S MICRO-NIKKOR 60mm f/2.8G ED      ║
@@ -299,6 +301,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.45,
   yScFill: 0.35,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonNikkor105f14E.data.ts
+++ b/src/lens-data/NikonNikkor105f14E.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON AF-S NIKKOR 105mm f/1.4E ED           ║
@@ -315,6 +317,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.55,
   yScFill: 0.32,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonNikkor85f14G.data.ts
+++ b/src/lens-data/NikonNikkor85f14G.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON AF-S NIKKOR 85mm f/1.4G               ║
@@ -224,6 +226,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.52,
   yScFill: 0.38,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonNikkorAuto24f28.data.ts
+++ b/src/lens-data/NikonNikkorAuto24f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKKOR-N Auto 24mm f/2.8                     ║
@@ -248,6 +250,6 @@ const LENS_DATA = {
    */
   scFill: 0.55,
   yScFill: 0.48,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonNikkorZ50f12.data.ts
+++ b/src/lens-data/NikonNikkorZ50f12.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║  LENS DATA — NIKON NIKKOR Z 50mm f/1.2 S                          ║
@@ -409,6 +411,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.58,
   yScFill: 0.52,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonNikkorZ50f18S.data.ts
+++ b/src/lens-data/NikonNikkorZ50f18S.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 // =============================================================================
 //  NIKKOR Z 50mm f/1.8 S — Patent WO2019/220618 A1, Example 9
 //  Inventors: Saburo Masugi, Tomoyuki Koshima (Nikon Corporation)
@@ -318,6 +320,6 @@ const LENS_DATA = {
   // §10 — Layout tuning (overrides defaults)
   scFill: 0.52,
   yScFill: 0.32,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonNikkorZ70200f28.data.ts
+++ b/src/lens-data/NikonNikkorZ70200f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON NIKKOR Z 70-200mm f/2.8 VR S          ║
@@ -483,6 +485,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.65,
   yScFill: 0.42,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonZ105f28.data.ts
+++ b/src/lens-data/NikonZ105f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKKOR Z MC 105mm f/2.8 VR S                ║
@@ -354,6 +356,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.52,
   yScFill: 0.42,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonZ135f18.data.ts
+++ b/src/lens-data/NikonZ135f18.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKKOR Z 135mm f/1.8 S Plena                ║
@@ -336,6 +338,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.5,
   yScFill: 0.35,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonZ2470f28.data.ts
+++ b/src/lens-data/NikonZ2470f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKKOR Z 24-70mm f/2.8 S                     ║
@@ -445,6 +447,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.48,
   yScFill: 0.3,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonZ26f28.data.ts
+++ b/src/lens-data/NikonZ26f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON NIKKOR Z 26mm f/2.8                    ║
@@ -259,6 +261,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.55,
   yScFill: 0.35,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/NikonZ85f18S.data.ts
+++ b/src/lens-data/NikonZ85f18S.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NIKON NIKKOR Z 85mm f/1.8 S                  ║
@@ -305,6 +307,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.5,
   yScFill: 0.32,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/RicohGR28f28.data.ts
+++ b/src/lens-data/RicohGR28f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — RICOH GR 28mm f/2.8                         ║
@@ -229,6 +231,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.48,
   yScFill: 0.38,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/RicohGR328f28.data.ts
+++ b/src/lens-data/RicohGR328f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — RICOH GR III  18.3mm f/2.8                   ║
@@ -218,6 +220,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.42,
   yScFill: 0.45,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/RicohGR428f28.data.ts
+++ b/src/lens-data/RicohGR428f28.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — RICOH GR IV 18.3mm f/2.8                     ║
@@ -250,6 +252,6 @@ const LENS_DATA = {
    */
   scFill: 0.55,
   yScFill: 0.45,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — [LENS NAME]                                  ║
@@ -253,6 +255,6 @@ const LENS_DATA = {
    */
   scFill:           0.50,   // override default 0.55 if needed
   yScFill:          0.30,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/VoigtlanderApoLanthar50f2.data.ts
+++ b/src/lens-data/VoigtlanderApoLanthar50f2.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — APO-LANTHAR 50mm f/2.0 Aspherical            ║
@@ -275,6 +277,6 @@ const LENS_DATA = {
   /* ── Layout tuning (overrides defaults) ── */
   scFill: 0.52,
   yScFill: 0.32,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/VoigtlanderHeliar.data.ts
+++ b/src/lens-data/VoigtlanderHeliar.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — VOIGTLÄNDER HELIAR (SYMMETRIC, 1902)         ║
@@ -180,6 +182,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.5,
   yScFill: 0.42,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/VoigtlanderNokton50f1.data.ts
+++ b/src/lens-data/VoigtlanderNokton50f1.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — NOKTON 50mm f/1.0                            ║
@@ -243,6 +245,6 @@ const LENS_DATA = {
   /* ── Layout tuning (overrides defaults) ── */
   scFill: 0.5,
   yScFill: 0.3,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/ZeissJenaSonnar50f2.data.ts
+++ b/src/lens-data/ZeissJenaSonnar50f2.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — CARL ZEISS JENA SONNAR 50mm f/2             ║
@@ -178,6 +180,6 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.48,
   yScFill: 0.38,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/ZeissSonnar50f15.data.ts
+++ b/src/lens-data/ZeissSonnar50f15.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — CARL ZEISS SONNAR 50mm f/1.5                 ║
@@ -206,6 +208,6 @@ const LENS_DATA = {
    */
   scFill: 0.55,
   yScFill: 0.42,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/lens-data/ZeissTessar144f55.data.ts
+++ b/src/lens-data/ZeissTessar144f55.data.ts
@@ -1,3 +1,5 @@
+import type { LensDataInput } from "../types/optics.js";
+
 /**
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║           LENS DATA — CARL ZEISS TESSAR 144mm f/5.5               ║
@@ -177,6 +179,6 @@ const LENS_DATA = {
    */
   scFill: 0.65,
   yScFill: 0.5,
-};
+} satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -3,7 +3,7 @@
  * runtime lens objects, ray-trace results, and diagram geometry.
  */
 
-/* ── Raw lens data types (as declared in .data.js files) ── */
+/* ── Raw lens data types (as declared in .data.ts files) ── */
 
 export interface SurfaceData {
   label: string;
@@ -34,9 +34,9 @@ export interface ElementData {
   fl?: number;
   glass?: string;
   role?: string;
-  apd?: "patent" | "inferred";
+  apd?: "patent" | "inferred" | false;
   apdNote?: string;
-  cemented?: boolean;
+  cemented?: string;
 }
 
 export interface AnnotationData {
@@ -99,6 +99,26 @@ export interface LensData {
   offAxisFieldFrac: number;
   offAxisFractions: number[];
 }
+
+/** Fields provided by LENS_DEFAULTS — optional in raw lens data files */
+type DefaultedFields =
+  | "rayFractions"
+  | "rayLeadFrac"
+  | "offAxisFieldFrac"
+  | "offAxisFractions"
+  | "svgW"
+  | "svgH"
+  | "scFill"
+  | "clipMargin"
+  | "maxRimAngleDeg"
+  | "gapSagFrac"
+  | "maxAspectRatio"
+  | "focusStep"
+  | "apertureStep"
+  | "maxFstop";
+
+/** Raw lens data shape before defaults merging (used in .data.ts files) */
+export type LensDataInput = Omit<LensData, DefaultedFields> & Partial<Pick<LensData, DefaultedFields>>;
 
 /** Entrance pupil data */
 export interface EntrancePupil {

--- a/src/utils/lensCatalog.ts
+++ b/src/utils/lensCatalog.ts
@@ -1,5 +1,5 @@
 /**
- * Lens catalog — auto-registered from lens-data/*.data.js
+ * Lens catalog — auto-registered from lens-data/*.data.ts
  *
  * Shared by LensViewer and LensDiagramPanel so the import.meta.glob
  * calls are not duplicated.
@@ -8,10 +8,10 @@
 import LENS_DEFAULTS from "../lens-data/defaults.js";
 import type { LensData } from "../types/optics.js";
 
-/* Eagerly import all *.data.js files — Vite resolves the glob at build time.
+/* Eagerly import all *.data.ts files — Vite resolves the glob at build time.
  * Each module's default export is a LENS_DATA object; defaults are merged
  * underneath so per-lens values take precedence. */
-const _modules = import.meta.glob<{ default: LensData }>("../lens-data/*.data.js", { eager: true });
+const _modules = import.meta.glob<{ default: LensData }>("../lens-data/*.data.ts", { eager: true });
 const LENS_CATALOG: Record<string, LensData> = {};
 for (const [path, mod] of Object.entries(_modules)) {
   const data = mod.default;
@@ -40,7 +40,7 @@ for (const [path, raw] of Object.entries(_mdModules)) {
 /* Map lens key → data file stem so we can find the matching .analysis.md */
 const KEY_TO_STEM: Record<string, string> = {};
 for (const [path, mod] of Object.entries(_modules)) {
-  const stem = path.replace("../lens-data/", "").replace(".data.js", "").replace(".js", "");
+  const stem = path.replace("../lens-data/", "").replace(".data.ts", "");
   if (mod.default?.key) KEY_TO_STEM[mod.default.key] = stem;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "types": ["vite/client"]
   },
   "include": ["src", "__tests__"],
-  "exclude": ["node_modules", "dist", "src/lens-data/*.data.js"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- **Migrates all 24 lens data files** from `.data.js` to `.data.ts` with compile-time type checking via `satisfies LensDataInput`
- **Adds `LensDataInput` type** — derived from `LensData` with defaulted fields made optional, matching the raw shape lens files actually export
- **Fixes `ElementData` type** to match actual usage: `apd` accepts `false` (not just `"patent" | "inferred"`), `cemented` accepts `string` group names (not `boolean`)
- **Updates all infrastructure**: glob patterns, tsconfig, test imports, build scripts, template, spec, CLAUDE.md, and agent docs

## Test plan

- [x] `npm run typecheck` — all 24 lens files pass strict TypeScript (zero errors)
- [x] `npm run test` — 566 tests pass across 32 test files (including new `lensDataTyping.test.ts`)
- [x] `npm run build` — production build succeeds (31 routes prerendered)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [ ] Verify dev server loads lenses correctly in browser

https://claude.ai/code/session_013b8PqecG5dt9xTP9pW7HNk