### PR TITLE
Add pathname-based URL scheme for lens comparisons

### DIFF
--- a/__tests__/lensMetadata.test.ts
+++ b/__tests__/lensMetadata.test.ts
@@ -8,6 +8,9 @@ import {
   lensCanonicalURL,
   makerCanonicalURL,
   lensJsonLd,
+  comparePageTitle,
+  comparePageDescription,
+  compareCanonicalURL,
   SITE_NAME,
   SITE_URL,
 } from "../src/utils/lensMetadata.js";
@@ -184,5 +187,45 @@ describe("lensJsonLd", () => {
     const lens = makeLens();
     const ld = lensJsonLd(lens, "nikkor-z-50mm");
     expect(ld.description).toBe(lensPageDescription(lens));
+  });
+});
+
+/* ── comparePageTitle ── */
+
+describe("comparePageTitle", () => {
+  it("returns 'Lens A vs Lens B' title", () => {
+    const lensA = makeLens({ name: "NIKON NIKKOR Z 50mm f/1.2 S" });
+    const lensB = makeLens({ name: "Voigtländer Nokton 50mm f/1.0" });
+    const title = comparePageTitle(lensA, lensB);
+    expect(title).toContain("NIKON NIKKOR Z 50mm f/1.2 S vs Voigtländer Nokton 50mm f/1.0");
+    expect(title).toContain(SITE_NAME);
+  });
+});
+
+/* ── comparePageDescription ── */
+
+describe("comparePageDescription", () => {
+  it("mentions both lens names", () => {
+    const lensA = makeLens({ name: "Lens A" });
+    const lensB = makeLens({ name: "Lens B" });
+    const desc = comparePageDescription(lensA, lensB);
+    expect(desc).toContain("Lens A");
+    expect(desc).toContain("Lens B");
+    expect(desc).toContain("Compare");
+  });
+
+  it("does not exceed 160 characters", () => {
+    const lensA = makeLens({ name: "A Very Long Lens Name That Goes On And On" });
+    const lensB = makeLens({ name: "Another Very Long Lens Name That Also Goes On" });
+    const desc = comparePageDescription(lensA, lensB);
+    expect(desc.length).toBeLessThanOrEqual(160);
+  });
+});
+
+/* ── compareCanonicalURL ── */
+
+describe("compareCanonicalURL", () => {
+  it("returns SITE_URL/compare/<slugA>/<slugB>", () => {
+    expect(compareCanonicalURL("nikkor-z-50mm", "nokton-50mm")).toBe(`${SITE_URL}/compare/nikkor-z-50mm/nokton-50mm`);
   });
 });

--- a/__tests__/parseComparisonParams.test.ts
+++ b/__tests__/parseComparisonParams.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseComparisonParams,
   buildComparisonURL,
+  buildComparePath,
   focalLengthToZoomT,
   zoomTToFocalLength,
 } from "../src/utils/parseComparisonParams.js";
@@ -129,6 +130,32 @@ describe("buildComparisonURL", () => {
   it("appends slider params in comparison mode", () => {
     const url = buildComparisonURL(true, "NikkorZ50f12", "Nokton50f1", { focus: 0.6 });
     expect(url).toBe("?a=NikkorZ50f12&b=Nokton50f1&focus=0.600");
+  });
+});
+
+describe("buildComparePath", () => {
+  it("builds pathname-based comparison URL", () => {
+    expect(buildComparePath("NikkorZ50f12", "Nokton50f1")).toBe("/compare/NikkorZ50f12/Nokton50f1");
+  });
+
+  it("appends slider params as query string", () => {
+    const path = buildComparePath("NikkorZ50f12", "Nokton50f1", { focus: 0.3, aperture: 0.5 });
+    expect(path).toBe("/compare/NikkorZ50f12/Nokton50f1?focus=0.300&aperture=0.500");
+  });
+
+  it("appends zoom param", () => {
+    const path = buildComparePath("NikkorZ50f12", "Nokton50f1", { zoom: 50 });
+    expect(path).toBe("/compare/NikkorZ50f12/Nokton50f1?zoom=50");
+  });
+
+  it("omits zero/null slider params", () => {
+    const path = buildComparePath("NikkorZ50f12", "Nokton50f1", { zoom: null, focus: 0, aperture: 0 });
+    expect(path).toBe("/compare/NikkorZ50f12/Nokton50f1");
+  });
+
+  it("encodes special characters in slugs", () => {
+    const path = buildComparePath("a b", "c&d");
+    expect(path).toBe("/compare/a%20b/c%26d");
   });
 });
 

--- a/src/components/layout/BreadcrumbBar.tsx
+++ b/src/components/layout/BreadcrumbBar.tsx
@@ -31,10 +31,12 @@ export default function BreadcrumbBar({ theme: t, isWide, lensKey }: BreadcrumbB
   const dispatch = useLensDispatch();
   const { dark, highContrast } = state.display;
 
-  const lens = LENS_CATALOG[lensKey];
-  if (!lens) return null;
+  const { comparing, lensKeyB } = state.lens;
+  const lensA = LENS_CATALOG[lensKey];
+  const lensB = comparing ? LENS_CATALOG[lensKeyB] : null;
+  if (!lensA) return null;
 
-  const maker = deriveMaker(lens.name, lens.maker);
+  const maker = deriveMaker(lensA.name, lensA.maker);
   const padding = isWide ? "6px 24px" : "6px 12px";
 
   const linkStyle: React.CSSProperties = {
@@ -71,15 +73,29 @@ export default function BreadcrumbBar({ theme: t, isWide, lensKey }: BreadcrumbB
             Home
           </Link>
           <span style={separatorStyle}>/</span>
-          <Link to="/makers" style={linkStyle}>
-            Makers
-          </Link>
-          <span style={separatorStyle}>/</span>
-          <Link to={`/makers/${maker.slug}`} style={linkStyle}>
-            {maker.display}
-          </Link>
-          <span style={separatorStyle}>/</span>
-          <span style={{ color: t.body }}>{lens.name}</span>
+          {comparing && lensB ? (
+            <>
+              <Link to="/lenses" style={linkStyle}>
+                Lenses
+              </Link>
+              <span style={separatorStyle}>/</span>
+              <span style={{ color: t.body }}>
+                {lensA.name} vs {lensB.name}
+              </span>
+            </>
+          ) : (
+            <>
+              <Link to="/makers" style={linkStyle}>
+                Makers
+              </Link>
+              <span style={separatorStyle}>/</span>
+              <Link to={`/makers/${maker.slug}`} style={linkStyle}>
+                {maker.display}
+              </Link>
+              <span style={separatorStyle}>/</span>
+              <span style={{ color: t.body }}>{lensA.name}</span>
+            </>
+          )}
         </div>
 
         <button

--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -74,12 +74,14 @@ import useOverlays from "../hooks/useOverlays.js";
 
 interface LensVisualizationProps {
   initialLensKey?: string;
+  initialLensKeyB?: string;
 }
 
-export default function LensVisualization({ initialLensKey }: LensVisualizationProps) {
+export default function LensVisualization({ initialLensKey, initialLensKeyB }: LensVisualizationProps) {
   const navigate = useNavigate();
-  const isLensPage = !!initialLensKey;
-  const [state, dispatch, isWide] = useLensState(CATALOG_KEYS, initialLensKey);
+  const isComparePage = !!initialLensKey && !!initialLensKeyB;
+  const isLensPage = !!initialLensKey && !initialLensKeyB;
+  const [state, dispatch, isWide] = useLensState(CATALOG_KEYS, initialLensKey, initialLensKeyB);
 
   /* ── Destructure state slices for convenient access ── */
   const { lens, display, rays, sharedSliders, overlays } = state;
@@ -114,6 +116,7 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
     dispatch,
     comparisonLenses as Parameters<typeof useURLSync>[2],
     isLensPage,
+    isComparePage,
   );
 
   /* ── Sticky slider state machine ── */
@@ -150,14 +153,24 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
       dispatch({ type: ENTER_COMPARE, catalogKeys: CATALOG_KEYS });
       resetSticky();
       justEnteredCompare.current = true;
+      /* Navigate to the comparison route — pick lensKeyB from the reducer
+       * (which auto-selects a different lens if A===B). We read it from
+       * the state that will be produced, but since the reducer runs sync
+       * we use the current values + the same auto-select logic. */
+      const autoB =
+        lensKeyA === lensKeyB && CATALOG_KEYS.length > 1
+          ? CATALOG_KEYS[(CATALOG_KEYS.indexOf(lensKeyA) + 1) % CATALOG_KEYS.length]
+          : lensKeyB;
+      void navigate(`/compare/${lensKeyA}/${autoB}`, { replace: false });
     } else {
       dispatch({
         type: EXIT_COMPARE,
         focusA: focusPair?.focusA,
         stopdownA: aperturePair?.stopdownA,
       });
+      void navigate(`/lens/${lensKeyA}`, { replace: false });
     }
-  }, [comparing, focusPair, aperturePair, dispatch, resetSticky]);
+  }, [comparing, lensKeyA, lensKeyB, focusPair, aperturePair, dispatch, resetSticky, navigate]);
 
   const markdown = useMemo(() => mdForKey(lensKeyA), [lensKeyA]);
 
@@ -183,23 +196,31 @@ export default function LensVisualization({ initialLensKey }: LensVisualizationP
   const switchLensA = useCallback(
     (key: string) => {
       dispatch({ type: SET_LENS_A, key });
-      if (isLensPage && !state.lens.comparing) {
+      if (isComparePage) {
+        void navigate(`/compare/${key}/${lensKeyB}`, { replace: true });
+      } else if (isLensPage && !state.lens.comparing) {
         void navigate(`/lens/${key}`, { replace: true });
       }
     },
-    [dispatch, isLensPage, state.lens.comparing, navigate],
+    [dispatch, isLensPage, isComparePage, lensKeyB, state.lens.comparing, navigate],
   );
 
   const switchLensB = useCallback(
     (key: string) => {
       dispatch({ type: SET_LENS_B, key });
+      if (isComparePage) {
+        void navigate(`/compare/${lensKeyA}/${key}`, { replace: true });
+      }
     },
-    [dispatch],
+    [dispatch, isComparePage, lensKeyA, navigate],
   );
 
   const swapLenses = useCallback(() => {
     dispatch({ type: SWAP_LENSES });
-  }, [dispatch]);
+    if (isComparePage) {
+      void navigate(`/compare/${lensKeyB}/${lensKeyA}`, { replace: true });
+    }
+  }, [dispatch, isComparePage, lensKeyA, lensKeyB, navigate]);
 
   /* ── Context value (replaces sharedProps prop drilling) ── */
   const ctxValue = useMemo(

--- a/src/pages/ComparePage.tsx
+++ b/src/pages/ComparePage.tsx
@@ -1,0 +1,96 @@
+/**
+ * Comparison page — /compare/:slugA/:slugB
+ *
+ * Renders SEO-friendly text content for both lenses plus the interactive
+ * comparison visualizer (client-only). Follows the LensPage pattern.
+ */
+
+import { useParams, Navigate, Link } from "react-router";
+import LensVisualization from "../components/layout/LensViewer.js";
+import SEOHead from "../components/SEOHead.js";
+import ClientOnly from "../components/ClientOnly.js";
+import { LENS_CATALOG, CATALOG_KEYS } from "../utils/lensCatalog.js";
+import { comparePageTitle, comparePageDescription, compareCanonicalURL, deriveMaker } from "../utils/lensMetadata.js";
+
+const CONTENT_STYLE: React.CSSProperties = {
+  maxWidth: 960,
+  margin: "0 auto",
+  padding: "1.5rem",
+  fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
+  color: "#e0e0e0",
+};
+
+const NAV_STYLE: React.CSSProperties = { marginBottom: "1rem", fontSize: "0.8rem" };
+const NAV_LINK_STYLE: React.CSSProperties = { color: "#7ec8e3", textDecoration: "none" };
+
+function LensSummary({ lensKey }: { lensKey: string }) {
+  const lens = LENS_CATALOG[lensKey];
+  if (!lens) return null;
+  const maker = deriveMaker(lens.name, lens.maker);
+  return (
+    <section style={{ marginBottom: "1.5rem" }}>
+      <h2 style={{ fontSize: "1rem", fontWeight: 600, marginBottom: "0.25rem" }}>
+        <Link to={`/lens/${lensKey}`} style={NAV_LINK_STYLE}>
+          {lens.name}
+        </Link>
+      </h2>
+      {lens.subtitle && <p style={{ fontSize: "0.8rem", color: "#999", marginBottom: "0.5rem" }}>{lens.subtitle}</p>}
+      <p style={{ fontSize: "0.8rem", color: "#ccc" }}>
+        {maker.display}
+        {lens.specs && lens.specs.length > 0 ? ` — ${lens.specs.slice(0, 3).join(", ")}` : ""}
+      </p>
+    </section>
+  );
+}
+
+export default function ComparePage() {
+  const { slugA, slugB } = useParams<{ slugA: string; slugB: string }>();
+
+  if (!slugA || !slugB || !CATALOG_KEYS.includes(slugA) || !CATALOG_KEYS.includes(slugB)) {
+    return <Navigate to="/lenses" replace />;
+  }
+
+  const lensA = LENS_CATALOG[slugA];
+  const lensB = LENS_CATALOG[slugB];
+
+  return (
+    <>
+      <SEOHead
+        title={comparePageTitle(lensA, lensB)}
+        description={comparePageDescription(lensA, lensB)}
+        canonicalURL={compareCanonicalURL(slugA, slugB)}
+        ogType="article"
+      />
+
+      <ClientOnly
+        fallback={
+          <div style={CONTENT_STYLE}>
+            <nav style={NAV_STYLE}>
+              <Link to="/" style={NAV_LINK_STYLE}>
+                Home
+              </Link>
+              {" / "}
+              <Link to="/lenses" style={NAV_LINK_STYLE}>
+                Lenses
+              </Link>
+              {" / Compare"}
+            </nav>
+
+            <h1 style={{ fontSize: "1.25rem", fontWeight: 600, marginBottom: "1rem" }}>
+              {lensA.name} vs {lensB.name}
+            </h1>
+
+            <LensSummary lensKey={slugA} />
+            <LensSummary lensKey={slugB} />
+
+            <p style={{ fontSize: "0.8rem", color: "#999" }}>
+              Interactive side-by-side comparison available in the viewer above.
+            </p>
+          </div>
+        }
+      >
+        <LensVisualization initialLensKey={slugA} initialLensKeyB={slugB} />
+      </ClientOnly>
+    </>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -23,6 +23,19 @@ export default function HomePage() {
     const lensKey = searchParams.get("lens");
     if (lensKey && CATALOG_KEYS.includes(lensKey)) {
       void navigate(`/lens/${lensKey}`, { replace: true });
+      return;
+    }
+    /* Redirect legacy ?a=KEY&b=KEY comparison URLs to /compare/KEY/KEY */
+    const a = searchParams.get("a");
+    const b = searchParams.get("b");
+    if (a && b && CATALOG_KEYS.includes(a) && CATALOG_KEYS.includes(b)) {
+      const params = new URLSearchParams();
+      for (const key of ["focus", "aperture", "zoom"]) {
+        const val = searchParams.get(key);
+        if (val) params.set(key, val);
+      }
+      const search = params.toString() ? `?${params.toString()}` : "";
+      void navigate(`/compare/${a}/${b}${search}`, { replace: true });
     }
   }, [searchParams, navigate]);
 

--- a/src/routes/routeManifest.tsx
+++ b/src/routes/routeManifest.tsx
@@ -11,6 +11,7 @@ import LensPage from "../pages/LensPage.js";
 import LensIndexPage from "../pages/LensIndexPage.js";
 import MakersIndexPage from "../pages/MakersIndexPage.js";
 import MakerPage from "../pages/MakerPage.js";
+import ComparePage from "../pages/ComparePage.js";
 import NotFoundPage from "../pages/NotFoundPage.js";
 
 export interface RouteManifestEntry {
@@ -22,6 +23,7 @@ const routeManifest: RouteManifestEntry[] = [
   { path: "/", element: <HomePage /> },
   { path: "/lenses", element: <LensIndexPage /> },
   { path: "/lens/:slug", element: <LensPage /> },
+  { path: "/compare/:slugA/:slugB", element: <ComparePage /> },
   { path: "/makers", element: <MakersIndexPage /> },
   { path: "/makers/:maker", element: <MakerPage /> },
   { path: "*", element: <NotFoundPage /> },

--- a/src/utils/lensMetadata.ts
+++ b/src/utils/lensMetadata.ts
@@ -93,4 +93,20 @@ export function lensJsonLd(lens: LensData, lensKey: string): Record<string, unkn
   };
 }
 
+/** Title for a comparison page. */
+export function comparePageTitle(lensA: LensData, lensB: LensData): string {
+  return `${lensA.name} vs ${lensB.name} — Lens Comparison | ${SITE_NAME}`;
+}
+
+/** Meta description for a comparison page. */
+export function comparePageDescription(lensA: LensData, lensB: LensData): string {
+  const base = `Compare ${lensA.name} and ${lensB.name} side by side. Interactive ray tracing, aperture, focus, and chromatic aberration comparison.`;
+  return base.length > 160 ? base.slice(0, 157) + "..." : base;
+}
+
+/** Canonical URL for a comparison page. */
+export function compareCanonicalURL(slugA: string, slugB: string): string {
+  return `${SITE_URL}/compare/${slugA}/${slugB}`;
+}
+
 export { SITE_NAME, SITE_URL };

--- a/src/utils/parseComparisonParams.ts
+++ b/src/utils/parseComparisonParams.ts
@@ -121,6 +121,24 @@ export function focalLengthToZoomT(fl: number, L: RuntimeLens): number {
  * @param L     — runtime lens object (needs isZoom, zoomPositions)
  * @returns focal length in mm, or null for prime lenses
  */
+/**
+ * Build a pathname-based comparison URL.
+ *
+ * @param slugA   — first lens key
+ * @param slugB   — second lens key
+ * @param sliders — optional slider values { zoom, focus, aperture }
+ * @returns URL path (e.g. "/compare/slugA/slugB?focus=0.300")
+ */
+export function buildComparePath(slugA: string, slugB: string, sliders: BuildURLSliders = {}): string {
+  const { zoom, focus, aperture } = sliders;
+  const params = new URLSearchParams();
+  if (zoom != null && zoom > 0) params.set("zoom", String(zoom));
+  if (focus != null && focus > 0) params.set("focus", focus.toFixed(3));
+  if (aperture != null && aperture > 0) params.set("aperture", aperture.toFixed(3));
+  const search = params.toString() ? `?${params.toString()}` : "";
+  return `/compare/${encodeURIComponent(slugA)}/${encodeURIComponent(slugB)}${search}`;
+}
+
 export function zoomTToFocalLength(zoomT: number, L: RuntimeLens): number | null {
   if (!L.isZoom) return null;
   const zp: number[] = L.zoomPositions!;

--- a/src/utils/useLensState.ts
+++ b/src/utils/useLensState.ts
@@ -10,21 +10,43 @@ import lensReducer, { createInitialState } from "./lensReducer.js";
 import { loadPrefs } from "./preferences.js";
 import { parseComparisonParams } from "./parseComparisonParams.js";
 import useMediaQuery from "./useMediaQuery.js";
-import type { LensState, LensAction } from "../types/state.js";
+import type { LensState, LensAction, URLState } from "../types/state.js";
 
 export default function useLensState(
   catalogKeys: string[],
   initialLensKey?: string,
+  initialLensKeyB?: string,
 ): [LensState, Dispatch<LensAction>, boolean] {
   const isWide = useMediaQuery("(min-width: 900px)");
 
   const [state, dispatch] = useReducer(
     lensReducer,
-    { catalogKeys, isWide, initialLensKey },
-    ({ catalogKeys: keys, isWide: wide, initialLensKey: initKey }) => {
+    { catalogKeys, isWide, initialLensKey, initialLensKeyB },
+    ({
+      catalogKeys: keys,
+      isWide: wide,
+      initialLensKey: initKeyA,
+      initialLensKeyB: initKeyB,
+    }: {
+      catalogKeys: string[];
+      isWide: boolean;
+      initialLensKey?: string;
+      initialLensKeyB?: string;
+    }) => {
       const prefs = loadPrefs(keys);
       const parsed = typeof window !== "undefined" ? parseComparisonParams(window.location.search, keys) : {};
-      const urlState = initKey && keys.includes(initKey) ? { ...parsed, singleLens: initKey } : parsed;
+      /* Extract slider values from query params (null → undefined for URLState compat) */
+      const sliders: Partial<URLState> = {};
+      if ("focus" in parsed && parsed.focus != null) sliders.focus = parsed.focus as number;
+      if ("aperture" in parsed && parsed.aperture != null) sliders.aperture = parsed.aperture as number;
+      let urlState: Partial<URLState>;
+      if (initKeyA && initKeyB && keys.includes(initKeyA) && keys.includes(initKeyB)) {
+        urlState = { ...sliders, comparing: true, lensKeyA: initKeyA, lensKeyB: initKeyB };
+      } else if (initKeyA && keys.includes(initKeyA)) {
+        urlState = { ...sliders, singleLens: initKeyA };
+      } else {
+        urlState = initKeyA ? sliders : { ...sliders, ...parsed };
+      }
       return createInitialState(prefs, urlState, wide, keys);
     },
   );

--- a/src/utils/useURLSync.ts
+++ b/src/utils/useURLSync.ts
@@ -35,6 +35,7 @@ export default function useURLSync(
   dispatch: Dispatch<LensAction>,
   comparisonLenses: ComparisonLensesParam,
   isLensPage?: boolean,
+  isComparePage?: boolean,
 ): UseURLSyncResult {
   const { lens, sliders, sharedSliders } = state;
   const { comparing, lensKeyA, lensKeyB } = lens;
@@ -56,12 +57,14 @@ export default function useURLSync(
   useEffect(() => {
     // On lens pages in single-lens mode, navigation is handled by LensViewer via React Router
     if (isLensPage && !comparing) return;
+    // On compare pages, navigation is handled by LensViewer via React Router
+    if (isComparePage) return;
     const url = buildComparisonURL(comparing, lensKeyA, lensKeyB);
     const current = window.location.search;
     if (url !== current) {
       history.replaceState(null, "", url || window.location.pathname);
     }
-  }, [comparing, lensKeyA, lensKeyB, isLensPage]);
+  }, [comparing, lensKeyA, lensKeyB, isLensPage, isComparePage]);
 
   /* ── 3a. Zoom init — comparison mode ── */
   useEffect(() => {
@@ -124,8 +127,8 @@ export default function useURLSync(
           /* ignore */
         }
       }
-      if (isLensPage && !comparing) {
-        // On lens pages, only encode slider params — the pathname already has the lens key
+      if ((isLensPage && !comparing) || isComparePage) {
+        // On lens/compare pages, only encode slider params — the pathname already has the lens key(s)
         const params = new URLSearchParams();
         if (sliderState.zoom != null && sliderState.zoom > 0) params.set("zoom", String(sliderState.zoom));
         if (sliderState.focus != null && sliderState.focus > 0) params.set("focus", sliderState.focus.toFixed(3));
@@ -155,6 +158,7 @@ export default function useURLSync(
     sharedZoomT,
     comparisonLenses,
     isLensPage,
+    isComparePage,
   ]);
 
   return { updateURLWithSliders };


### PR DESCRIPTION
## Summary

- Introduces `/compare/:slugA/:slugB` route for lens comparisons, replacing the query-param approach (`/?a=KEY&b=KEY`) so the URL always reflects the current comparison state and survives page refresh
- Lens selection changes (switch A/B, swap, enter/exit comparison) now navigate via React Router, keeping the URL in sync
- Legacy `/?a=...&b=...` URLs redirect to the new `/compare/a/b` path for backward compatibility

## Changes

- **New `ComparePage.tsx`** — page component following the `LensPage` pattern with SEO metadata and SSR fallback
- **`routeManifest.tsx`** — added `/compare/:slugA/:slugB` route
- **`LensViewer.tsx`** — new `initialLensKeyB` prop, `isComparePage` flag, navigation in `switchLensA`/`switchLensB`/`swapLenses`/`toggleCompare`
- **`useLensState.ts`** — initializes comparison state from pathname params when both keys provided
- **`useURLSync.ts`** — skips `replaceState` for lens changes on compare pages (handled by Router); writes slider-only query params
- **`parseComparisonParams.ts`** — new `buildComparePath()` helper
- **`HomePage.tsx`** — backward compat redirect for `?a=...&b=...`
- **`BreadcrumbBar.tsx`** — shows "Lens A vs Lens B" breadcrumb in comparison mode
- **`lensMetadata.ts`** — comparison-specific SEO title/description/canonical helpers
- **Tests** — 9 new tests for `buildComparePath` and comparison SEO helpers

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 628 tests pass (36 files)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds (comparison routes not prerendered by design)
- [ ] Navigate to `/compare/lens-a/lens-b` directly — loads comparison
- [ ] Change lens A/B via dropdown — URL updates to `/compare/newA/b`
- [ ] Swap lenses — URL updates to `/compare/b/a`
- [ ] Adjust sliders — query params update after debounce
- [ ] Refresh page — state preserved from URL
- [ ] Exit comparison — navigates to `/lens/keyA`
- [ ] Visit `/?a=x&b=y` — redirects to `/compare/x/y`
- [ ] Click COMPARE from `/lens/slug` — navigates to `/compare/slug/otherLens`

https://claude.ai/code/session_01M6bxdksUKHUEGcCevsNP7i