### PR TITLE
Apply theming to maker, lens index, and 404 pages

### DIFF
--- a/src/pages/LensIndexPage.tsx
+++ b/src/pages/LensIndexPage.tsx
@@ -9,6 +9,7 @@ import SEOHead from "../components/SEOHead.js";
 import { LENS_CATALOG, CATALOG_KEYS } from "../utils/lensCatalog.js";
 import { deriveMaker, SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
 import { getMakerDetails } from "../utils/makerDetails.js";
+import { usePageTheme } from "../utils/usePageTheme.js";
 import type { LensData } from "../types/optics.js";
 
 interface MakerGroup {
@@ -30,15 +31,13 @@ function groupByMaker(): MakerGroup[] {
   return Array.from(groups.values()).sort((a, b) => a.display.localeCompare(b.display));
 }
 
-const PAGE_STYLE: React.CSSProperties = {
+const PAGE_BASE_STYLE = {
   maxWidth: 960,
   margin: "0 auto",
   padding: "2rem 1.5rem",
   fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
-  color: "#e0e0e0",
-  backgroundColor: "#1a1a2e",
   minHeight: "100vh",
-};
+} satisfies React.CSSProperties;
 
 const H1_STYLE: React.CSSProperties = {
   fontSize: "1.5rem",
@@ -46,53 +45,35 @@ const H1_STYLE: React.CSSProperties = {
   marginBottom: "0.5rem",
 };
 
-const SUBTITLE_STYLE: React.CSSProperties = {
-  fontSize: "0.875rem",
-  color: "#999",
-  marginBottom: "2rem",
-};
-
-const MAKER_HEADING_STYLE: React.CSSProperties = {
+const MAKER_HEADING_BASE_STYLE = {
   fontSize: "1.125rem",
   fontWeight: 600,
   marginTop: "1.5rem",
   marginBottom: "0.75rem",
-  borderBottom: "1px solid #333",
   paddingBottom: "0.25rem",
-};
+} satisfies React.CSSProperties;
 
-const LENS_LINK_STYLE: React.CSSProperties = {
+const LENS_LINK_BASE_STYLE = {
   display: "block",
   padding: "0.5rem 0.75rem",
   marginBottom: "0.25rem",
-  color: "#7ec8e3",
   textDecoration: "none",
   borderRadius: 4,
   fontSize: "0.875rem",
-};
-
-const SPEC_STYLE: React.CSSProperties = {
-  color: "#888",
-  fontSize: "0.75rem",
-  marginLeft: "0.5rem",
-};
+} satisfies React.CSSProperties;
 
 const NAV_STYLE: React.CSSProperties = {
   marginBottom: "1.5rem",
   fontSize: "0.8rem",
 };
 
-const NAV_LINK_STYLE: React.CSSProperties = {
-  color: "#7ec8e3",
-  textDecoration: "none",
-};
-
 export default function LensIndexPage() {
   const groups = groupByMaker();
   const totalLenses = CATALOG_KEYS.length;
+  const t = usePageTheme();
 
   return (
-    <div style={PAGE_STYLE}>
+    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
       <SEOHead
         title={`All Lenses — ${SITE_NAME}`}
         description={`Browse ${totalLenses} interactive lens cross-section diagrams from Nikon, Carl Zeiss, Ricoh, Voigtländer, and more. Each lens features ray tracing, element inspection, and aberration analysis.`}
@@ -100,30 +81,34 @@ export default function LensIndexPage() {
       />
 
       <nav style={NAV_STYLE}>
-        <Link to="/" style={NAV_LINK_STYLE}>
+        <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Home
         </Link>
         {" / Lenses"}
       </nav>
 
       <h1 style={H1_STYLE}>Lens Library</h1>
-      <p style={SUBTITLE_STYLE}>{totalLenses} interactive optical cross-section diagrams built from patent data.</p>
+      <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "2rem" }}>
+        {totalLenses} interactive optical cross-section diagrams built from patent data.
+      </p>
 
       {groups.map((group) => {
         const details = getMakerDetails(group.slug);
         return (
           <section key={group.slug}>
-            <h2 style={MAKER_HEADING_STYLE}>
+            <h2 style={{ ...MAKER_HEADING_BASE_STYLE, borderBottom: `1px solid ${t.panelBorder}` }}>
               <Link to={`/makers/${group.slug}`} style={{ color: "inherit", textDecoration: "none" }}>
                 {group.display}
               </Link>
-              <span style={{ ...SPEC_STYLE, fontWeight: 400 }}> ({group.lenses.length})</span>
+              <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem", fontWeight: 400 }}>
+                ({group.lenses.length})
+              </span>
             </h2>
             {details && (
               <p
                 style={{
                   fontSize: "0.8rem",
-                  color: "#999",
+                  color: t.muted,
                   lineHeight: 1.4,
                   marginTop: "-0.5rem",
                   marginBottom: "0.75rem",
@@ -133,10 +118,12 @@ export default function LensIndexPage() {
               </p>
             )}
             {group.lenses.map(({ key, data }) => (
-              <Link key={key} to={`/lens/${key}`} style={LENS_LINK_STYLE}>
+              <Link key={key} to={`/lens/${key}`} style={{ ...LENS_LINK_BASE_STYLE, color: t.descLinkColor }}>
                 {data.name}
                 {data.specs && data.specs.length > 0 && (
-                  <span style={SPEC_STYLE}>— {data.specs.slice(0, 2).join(", ")}</span>
+                  <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem" }}>
+                    — {data.specs.slice(0, 2).join(", ")}
+                  </span>
                 )}
               </Link>
             ))}

--- a/src/pages/MakerPage.tsx
+++ b/src/pages/MakerPage.tsx
@@ -9,6 +9,7 @@ import SEOHead from "../components/SEOHead.js";
 import { LENS_CATALOG, CATALOG_KEYS } from "../utils/lensCatalog.js";
 import { deriveMaker, makerDisplayName, makerCanonicalURL, SITE_NAME } from "../utils/lensMetadata.js";
 import { getMakerDetails } from "../utils/makerDetails.js";
+import { usePageTheme } from "../utils/usePageTheme.js";
 import type { LensData } from "../types/optics.js";
 
 function lensesForMaker(makerSlug: string): { key: string; data: LensData }[] {
@@ -20,35 +21,27 @@ function lensesForMaker(makerSlug: string): { key: string; data: LensData }[] {
   }));
 }
 
-const PAGE_STYLE: React.CSSProperties = {
+const PAGE_BASE_STYLE = {
   maxWidth: 960,
   margin: "0 auto",
   padding: "2rem 1.5rem",
   fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
-  color: "#e0e0e0",
-  backgroundColor: "#1a1a2e",
   minHeight: "100vh",
-};
+} satisfies React.CSSProperties;
 
 const NAV_STYLE: React.CSSProperties = { marginBottom: "1.5rem", fontSize: "0.8rem" };
-const NAV_LINK_STYLE: React.CSSProperties = { color: "#7ec8e3", textDecoration: "none" };
-const LENS_LINK_STYLE: React.CSSProperties = {
+const LENS_LINK_BASE_STYLE = {
   display: "block",
   padding: "0.5rem 0.75rem",
   marginBottom: "0.25rem",
-  color: "#7ec8e3",
   textDecoration: "none",
   borderRadius: 4,
   fontSize: "0.875rem",
-};
-const SPEC_STYLE: React.CSSProperties = {
-  color: "#888",
-  fontSize: "0.75rem",
-  marginLeft: "0.5rem",
-};
+} satisfies React.CSSProperties;
 
 export default function MakerPage() {
   const { maker } = useParams<{ maker: string }>();
+  const t = usePageTheme();
 
   if (!maker) return <Navigate to="/makers" replace />;
 
@@ -63,7 +56,7 @@ export default function MakerPage() {
     : `Explore ${lenses.length} ${displayName} lens designs with interactive cross-section diagrams, ray tracing, and element inspection.`;
 
   return (
-    <div style={PAGE_STYLE}>
+    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
       <SEOHead
         title={`${displayName} Lenses — ${SITE_NAME}`}
         description={seoDescription}
@@ -71,11 +64,11 @@ export default function MakerPage() {
       />
 
       <nav style={NAV_STYLE}>
-        <Link to="/" style={NAV_LINK_STYLE}>
+        <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Home
         </Link>
         {" / "}
-        <Link to="/makers" style={NAV_LINK_STYLE}>
+        <Link to="/makers" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Makers
         </Link>
         {` / ${displayName}`}
@@ -85,16 +78,16 @@ export default function MakerPage() {
 
       {details && (
         <div style={{ marginBottom: "1.5rem" }}>
-          <p style={{ fontSize: "0.8rem", color: "#888", marginBottom: "0.75rem" }}>
+          <p style={{ fontSize: "0.8rem", color: t.label, marginBottom: "0.75rem" }}>
             Est. {details.founded} · {details.headquarters} · {lenses.length} {lenses.length === 1 ? "lens" : "lenses"}
           </p>
           {details.history.split("\n\n").map((paragraph, i) => (
-            <p key={i} style={{ fontSize: "0.85rem", color: "#ccc", lineHeight: 1.6, marginBottom: "0.75rem" }}>
+            <p key={i} style={{ fontSize: "0.85rem", color: t.desc, lineHeight: 1.6, marginBottom: "0.75rem" }}>
               {paragraph}
             </p>
           ))}
           {details.notableDesigns && (
-            <p style={{ fontSize: "0.8rem", color: "#999", fontStyle: "italic", marginBottom: "0.5rem" }}>
+            <p style={{ fontSize: "0.8rem", color: t.muted, fontStyle: "italic", marginBottom: "0.5rem" }}>
               Notable designs: {details.notableDesigns}
             </p>
           )}
@@ -102,17 +95,19 @@ export default function MakerPage() {
       )}
 
       {!details && (
-        <p style={{ fontSize: "0.875rem", color: "#999", marginBottom: "1.5rem" }}>
+        <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "1.5rem" }}>
           {lenses.length} interactive lens {lenses.length === 1 ? "diagram" : "diagrams"}
         </p>
       )}
 
-      <div style={{ borderTop: "1px solid #333", paddingTop: "1rem" }}>
+      <div style={{ borderTop: `1px solid ${t.panelBorder}`, paddingTop: "1rem" }}>
         {lenses.map(({ key, data }) => (
-          <Link key={key} to={`/lens/${key}`} style={LENS_LINK_STYLE}>
+          <Link key={key} to={`/lens/${key}`} style={{ ...LENS_LINK_BASE_STYLE, color: t.descLinkColor }}>
             {data.name}
             {data.specs && data.specs.length > 0 && (
-              <span style={SPEC_STYLE}>— {data.specs.slice(0, 3).join(", ")}</span>
+              <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem" }}>
+                — {data.specs.slice(0, 3).join(", ")}
+              </span>
             )}
           </Link>
         ))}

--- a/src/pages/MakersIndexPage.tsx
+++ b/src/pages/MakersIndexPage.tsx
@@ -9,6 +9,7 @@ import SEOHead from "../components/SEOHead.js";
 import { LENS_CATALOG, CATALOG_KEYS } from "../utils/lensCatalog.js";
 import { deriveMaker, SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
 import { getMakerDetails } from "../utils/makerDetails.js";
+import { usePageTheme } from "../utils/usePageTheme.js";
 
 interface MakerEntry {
   display: string;
@@ -31,24 +32,22 @@ function getAllMakers(): MakerEntry[] {
   return Array.from(counts.values()).sort((a, b) => a.display.localeCompare(b.display));
 }
 
-const PAGE_STYLE: React.CSSProperties = {
+const PAGE_BASE_STYLE = {
   maxWidth: 960,
   margin: "0 auto",
   padding: "2rem 1.5rem",
   fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
-  color: "#e0e0e0",
-  backgroundColor: "#1a1a2e",
   minHeight: "100vh",
-};
+} satisfies React.CSSProperties;
 
 const NAV_STYLE: React.CSSProperties = { marginBottom: "1.5rem", fontSize: "0.8rem" };
-const NAV_LINK_STYLE: React.CSSProperties = { color: "#7ec8e3", textDecoration: "none" };
 
 export default function MakersIndexPage() {
   const makers = getAllMakers();
+  const t = usePageTheme();
 
   return (
-    <div style={PAGE_STYLE}>
+    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
       <SEOHead
         title={`Lens Makers — ${SITE_NAME}`}
         description={`Browse lenses by maker: ${makers.map((m) => m.display).join(", ")}. Interactive cross-section diagrams with ray tracing and element inspection.`}
@@ -56,7 +55,7 @@ export default function MakersIndexPage() {
       />
 
       <nav style={NAV_STYLE}>
-        <Link to="/" style={NAV_LINK_STYLE}>
+        <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Home
         </Link>
         {" / Makers"}
@@ -69,26 +68,26 @@ export default function MakersIndexPage() {
         return (
           <div
             key={maker.slug}
-            style={{ padding: "1rem 0.75rem", marginBottom: "0.75rem", borderBottom: "1px solid #333" }}
+            style={{ padding: "1rem 0.75rem", marginBottom: "0.75rem", borderBottom: `1px solid ${t.panelBorder}` }}
           >
             <Link
               to={`/makers/${maker.slug}`}
-              style={{ color: "#7ec8e3", textDecoration: "none", fontSize: "1rem", fontWeight: 600 }}
+              style={{ color: t.descLinkColor, textDecoration: "none", fontSize: "1rem", fontWeight: 600 }}
             >
               {maker.display}
             </Link>
             {details ? (
               <>
-                <div style={{ fontSize: "0.8rem", color: "#888", marginTop: "0.25rem" }}>
+                <div style={{ fontSize: "0.8rem", color: t.label, marginTop: "0.25rem" }}>
                   Est. {details.founded} · {details.headquarters} · {maker.count}{" "}
                   {maker.count === 1 ? "lens" : "lenses"}
                 </div>
-                <p style={{ fontSize: "0.8rem", color: "#bbb", lineHeight: 1.5, marginTop: "0.5rem" }}>
+                <p style={{ fontSize: "0.8rem", color: t.subtitle, lineHeight: 1.5, marginTop: "0.5rem" }}>
                   {details.summary}
                 </p>
               </>
             ) : (
-              <span style={{ color: "#888", fontSize: "0.8rem", marginLeft: "0.5rem" }}>
+              <span style={{ color: t.label, fontSize: "0.8rem", marginLeft: "0.5rem" }}>
                 ({maker.count} {maker.count === 1 ? "lens" : "lenses"})
               </span>
             )}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -5,29 +5,29 @@
 import { Link } from "react-router";
 import SEOHead from "../components/SEOHead.js";
 import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
+import { usePageTheme } from "../utils/usePageTheme.js";
 
-const PAGE_STYLE: React.CSSProperties = {
+const PAGE_BASE_STYLE = {
   maxWidth: 960,
   margin: "0 auto",
   padding: "4rem 1.5rem",
   fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
-  color: "#e0e0e0",
-  backgroundColor: "#1a1a2e",
   minHeight: "100vh",
   textAlign: "center",
-};
+} satisfies React.CSSProperties;
 
 export default function NotFoundPage() {
+  const t = usePageTheme();
   return (
-    <div style={PAGE_STYLE}>
+    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
       <SEOHead title={`Page Not Found — ${SITE_NAME}`} description="Page not found." canonicalURL={SITE_URL} />
       <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>404</h1>
-      <p style={{ marginBottom: "2rem", color: "#999" }}>Page not found.</p>
-      <Link to="/" style={{ color: "#7ec8e3" }}>
+      <p style={{ marginBottom: "2rem", color: t.muted }}>Page not found.</p>
+      <Link to="/" style={{ color: t.descLinkColor }}>
         Go to Optical Bench
       </Link>
-      <span style={{ margin: "0 1rem", color: "#555" }}>|</span>
-      <Link to="/lenses" style={{ color: "#7ec8e3" }}>
+      <span style={{ margin: "0 1rem", color: t.label }}>|</span>
+      <Link to="/lenses" style={{ color: t.descLinkColor }}>
         Browse all lenses
       </Link>
     </div>

--- a/src/utils/usePageTheme.ts
+++ b/src/utils/usePageTheme.ts
@@ -1,0 +1,25 @@
+/**
+ * Reads persisted dark/highContrast preferences and returns the matching Theme object.
+ *
+ * Initializes to T.dark so the SSR-rendered HTML and the initial client render agree,
+ * then updates after mount by reading localStorage (with system media-query fallbacks).
+ */
+
+import { useState, useEffect } from "react";
+import T from "./themes.js";
+import { loadPrefs } from "./preferences.js";
+import { CATALOG_KEYS } from "./lensCatalog.js";
+import type { Theme } from "../types/theme.js";
+
+export function usePageTheme(): Theme {
+  const [theme, setTheme] = useState<Theme>(T.dark);
+
+  useEffect(() => {
+    const prefs = loadPrefs(CATALOG_KEYS);
+    const dark = prefs.dark ?? window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const highContrast = prefs.highContrast ?? window.matchMedia("(prefers-contrast: more)").matches;
+    setTheme(T[dark ? (highContrast ? "darkHC" : "dark") : highContrast ? "lightHC" : "light"]);
+  }, []);
+
+  return theme;
+}


### PR DESCRIPTION
## Summary

- Add `usePageTheme()` hook (`src/utils/usePageTheme.ts`) that reads `dark`/`highContrast` from localStorage via `loadPrefs`, falling back to `prefers-color-scheme`/`prefers-contrast` media queries — mirroring the same logic in `lensReducer.ts`
- Replace hardcoded dark-theme color constants in `MakerPage`, `MakersIndexPage`, `LensIndexPage`, and `NotFoundPage` with theme token references (`t.bg`, `t.body`, `t.descLinkColor`, `t.label`, `t.panelBorder`, etc.)
- `LensPage` is unchanged — its interactive content is already handled by `LensVisualization`

## How it works

The hook initializes to `T.dark` (matches SSR output, no hydration mismatch) and updates after mount via `useEffect`. Light-mode users see the correct theme immediately after hydration.

## Test plan

- [ ] `npm run lint` — passes clean
- [ ] `npm run format:check` — passes clean
- [ ] `npm run test` — all 619 tests pass
- [ ] Navigate to `/lenses`, `/makers`, `/makers/:slug`, and a 404 URL — pages should reflect the stored theme preference
- [ ] Toggle dark/light on the home page, then navigate to `/lenses` — colors should match

https://claude.ai/code/session_01YVd4KdoAk6A4D4TnhQcU69