### PR TITLE
Upgrade pupil positions and half-field to real Snell's law traces

### DIFF
--- a/src/components/hooks/useOffAxisRays.ts
+++ b/src/components/hooks/useOffAxisRays.ts
@@ -49,15 +49,31 @@ export default function useOffAxisRays({
     if (!L || showOffAxis === "off") return [];
     try {
       const out: RaySegment[] = [];
-      /* Zoom-aware field angle and chief ray entry position */
+      /* Zoom-aware field angle and chief ray entry position.
+       * Note: yChief uses the paraxial EP position (B/yRatio), which is
+       * field-independent.  Real entrance pupils shift with field angle due
+       * to pupil aberration (pupil coma), but computing the field-dependent
+       * EP requires iterative real ray tracing — deferred as a known
+       * limitation since the error is small for typical visualization angles. */
       const currentOffAxisDeg = halfFieldAtZoom(zoomT, L) * L.offAxisFieldFrac;
       const uField = -Math.tan((currentOffAxisDeg * Math.PI) / 180);
       const yChief = -(bAtZoom(zoomT, L) / yRatioAtZoom(zoomT, L)) * uField;
 
-      /* Paraxial image height for "edge" mode */
-      const edgeImgH = -(eflAtZoom(zoomT, L) * Math.tan((currentOffAxisDeg * Math.PI) / 180));
-      const edgeEnd: number[] = [sx(IMG_MM), sy(edgeImgH)];
+      /* Image height for "edge" mode — trace a real chief ray to account for
+       * distortion, falling back to the paraxial estimate on failure. */
       const useEdge = ENABLE_EDGE_PROJECTION && showOffAxis === "edge";
+      let edgeImgH: number;
+      if (useEdge) {
+        const chiefTrace = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, false, L);
+        const lastSurfZ = zPos[L.N - 1];
+        const chiefEndY = chiefTrace.y + chiefTrace.u * (IMG_MM - lastSurfZ);
+        edgeImgH = isFinite(chiefEndY)
+          ? chiefEndY
+          : -(eflAtZoom(zoomT, L) * Math.tan((currentOffAxisDeg * Math.PI) / 180));
+      } else {
+        edgeImgH = -(eflAtZoom(zoomT, L) * Math.tan((currentOffAxisDeg * Math.PI) / 180));
+      }
+      const edgeEnd: number[] = [sx(IMG_MM), sy(edgeImgH)];
 
       for (const f of L.offAxisFractions) {
         const h = f * currentEPSD;

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -96,24 +96,32 @@ function _sagSlope(h: number, R: number, asph: AsphericCoefficients | undefined)
   );
 }
 
+/** Result of a real ray trace to an intermediate surface. */
+interface RealTraceToStopResult {
+  y: number;
+  u: number; /* slope = tan(U) at the target surface */
+}
+
 /**
- * Real (exact Snell's law) ray trace from the first surface to the stop.
+ * Real (exact Snell's law) ray trace from the first surface to a target surface.
  *
  * Unlike paraxialTrace which uses the linear u' = (n·u − y·φ)/n' formula,
  * this applies exact Snell's law with aspheric surface normals — matching
- * the rendering engine (_traceRayCore in optics.ts).  Used to compute a
- * corrected entrance pupil SD that accounts for spherical aberration and
- * aspheric deviations from the paraxial model.
+ * the rendering engine (_traceRayCore in optics.ts).  Returns both the ray
+ * height and slope at the target surface.
  *
- * @returns ray height at the stop surface, or NaN on TIR
+ * Used to compute corrected entrance pupil SD and z-position that account
+ * for spherical aberration and aspheric deviations from the paraxial model.
+ *
+ * @returns { y, u } at the target surface, or { y: NaN, u: NaN } on TIR
  */
-function realTraceToStop(
+function realTraceToStopFull(
   S: SurfaceData[],
   asphByIdx: Record<number, AsphericCoefficients>,
   y0: number,
   u0: number,
   stopIdx: number,
-): number {
+): RealTraceToStopResult {
   let y = y0,
     U = Math.atan(u0),
     n = 1.0;
@@ -125,13 +133,89 @@ function realTraceToStop(
       const slope = _sagSlope(absY, R, asphByIdx[i]);
       const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
       const sinIp = (n / nn) * Math.sin(U - alpha);
-      if (Math.abs(sinIp) > 1.0) return NaN;
+      if (Math.abs(sinIp) > 1.0) return { y: NaN, u: NaN };
       U = alpha + Math.asin(sinIp);
     }
     n = nn;
     y += d * Math.tan(U);
   }
-  return y;
+  return { y, u: Math.tan(U) };
+}
+
+/**
+ * Real (exact Snell's law) ray trace from the first surface to the stop.
+ * Convenience wrapper that returns only the ray height.
+ *
+ * @returns ray height at the stop surface, or NaN on TIR
+ */
+function realTraceToStop(
+  S: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  y0: number,
+  u0: number,
+  stopIdx: number,
+): number {
+  return realTraceToStopFull(S, asphByIdx, y0, u0, stopIdx).y;
+}
+
+/** Result of a real ray trace through the full system with per-surface heights. */
+interface RealTraceFullResult extends RealTraceToStopResult {
+  heights: number[];
+  clipped: boolean; /* true if |y| exceeded any surface SD */
+}
+
+/**
+ * Real (exact Snell's law) ray trace through the full system, stopping
+ * after refraction at the last surface (before the final transfer / BFL).
+ * Returns { y, u } at the last surface — the same convention as
+ * paraxialTrace with skipLastTransfer=true.
+ *
+ * @returns { y, u } at the last surface, or { y: NaN, u: NaN } on TIR
+ */
+function realTraceFullSystem(
+  S: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  y0: number,
+  u0: number,
+): RealTraceToStopResult {
+  const r = realTraceFullSystemDetailed(S, asphByIdx, y0, u0);
+  return { y: r.y, u: r.u };
+}
+
+/**
+ * Real (exact Snell's law) ray trace through the full system with
+ * per-surface height recording and vignetting clip detection.
+ * Used for exit pupil computation and half-field refinement.
+ */
+function realTraceFullSystemDetailed(
+  S: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  y0: number,
+  u0: number,
+): RealTraceFullResult {
+  const N = S.length;
+  const heights: number[] = [];
+  let y = y0,
+    U = Math.atan(u0),
+    n = 1.0;
+  let clipped = false;
+  for (let i = 0; i < N; i++) {
+    heights.push(y);
+    const { R, nd, d, sd } = S[i];
+    if (Math.abs(y) > sd) clipped = true;
+    const nn = nd === 1.0 ? 1.0 : nd;
+    if (nn !== n) {
+      const absY = Math.abs(y);
+      const slope = _sagSlope(absY, R, asphByIdx[i]);
+      const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
+      const sinIp = (n / nn) * Math.sin(U - alpha);
+      if (Math.abs(sinIp) > 1.0) return { y: NaN, u: NaN, heights, clipped: true };
+      U = alpha + Math.asin(sinIp);
+    }
+    n = nn;
+    if (i < N - 1) y += d * Math.tan(U);
+  }
+  return { y, u: Math.tan(U), heights, clipped };
 }
 
 /**
@@ -248,26 +332,50 @@ export default function buildLens(data: LensData): RuntimeLens {
   /* B = chief ray height at stop (for vignetting computation below) */
   const B = paraxialTrace(S, 0, 1, { stopAt: stopIdx }).y;
 
-  /* Entrance pupil z-position (absolute from z=0) = B / yRatio, derived from
-   * the two-ray decomposition: a chief ray through the stop center (y_stop=0)
-   * satisfies y_in = -(B/yRatio)·u_in, which crosses the axis at z = B/yRatio.
-   * epZRelStop is the offset from the stop's baseline z-position. */
+  /* Entrance pupil z-position — use real (Snell's law) two-ray decomposition.
+   * Trace a small marginal ray (y=δ, u=0) and a small chief ray (y=0, u=δ)
+   * through the front group to the stop using exact refraction.  The real
+   * yRatio and B are the ray heights at the stop (normalized by δ), so
+   * epZ = realB / realYRatio gives the z where the chief ray crosses the axis.
+   * Falls back to paraxial if the real traces hit TIR. */
   let zStopBaseline = 0;
   for (let i = 0; i < stopIdx; i++) zStopBaseline += S[i].d;
-  const epZRelStop = Math.abs(epTrace.y) > 1e-9 ? B / epTrace.y - zStopBaseline : 0;
+  const realEpDelta = 1e-4;
+  const realMarginal = realTraceToStopFull(S, asphByIdx, realEpDelta, 0, stopIdx);
+  const realChief = realTraceToStopFull(S, asphByIdx, 0, realEpDelta, stopIdx);
+  const realYRatio = isFinite(realMarginal.y) ? realMarginal.y / realEpDelta : epTrace.y;
+  const realB = isFinite(realChief.y) ? realChief.y / realEpDelta : B;
+  const epZRelStop = Math.abs(realYRatio) > 1e-9 ? realB / realYRatio - zStopBaseline : 0;
 
-  /* Exit pupil: construct the chief ray that actually passes through the stop
-   * center (y=0 at stop) by combining the two full-system basis rays.
-   * The basis chief ray (y=0, u=1) hits the stop at y=B ≠ 0, so we use the
-   * two-ray decomposition: the stop-center chief ray at z=0 is (y=−B, u=yRatio).
-   * At the last surface this gives y_last = yRatio·chiefFull.y − eflTrace.y·B
-   * and u_last = yRatio·chiefFull.u − eflTrace.u·B.  Back-projecting finds XP.
-   * xpSD scales the unit marginal ray height to physical mm via EP.epSD. */
-  const chiefFull = paraxialTrace(S, 0, 1, { skipLastTransfer: true });
-  const xpNumer = -(epTrace.y * chiefFull.y - eflTrace.y * B);
-  const xpDenom = epTrace.y * chiefFull.u - eflTrace.u * B;
-  const xpZRelLastSurf = Math.abs(xpDenom) > 1e-9 ? xpNumer / xpDenom : 0;
-  const xpSD = Math.abs(eflTrace.y + eflTrace.u * xpZRelLastSurf) * EP.epSD;
+  /* Exit pupil: use real (Snell's law) two-ray decomposition through the
+   * full system.  Trace small marginal (y=δ, u=0) and chief (y=0, u=δ)
+   * rays with exact refraction, then combine to find the chief ray that
+   * passes through the stop center.  Back-project from the last surface
+   * to find XP position and size.  Falls back to paraxial on TIR. */
+  const realMargFull = realTraceFullSystem(S, asphByIdx, realEpDelta, 0);
+  const realChiefFull = realTraceFullSystem(S, asphByIdx, 0, realEpDelta);
+  let xpZRelLastSurf: number;
+  let xpSD: number;
+  if (isFinite(realMargFull.y) && isFinite(realChiefFull.y)) {
+    /* Normalize to unit-input basis rays (divide out δ) */
+    const mY = realMargFull.y / realEpDelta,
+      mU = realMargFull.u / realEpDelta;
+    const cY = realChiefFull.y / realEpDelta,
+      cU = realChiefFull.u / realEpDelta;
+    /* Two-ray decomposition: stop-center chief = yRatio·chief − B·marginal
+     * (using real yRatio and B from the front-group traces above) */
+    const xpY = realYRatio * cY - realB * mY;
+    const xpU = realYRatio * cU - realB * mU;
+    xpZRelLastSurf = Math.abs(xpU) > 1e-9 ? -xpY / xpU : 0;
+    xpSD = Math.abs(mY + mU * xpZRelLastSurf) * EP.epSD;
+  } else {
+    /* Fallback: paraxial exit pupil */
+    const chiefFull = paraxialTrace(S, 0, 1, { skipLastTransfer: true });
+    const xpNumer = -(epTrace.y * chiefFull.y - eflTrace.y * B);
+    const xpDenom = epTrace.y * chiefFull.u - eflTrace.u * B;
+    xpZRelLastSurf = Math.abs(xpDenom) > 1e-9 ? xpNumer / xpDenom : 0;
+    xpSD = Math.abs(eflTrace.y + eflTrace.u * xpZRelLastSurf) * EP.epSD;
+  }
 
   const stopPhysSD = S[stopIdx].sd;
   const FOPEN = EFL / (2 * EP.epSD); /* wide-open f-number */
@@ -295,9 +403,36 @@ export default function buildLens(data: LensData): RuntimeLens {
       if (uMax < minU) minU = uMax;
     }
   }
-  const halfField = (Math.atan(minU) * 180) / Math.PI;
-  if (!isFinite(halfField))
+  const halfFieldParaxial = (Math.atan(minU) * 180) / Math.PI;
+  if (!isFinite(halfFieldParaxial))
     throw new Error(`Lens "${data.key}": Half-field angle is not finite — vignetting computation failed`);
+
+  /* Refine half-field with real (Snell's law) chief ray vignetting check.
+   * The paraxial two-ray model can overestimate the field angle for strongly
+   * curved or aspheric front groups.  Bisect to find the real clipping angle.
+   * Uses the real EP position (realB/realYRatio) for chief ray entry. */
+  let halfField = halfFieldParaxial;
+  {
+    const epRatio = Math.abs(realYRatio) > 1e-9 ? realB / realYRatio : B / epTrace.y;
+    const testChief = (deg: number): boolean => {
+      const uTest = -Math.tan((deg * Math.PI) / 180);
+      const yIn = -epRatio * uTest;
+      const result = realTraceFullSystemDetailed(S, asphByIdx, yIn, uTest);
+      return isFinite(result.y) && !result.clipped;
+    };
+    if (!testChief(halfFieldParaxial)) {
+      /* Paraxial overestimates — bisect downward */
+      let lo = 0,
+        hi = halfFieldParaxial;
+      for (let iter = 0; iter < 20; iter++) {
+        const mid = (lo + hi) / 2;
+        if (testChief(mid)) lo = mid;
+        else hi = mid;
+      }
+      halfField = lo;
+    }
+    /* If the paraxial field passes the real check, keep it (conservative). */
+  }
 
   /* ── Petzval sum ──
    * P = Σ (n'−n) / (n'·n·R) over all refracting surfaces.
@@ -415,32 +550,72 @@ export default function buildLens(data: LensData): RuntimeLens {
       const zBValue = paraxialTrace(tmpS, 0, 1, { stopAt: stopIdx }).y;
       zoomBs.push(zBValue);
 
-      /* Pupil positions at this zoom position (same derivation as baseline) */
+      /* Pupil positions at this zoom position — real (Snell's law) traces */
       let zStopBaselineZ = 0;
       for (let i = 0; i < stopIdx; i++) zStopBaselineZ += tmpS[i].d;
-      const zEpRelStop = Math.abs(epT.y) > 1e-9 ? zBValue / epT.y - zStopBaselineZ : 0;
+      const zRealMarg = realTraceToStopFull(tmpS, asphByIdx, realEpDelta, 0, stopIdx);
+      const zRealChief = realTraceToStopFull(tmpS, asphByIdx, 0, realEpDelta, stopIdx);
+      const zRealYRatio = isFinite(zRealMarg.y) ? zRealMarg.y / realEpDelta : epT.y;
+      const zRealB = isFinite(zRealChief.y) ? zRealChief.y / realEpDelta : zBValue;
+      const zEpRelStop = Math.abs(zRealYRatio) > 1e-9 ? zRealB / zRealYRatio - zStopBaselineZ : 0;
       zoomEpZRelStops.push(zEpRelStop);
-      const zChiefFull = paraxialTrace(tmpS, 0, 1, { skipLastTransfer: true });
-      const zXpNumer = -(epT.y * zChiefFull.y - zMargLast.y * zBValue);
-      const zXpDenom = epT.y * zChiefFull.u - zMargLast.u * zBValue;
-      const zXpRelLast = Math.abs(zXpDenom) > 1e-9 ? zXpNumer / zXpDenom : 0;
-      zoomXpZRelLastSurfs.push(zXpRelLast);
-      zoomXpSDs.push(Math.abs(zMargLast.y + zMargLast.u * zXpRelLast) * zNomEP);
 
-      /* Half-field (vignetting-limited) */
+      /* Exit pupil — real full-system two-ray decomposition */
+      const zRealMargFull = realTraceFullSystem(tmpS, asphByIdx, realEpDelta, 0);
+      const zRealChiefFull = realTraceFullSystem(tmpS, asphByIdx, 0, realEpDelta);
+      if (isFinite(zRealMargFull.y) && isFinite(zRealChiefFull.y)) {
+        const zmY = zRealMargFull.y / realEpDelta,
+          zmU = zRealMargFull.u / realEpDelta;
+        const zcY = zRealChiefFull.y / realEpDelta,
+          zcU = zRealChiefFull.u / realEpDelta;
+        const zXpY = zRealYRatio * zcY - zRealB * zmY;
+        const zXpU = zRealYRatio * zcU - zRealB * zmU;
+        const zXpRelLast = Math.abs(zXpU) > 1e-9 ? -zXpY / zXpU : 0;
+        zoomXpZRelLastSurfs.push(zXpRelLast);
+        zoomXpSDs.push(Math.abs(zmY + zmU * zXpRelLast) * zNomEP);
+      } else {
+        /* Fallback: paraxial exit pupil */
+        const zChiefFull = paraxialTrace(tmpS, 0, 1, { skipLastTransfer: true });
+        const zXpNumer = -(epT.y * zChiefFull.y - zMargLast.y * zBValue);
+        const zXpDenom = epT.y * zChiefFull.u - zMargLast.u * zBValue;
+        const zXpRelLast = Math.abs(zXpDenom) > 1e-9 ? zXpNumer / zXpDenom : 0;
+        zoomXpZRelLastSurfs.push(zXpRelLast);
+        zoomXpSDs.push(Math.abs(zMargLast.y + zMargLast.u * zXpRelLast) * zNomEP);
+      }
+
+      /* Half-field (vignetting-limited) — paraxial estimate refined with real ray */
       const zA = paraxialTrace(tmpS, 1, 0, { skipLastTransfer: true, recordHeights: true }).heights!;
-      const zB = paraxialTrace(tmpS, 0, 1, { skipLastTransfer: true, recordHeights: true }).heights!;
-      const zr = Math.abs(zA[stopIdx]) > 1e-15 ? zB[stopIdx] / zA[stopIdx] : r;
+      const zB2 = paraxialTrace(tmpS, 0, 1, { skipLastTransfer: true, recordHeights: true }).heights!;
+      const zr = Math.abs(zA[stopIdx]) > 1e-15 ? zB2[stopIdx] / zA[stopIdx] : r;
       let zMinU = Infinity;
       for (let j = 0; j < N; j++) {
         if (j === stopIdx) continue;
-        const coeff = Math.abs(zB[j] - zr * zA[j]);
+        const coeff = Math.abs(zB2[j] - zr * zA[j]);
         if (coeff > 1e-8) {
           const uMax = tmpS[j].sd / coeff;
           if (uMax < zMinU) zMinU = uMax;
         }
       }
-      zoomHalfFields.push((Math.atan(zMinU) * 180) / Math.PI);
+      let zHalfField = (Math.atan(zMinU) * 180) / Math.PI;
+      /* Refine with real chief ray bisection (same as baseline) */
+      const zEpRatio = Math.abs(zRealYRatio) > 1e-9 ? zRealB / zRealYRatio : zBValue / epT.y;
+      const zTestChief = (deg: number): boolean => {
+        const uTest = -Math.tan((deg * Math.PI) / 180);
+        const yIn = -zEpRatio * uTest;
+        const result = realTraceFullSystemDetailed(tmpS, asphByIdx, yIn, uTest);
+        return isFinite(result.y) && !result.clipped;
+      };
+      if (isFinite(zHalfField) && !zTestChief(zHalfField)) {
+        let lo = 0,
+          hi = zHalfField;
+        for (let iter = 0; iter < 20; iter++) {
+          const mid = (lo + hi) / 2;
+          if (zTestChief(mid)) lo = mid;
+          else hi = mid;
+        }
+        zHalfField = lo;
+      }
+      zoomHalfFields.push(zHalfField);
     }
   }
 

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -474,7 +474,9 @@ export function computeChromaticSpread(
  * Uses the paraxial (small-angle) refraction formula:
  *   u' = (n·u − y·(n'−n)/R) / n'
  * This is faster than traceRay but only accurate for rays near the axis.
- * Used by conjugateK as a fast initial estimate.
+ * Not used in production code paths — conjugateK uses traceToImageReal
+ * for self-consistency with the rendering engine.  Retained as a paraxial
+ * reference for testing (e.g. comparing real vs paraxial image heights).
  *
  * @param y0      — initial ray height (mm)
  * @param u0      — initial ray slope


### PR DESCRIPTION
## Summary

- **Entrance pupil z-position**: Replaced paraxial `B/yRatio` with real (Snell's law) two-ray decomposition through the front group, giving more accurate EP marker placement for retrofocus and aspheric designs
- **Exit pupil position & size**: Replaced paraxial basis-ray computation with real full-system two-ray decomposition for accurate XP marker placement
- **Half-field angle**: Added bisection refinement using a real chief ray vignetting check after the paraxial estimate — prevents overestimating the field angle on wide-angle lenses with strongly curved front groups
- **Edge projection image height**: Replaced `-(EFL × tan(angle))` with a real chief ray trace that accounts for distortion (feature-flagged off, ready when enabled)
- **Zoom lenses**: All above changes applied to per-zoom-position arrays (`zoomEpZRelStops`, `zoomXpZRelLastSurfs`, `zoomXpSDs`, `zoomHalfFields`)
- Fixed stale `traceToImage()` docstring and documented the known off-axis pupil aberration limitation

All changes fall back to paraxial values on TIR (total internal reflection). Quantities that are paraxial by definition (EFL, Petzval sum, f-number) are unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — all 628 tests pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [ ] Visual check: compare pupil marker positions before/after on aspheric lenses (e.g. Nikon 60mm Micro)
- [ ] Visual check: verify off-axis rays at wide field angles on retrofocus wide-angle lenses

https://claude.ai/code/session_017VGCtcWMsKCDQyhzFa4BZe