### PR TITLE
Add Nikon Z 28mm f/2.8 lens optical data and patent analysis

### DIFF
--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -155,6 +155,13 @@ Each entry in the `surfaces` array describes one optical surface, in strict fron
   { label: "5",  R: ..., d: ..., nd: 1.6890, elemId: 4, sd: ... },  // L3→L4 junction — elemId: 4
   { label: "6",  R: ..., d: ..., nd: 1.0,    elemId: 0, sd: ... },  // L4 rear → air
   ```
+- **Hybrid composite (glass + resin):** A glass body with a thin aspherical resin layer bonded to one surface. Treated identically to a cemented doublet — the glass body and resin layer are separate elements with a junction surface. The resin layer's outer surface is typically aspherical. Use `cemented: "H1"` (or similar) on both elements to annotate the hybrid group. Note: the resin layer is very thin (typically 0.1–0.2 mm center thickness), so edge thickness validation may only pass when the aspherical departure at the rim compensates for the curvature mismatch between the junction and outer surfaces. Verify with tests.
+  ```javascript
+  // Hybrid composite: L5 glass body + L5r resin layer
+  { label: "9",   R: 1e15,    d: 6.55, nd: 1.804,   elemId: 5, sd: ... },  // Glass front (flat)
+  { label: "10",  R: -17.503, d: 0.14, nd: 1.56093, elemId: 6, sd: ... },  // Glass/resin junction — elemId: 6
+  { label: "11A", R: -16.276, d: ...,  nd: 1.0,     elemId: 0, sd: ... },  // Resin rear (asph) → air
+  ```
 - **Last surface:** `d` = back focal distance to image plane
 
 ### Aperture Stop

--- a/src/lens-data/NikonZ28f28.analysis.md
+++ b/src/lens-data/NikonZ28f28.analysis.md
@@ -417,15 +417,17 @@ The NIKKOR Z 28mm f/2.8 represents a deliberate exercise in compact, cost-effect
 
 ## 9. Semi-Diameter Estimation
 
-The patent does not list semi-diameters (clear aperture half-widths) for any surface. Semi-diameters were estimated via paraxial marginal ray trace (y₀ = EP semi-diameter = 4.95 mm, u₀ = 0) and paraxial chief ray trace (full-field, ω = 38.029°) through the complete prescription. The chief ray heights were corrected by a distortion factor of Y_patent / Y_paraxial = 21.700 / 22.543 = 0.963 to account for the paraxial approximation overestimating ray heights at large field angles.
+The patent does not list semi-diameters (clear aperture half-widths) for any surface. Semi-diameters were initially estimated via paraxial marginal ray trace (y₀ = EP semi-diameter = 4.95 mm, u₀ = 0) and paraxial chief ray trace (full-field, ω = 38.029°) through the complete prescription. The chief ray heights were corrected by a distortion factor of Y_patent / Y_paraxial = 21.700 / 22.543 = 0.963 to account for the paraxial approximation overestimating ray heights at large field angles.
 
-The combined semi-diameter at each surface is SD = (|y_marginal| + |y_chief_corrected|) × 1.10, where the 1.10 factor provides 10% mechanical clearance. The stop SD = |y_marginal| directly (no chief ray contribution, no clearance factor). Specific adjustments:
+The initial combined semi-diameter at each surface was SD = (|y_marginal| + |y_chief_corrected|) × 1.10, where the 1.10 factor provides 10% mechanical clearance. The stop SD = |y_marginal| directly (no chief ray contribution, no clearance factor). However, several initial estimates exceeded the renderer's geometric constraints and were reduced:
 
-- **Cemented doublet L21+L22** (surfaces 6–8): SD varies smoothly from 9.5 to 10.5 mm; front/rear ratio within 1.25× constraint.
-- **Hybrid composite L24** (surfaces 11–13A): The 6.55 mm glass body thickness causes significant chief ray divergence (height grows from ~12 mm to ~16 mm). Front SD was increased from the computed 13.2 to 14.5 mm to maintain the SD-ratio constraint (17.0/14.5 = 1.17).
+- **Cemented doublet L21+L22** (surfaces 6–8): SDs reduced from 9.5–10.5 to 7.0–9.0 mm to maintain positive edge thickness on L21 (the strongly curved R₂ = −14.018 mm junction surface causes the front/rear surfaces to cross at the rim for sd > ~7.5 mm given the 3.0 mm center thickness).
+- **L23** (surfaces 9–10): Front SD reduced from 12.5 to 9.5 mm to satisfy the sd/|R| ≤ 0.9 constraint (|R₁| = 11.08 mm → max sd = 9.97 mm). Rear SD reduced from 13.0 to 11.5 mm for front/rear ratio consistency.
+- **Hybrid composite L24** (surfaces 11–13A): Glass body front SD reduced from 14.5 to 13.0 mm to maintain positive edge thickness (the concave R = −17.50 mm rear surface crosses the flat front at sd ≈ 13.8 mm given the 6.55 mm center thickness). Junction and resin-layer SDs reduced from 17.0 to 15.5 and 14.5 mm respectively for sd/|R| compliance (|R| = 17.50 and 16.28 mm). The aspherical departure on surface 13A (+1.2 mm at the rim) keeps the resin layer's edge thickness positive.
+- **L32** (surfaces 16–17): SDs reduced from 19.5–20.5 to 17.0–17.5 mm to maintain positive edge thickness (the concave R = −36.85 mm rear surface crosses the flat front at sd ≈ 18.2 mm given the 4.5 mm center thickness).
 - **Sensor cover glass** (surfaces 20–21): SD set to 21.7 mm (the patent image height Y).
 
-The rear-heavy power distribution produces an unusual SD progression: front elements have small SDs (≈8–9 mm) while the rear elements are large (≈18–21 mm), reflecting the inverted beam diameter profile characteristic of this design.
+The rear-heavy power distribution produces an unusual SD progression: front elements have small SDs (≈7–9 mm in G2) while the rear elements are larger (≈17–20 mm in G3/G4), reflecting the inverted beam diameter profile characteristic of this design. The SD reductions relative to the initial ray-trace estimates are most significant in G2, where the ultra-high-index cemented doublet (L21+L22) and the thick hybrid composite (L24) have strongly curved surfaces that impose tight geometric constraints.
 
 ---
 

--- a/src/lens-data/NikonZ28f28.data.ts
+++ b/src/lens-data/NikonZ28f28.data.ts
@@ -12,12 +12,12 @@ import type { LensDataInput } from "../types/optics.js";
  * ║  G1 and G4 fixed; aperture stop fixed between G1 and G2.          ║
  * ║                                                                    ║
  * ║  NOTE ON SEMI-DIAMETERS:                                           ║
- * ║    Patent does not list semi-diameters. All SDs estimated via      ║
+ * ║    Patent does not list semi-diameters. Initial SDs estimated via  ║
  * ║    paraxial marginal + chief ray trace at full field (ω = 38°),   ║
- * ║    with distortion correction factor (patent Y / paraxial Y) and  ║
- * ║    10% mechanical clearance. L24g front SD enlarged slightly to    ║
- * ║    satisfy the 1.25 SD-ratio constraint on the 6.55 mm thick      ║
- * ║    glass body.                                                     ║
+ * ║    with distortion correction factor and 10% mechanical clearance. ║
+ * ║    G2 and G3 SDs then reduced to satisfy renderer constraints:     ║
+ * ║    positive edge thickness (L21, L24g, L32), sd/|R| ≤ 0.9         ║
+ * ║    (L23 front, L24 junction/rear), and cross-gap clearance.        ║
  * ╚══════════════════════════════════════════════════════════════════════╝
  */
 
@@ -199,20 +199,20 @@ const LENS_DATA = {
     { label: "STO", R: 1e15, d: 4.85, nd: 1.0, elemId: 0, sd: 5.1 }, // D5, variable
 
     // ── G2 — First focusing group / GF1 (positive, f = +34.7 mm) ──
-    { label: "6", R: 39.03942, d: 3.0, nd: 2.001, elemId: 3, sd: 9.5 }, // L21 front
-    { label: "7", R: -14.018, d: 0.7, nd: 1.80518, elemId: 4, sd: 10.0 }, // L21→L22 junction
-    { label: "8", R: 44.52125, d: 3.457, nd: 1.0, elemId: 0, sd: 10.5 }, // L22 rear → air
-    { label: "9", R: -11.08066, d: 0.9, nd: 1.80809, elemId: 5, sd: 12.5 }, // L23 front
-    { label: "10", R: -29.93301, d: 0.15, nd: 1.0, elemId: 0, sd: 13.0 }, // L23 rear → air
-    { label: "11", R: 1e15, d: 6.55, nd: 1.804, elemId: 6, sd: 14.5 }, // L24g front (flat)
-    { label: "12", R: -17.50329, d: 0.14, nd: 1.56093, elemId: 7, sd: 17.0 }, // L24g/resin junction
-    { label: "13A", R: -16.27553, d: 4.45, nd: 1.0, elemId: 0, sd: 17.0 }, // L24r rear (asph) → air — D13, variable
+    { label: "6", R: 39.03942, d: 3.0, nd: 2.001, elemId: 3, sd: 7.0 }, // L21 front
+    { label: "7", R: -14.018, d: 0.7, nd: 1.80518, elemId: 4, sd: 7.5 }, // L21→L22 junction
+    { label: "8", R: 44.52125, d: 3.457, nd: 1.0, elemId: 0, sd: 9.0 }, // L22 rear → air
+    { label: "9", R: -11.08066, d: 0.9, nd: 1.80809, elemId: 5, sd: 9.5 }, // L23 front
+    { label: "10", R: -29.93301, d: 0.15, nd: 1.0, elemId: 0, sd: 11.5 }, // L23 rear → air
+    { label: "11", R: 1e15, d: 6.55, nd: 1.804, elemId: 6, sd: 13.0 }, // L24g front (flat)
+    { label: "12", R: -17.50329, d: 0.14, nd: 1.56093, elemId: 7, sd: 15.5 }, // L24g/resin junction
+    { label: "13A", R: -16.27553, d: 4.45, nd: 1.0, elemId: 0, sd: 14.5 }, // L24r rear (asph) → air — D13, variable
 
     // ── G3 — Second focusing group / GF2 (positive, f = +46.6 mm) ──
     { label: "14A", R: -26.85154, d: 2.0, nd: 1.53113, elemId: 8, sd: 18.5 }, // L31 front (asph)
     { label: "15A", R: -28.96313, d: 0.2, nd: 1.0, elemId: 0, sd: 19.5 }, // L31 rear (asph) → air
-    { label: "16", R: 1e15, d: 4.5, nd: 1.804, elemId: 9, sd: 19.5 }, // L32 front (flat)
-    { label: "17", R: -36.85132, d: 3.7, nd: 1.0, elemId: 0, sd: 20.5 }, // L32 rear → air — D17, variable
+    { label: "16", R: 1e15, d: 4.5, nd: 1.804, elemId: 9, sd: 17.0 }, // L32 front (flat)
+    { label: "17", R: -36.85132, d: 3.7, nd: 1.0, elemId: 0, sd: 17.5 }, // L32 rear → air — D17, variable
 
     // ── G4 — Rear negative group (fixed, f = −44.3 mm) ──
     { label: "18", R: -34.46648, d: 1.2, nd: 1.64769, elemId: 10, sd: 20.0 }, // L41 front
@@ -233,7 +233,7 @@ const LENS_DATA = {
       K: 0,
       A4: 2.85655e-5,
       A6: -1.38279e-8,
-      A8: 5.7928899999999996e-10,
+      A8: 5.79289e-10,
       A10: 9.06875e-13,
       A12: -2.2576e-15,
       A14: 1.3307e-17,

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -139,6 +139,15 @@ const LENS_DATA = {
    *    { label: "5",  R: ..., d: ..., nd: 1.6890, elemId: 4, sd: ... },  // L3→L4 junction — elemId: 4
    *    { label: "6",  R: ..., d: ..., nd: 1.0,    elemId: 0, sd: ... },  // L4 rear → air — elemId: 0
    *
+   *  Hybrid composite pattern (glass body + resin layer):
+   *    Treated like a cemented doublet. The glass body and resin layer are separate elements.
+   *    The resin layer's outer surface is typically aspherical. Use cemented: "H1" on both.
+   *    NOTE: Resin layers are very thin (~0.1–0.2 mm). Edge thickness may only pass when
+   *    the aspherical departure compensates for curvature mismatch. Verify with tests.
+   *    { label: "9",   R: 1e15,    d: 6.55, nd: 1.804,   elemId: 5, sd: ... },  // Glass front
+   *    { label: "10",  R: -17.503, d: 0.14, nd: 1.56093, elemId: 6, sd: ... },  // Glass/resin junction
+   *    { label: "11A", R: -16.276, d: ...,  nd: 1.0,     elemId: 0, sd: ... },  // Resin rear (asph) → air
+   *
    *  Why: buildLens.ts finds the FIRST surface with each elemId and uses (index, index+1)
    *  as the element's front/rear pair for rendering. Tagging rear or air surfaces with
    *  non-zero elemId will cause rendering errors or crashes.


### PR DESCRIPTION
## Summary

This PR adds comprehensive optical design data and patent analysis for the Nikon NIKKOR Z 28mm f/2.8 lens, based on WO 2022/071249 A1 Example 2 (Nikon / SHIMADA, Toshiyuki).

## Changes

- **NikonZ28f28.analysis.md** (434 lines): Detailed patent design analysis covering:
  - Production design identification with convergence criteria matching all published specifications
  - Complete optical architecture overview with system parameters and group powers
  - Element-by-element analysis of all 9 optical elements across 4 groups
  - Aspherical surface specifications and manufacturing methods (composite hybrid and glass-molded)
  - Floating inner-focus mechanism with variable air gap analysis
  - Glass usage optimization strategy (6 distinct types, triple use of S-LAH55V)
  - Conditional expression verification against patent claims
  - Aberration correction strategy and design trade-offs

- **NikonZ28f28.data.ts** (309 lines): Structured optical prescription data including:
  - 11 surface entries (9 lens elements + sensor cover glass)
  - Complete surface prescription with radii, thicknesses, refractive indices, and semi-diameters
  - Aspherical coefficients for 3 aspherical surfaces (L24 resin layer, L31 both surfaces)
  - Variable air gap definitions for floating focus system (3 variable spacings)
  - Group and doublet annotations (4 groups, 1 cemented doublet, 1 hybrid composite)
  - Focus configuration and aperture specifications

- **LENS_DATA_SPEC.md** (modified): Added documentation for hybrid composite element handling (glass body + resin layer as separate entries with different refractive indices)

- **TEMPLATE.data.ts.template** (modified): Added guidance for hybrid composite pattern in lens data templates

## Notable Implementation Details

- **Hybrid composite element (L24):** Modeled as two separate entries (L24g glass body + L24r resin layer) to accommodate different refractive indices (1.804 vs 1.56093), enabling accurate optical simulation
- **Semi-diameter estimation:** Patent does not provide semi-diameters; values estimated via paraxial ray tracing at full field (ω = 38°) with distortion correction and 10% mechanical clearance, then refined to satisfy renderer constraints
- **Floating focus verification:** Variable gap sum conservation (13.000 mm at both infinity and close focus) confirms internal focus mechanism with two independently moving groups (GF1 = G2, GF2 = G3)
- **Glass optimization:** Design uses only 6 distinct OHARA glass types plus one proprietary UV-curing resin, with S-LAH55V appearing 3 times as a cost optimization strategy

https://claude.ai/code/session_01XCYy4cBHqgSrShQhpnffAb