### PR TITLE
Convert settings dropdown to portal-based overlay, extract DropdownPanel

### DIFF
--- a/src/components/controls/LensSelector.tsx
+++ b/src/components/controls/LensSelector.tsx
@@ -5,9 +5,9 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import ReactDOM from "react-dom";
 import type { Theme } from "../../types/theme.js";
 import { selector } from "../../utils/styles.js";
+import DropdownPanel from "../layout/DropdownPanel.js";
 
 interface LensSelectorProps {
   theme: Theme;
@@ -57,29 +57,6 @@ export default function LensSelector({ theme: t, isWide, value, options, onChang
     listRef.current.scrollTop = Math.max(0, targetScroll);
   }, [open, options, value, dropdownPos]);
 
-  // Close on outside click or Escape
-  useEffect(() => {
-    if (!open) return;
-
-    const handleMouseDown = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (triggerRef.current?.contains(target)) return;
-      if (listRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-
-    document.addEventListener("mousedown", handleMouseDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleMouseDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
   const handleSelect = useCallback(
     (key: string) => {
       onChange(key);
@@ -99,71 +76,51 @@ export default function LensSelector({ theme: t, isWide, value, options, onChang
     whiteSpace: "nowrap",
   };
 
-  const dropdown =
-    open && dropdownPos
-      ? ReactDOM.createPortal(
-          <div
-            ref={listRef}
-            style={{
-              position: "fixed",
-              top: dropdownPos.top,
-              left: dropdownPos.left,
-              width: dropdownPos.width,
-              maxHeight: dropdownPos.maxHeight,
-              overflowY: "scroll",
-              backgroundColor: t.selectorBg,
-              backdropFilter: t.selectorBlur ? "blur(20px)" : undefined,
-              WebkitBackdropFilter: t.selectorBlur ? "blur(20px)" : undefined,
-              border: `1.5px solid ${t.sliderAccent}40`,
-              borderRadius: 6,
-              boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
-              zIndex: 9999,
-              fontFamily: "inherit",
-              willChange: "transform",
-            }}
-          >
-            {options.map((o) => {
-              const isSelected = o.key === value;
-              const isHovered = o.key === hoveredKey;
-              return (
-                <div
-                  key={o.key}
-                  onMouseDown={() => handleSelect(o.key)}
-                  onMouseEnter={() => setHoveredKey(o.key)}
-                  onMouseLeave={() => setHoveredKey(null)}
-                  style={{
-                    height: ITEM_HEIGHT,
-                    lineHeight: `${ITEM_HEIGHT}px`,
-                    padding: "0 12px",
-                    cursor: "pointer",
-                    fontSize: isWide ? 13 : 12,
-                    letterSpacing: "0.06em",
-                    color: isSelected ? t.sliderAccent : t.selectorText,
-                    backgroundColor: isSelected ? `${t.sliderAccent}20` : isHovered ? t.selectorHover : "transparent",
-                    fontWeight: isSelected ? "bold" : "normal",
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    boxSizing: "border-box",
-                    borderLeft: isSelected ? `2px solid ${t.sliderAccent}` : "2px solid transparent",
-                    transition: "background-color 0.1s",
-                  }}
-                >
-                  {o.label}
-                </div>
-              );
-            })}
-          </div>,
-          document.body,
-        )
-      : null;
-
   return (
     <>
       <button ref={triggerRef} onClick={open ? () => setOpen(false) : openDropdown} style={triggerStyle}>
         {selectedLabel}
       </button>
-      {dropdown}
+      <DropdownPanel
+        ref={listRef}
+        open={open}
+        pos={dropdownPos}
+        triggerRef={triggerRef}
+        onClose={() => setOpen(false)}
+        theme={t}
+      >
+        {options.map((o) => {
+          const isSelected = o.key === value;
+          const isHovered = o.key === hoveredKey;
+          return (
+            <div
+              key={o.key}
+              onMouseDown={() => handleSelect(o.key)}
+              onMouseEnter={() => setHoveredKey(o.key)}
+              onMouseLeave={() => setHoveredKey(null)}
+              style={{
+                height: ITEM_HEIGHT,
+                lineHeight: `${ITEM_HEIGHT}px`,
+                padding: "0 12px",
+                cursor: "pointer",
+                fontSize: isWide ? 13 : 12,
+                letterSpacing: "0.06em",
+                color: isSelected ? t.sliderAccent : t.selectorText,
+                backgroundColor: isSelected ? `${t.sliderAccent}20` : isHovered ? t.selectorHover : "transparent",
+                fontWeight: isSelected ? "bold" : "normal",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                boxSizing: "border-box",
+                borderLeft: isSelected ? `2px solid ${t.sliderAccent}` : "2px solid transparent",
+                transition: "background-color 0.1s",
+              }}
+            >
+              {o.label}
+            </div>
+          );
+        })}
+      </DropdownPanel>
     </>
   );
 }

--- a/src/components/layout/BreadcrumbBar.tsx
+++ b/src/components/layout/BreadcrumbBar.tsx
@@ -3,14 +3,14 @@
  *
  * Renders above the TopBar in the LensViewer, matching the breadcrumb
  * pattern used on the multipage layout pages (LensPage, MakerPage, etc.).
- * Includes a right-aligned Settings button that expands a collapsible panel
- * with theme controls (Dark/Light and High Contrast toggles).
+ * Includes a right-aligned Settings button that opens a portal-based overlay
+ * panel with theme controls (Dark/Light and High Contrast toggles).
  *
  * Reads theme state and dispatches theme changes directly via context,
  * consistent with how LensDiagramPanel and ControlsBar wire theme actions.
  */
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Link } from "react-router";
 import type { Theme } from "../../types/theme.js";
 import { headerStrip, topBarBtn, toggleGroup, toggleBtn } from "../../utils/styles.js";
@@ -18,6 +18,8 @@ import { LENS_CATALOG } from "../../utils/lensCatalog.js";
 import { deriveMaker } from "../../utils/lensMetadata.js";
 import { useLensCtx, useLensDispatch } from "../../utils/LensContext.js";
 import { SET_DARK, SET_HIGH_CONTRAST } from "../../utils/lensReducer.js";
+import DropdownPanel from "./DropdownPanel.js";
+import type { DropdownPanelPos } from "./DropdownPanel.js";
 
 interface BreadcrumbBarProps {
   theme: Theme;
@@ -27,9 +29,18 @@ interface BreadcrumbBarProps {
 
 export default function BreadcrumbBar({ theme: t, isWide, lensKey }: BreadcrumbBarProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsPos, setSettingsPos] = useState<DropdownPanelPos | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const { state } = useLensCtx();
   const dispatch = useLensDispatch();
   const { dark, highContrast } = state.display;
+
+  const openSettings = useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setSettingsPos({ top: rect.bottom + 2, right: window.innerWidth - rect.right });
+    setSettingsOpen(true);
+  }, []);
 
   const { comparing, lensKeyB } = state.lens;
   const lensA = LENS_CATALOG[lensKey];
@@ -99,7 +110,8 @@ export default function BreadcrumbBar({ theme: t, isWide, lensKey }: BreadcrumbB
         </div>
 
         <button
-          onClick={() => setSettingsOpen((o) => !o)}
+          ref={triggerRef}
+          onClick={settingsOpen ? () => setSettingsOpen(false) : openSettings}
           style={{
             ...topBarBtn(t, isWide),
             marginLeft: 12,
@@ -125,16 +137,14 @@ export default function BreadcrumbBar({ theme: t, isWide, lensKey }: BreadcrumbB
         </button>
       </nav>
 
-      {settingsOpen && (
-        <div
-          style={{
-            ...headerStrip(t, { padding }),
-            display: "flex",
-            gap: 8,
-            alignItems: "center",
-            justifyContent: "flex-end",
-          }}
-        >
+      <DropdownPanel
+        open={settingsOpen}
+        pos={settingsPos}
+        triggerRef={triggerRef}
+        onClose={() => setSettingsOpen(false)}
+        theme={t}
+      >
+        <div style={{ padding: 10 }}>
           <div style={toggleGroup(t)}>
             <button
               onClick={() => dispatch({ type: SET_HIGH_CONTRAST, highContrast: !highContrast })}
@@ -152,7 +162,7 @@ export default function BreadcrumbBar({ theme: t, isWide, lensKey }: BreadcrumbB
             </button>
           </div>
         </div>
-      )}
+      </DropdownPanel>
     </div>
   );
 }

--- a/src/components/layout/DropdownPanel.tsx
+++ b/src/components/layout/DropdownPanel.tsx
@@ -1,0 +1,105 @@
+/**
+ * Shared portal-based dropdown panel component.
+ *
+ * Renders children in a fixed-position overlay via ReactDOM.createPortal,
+ * using the same selectorBg/selectorBlur/sliderAccent theme tokens as LensSelector.
+ * Handles Escape and outside-mousedown close. The container div ref is forwarded
+ * so callers can imperatively scroll within the panel (e.g. LensSelector).
+ */
+
+import { forwardRef, useEffect, useRef } from "react";
+import ReactDOM from "react-dom";
+import type { RefObject } from "react";
+import type { Theme } from "../../types/theme.js";
+
+export interface DropdownPanelPos {
+  top: number;
+  /** Left edge (px). Mutually exclusive with `right`. */
+  left?: number;
+  /** Right edge distance from viewport right (px). Use for right-aligned panels. */
+  right?: number;
+  /** Fixed width (px). Omit for intrinsic/auto width. */
+  width?: number;
+  /** Maximum height (px). Omit for no constraint. */
+  maxHeight?: number;
+}
+
+interface DropdownPanelProps {
+  open: boolean;
+  pos: DropdownPanelPos | null;
+  /** Ref to the trigger element — excluded from outside-click detection. */
+  triggerRef: RefObject<HTMLElement | null>;
+  onClose: () => void;
+  theme: Theme;
+  children: React.ReactNode;
+}
+
+const DropdownPanel = forwardRef<HTMLDivElement, DropdownPanelProps>(function DropdownPanel(
+  { open, pos, triggerRef, onClose, theme: t, children },
+  ref,
+) {
+  const innerRef = useRef<HTMLDivElement>(null);
+
+  // Merge forwarded ref with local ref so we can use both
+  const setRef = (el: HTMLDivElement | null) => {
+    innerRef.current = el;
+    if (typeof ref === "function") {
+      ref(el);
+    } else if (ref) {
+      (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
+    }
+  };
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  // Close on outside mousedown (excluding trigger and panel itself)
+  useEffect(() => {
+    if (!open) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (innerRef.current?.contains(target)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [open, onClose, triggerRef]);
+
+  if (!open || !pos) return null;
+
+  const panel = (
+    <div
+      ref={setRef}
+      style={{
+        position: "fixed",
+        top: pos.top,
+        ...(pos.right != null ? { right: pos.right } : { left: pos.left }),
+        ...(pos.width != null ? { width: pos.width } : {}),
+        ...(pos.maxHeight != null ? { maxHeight: pos.maxHeight, overflowY: "scroll" } : {}),
+        backgroundColor: t.selectorBg,
+        backdropFilter: t.selectorBlur ? "blur(20px)" : undefined,
+        WebkitBackdropFilter: t.selectorBlur ? "blur(20px)" : undefined,
+        border: `1.5px solid ${t.sliderAccent}40`,
+        borderRadius: 6,
+        boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
+        zIndex: 9999,
+        fontFamily: "inherit",
+        willChange: "transform",
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  return ReactDOM.createPortal(panel, document.body);
+});
+
+export default DropdownPanel;


### PR DESCRIPTION
## Summary

- Extracts a new `DropdownPanel` shared component (`src/components/layout/DropdownPanel.tsx`) that encapsulates portal rendering, outside-click/Escape close, and the `selectorBg`/`selectorBlur`/`sliderAccent` theme styling used by the lens selector
- Refactors `LensSelector` to use `DropdownPanel` via `React.forwardRef` (scroll-to-center behavior preserved)
- Converts the BreadcrumbBar settings dropdown from an inline expanding row (which shifted page content down) to a right-aligned `DropdownPanel` overlay that floats above the page

## Test plan

- [ ] LensSelector opens and closes correctly (Escape, outside click, trigger toggle)
- [ ] LensSelector scrolls to the selected item on open
- [ ] Settings button opens a floating panel that does not push page content down
- [ ] Settings panel closes on Escape and outside click
- [ ] HC and Dark/Light toggles still work from the settings panel
- [ ] Dark, Light, DarkHC, LightHC themes all apply correct `selectorBg` opacity and backdrop blur to both dropdowns
- [ ] `npm run typecheck`, `npm run test`, `npm run lint` all pass

https://claude.ai/code/session_01LBAbYoujUacDnprrXyQbaP