### PR TITLE
feat: create real homepage with articles, nav bar, and theme controls

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -44,8 +44,21 @@ function extractLensInfo(filePath) {
 /** Collect all routes to prerender. */
 function collectRoutes() {
   const dataFiles = readdirSync(LENS_DATA_DIR).filter((f) => f.endsWith(".data.ts"));
-  const routes = ["/", "/lenses", "/makers"];
+  const routes = ["/", "/lenses", "/makers", "/articles"];
   const makers = new Set();
+
+  /* Article slugs for standalone article pages */
+  const articleSlugs = [
+    "optics-primer",
+    "optics-primer-intermediate",
+    "aberrations-primer",
+    "aberrations-primer-intermediate",
+    "about-site",
+    "about-author",
+  ];
+  for (const slug of articleSlugs) {
+    routes.push(`/articles/${slug}`);
+  }
 
   for (const file of dataFiles) {
     const { key, name } = extractLensInfo(join(LENS_DATA_DIR, file));

--- a/src/components/homepage/ArticleCard.tsx
+++ b/src/components/homepage/ArticleCard.tsx
@@ -1,0 +1,65 @@
+/**
+ * ArticleCard — reusable summary card for a single article.
+ *
+ * Used on both the homepage (limited list) and the articles archive page.
+ */
+
+import { Link } from "react-router";
+import type { Theme } from "../../types/theme.js";
+import type { HomepageArticle } from "../../utils/homepageContent.js";
+
+interface ArticleCardProps {
+  article: HomepageArticle;
+  theme: Theme;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+const TAG_COLORS: Record<string, string> = {
+  guide: "#2a7",
+  article: "#58c",
+  announcement: "#c84",
+};
+
+export default function ArticleCard({ article, theme: t }: ArticleCardProps) {
+  return (
+    <Link
+      to={article.linkTo}
+      style={{
+        display: "block",
+        padding: "0.875rem 1rem",
+        marginBottom: "0.5rem",
+        borderRadius: 6,
+        border: `1px solid ${t.panelBorder}`,
+        background: t.panelBg,
+        textDecoration: "none",
+        transition: "border-color 0.2s",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.3rem" }}>
+        <span style={{ fontSize: "0.875rem", fontWeight: 600, color: t.descLinkColor }}>{article.title}</span>
+        {article.tag && (
+          <span
+            style={{
+              fontSize: "0.6rem",
+              padding: "1px 6px",
+              borderRadius: 3,
+              background: `${TAG_COLORS[article.tag] ?? t.toggleActiveBg}22`,
+              color: TAG_COLORS[article.tag] ?? t.toggleActiveText,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              fontWeight: 600,
+            }}
+          >
+            {article.tag}
+          </span>
+        )}
+      </div>
+      <div style={{ fontSize: "0.7rem", color: t.label, marginBottom: "0.3rem" }}>{formatDate(article.date)}</div>
+      <div style={{ fontSize: "0.8rem", color: t.muted, lineHeight: 1.5 }}>{article.summary}</div>
+    </Link>
+  );
+}

--- a/src/components/homepage/ArticleList.tsx
+++ b/src/components/homepage/ArticleList.tsx
@@ -1,0 +1,55 @@
+/**
+ * ArticleList — section heading + list of ArticleCards.
+ *
+ * Shows a "View all articles" link when there are more articles
+ * than the displayed slice.
+ */
+
+import { Link } from "react-router";
+import type { Theme } from "../../types/theme.js";
+import type { HomepageArticle } from "../../utils/homepageContent.js";
+import ArticleCard from "./ArticleCard.js";
+
+interface ArticleListProps {
+  articles: HomepageArticle[];
+  theme: Theme;
+  showMoreLink?: boolean;
+}
+
+export default function ArticleList({ articles, theme: t, showMoreLink }: ArticleListProps) {
+  if (articles.length === 0) return null;
+
+  return (
+    <section style={{ marginBottom: "2.5rem" }}>
+      <h2
+        style={{
+          fontSize: "1.125rem",
+          fontWeight: 600,
+          color: t.body,
+          marginBottom: "1rem",
+          paddingBottom: "0.25rem",
+          borderBottom: `1px solid ${t.panelBorder}`,
+        }}
+      >
+        Articles &amp; Guides
+      </h2>
+      {articles.map((article) => (
+        <ArticleCard key={article.slug} article={article} theme={t} />
+      ))}
+      {showMoreLink && (
+        <Link
+          to="/articles"
+          style={{
+            display: "inline-block",
+            marginTop: "0.75rem",
+            fontSize: "0.8rem",
+            color: t.descLinkColor,
+            textDecoration: "none",
+          }}
+        >
+          View all articles →
+        </Link>
+      )}
+    </section>
+  );
+}

--- a/src/components/homepage/HeroSection.tsx
+++ b/src/components/homepage/HeroSection.tsx
@@ -1,0 +1,53 @@
+/**
+ * HeroSection — site hero with name, tagline, and description.
+ */
+
+import type { Theme } from "../../types/theme.js";
+import useMediaQuery from "../../utils/useMediaQuery.js";
+
+interface HeroSectionProps {
+  theme: Theme;
+}
+
+export default function HeroSection({ theme: t }: HeroSectionProps) {
+  const isWide = useMediaQuery("(min-width: 720px)");
+
+  return (
+    <section style={{ textAlign: "center", padding: isWide ? "3rem 1rem 2rem" : "2rem 0.5rem 1.5rem" }}>
+      <h1
+        style={{
+          fontSize: isWide ? "2.25rem" : "1.75rem",
+          fontWeight: 700,
+          color: t.title,
+          margin: "0 0 0.5rem",
+          letterSpacing: "-0.02em",
+        }}
+      >
+        Optical Bench
+      </h1>
+      <p
+        style={{
+          fontSize: isWide ? "1rem" : "0.875rem",
+          color: t.subtitle,
+          margin: "0 0 1.25rem",
+          letterSpacing: "0.04em",
+          fontWeight: 500,
+        }}
+      >
+        Interactive Camera Lens Cross-Section Visualizer
+      </p>
+      <p
+        style={{
+          fontSize: isWide ? "0.85rem" : "0.8rem",
+          color: t.muted,
+          maxWidth: 560,
+          margin: "0 auto",
+          lineHeight: 1.6,
+        }}
+      >
+        Explore real camera lens designs built from optical patent data. Trace rays through multi-element systems,
+        adjust focus and aperture in real time, inspect individual elements, and analyze chromatic aberrations.
+      </p>
+    </section>
+  );
+}

--- a/src/components/homepage/HomeFooter.tsx
+++ b/src/components/homepage/HomeFooter.tsx
@@ -1,0 +1,45 @@
+/**
+ * HomeFooter — minimal footer for the homepage.
+ */
+
+import { Link } from "react-router";
+import type { Theme } from "../../types/theme.js";
+
+interface HomeFooterProps {
+  theme: Theme;
+}
+
+export default function HomeFooter({ theme: t }: HomeFooterProps) {
+  const linkStyle: React.CSSProperties = {
+    color: t.descLinkColor,
+    textDecoration: "none",
+    fontSize: "0.75rem",
+  };
+
+  return (
+    <footer
+      style={{
+        borderTop: `1px solid ${t.panelBorder}`,
+        paddingTop: "1.5rem",
+        marginTop: "1rem",
+        display: "flex",
+        justifyContent: "center",
+        gap: "1.5rem",
+        flexWrap: "wrap",
+      }}
+    >
+      <Link to="/lenses" style={linkStyle}>
+        Lens Library
+      </Link>
+      <Link to="/makers" style={linkStyle}>
+        Makers
+      </Link>
+      <Link to="/articles" style={linkStyle}>
+        Articles
+      </Link>
+      <Link to="/articles/about-site" style={linkStyle}>
+        About
+      </Link>
+    </footer>
+  );
+}

--- a/src/components/homepage/QuickNavCards.tsx
+++ b/src/components/homepage/QuickNavCards.tsx
@@ -1,0 +1,78 @@
+/**
+ * QuickNavCards — navigation card grid for the homepage.
+ *
+ * Three cards linking to the lens library, makers index, and the
+ * interactive viewer (first lens in the catalog).
+ */
+
+import { Link } from "react-router";
+import type { Theme } from "../../types/theme.js";
+import { CATALOG_KEYS, LENS_CATALOG } from "../../utils/lensCatalog.js";
+import { deriveMaker } from "../../utils/lensMetadata.js";
+import useMediaQuery from "../../utils/useMediaQuery.js";
+
+interface QuickNavCardsProps {
+  theme: Theme;
+}
+
+function countMakers(): number {
+  const slugs = new Set<string>();
+  for (const key of CATALOG_KEYS) {
+    slugs.add(deriveMaker(LENS_CATALOG[key].name, LENS_CATALOG[key].maker).slug);
+  }
+  return slugs.size;
+}
+
+interface CardDef {
+  title: string;
+  subtitle: string;
+  to: string;
+}
+
+export default function QuickNavCards({ theme: t }: QuickNavCardsProps) {
+  const isWide = useMediaQuery("(min-width: 720px)");
+  const makerCount = countMakers();
+  const firstLens = CATALOG_KEYS[0];
+
+  const cards: CardDef[] = [
+    { title: "Lens Library", subtitle: `${CATALOG_KEYS.length} interactive diagrams`, to: "/lenses" },
+    { title: "Browse by Maker", subtitle: `${makerCount} manufacturers`, to: "/makers" },
+    {
+      title: "Open Viewer",
+      subtitle: firstLens ? LENS_CATALOG[firstLens].name : "Explore a lens",
+      to: firstLens ? `/lens/${firstLens}` : "/lenses",
+    },
+  ];
+
+  const cardStyle = (hoverable: boolean): React.CSSProperties => ({
+    flex: isWide ? 1 : undefined,
+    background: t.panelBg,
+    border: `1px solid ${t.panelBorder}`,
+    borderRadius: 8,
+    padding: isWide ? "1.25rem 1.5rem" : "1rem 1.25rem",
+    textDecoration: "none",
+    display: "block",
+    transition: "border-color 0.2s, box-shadow 0.2s",
+    ...(hoverable ? {} : {}),
+  });
+
+  return (
+    <section
+      style={{
+        display: "flex",
+        flexDirection: isWide ? "row" : "column",
+        gap: isWide ? "1rem" : "0.75rem",
+        margin: "0 0 2.5rem",
+      }}
+    >
+      {cards.map((card) => (
+        <Link key={card.to} to={card.to} style={cardStyle(true)}>
+          <div style={{ fontSize: "0.9rem", fontWeight: 600, color: t.descLinkColor, marginBottom: "0.35rem" }}>
+            {card.title}
+          </div>
+          <div style={{ fontSize: "0.75rem", color: t.muted, lineHeight: 1.4 }}>{card.subtitle}</div>
+        </Link>
+      ))}
+    </section>
+  );
+}

--- a/src/components/homepage/RecentLenses.tsx
+++ b/src/components/homepage/RecentLenses.tsx
@@ -1,0 +1,72 @@
+/**
+ * RecentLenses — section showing recently added lens announcements.
+ *
+ * Each announcement references a lens catalog key; name and specs
+ * are derived from the catalog automatically. Entries with invalid
+ * keys are silently skipped.
+ */
+
+import { Link } from "react-router";
+import type { Theme } from "../../types/theme.js";
+import type { LensAnnouncement } from "../../utils/homepageContent.js";
+import { LENS_CATALOG } from "../../utils/lensCatalog.js";
+
+interface RecentLensesProps {
+  announcements: LensAnnouncement[];
+  theme: Theme;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default function RecentLenses({ announcements, theme: t }: RecentLensesProps) {
+  const valid = announcements.filter((a) => LENS_CATALOG[a.lensKey]);
+  if (valid.length === 0) return null;
+
+  return (
+    <section style={{ marginBottom: "2.5rem" }}>
+      <h2
+        style={{
+          fontSize: "1.125rem",
+          fontWeight: 600,
+          color: t.body,
+          marginBottom: "1rem",
+          paddingBottom: "0.25rem",
+          borderBottom: `1px solid ${t.panelBorder}`,
+        }}
+      >
+        Recently Added
+      </h2>
+      {valid.map((a) => {
+        const lens = LENS_CATALOG[a.lensKey];
+        return (
+          <Link
+            key={a.lensKey}
+            to={`/lens/${a.lensKey}`}
+            style={{
+              display: "block",
+              padding: "0.75rem 1rem",
+              marginBottom: "0.5rem",
+              borderRadius: 6,
+              border: `1px solid ${t.panelBorder}`,
+              background: t.panelBg,
+              textDecoration: "none",
+              transition: "border-color 0.2s",
+            }}
+          >
+            <div style={{ fontSize: "0.875rem", fontWeight: 600, color: t.descLinkColor }}>{lens.name}</div>
+            <div style={{ fontSize: "0.7rem", color: t.label, margin: "0.2rem 0" }}>{formatDate(a.date)}</div>
+            {lens.specs && lens.specs.length > 0 && (
+              <div style={{ fontSize: "0.75rem", color: t.muted, marginBottom: "0.2rem" }}>
+                {lens.specs.slice(0, 3).join(" · ")}
+              </div>
+            )}
+            <div style={{ fontSize: "0.8rem", color: t.muted, lineHeight: 1.5 }}>{a.blurb}</div>
+          </Link>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/components/layout/PageNavBar.tsx
+++ b/src/components/layout/PageNavBar.tsx
@@ -1,0 +1,76 @@
+/**
+ * PageNavBar — shared navigation bar for static pages.
+ *
+ * Renders a top bar with breadcrumb content on the left and theme toggle
+ * buttons (Dark/Light + High Contrast) on the right. Used on all static
+ * pages (homepage, articles, lenses index, makers index, etc.).
+ *
+ * The interactive LensViewer keeps its own BreadcrumbBar which has
+ * additional lens-specific context and settings.
+ */
+
+import type { ReactNode } from "react";
+import type { Theme } from "../../types/theme.js";
+import { headerStrip, toggleGroup, toggleBtn } from "../../utils/styles.js";
+import useMediaQuery from "../../utils/useMediaQuery.js";
+
+interface PageNavBarProps {
+  theme: Theme;
+  dark: boolean;
+  highContrast: boolean;
+  onToggleDark: () => void;
+  onToggleHC: () => void;
+  children?: ReactNode;
+}
+
+export default function PageNavBar({
+  theme: t,
+  dark,
+  highContrast,
+  onToggleDark,
+  onToggleHC,
+  children,
+}: PageNavBarProps) {
+  const isWide = useMediaQuery("(min-width: 720px)");
+  const padding = isWide ? "6px 24px" : "6px 12px";
+
+  return (
+    <nav
+      style={{
+        ...headerStrip(t, { padding }),
+        fontSize: isWide ? 11 : 10,
+        fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        position: "sticky",
+        top: 0,
+        zIndex: 100,
+      }}
+    >
+      <div
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          minWidth: 0,
+        }}
+      >
+        {children}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0, marginLeft: 12 }}>
+        <div style={toggleGroup(t)}>
+          <button onClick={onToggleHC} style={toggleBtn(t, highContrast)}>
+            <span style={{ fontSize: 12, lineHeight: 1, fontWeight: 700 }}>◐</span>
+            <span>HC</span>
+          </button>
+          <button onClick={onToggleDark} style={toggleBtn(t, false, { hasRightBorder: false })}>
+            <span style={{ fontSize: 14, lineHeight: 1 }}>{t.toggleIcon}</span>
+            <span>{dark ? "Light" : "Dark"}</span>
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -1,0 +1,205 @@
+/**
+ * Individual article page — /articles/:slug
+ *
+ * Renders a standalone article from the ARTICLE_CONTENT registry
+ * using react-markdown with theme-aware styling.
+ */
+
+import { useMemo } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useParams, Navigate, Link } from "react-router";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import SEOHead from "../components/SEOHead.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
+import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
+import { ARTICLE_CONTENT } from "../utils/homepageContent.js";
+import type { Theme } from "../types/theme.js";
+
+const PAGE_BASE_STYLE = {
+  maxWidth: 960,
+  margin: "0 auto",
+  padding: "0 1.5rem 2rem",
+  fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
+  minHeight: "100vh",
+} satisfies React.CSSProperties;
+
+const NAV_STYLE: CSSProperties = { marginTop: "1.5rem", marginBottom: "1.5rem", fontSize: "0.8rem" };
+
+/** Theme-aware markdown components — same pattern as DescriptionPanel */
+function useMarkdownComponents(t: Theme) {
+  return useMemo(
+    () => ({
+      h1: ({ children }: { children?: ReactNode }) => (
+        <h1
+          style={{
+            fontSize: 20,
+            fontWeight: 700,
+            color: t.descH1,
+            margin: "18px 0 8px",
+            fontFamily: "'DM Sans','Helvetica Neue',sans-serif",
+            letterSpacing: "0.02em",
+          }}
+        >
+          {children}
+        </h1>
+      ),
+      h2: ({ children }: { children?: ReactNode }) => (
+        <h2 style={{ fontSize: 16, fontWeight: 600, color: t.descH2, margin: "16px 0 6px", letterSpacing: "0.04em" }}>
+          {children}
+        </h2>
+      ),
+      h3: ({ children }: { children?: ReactNode }) => (
+        <h3 style={{ fontSize: 14, fontWeight: 600, color: t.descH2, margin: "12px 0 4px", letterSpacing: "0.04em" }}>
+          {children}
+        </h3>
+      ),
+      p: ({ children }: { children?: ReactNode }) => (
+        <p style={{ margin: "8px 0", fontSize: 13, color: t.descText, lineHeight: 1.7 }}>{children}</p>
+      ),
+      strong: ({ children }: { children?: ReactNode }) => (
+        <strong style={{ color: t.descH2, fontWeight: 600 }}>{children}</strong>
+      ),
+      a: ({ href, children }: { href?: string; children?: ReactNode }) => (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: t.descLinkColor, textDecoration: "none", borderBottom: `1px solid ${t.descLinkColor}40` }}
+        >
+          {children}
+        </a>
+      ),
+      code: ({ className, children }: { className?: string; children?: ReactNode }) => {
+        const isBlock = className?.startsWith("language-");
+        if (isBlock) return <code style={{ fontSize: 12 }}>{children}</code>;
+        return (
+          <code
+            style={{
+              background: t.descCodeBg,
+              padding: "1px 5px",
+              borderRadius: 3,
+              fontSize: 12,
+              color: t.descLinkColor,
+            }}
+          >
+            {children}
+          </code>
+        );
+      },
+      pre: ({ children }: { children?: ReactNode }) => (
+        <pre
+          style={{
+            background: t.descCodeBg,
+            padding: 14,
+            borderRadius: 6,
+            overflow: "auto",
+            margin: "12px 0",
+            fontSize: 12,
+            lineHeight: 1.5,
+          }}
+        >
+          {children}
+        </pre>
+      ),
+      ul: ({ children }: { children?: ReactNode }) => (
+        <ul style={{ paddingLeft: 22, margin: "8px 0", fontSize: 13, color: t.descText, lineHeight: 1.7 }}>
+          {children}
+        </ul>
+      ),
+      ol: ({ children }: { children?: ReactNode }) => (
+        <ol style={{ paddingLeft: 22, margin: "8px 0", fontSize: 13, color: t.descText, lineHeight: 1.7 }}>
+          {children}
+        </ol>
+      ),
+      li: ({ children }: { children?: ReactNode }) => <li style={{ marginBottom: 4 }}>{children}</li>,
+      blockquote: ({ children }: { children?: ReactNode }) => (
+        <blockquote
+          style={{ borderLeft: `3px solid ${t.descLinkColor}`, paddingLeft: 16, margin: "12px 0", color: t.muted }}
+        >
+          {children}
+        </blockquote>
+      ),
+      table: ({ children }: { children?: ReactNode }) => (
+        <div style={{ overflowX: "auto", margin: "12px 0" }}>
+          <table style={{ borderCollapse: "collapse", width: "100%", fontSize: 12 }}>{children}</table>
+        </div>
+      ),
+      thead: ({ children }: { children?: ReactNode }) => (
+        <thead style={{ background: t.descTableHeaderBg }}>{children}</thead>
+      ),
+      th: ({ children }: { children?: ReactNode }) => (
+        <th
+          style={{
+            border: `1px solid ${t.descTableBorder}`,
+            padding: "6px 10px",
+            textAlign: "left",
+            color: t.descH2,
+            fontWeight: 600,
+            fontSize: 11.5,
+          }}
+        >
+          {children}
+        </th>
+      ),
+      td: ({ children }: { children?: ReactNode }) => (
+        <td
+          style={{ border: `1px solid ${t.descTableBorder}`, padding: "5px 10px", color: t.descText, fontSize: 11.5 }}
+        >
+          {children}
+        </td>
+      ),
+      hr: () => <hr style={{ border: "none", borderTop: `1px solid ${t.descBorder}`, margin: "18px 0" }} />,
+    }),
+    [t],
+  );
+}
+
+export default function ArticlePage() {
+  const { slug } = useParams<{ slug: string }>();
+  const { theme: t, dark, highContrast, toggleDark, toggleHC } = usePageThemeToggle();
+  const components = useMarkdownComponents(t);
+
+  if (!slug || !ARTICLE_CONTENT[slug]) {
+    return <Navigate to="/articles" replace />;
+  }
+
+  const entry = ARTICLE_CONTENT[slug];
+
+  return (
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
+      <SEOHead
+        title={`${entry.title} — ${SITE_NAME}`}
+        description={entry.description}
+        canonicalURL={`${SITE_URL}/articles/${slug}`}
+      />
+
+      <PageNavBar theme={t} dark={dark} highContrast={highContrast} onToggleDark={toggleDark} onToggleHC={toggleHC}>
+        <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
+          Home
+        </Link>
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
+        <Link to="/articles" style={{ color: t.descLinkColor, textDecoration: "none" }}>
+          Articles
+        </Link>
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
+        <span style={{ color: t.body }}>{entry.title}</span>
+      </PageNavBar>
+
+      <div style={PAGE_BASE_STYLE}>
+        <nav style={NAV_STYLE}>
+          <Link to="/articles" style={{ color: t.descLinkColor, textDecoration: "none", fontSize: "0.8rem" }}>
+            ← All Articles
+          </Link>
+        </nav>
+
+        <article style={{ maxWidth: 700, lineHeight: 1.7 }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+            {entry.markdown}
+          </ReactMarkdown>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ArticlesPage.tsx
+++ b/src/pages/ArticlesPage.tsx
@@ -1,0 +1,57 @@
+/**
+ * Articles archive page — /articles
+ *
+ * Lists all articles with summary cards, following the same
+ * layout pattern as LensIndexPage and MakersIndexPage.
+ */
+
+import { Link } from "react-router";
+import SEOHead from "../components/SEOHead.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
+import ArticleCard from "../components/homepage/ArticleCard.js";
+import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
+import { ARTICLES } from "../utils/homepageContent.js";
+
+const PAGE_BASE_STYLE = {
+  maxWidth: 960,
+  margin: "0 auto",
+  padding: "0 1.5rem 2rem",
+  fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
+  minHeight: "100vh",
+} satisfies React.CSSProperties;
+
+export default function ArticlesPage() {
+  const { theme: t, dark, highContrast, toggleDark, toggleHC } = usePageThemeToggle();
+
+  return (
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
+      <SEOHead
+        title={`Articles — ${SITE_NAME}`}
+        description={`${ARTICLES.length} articles and guides about optical design, lens aberrations, and how camera lenses work.`}
+        canonicalURL={`${SITE_URL}/articles`}
+      />
+
+      <PageNavBar theme={t} dark={dark} highContrast={highContrast} onToggleDark={toggleDark} onToggleHC={toggleHC}>
+        <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
+          Home
+        </Link>
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
+        <span style={{ color: t.body }}>Articles</span>
+      </PageNavBar>
+
+      <div style={PAGE_BASE_STYLE}>
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 600, marginTop: "1.5rem", marginBottom: "0.5rem" }}>
+          All Articles
+        </h1>
+        <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "2rem" }}>
+          {ARTICLES.length} articles and guides about optical design and lens engineering.
+        </p>
+
+        {ARTICLES.map((article) => (
+          <ArticleCard key={article.slug} article={article} theme={t} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,22 +1,36 @@
 /**
- * Home page — default lens visualizer view.
+ * Home page — landing page for Optical Bench.
  *
- * Handles legacy ?lens=KEY redirects to /lens/KEY.
- * During SSR, renders SEO text content; the interactive visualizer
- * mounts client-side.
+ * Renders the site hero, navigation cards, recent articles, and lens
+ * announcements. Preserves legacy ?lens=KEY redirects to /lens/KEY.
  */
 
 import { useEffect } from "react";
-import { useSearchParams, useNavigate } from "react-router";
-import LensVisualization from "../components/layout/LensViewer.js";
+import { Link, useSearchParams, useNavigate } from "react-router";
 import SEOHead from "../components/SEOHead.js";
-import ClientOnly from "../components/ClientOnly.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
+import HeroSection from "../components/homepage/HeroSection.js";
+import QuickNavCards from "../components/homepage/QuickNavCards.js";
+import ArticleList from "../components/homepage/ArticleList.js";
+import RecentLenses from "../components/homepage/RecentLenses.js";
+import HomeFooter from "../components/homepage/HomeFooter.js";
 import { CATALOG_KEYS } from "../utils/lensCatalog.js";
 import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
+import { ARTICLES, LENS_ANNOUNCEMENTS, HOMEPAGE_ARTICLE_LIMIT } from "../utils/homepageContent.js";
+
+const PAGE_BASE_STYLE = {
+  maxWidth: 960,
+  margin: "0 auto",
+  padding: "0 1.5rem 2rem",
+  fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
+  minHeight: "100vh",
+} satisfies React.CSSProperties;
 
 export default function HomePage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { theme: t, dark, highContrast, toggleDark, toggleHC } = usePageThemeToggle();
 
   /* Redirect legacy ?lens=KEY URLs to /lens/KEY */
   useEffect(() => {
@@ -39,16 +53,30 @@ export default function HomePage() {
     }
   }, [searchParams, navigate]);
 
+  const displayedArticles = ARTICLES.slice(0, HOMEPAGE_ARTICLE_LIMIT);
+  const showMoreLink = ARTICLES.length > HOMEPAGE_ARTICLE_LIMIT;
+
   return (
-    <>
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
       <SEOHead
         title={`${SITE_NAME} — Interactive Lens Cross-Section Visualizer`}
         description="Explore real camera lens designs with interactive cross-section diagrams, ray tracing, focus and aperture adjustment, element inspection, and chromatic aberration analysis. Built from optical patent data."
         canonicalURL={`${SITE_URL}/`}
       />
-      <ClientOnly>
-        <LensVisualization />
-      </ClientOnly>
-    </>
+
+      <PageNavBar theme={t} dark={dark} highContrast={highContrast} onToggleDark={toggleDark} onToggleHC={toggleHC}>
+        <Link to="/" style={{ color: t.title, textDecoration: "none", fontWeight: 600 }}>
+          Optical Bench
+        </Link>
+      </PageNavBar>
+
+      <div style={PAGE_BASE_STYLE}>
+        <HeroSection theme={t} />
+        <QuickNavCards theme={t} />
+        <ArticleList articles={displayedArticles} theme={t} showMoreLink={showMoreLink} />
+        <RecentLenses announcements={LENS_ANNOUNCEMENTS.slice(0, 4)} theme={t} />
+        <HomeFooter theme={t} />
+      </div>
+    </div>
   );
 }

--- a/src/pages/LensIndexPage.tsx
+++ b/src/pages/LensIndexPage.tsx
@@ -6,10 +6,11 @@
 
 import { Link } from "react-router";
 import SEOHead from "../components/SEOHead.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
 import { LENS_CATALOG, CATALOG_KEYS } from "../utils/lensCatalog.js";
 import { deriveMaker, SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
 import { getMakerDetails } from "../utils/makerDetails.js";
-import { usePageTheme } from "../utils/usePageTheme.js";
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
 import type { LensData } from "../types/optics.js";
 
 interface MakerGroup {
@@ -34,7 +35,7 @@ function groupByMaker(): MakerGroup[] {
 const PAGE_BASE_STYLE = {
   maxWidth: 960,
   margin: "0 auto",
-  padding: "2rem 1.5rem",
+  padding: "0 1.5rem 2rem",
   fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
   minHeight: "100vh",
 } satisfies React.CSSProperties;
@@ -42,6 +43,7 @@ const PAGE_BASE_STYLE = {
 const H1_STYLE: React.CSSProperties = {
   fontSize: "1.5rem",
   fontWeight: 600,
+  marginTop: "1.5rem",
   marginBottom: "0.5rem",
 };
 
@@ -62,74 +64,72 @@ const LENS_LINK_BASE_STYLE = {
   fontSize: "0.875rem",
 } satisfies React.CSSProperties;
 
-const NAV_STYLE: React.CSSProperties = {
-  marginBottom: "1.5rem",
-  fontSize: "0.8rem",
-};
-
 export default function LensIndexPage() {
   const groups = groupByMaker();
   const totalLenses = CATALOG_KEYS.length;
-  const t = usePageTheme();
+  const { theme: t, dark, highContrast, toggleDark, toggleHC } = usePageThemeToggle();
 
   return (
-    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
       <SEOHead
         title={`All Lenses — ${SITE_NAME}`}
         description={`Browse ${totalLenses} interactive lens cross-section diagrams from Nikon, Carl Zeiss, Ricoh, Voigtländer, and more. Each lens features ray tracing, element inspection, and aberration analysis.`}
         canonicalURL={`${SITE_URL}/lenses`}
       />
 
-      <nav style={NAV_STYLE}>
+      <PageNavBar theme={t} dark={dark} highContrast={highContrast} onToggleDark={toggleDark} onToggleHC={toggleHC}>
         <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Home
         </Link>
-        {" / Lenses"}
-      </nav>
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
+        <span style={{ color: t.body }}>Lenses</span>
+      </PageNavBar>
 
-      <h1 style={H1_STYLE}>Lens Library</h1>
-      <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "2rem" }}>
-        {totalLenses} interactive optical cross-section diagrams built from patent data.
-      </p>
+      <div style={PAGE_BASE_STYLE}>
+        <h1 style={H1_STYLE}>Lens Library</h1>
+        <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "2rem" }}>
+          {totalLenses} interactive optical cross-section diagrams built from patent data.
+        </p>
 
-      {groups.map((group) => {
-        const details = getMakerDetails(group.slug);
-        return (
-          <section key={group.slug}>
-            <h2 style={{ ...MAKER_HEADING_BASE_STYLE, borderBottom: `1px solid ${t.panelBorder}` }}>
-              <Link to={`/makers/${group.slug}`} style={{ color: "inherit", textDecoration: "none" }}>
-                {group.display}
-              </Link>
-              <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem", fontWeight: 400 }}>
-                ({group.lenses.length})
-              </span>
-            </h2>
-            {details && (
-              <p
-                style={{
-                  fontSize: "0.8rem",
-                  color: t.muted,
-                  lineHeight: 1.4,
-                  marginTop: "-0.5rem",
-                  marginBottom: "0.75rem",
-                }}
-              >
-                {details.summary}
-              </p>
-            )}
-            {group.lenses.map(({ key, data }) => (
-              <Link key={key} to={`/lens/${key}`} style={{ ...LENS_LINK_BASE_STYLE, color: t.descLinkColor }}>
-                {data.name}
-                {data.specs && data.specs.length > 0 && (
-                  <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem" }}>
-                    — {data.specs.slice(0, 2).join(", ")}
-                  </span>
-                )}
-              </Link>
-            ))}
-          </section>
-        );
-      })}
+        {groups.map((group) => {
+          const details = getMakerDetails(group.slug);
+          return (
+            <section key={group.slug}>
+              <h2 style={{ ...MAKER_HEADING_BASE_STYLE, borderBottom: `1px solid ${t.panelBorder}` }}>
+                <Link to={`/makers/${group.slug}`} style={{ color: "inherit", textDecoration: "none" }}>
+                  {group.display}
+                </Link>
+                <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem", fontWeight: 400 }}>
+                  ({group.lenses.length})
+                </span>
+              </h2>
+              {details && (
+                <p
+                  style={{
+                    fontSize: "0.8rem",
+                    color: t.muted,
+                    lineHeight: 1.4,
+                    marginTop: "-0.5rem",
+                    marginBottom: "0.75rem",
+                  }}
+                >
+                  {details.summary}
+                </p>
+              )}
+              {group.lenses.map(({ key, data }) => (
+                <Link key={key} to={`/lens/${key}`} style={{ ...LENS_LINK_BASE_STYLE, color: t.descLinkColor }}>
+                  {data.name}
+                  {data.specs && data.specs.length > 0 && (
+                    <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem" }}>
+                      — {data.specs.slice(0, 2).join(", ")}
+                    </span>
+                  )}
+                </Link>
+              ))}
+            </section>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/pages/MakerPage.tsx
+++ b/src/pages/MakerPage.tsx
@@ -6,10 +6,11 @@
 
 import { useParams, Navigate, Link } from "react-router";
 import SEOHead from "../components/SEOHead.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
 import { LENS_CATALOG, CATALOG_KEYS } from "../utils/lensCatalog.js";
 import { deriveMaker, makerDisplayName, makerCanonicalURL, SITE_NAME } from "../utils/lensMetadata.js";
 import { getMakerDetails } from "../utils/makerDetails.js";
-import { usePageTheme } from "../utils/usePageTheme.js";
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
 import type { LensData } from "../types/optics.js";
 
 function lensesForMaker(makerSlug: string): { key: string; data: LensData }[] {
@@ -24,12 +25,11 @@ function lensesForMaker(makerSlug: string): { key: string; data: LensData }[] {
 const PAGE_BASE_STYLE = {
   maxWidth: 960,
   margin: "0 auto",
-  padding: "2rem 1.5rem",
+  padding: "0 1.5rem 2rem",
   fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
   minHeight: "100vh",
 } satisfies React.CSSProperties;
 
-const NAV_STYLE: React.CSSProperties = { marginBottom: "1.5rem", fontSize: "0.8rem" };
 const LENS_LINK_BASE_STYLE = {
   display: "block",
   padding: "0.5rem 0.75rem",
@@ -41,7 +41,7 @@ const LENS_LINK_BASE_STYLE = {
 
 export default function MakerPage() {
   const { maker } = useParams<{ maker: string }>();
-  const t = usePageTheme();
+  const { theme: t, dark, highContrast, toggleDark, toggleHC } = usePageThemeToggle();
 
   if (!maker) return <Navigate to="/makers" replace />;
 
@@ -56,61 +56,67 @@ export default function MakerPage() {
     : `Explore ${lenses.length} ${displayName} lens designs with interactive cross-section diagrams, ray tracing, and element inspection.`;
 
   return (
-    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
       <SEOHead
         title={`${displayName} Lenses — ${SITE_NAME}`}
         description={seoDescription}
         canonicalURL={makerCanonicalURL(maker)}
       />
 
-      <nav style={NAV_STYLE}>
+      <PageNavBar theme={t} dark={dark} highContrast={highContrast} onToggleDark={toggleDark} onToggleHC={toggleHC}>
         <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Home
         </Link>
-        {" / "}
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
         <Link to="/makers" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Makers
         </Link>
-        {` / ${displayName}`}
-      </nav>
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
+        <span style={{ color: t.body }}>{displayName}</span>
+      </PageNavBar>
 
-      <h1 style={{ fontSize: "1.5rem", fontWeight: 600, marginBottom: "0.5rem" }}>{displayName} Lenses</h1>
+      <div style={PAGE_BASE_STYLE}>
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 600, marginTop: "1.5rem", marginBottom: "0.5rem" }}>
+          {displayName} Lenses
+        </h1>
 
-      {details && (
-        <div style={{ marginBottom: "1.5rem" }}>
-          <p style={{ fontSize: "0.8rem", color: t.label, marginBottom: "0.75rem" }}>
-            Est. {details.founded} · {details.headquarters} · {lenses.length} {lenses.length === 1 ? "lens" : "lenses"}
-          </p>
-          {details.history.split("\n\n").map((paragraph, i) => (
-            <p key={i} style={{ fontSize: "0.85rem", color: t.desc, lineHeight: 1.6, marginBottom: "0.75rem" }}>
-              {paragraph}
+        {details && (
+          <div style={{ marginBottom: "1.5rem" }}>
+            <p style={{ fontSize: "0.8rem", color: t.label, marginBottom: "0.75rem" }}>
+              Est. {details.founded} · {details.headquarters} · {lenses.length}{" "}
+              {lenses.length === 1 ? "lens" : "lenses"}
             </p>
-          ))}
-          {details.notableDesigns && (
-            <p style={{ fontSize: "0.8rem", color: t.muted, fontStyle: "italic", marginBottom: "0.5rem" }}>
-              Notable designs: {details.notableDesigns}
-            </p>
-          )}
-        </div>
-      )}
-
-      {!details && (
-        <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "1.5rem" }}>
-          {lenses.length} interactive lens {lenses.length === 1 ? "diagram" : "diagrams"}
-        </p>
-      )}
-
-      <div style={{ borderTop: `1px solid ${t.panelBorder}`, paddingTop: "1rem" }}>
-        {lenses.map(({ key, data }) => (
-          <Link key={key} to={`/lens/${key}`} style={{ ...LENS_LINK_BASE_STYLE, color: t.descLinkColor }}>
-            {data.name}
-            {data.specs && data.specs.length > 0 && (
-              <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem" }}>
-                — {data.specs.slice(0, 3).join(", ")}
-              </span>
+            {details.history.split("\n\n").map((paragraph, i) => (
+              <p key={i} style={{ fontSize: "0.85rem", color: t.desc, lineHeight: 1.6, marginBottom: "0.75rem" }}>
+                {paragraph}
+              </p>
+            ))}
+            {details.notableDesigns && (
+              <p style={{ fontSize: "0.8rem", color: t.muted, fontStyle: "italic", marginBottom: "0.5rem" }}>
+                Notable designs: {details.notableDesigns}
+              </p>
             )}
-          </Link>
-        ))}
+          </div>
+        )}
+
+        {!details && (
+          <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "1.5rem" }}>
+            {lenses.length} interactive lens {lenses.length === 1 ? "diagram" : "diagrams"}
+          </p>
+        )}
+
+        <div style={{ borderTop: `1px solid ${t.panelBorder}`, paddingTop: "1rem" }}>
+          {lenses.map(({ key, data }) => (
+            <Link key={key} to={`/lens/${key}`} style={{ ...LENS_LINK_BASE_STYLE, color: t.descLinkColor }}>
+              {data.name}
+              {data.specs && data.specs.length > 0 && (
+                <span style={{ color: t.label, fontSize: "0.75rem", marginLeft: "0.5rem" }}>
+                  — {data.specs.slice(0, 3).join(", ")}
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/MakersIndexPage.tsx
+++ b/src/pages/MakersIndexPage.tsx
@@ -6,10 +6,11 @@
 
 import { Link } from "react-router";
 import SEOHead from "../components/SEOHead.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
 import { LENS_CATALOG, CATALOG_KEYS } from "../utils/lensCatalog.js";
 import { deriveMaker, SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
 import { getMakerDetails } from "../utils/makerDetails.js";
-import { usePageTheme } from "../utils/usePageTheme.js";
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
 
 interface MakerEntry {
   display: string;
@@ -35,65 +36,68 @@ function getAllMakers(): MakerEntry[] {
 const PAGE_BASE_STYLE = {
   maxWidth: 960,
   margin: "0 auto",
-  padding: "2rem 1.5rem",
+  padding: "0 1.5rem 2rem",
   fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
   minHeight: "100vh",
 } satisfies React.CSSProperties;
 
-const NAV_STYLE: React.CSSProperties = { marginBottom: "1.5rem", fontSize: "0.8rem" };
-
 export default function MakersIndexPage() {
   const makers = getAllMakers();
-  const t = usePageTheme();
+  const { theme: t, dark, highContrast, toggleDark, toggleHC } = usePageThemeToggle();
 
   return (
-    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
       <SEOHead
         title={`Lens Makers — ${SITE_NAME}`}
         description={`Browse lenses by maker: ${makers.map((m) => m.display).join(", ")}. Interactive cross-section diagrams with ray tracing and element inspection.`}
         canonicalURL={`${SITE_URL}/makers`}
       />
 
-      <nav style={NAV_STYLE}>
+      <PageNavBar theme={t} dark={dark} highContrast={highContrast} onToggleDark={toggleDark} onToggleHC={toggleHC}>
         <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
           Home
         </Link>
-        {" / Makers"}
-      </nav>
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
+        <span style={{ color: t.body }}>Makers</span>
+      </PageNavBar>
 
-      <h1 style={{ fontSize: "1.5rem", fontWeight: 600, marginBottom: "1.5rem" }}>Lens Makers</h1>
+      <div style={PAGE_BASE_STYLE}>
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 600, marginTop: "1.5rem", marginBottom: "1.5rem" }}>
+          Lens Makers
+        </h1>
 
-      {makers.map((maker) => {
-        const details = getMakerDetails(maker.slug);
-        return (
-          <div
-            key={maker.slug}
-            style={{ padding: "1rem 0.75rem", marginBottom: "0.75rem", borderBottom: `1px solid ${t.panelBorder}` }}
-          >
-            <Link
-              to={`/makers/${maker.slug}`}
-              style={{ color: t.descLinkColor, textDecoration: "none", fontSize: "1rem", fontWeight: 600 }}
+        {makers.map((maker) => {
+          const details = getMakerDetails(maker.slug);
+          return (
+            <div
+              key={maker.slug}
+              style={{ padding: "1rem 0.75rem", marginBottom: "0.75rem", borderBottom: `1px solid ${t.panelBorder}` }}
             >
-              {maker.display}
-            </Link>
-            {details ? (
-              <>
-                <div style={{ fontSize: "0.8rem", color: t.label, marginTop: "0.25rem" }}>
-                  Est. {details.founded} · {details.headquarters} · {maker.count}{" "}
-                  {maker.count === 1 ? "lens" : "lenses"}
-                </div>
-                <p style={{ fontSize: "0.8rem", color: t.subtitle, lineHeight: 1.5, marginTop: "0.5rem" }}>
-                  {details.summary}
-                </p>
-              </>
-            ) : (
-              <span style={{ color: t.label, fontSize: "0.8rem", marginLeft: "0.5rem" }}>
-                ({maker.count} {maker.count === 1 ? "lens" : "lenses"})
-              </span>
-            )}
-          </div>
-        );
-      })}
+              <Link
+                to={`/makers/${maker.slug}`}
+                style={{ color: t.descLinkColor, textDecoration: "none", fontSize: "1rem", fontWeight: 600 }}
+              >
+                {maker.display}
+              </Link>
+              {details ? (
+                <>
+                  <div style={{ fontSize: "0.8rem", color: t.label, marginTop: "0.25rem" }}>
+                    Est. {details.founded} · {details.headquarters} · {maker.count}{" "}
+                    {maker.count === 1 ? "lens" : "lenses"}
+                  </div>
+                  <p style={{ fontSize: "0.8rem", color: t.subtitle, lineHeight: 1.5, marginTop: "0.5rem" }}>
+                    {details.summary}
+                  </p>
+                </>
+              ) : (
+                <span style={{ color: t.label, fontSize: "0.8rem", marginLeft: "0.5rem" }}>
+                  ({maker.count} {maker.count === 1 ? "lens" : "lenses"})
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -4,32 +4,41 @@
 
 import { Link } from "react-router";
 import SEOHead from "../components/SEOHead.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
 import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
-import { usePageTheme } from "../utils/usePageTheme.js";
-
-const PAGE_BASE_STYLE = {
-  maxWidth: 960,
-  margin: "0 auto",
-  padding: "4rem 1.5rem",
-  fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
-  minHeight: "100vh",
-  textAlign: "center",
-} satisfies React.CSSProperties;
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
 
 export default function NotFoundPage() {
-  const t = usePageTheme();
+  const { theme: t, dark, highContrast, toggleDark, toggleHC } = usePageThemeToggle();
   return (
-    <div style={{ ...PAGE_BASE_STYLE, backgroundColor: t.bg, color: t.body }}>
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
       <SEOHead title={`Page Not Found — ${SITE_NAME}`} description="Page not found." canonicalURL={SITE_URL} />
-      <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>404</h1>
-      <p style={{ marginBottom: "2rem", color: t.muted }}>Page not found.</p>
-      <Link to="/" style={{ color: t.descLinkColor }}>
-        Go to Optical Bench
-      </Link>
-      <span style={{ margin: "0 1rem", color: t.label }}>|</span>
-      <Link to="/lenses" style={{ color: t.descLinkColor }}>
-        Browse all lenses
-      </Link>
+
+      <PageNavBar theme={t} dark={dark} highContrast={highContrast} onToggleDark={toggleDark} onToggleHC={toggleHC}>
+        <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
+          Home
+        </Link>
+      </PageNavBar>
+
+      <div
+        style={{
+          maxWidth: 960,
+          margin: "0 auto",
+          padding: "4rem 1.5rem",
+          fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
+          textAlign: "center",
+        }}
+      >
+        <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>404</h1>
+        <p style={{ marginBottom: "2rem", color: t.muted }}>Page not found.</p>
+        <Link to="/" style={{ color: t.descLinkColor }}>
+          Go to Optical Bench
+        </Link>
+        <span style={{ margin: "0 1rem", color: t.label }}>|</span>
+        <Link to="/lenses" style={{ color: t.descLinkColor }}>
+          Browse all lenses
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/routes/routeManifest.tsx
+++ b/src/routes/routeManifest.tsx
@@ -12,6 +12,8 @@ import LensIndexPage from "../pages/LensIndexPage.js";
 import MakersIndexPage from "../pages/MakersIndexPage.js";
 import MakerPage from "../pages/MakerPage.js";
 import ComparePage from "../pages/ComparePage.js";
+import ArticlesPage from "../pages/ArticlesPage.js";
+import ArticlePage from "../pages/ArticlePage.js";
 import NotFoundPage from "../pages/NotFoundPage.js";
 
 export interface RouteManifestEntry {
@@ -26,6 +28,8 @@ const routeManifest: RouteManifestEntry[] = [
   { path: "/compare/:slugA/:slugB", element: <ComparePage /> },
   { path: "/makers", element: <MakersIndexPage /> },
   { path: "/makers/:maker", element: <MakerPage /> },
+  { path: "/articles", element: <ArticlesPage /> },
+  { path: "/articles/:slug", element: <ArticlePage /> },
   { path: "*", element: <NotFoundPage /> },
 ];
 

--- a/src/utils/homepageContent.ts
+++ b/src/utils/homepageContent.ts
@@ -1,0 +1,170 @@
+/**
+ * Homepage content registry — articles, announcements, and article page content.
+ *
+ * Adding a new article:
+ *   1. Add an entry to the ARTICLES array (newest first)
+ *   2. If it has a standalone page, add an entry to ARTICLE_CONTENT
+ *   3. The homepage shows the first HOMEPAGE_ARTICLE_LIMIT entries
+ *
+ * Adding a new lens announcement:
+ *   1. Add an entry to the LENS_ANNOUNCEMENTS array (newest first)
+ *   2. The lensKey must match a key in LENS_CATALOG
+ */
+
+import opticsPrimer from "../content/OpticsPrimerSimple.md?raw";
+import opticsPrimerIntermediate from "../content/OpticsPrimerIntermediate.md?raw";
+import aberrationsPrimer from "../content/AberrationsPrimerSimple.md?raw";
+import aberrationsPrimerIntermediate from "../content/AberrationsPrimerIntermediate.md?raw";
+import aboutSite from "../content/AboutSite.md?raw";
+import aboutMe from "../content/AboutMe.md?raw";
+
+/* ── Types ─────────────────────────────────────────────────────────── */
+
+export interface HomepageArticle {
+  /** URL-safe slug — used in /articles/:slug routes */
+  slug: string;
+  /** Display title */
+  title: string;
+  /** ISO date string for sorting/display (e.g. "2026-03-15") */
+  date: string;
+  /** 1-2 sentence summary shown on homepage card */
+  summary: string;
+  /** Where the card links to: internal path (e.g. "/articles/optics-primer") */
+  linkTo: string;
+  /** Optional category tag displayed on the card */
+  tag?: "article" | "announcement" | "guide";
+}
+
+export interface LensAnnouncement {
+  /** Lens catalog key — must exist in LENS_CATALOG */
+  lensKey: string;
+  /** ISO date string */
+  date: string;
+  /** Short announcement text */
+  blurb: string;
+}
+
+export interface ArticleContentEntry {
+  title: string;
+  description: string;
+  markdown: string;
+}
+
+/* ── Constants ─────────────────────────────────────────────────────── */
+
+/** Maximum articles shown on the homepage before "View all" link appears */
+export const HOMEPAGE_ARTICLE_LIMIT = 5;
+
+/* ── Article Content Registry ──────────────────────────────────────── */
+
+/**
+ * Maps article slugs to their full page content.
+ * Used by ArticlePage to render standalone article pages.
+ */
+export const ARTICLE_CONTENT: Record<string, ArticleContentEntry> = {
+  "optics-primer": {
+    title: "How Camera Lenses Work",
+    description:
+      "A gentle introduction to refraction, focal length, and how multiple glass elements combine to form an image.",
+    markdown: opticsPrimer,
+  },
+  "optics-primer-intermediate": {
+    title: "Optics In More Detail",
+    description:
+      "A deeper look at optical design principles including Petzval sums, field curvature correction, and retrofocus designs.",
+    markdown: opticsPrimerIntermediate,
+  },
+  "aberrations-primer": {
+    title: "Understanding Aberrations",
+    description:
+      "An introduction to the optical aberrations that lens designers work to minimize — spherical, coma, astigmatism, and more.",
+    markdown: aberrationsPrimer,
+  },
+  "aberrations-primer-intermediate": {
+    title: "Aberrations In Depth",
+    description:
+      "Advanced aberration concepts including higher-order effects, balancing strategies, and how aspherical surfaces help.",
+    markdown: aberrationsPrimerIntermediate,
+  },
+  "about-site": {
+    title: "About Optical Bench",
+    description: "How this interactive lens visualization tool was built and what makes it unique.",
+    markdown: aboutSite,
+  },
+  "about-author": {
+    title: "About the Author",
+    description: "Meet the creator of Optical Bench — background in photography and optical engineering.",
+    markdown: aboutMe,
+  },
+};
+
+/* ── Articles ──────────────────────────────────────────────────────── */
+
+/**
+ * Articles ordered newest-first. Add new entries at the top.
+ * The homepage shows the first HOMEPAGE_ARTICLE_LIMIT entries;
+ * the /articles page shows all.
+ */
+export const ARTICLES: HomepageArticle[] = [
+  {
+    slug: "aberrations-primer-intermediate",
+    title: "Aberrations In Depth",
+    date: "2026-03-20",
+    summary:
+      "Advanced aberration concepts including higher-order effects, balancing strategies, and aspherical surfaces.",
+    linkTo: "/articles/aberrations-primer-intermediate",
+    tag: "guide",
+  },
+  {
+    slug: "aberrations-primer",
+    title: "Understanding Aberrations",
+    date: "2026-03-18",
+    summary:
+      "An introduction to the optical aberrations that lens designers work to minimize — spherical, coma, astigmatism, and more.",
+    linkTo: "/articles/aberrations-primer",
+    tag: "guide",
+  },
+  {
+    slug: "optics-primer-intermediate",
+    title: "Optics In More Detail",
+    date: "2026-03-15",
+    summary:
+      "A deeper look at optical design principles including Petzval sums, field curvature correction, and retrofocus designs.",
+    linkTo: "/articles/optics-primer-intermediate",
+    tag: "guide",
+  },
+  {
+    slug: "optics-primer",
+    title: "How Camera Lenses Work",
+    date: "2026-03-12",
+    summary:
+      "A gentle introduction to refraction, focal length, and how multiple glass elements combine to form an image.",
+    linkTo: "/articles/optics-primer",
+    tag: "guide",
+  },
+  {
+    slug: "about-site",
+    title: "About Optical Bench",
+    date: "2026-03-10",
+    summary: "How this interactive lens visualization tool was built and what makes it unique.",
+    linkTo: "/articles/about-site",
+    tag: "article",
+  },
+  {
+    slug: "about-author",
+    title: "About the Author",
+    date: "2026-03-08",
+    summary: "Meet the creator of Optical Bench — background in photography and optical engineering.",
+    linkTo: "/articles/about-author",
+    tag: "article",
+  },
+];
+
+/* ── Lens Announcements ────────────────────────────────────────────── */
+
+/**
+ * Recent lens additions, newest-first.
+ * Each references a CATALOG_KEYS entry — the homepage component
+ * derives name/specs from the catalog automatically.
+ */
+export const LENS_ANNOUNCEMENTS: LensAnnouncement[] = [];

--- a/src/utils/usePageThemeToggle.ts
+++ b/src/utils/usePageThemeToggle.ts
@@ -1,0 +1,66 @@
+/**
+ * usePageThemeToggle — extends usePageTheme with dark/HC toggle capability.
+ *
+ * Returns the current Theme plus boolean state and toggle functions for
+ * dark mode and high contrast. Persists changes to localStorage so they
+ * are picked up by both static pages and the LensViewer.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import T from "./themes.js";
+import { loadPrefs, PREFS_KEY } from "./preferences.js";
+import { CATALOG_KEYS } from "./lensCatalog.js";
+import type { Theme } from "../types/theme.js";
+
+interface PageThemeToggle {
+  theme: Theme;
+  dark: boolean;
+  highContrast: boolean;
+  toggleDark: () => void;
+  toggleHC: () => void;
+}
+
+function resolveTheme(dark: boolean, hc: boolean): Theme {
+  return T[dark ? (hc ? "darkHC" : "dark") : hc ? "lightHC" : "light"];
+}
+
+export function usePageThemeToggle(): PageThemeToggle {
+  const [dark, setDark] = useState(true);
+  const [highContrast, setHighContrast] = useState(false);
+
+  useEffect(() => {
+    const prefs = loadPrefs(CATALOG_KEYS);
+    const d = prefs.dark ?? window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const hc = prefs.highContrast ?? window.matchMedia("(prefers-contrast: more)").matches;
+    setDark(d);
+    setHighContrast(hc);
+  }, []);
+
+  const persist = useCallback((d: boolean, hc: boolean) => {
+    try {
+      const raw = localStorage.getItem(PREFS_KEY);
+      const existing = raw ? JSON.parse(raw) : {};
+      localStorage.setItem(PREFS_KEY, JSON.stringify({ ...existing, dark: d, highContrast: hc }));
+    } catch {
+      /* private browsing or quota — ignore */
+    }
+  }, []);
+
+  const toggleDark = useCallback(() => {
+    setDark((prev) => {
+      const next = !prev;
+      persist(next, highContrast);
+      return next;
+    });
+  }, [highContrast, persist]);
+
+  const toggleHC = useCallback(() => {
+    setHighContrast((prev) => {
+      const next = !prev;
+      persist(dark, next);
+      return next;
+    });
+  }, [dark, persist]);
+
+  return { theme: resolveTheme(dark, highContrast), dark, highContrast, toggleDark, toggleHC };
+}


### PR DESCRIPTION
## Summary

- **New homepage at `/`** replacing the bare LensViewer wrapper with a proper landing page featuring hero section, quick-nav cards (Lens Library, Browse by Maker, Open Viewer), article summaries, and lens announcement slots
- **Standalone article pages at `/articles/:slug`** rendering existing markdown content (optics primers, aberrations primers, about pages) as full SEO-friendly pages with theme-aware styling
- **Articles archive at `/articles`** listing all articles with summary cards
- **Shared `PageNavBar` component** with breadcrumbs + theme toggle (Dark/Light + High Contrast) retrofitted across all static pages for consistent navigation
- **`usePageThemeToggle` hook** extending `usePageTheme` with localStorage-persisted dark/HC toggle capability for static pages
- **Data-driven content system** (`homepageContent.ts`) — adding a new article or lens announcement is a single array entry

### New files
- `src/utils/homepageContent.ts` — article/announcement data + types
- `src/utils/usePageThemeToggle.ts` — theme toggle hook for static pages
- `src/components/layout/PageNavBar.tsx` — shared nav bar
- `src/components/homepage/` — HeroSection, QuickNavCards, ArticleCard, ArticleList, RecentLenses, HomeFooter
- `src/pages/ArticlePage.tsx`, `src/pages/ArticlesPage.tsx` — new article pages

### Modified files
- `src/pages/HomePage.tsx` — rewritten from LensViewer wrapper to homepage composition
- `src/pages/LensIndexPage.tsx`, `MakersIndexPage.tsx`, `MakerPage.tsx`, `NotFoundPage.tsx` — retrofitted with PageNavBar
- `src/routes/routeManifest.tsx` — added `/articles` and `/articles/:slug` routes
- `scripts/prerender.mjs` — added article routes to SSR prerender

Closes #251

## Test plan

- [ ] Verify homepage renders at `/` with hero, nav cards, articles, and footer
- [ ] Verify all 4 themes (dark, light, darkHC, lightHC) work via PageNavBar toggles
- [ ] Verify theme preference persists across page navigation
- [ ] Verify nav cards link correctly to `/lenses`, `/makers`, and first lens
- [ ] Verify article cards link to `/articles/:slug` and render markdown content
- [ ] Verify `/articles` archive page lists all articles
- [ ] Verify legacy `?lens=KEY` redirect still works from homepage
- [ ] Verify LensViewer pages (`/lens/:slug`) still use their own BreadcrumbBar
- [ ] Verify PageNavBar appears on all static pages (lenses, makers, maker detail, 404)
- [ ] Run `npm run typecheck && npm run lint && npm run test` — all pass
- [ ] Run `npm run build` — production build succeeds including prerender of article routes

https://claude.ai/code/session_018Mwg9DFZaGqKgc1aZR4iTk