### PR TITLE
Fix on-axis rays tracing outside aperture stop

### DIFF
--- a/__tests__/buildLens.test.ts
+++ b/__tests__/buildLens.test.ts
@@ -95,9 +95,9 @@ describe("buildLens — production lenses", () => {
   });
 
   /* ── f-number regression tests ── */
-  it("ApoLanthar FOPEN ≈ f/1.93", () => {
+  it("ApoLanthar FOPEN ≈ f/2.04 (real-ray EP)", () => {
     const L = buildLens(ApoLanthar);
-    expect(L.FOPEN).toBeCloseTo(1.93, 1);
+    expect(L.FOPEN).toBeCloseTo(2.04, 1);
   });
 
   it("Nokton FOPEN ≈ f/1.0", () => {

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -71,6 +71,100 @@ function paraxialTrace(
 }
 
 /**
+ * Surface-normal slope dz/dh from raw parameters (R, aspheric coefficients).
+ *
+ * Same math as sagSlope() in optics.ts but operates on raw surface parameters
+ * instead of a RuntimeLens object — needed during buildLens() before L exists.
+ */
+function _sagSlope(h: number, R: number, asph: AsphericCoefficients | undefined): number {
+  if (Math.abs(R) > FLAT_R_THRESHOLD && !asph) return 0;
+  const c = Math.abs(R) > FLAT_R_THRESHOLD ? 0 : 1.0 / R;
+  const K = asph ? asph.K : 0;
+  const h2 = h * h;
+  const denom2 = 1 - (1 + K) * c * c * h2;
+  const conicSlope = (c * h) / Math.sqrt(denom2 > 0 ? denom2 : 1e-12);
+  if (!asph) return conicSlope;
+  return (
+    conicSlope +
+    h *
+      (4 * asph.A4 * h2 +
+        6 * asph.A6 * h2 * h2 +
+        8 * asph.A8 * h2 ** 3 +
+        10 * asph.A10 * h2 ** 4 +
+        12 * asph.A12 * h2 ** 5 +
+        14 * asph.A14 * h2 ** 6)
+  );
+}
+
+/**
+ * Real (exact Snell's law) ray trace from the first surface to the stop.
+ *
+ * Unlike paraxialTrace which uses the linear u' = (n·u − y·φ)/n' formula,
+ * this applies exact Snell's law with aspheric surface normals — matching
+ * the rendering engine (_traceRayCore in optics.ts).  Used to compute a
+ * corrected entrance pupil SD that accounts for spherical aberration and
+ * aspheric deviations from the paraxial model.
+ *
+ * @returns ray height at the stop surface, or NaN on TIR
+ */
+function realTraceToStop(
+  S: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  y0: number,
+  u0: number,
+  stopIdx: number,
+): number {
+  let y = y0,
+    U = Math.atan(u0),
+    n = 1.0;
+  for (let i = 0; i < stopIdx; i++) {
+    const { R, nd, d } = S[i];
+    const nn = nd === 1.0 ? 1.0 : nd;
+    if (nn !== n) {
+      const absY = Math.abs(y);
+      const slope = _sagSlope(absY, R, asphByIdx[i]);
+      const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
+      const sinIp = (n / nn) * Math.sin(U - alpha);
+      if (Math.abs(sinIp) > 1.0) return NaN;
+      U = alpha + Math.asin(sinIp);
+    }
+    n = nn;
+    y += d * Math.tan(U);
+  }
+  return y;
+}
+
+/**
+ * Refine a paraxial entrance pupil estimate using real ray tracing.
+ *
+ * Iteratively adjusts the EP SD so that a real marginal ray (traced with
+ * exact Snell's law including aspherics) arrives at the stop at exactly
+ * the physical stop SD.  Converges in 2-3 iterations for typical lenses.
+ *
+ * Only *decreases* the EP — when real rays overshoot the stop (the visual
+ * bug this fixes).  If the real trace shows rays arriving *below* the stop
+ * SD, the paraxial EP is kept: the stop isn't the true limiting aperture
+ * and increasing the EP would push rays past element semi-diameters.
+ */
+function refineEPWithRealTrace(
+  S: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  paraxialEPSD: number,
+  stopSD: number,
+  stopIdx: number,
+): number {
+  let ep = paraxialEPSD;
+  for (let iter = 0; iter < 3; iter++) {
+    const realY = realTraceToStop(S, asphByIdx, ep, 0, stopIdx);
+    if (!isFinite(realY) || Math.abs(realY) < 1e-15) break;
+    ep *= stopSD / realY;
+    if (ep >= paraxialEPSD) break; /* rays undershoot stop — stop isn't the limit */
+  }
+  /* Only shrink — never enlarge beyond the paraxial EP */
+  return Math.min(ep, paraxialEPSD);
+}
+
+/**
  * Build a frozen runtime lens object from validated LENS_DATA.
  *
  * Pipeline: validate → resolve label indices → derive optical constants
@@ -173,6 +267,10 @@ export default function buildLens(data: LensData): RuntimeLens {
   if (Math.abs(epTrace.y) < 1e-15)
     throw new Error(`Lens "${data.key}": Entrance pupil trace y≈0 at stop — cannot compute entrance pupil`);
   const EP: EntrancePupil = { epSD: S[stopIdx].sd / epTrace.y, yRatio: epTrace.y };
+
+  /* Real EP refinement: the paraxial EP ignores aspherics and higher-order
+   * aberrations.  Refine so a real marginal ray exactly fills the stop. */
+  EP.epSD = refineEPWithRealTrace(S, asphByIdx, EP.epSD, S[stopIdx].sd, stopIdx);
 
   /* B = chief ray height at stop (for vignetting computation below) */
   const B = paraxialTrace(S, 0, 1, { stopAt: stopIdx }).y;
@@ -333,7 +431,8 @@ export default function buildLens(data: LensData): RuntimeLens {
 
       /* Entrance pupil and yRatio */
       const epT = paraxialTrace(tmpS, 1, 0, { stopAt: stopIdx });
-      const epSD = Math.abs(epT.y) > 1e-15 ? tmpS[stopIdx].sd / epT.y : EP.epSD;
+      let epSD = Math.abs(epT.y) > 1e-15 ? tmpS[stopIdx].sd / epT.y : EP.epSD;
+      epSD = refineEPWithRealTrace(tmpS, asphByIdx, epSD, tmpS[stopIdx].sd, stopIdx);
       zoomEPs.push(epSD);
       zoomYRatios.push(epT.y);
 


### PR DESCRIPTION
## Summary

- **Root cause**: The entrance pupil SD was computed using paraxial ray tracing, which ignores aspheric surface terms (K, A4–A14). The diagram traces rays with exact Snell's law including aspherics, so the real marginal ray height at the stop differed from the paraxial prediction — causing rays to visually overshoot the rendered stop blades.
- **Fix**: Add a real (exact Snell's law) ray trace refinement in `buildLens()` that iteratively corrects `EP.epSD` so the real marginal ray exactly fills the physical stop opening. Only shrinks the EP (never enlarges), since increasing it could push rays past element SDs in very fast lenses.
- **Impact**: Most visible on Nikon 60mm f/2.8 G (K=−5.31 aspheric before stop) and ApoLanthar 50mm f/2 (4 aspherics). Lenses without aspherics see no change. ApoLanthar FOPEN shifts from 1.93→2.04 (the real f-number accounting for aspheric ray behavior).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — all 628 tests pass (ApoLanthar FOPEN regression test updated to match new real-ray value)
- [x] `npm run lint` passes
- [x] `npm run format` — all files unchanged
- [ ] Visual verification: Nikon 60mm f/2.8 G on-axis rays align with stop blade tips
- [ ] Visual verification: other lenses (Sonnar, Nokton, Nikkor Z) look correct
- [ ] Visual verification: stopped-down aperture still clips rays correctly

https://claude.ai/code/session_016STt9BdKtN9VGQyCS2MfsL