### PR TITLE
Add glass type toggle to Abbe diagram overlay

### DIFF
--- a/__tests__/preferences.test.ts
+++ b/__tests__/preferences.test.ts
@@ -102,6 +102,7 @@ describe("loadPrefs", () => {
         apertureExpanded: false,
         headerControlsExpanded: true,
         legendExpanded: false,
+        abbeShowGlassType: false,
       }),
     );
     const prefs = loadPrefs();
@@ -109,6 +110,7 @@ describe("loadPrefs", () => {
     expect(prefs.apertureExpanded).toBe(false);
     expect(prefs.headerControlsExpanded).toBe(true);
     expect(prefs.legendExpanded).toBe(false);
+    expect(prefs.abbeShowGlassType).toBe(false);
   });
 
   it("ignores non-boolean values for collapsible panel fields", () => {

--- a/__tests__/usePreferences.test.ts
+++ b/__tests__/usePreferences.test.ts
@@ -87,6 +87,7 @@ describe("usePreferences — persisted fields", () => {
     expect(typeof parsed.headerControlsExpanded).toBe("boolean");
     expect(typeof parsed.legendExpanded).toBe("boolean");
     expect(typeof parsed.headerInfoExpanded).toBe("boolean");
+    expect(typeof parsed.abbeShowGlassType).toBe("boolean");
   });
 
   it("does NOT persist slider positions", () => {

--- a/src/components/display/AbbeDiagram.tsx
+++ b/src/components/display/AbbeDiagram.tsx
@@ -12,10 +12,13 @@
 
 import type { RuntimeLens } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
+import { toggleGroup, toggleBtn } from "../../utils/styles.js";
 
 interface AbbeDiagramProps {
   L: RuntimeLens;
   t: Theme;
+  showGlassType: boolean;
+  onToggleGlassType: () => void;
 }
 
 /* ── Chart geometry constants ── */
@@ -53,7 +56,7 @@ function labelAnchor(px: number): { anchor: "start" | "end"; dx: number } {
   return px > SVG_W - 130 ? { anchor: "end", dx: -12 } : { anchor: "start", dx: 12 };
 }
 
-export default function AbbeDiagram({ L, t }: AbbeDiagramProps) {
+export default function AbbeDiagram({ L, t, showGlassType, onToggleGlassType }: AbbeDiagramProps) {
   const allElements = L.elements;
   const plotElements = allElements.filter((e) => e.vd != null && e.nd != null);
   const missingCount = allElements.length - plotElements.length;
@@ -183,9 +186,11 @@ export default function AbbeDiagram({ L, t }: AbbeDiagramProps) {
                 {e.name}
               </text>
               {/* Glass type label — above and offset from dot */}
-              <text x={px + dx} y={py - 11} textAnchor={anchor} fontSize={7.5} fill={mutedColor} fontFamily="inherit">
-                {glassLabel}
-              </text>
+              {showGlassType && (
+                <text x={px + dx} y={py - 11} textAnchor={anchor} fontSize={7.5} fill={mutedColor} fontFamily="inherit">
+                  {glassLabel}
+                </text>
+              )}
             </g>
           );
         })}
@@ -204,6 +209,13 @@ export default function AbbeDiagram({ L, t }: AbbeDiagramProps) {
           </text>
         )}
       </svg>
+      <div style={{ display: "flex", justifyContent: "center", padding: "6px 0 4px" }}>
+        <div style={toggleGroup(t, { width: 160 })}>
+          <button style={toggleBtn(t, showGlassType, { hasRightBorder: false })} onClick={onToggleGlassType}>
+            GLASS TYPE
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/hooks/useDispatchAdapters.ts
+++ b/src/components/hooks/useDispatchAdapters.ts
@@ -35,6 +35,7 @@ export interface DispatchAdapters {
   onHeaderControlsExpandedChange: (v: boolean) => void;
   onLegendExpandedChange: (v: boolean) => void;
   onHeaderInfoExpandedChange: (v: boolean) => void;
+  onAbbeShowGlassTypeChange: (v: boolean) => void;
 }
 
 export default function useDispatchAdapters(): DispatchAdapters {
@@ -66,6 +67,8 @@ export default function useDispatchAdapters(): DispatchAdapters {
         dispatch({ type: SET_PANEL_EXPANDED, panel: "legendExpanded", expanded: v }),
       onHeaderInfoExpandedChange: (v: boolean) =>
         dispatch({ type: SET_PANEL_EXPANDED, panel: "headerInfoExpanded", expanded: v }),
+      onAbbeShowGlassTypeChange: (v: boolean) =>
+        dispatch({ type: SET_PANEL_EXPANDED, panel: "abbeShowGlassType", expanded: v }),
     }),
     [dispatch, updateURLWithSliders],
   );

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -76,7 +76,7 @@ export default function LensDiagramPanel({
   const { rays: raysState, display, panels, sliders } = state;
   const { showOnAxis, showOffAxis, showChromatic, chromR, chromG, chromB, rayTracksF, showPupils } = raysState;
   const { dark } = display;
-  const { focusExpanded, apertureExpanded, legendExpanded, headerInfoExpanded } = panels;
+  const { focusExpanded, apertureExpanded, legendExpanded, headerInfoExpanded, abbeShowGlassType } = panels;
 
   /* Per-instance sliders: use props if provided (comparison mode), else context */
   const focusT = focusTProp ?? sliders.focusT;
@@ -293,7 +293,12 @@ export default function LensDiagramPanel({
       ) : null}
       {overlays.showAbbeDiagram && L && (
         <OverlayModal onClose={overlays.closeAbbeDiagram} theme={t} maxWidth={580}>
-          <AbbeDiagram L={L} t={t} />
+          <AbbeDiagram
+            L={L}
+            t={t}
+            showGlassType={abbeShowGlassType}
+            onToggleGlassType={() => adapters.onAbbeShowGlassTypeChange(!abbeShowGlassType)}
+          />
         </OverlayModal>
       )}
     </PanelErrorBoundary>

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -56,7 +56,8 @@ export type PanelField =
   | "apertureExpanded"
   | "headerControlsExpanded"
   | "legendExpanded"
-  | "headerInfoExpanded";
+  | "headerInfoExpanded"
+  | "abbeShowGlassType";
 
 export interface PanelsSlice {
   focusExpanded: boolean;
@@ -64,6 +65,7 @@ export interface PanelsSlice {
   headerControlsExpanded: boolean;
   legendExpanded: boolean;
   headerInfoExpanded: boolean;
+  abbeShowGlassType: boolean;
 }
 
 export type OverlayField = "showAbout" | "showAboutSite" | "showOpticsPrimer" | "showAberrationsPrimer";
@@ -130,6 +132,7 @@ export interface Preferences {
   headerControlsExpanded: boolean;
   legendExpanded: boolean;
   headerInfoExpanded: boolean;
+  abbeShowGlassType: boolean;
 }
 
 /* ── URL state (from query params) ── */

--- a/src/utils/lensReducer.ts
+++ b/src/utils/lensReducer.ts
@@ -49,6 +49,7 @@ const PANEL_FIELDS = new Set([
   "headerControlsExpanded",
   "legendExpanded",
   "headerInfoExpanded",
+  "abbeShowGlassType",
 ]);
 const OVERLAY_FIELDS = new Set(["showAbout", "showAboutSite", "showOpticsPrimer", "showAberrationsPrimer"]);
 
@@ -107,6 +108,7 @@ export function createInitialState(
       headerControlsExpanded: prefs.headerControlsExpanded ?? false,
       legendExpanded: prefs.legendExpanded ?? false,
       headerInfoExpanded: prefs.headerInfoExpanded ?? true,
+      abbeShowGlassType: prefs.abbeShowGlassType ?? true,
     },
     overlays: {
       showAbout: false,

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -49,6 +49,7 @@ export function loadPrefs(): Partial<Preferences> {
     if (typeof p.headerControlsExpanded === "boolean") out.headerControlsExpanded = p.headerControlsExpanded;
     if (typeof p.legendExpanded === "boolean") out.legendExpanded = p.legendExpanded;
     if (typeof p.headerInfoExpanded === "boolean") out.headerInfoExpanded = p.headerInfoExpanded;
+    if (typeof p.abbeShowGlassType === "boolean") out.abbeShowGlassType = p.abbeShowGlassType;
     return out;
   } catch {
     return {};

--- a/src/utils/usePreferences.ts
+++ b/src/utils/usePreferences.ts
@@ -34,6 +34,7 @@ export default function usePreferences(state: LensState): void {
       headerControlsExpanded: panels.headerControlsExpanded,
       legendExpanded: panels.legendExpanded,
       headerInfoExpanded: panels.headerInfoExpanded,
+      abbeShowGlassType: panels.abbeShowGlassType,
     };
 
     const json = JSON.stringify(prefs);


### PR DESCRIPTION
## Summary

- Adds a **GLASS TYPE** toggle button below the Abbe chart in the overlay, using the existing `toggleBtn`/`toggleGroup` style utilities for visual consistency
- Defaults to **on** (glass type labels visible)
- State is persisted to localStorage via the preferences system and restored on next visit

## Implementation

- `src/types/state.ts` — `abbeShowGlassType` added to `PanelField`, `PanelsSlice`, and `Preferences`
- `src/utils/lensReducer.ts` — Added to `PANEL_FIELDS` set; initial state defaults to `true`
- `src/utils/preferences.ts` / `usePreferences.ts` — Load and persist `abbeShowGlassType`
- `src/components/hooks/useDispatchAdapters.ts` — `onAbbeShowGlassTypeChange` adapter via `SET_PANEL_EXPANDED`
- `src/components/layout/LensDiagramPanel.tsx` — Reads from panels slice, passes props to `AbbeDiagram`
- `src/components/display/AbbeDiagram.tsx` — Conditionally renders glass labels; renders toggle button below the SVG

## Test plan

- [ ] Open the Abbe diagram overlay — glass type labels are visible by default
- [ ] Click **GLASS TYPE** toggle — labels hide, toggle shows inactive state
- [ ] Close and reopen the overlay — toggle state is preserved (in-memory)
- [ ] Reload the page — toggle state is restored from localStorage
- [ ] All unit tests pass: `npm run test`
- [ ] Typecheck passes: `npm run typecheck`
- [ ] Format passes: `npm run format:check`

https://claude.ai/code/session_01RziuBaTUPe16SXeqXRxQVD