### PR TITLE
Simplify Abbe diagram labels to reduce visual clutter

### DIFF
--- a/src/components/display/AbbeDiagram.tsx
+++ b/src/components/display/AbbeDiagram.tsx
@@ -142,7 +142,7 @@ export default function AbbeDiagram({ L, t }: AbbeDiagramProps) {
           fontFamily="inherit"
           letterSpacing="0.06em"
         >
-          Abbe number Vd → (low dispersion)
+          Abbe number Vd →
         </text>
         <text
           x={14}
@@ -169,7 +169,7 @@ export default function AbbeDiagram({ L, t }: AbbeDiagramProps) {
           return (
             <g key={e.id}>
               {/* Dot */}
-              <circle cx={px} cy={py} r={7} fill={fill} stroke={stroke} strokeWidth={1.5} />
+              <circle cx={px} cy={py} r={8} fill={fill} stroke={stroke} strokeWidth={1.5} />
               {/* Element name inside dot */}
               <text
                 x={px}
@@ -182,19 +182,8 @@ export default function AbbeDiagram({ L, t }: AbbeDiagramProps) {
               >
                 {e.name}
               </text>
-              {/* Glass label (element name + glass type) */}
-              <text
-                x={px + dx}
-                y={py - 5}
-                textAnchor={anchor}
-                fontSize={8.5}
-                fontWeight={600}
-                fill={labelColor}
-                fontFamily="inherit"
-              >
-                {e.name}
-              </text>
-              <text x={px + dx} y={py + 6} textAnchor={anchor} fontSize={7.5} fill={mutedColor} fontFamily="inherit">
+              {/* Glass type label — above and offset from dot */}
+              <text x={px + dx} y={py - 11} textAnchor={anchor} fontSize={7.5} fill={mutedColor} fontFamily="inherit">
                 {glassLabel}
               </text>
             </g>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove redundant element name label shown outside each dot (the name is already inside the dot, so showing it again externally was pure visual noise)
- Move glass type label from below the dot (`py + 6`, which was inside the dot's radius) to above the dot (`py - 11`), clearing the dot stroke and reducing stacking on dense charts
- Increase dot radius from 7 → 8 for better legibility of the name inside the dot
- Shorten verbose Vd axis label from `"Abbe number Vd → (low dispersion)"` to `"Abbe number Vd →"` (less text competing in the bottom margin)

Closes #256

## Test plan

- [ ] `npm run typecheck && npm run format:check && npm run lint && npm run test` — all pass
- [ ] Open a lens with many elements (e.g. NikonNikkorZ70200f28) → open Abbe diagram → verify labels are readable and non-overlapping
- [ ] Check a lens with missing Vd data → footnote and axis label no longer collide

https://claude.ai/code/session_019sAsQoCCQpfQm3NvgLkiPr
EOF
)