### PR TITLE
feat(homepage): two-column layout for articles and recent lenses on desktop

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -18,6 +18,7 @@ import { CATALOG_KEYS, RECENT_LENS_KEYS } from "../utils/lensCatalog.js";
 import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
 import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
 import { ARTICLES, HOMEPAGE_ARTICLE_LIMIT } from "../utils/homepageContent.js";
+import useMediaQuery from "../utils/useMediaQuery.js";
 
 const PAGE_BASE_STYLE = {
   maxWidth: 960,
@@ -53,6 +54,8 @@ export default function HomePage() {
     }
   }, [searchParams, navigate]);
 
+  const isDesktop = useMediaQuery("(min-width: 720px)");
+
   const displayedArticles = ARTICLES.slice(0, HOMEPAGE_ARTICLE_LIMIT);
   const showMoreLink = ARTICLES.length > HOMEPAGE_ARTICLE_LIMIT;
 
@@ -79,8 +82,14 @@ export default function HomePage() {
       <div style={PAGE_BASE_STYLE}>
         <HeroSection theme={t} />
         <QuickNavCards theme={t} />
-        <ArticleList articles={displayedArticles} theme={t} showMoreLink={showMoreLink} />
-        <RecentLenses entries={RECENT_LENS_KEYS} theme={t} />
+        <div style={isDesktop ? { display: "flex", gap: "2rem", alignItems: "flex-start" } : {}}>
+          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0 } : {}}>
+            <ArticleList articles={displayedArticles} theme={t} showMoreLink={showMoreLink} />
+          </div>
+          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0 } : {}}>
+            <RecentLenses entries={RECENT_LENS_KEYS} theme={t} />
+          </div>
+        </div>
         <HomeFooter theme={t} />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- On viewports ≥720px, **Articles & Guides** and **Recently Added** sections are displayed side by side in equal-width flex columns beneath the QuickNavCards
- On mobile (<720px) the sections remain stacked vertically — no change to mobile layout
- Uses the existing `useMediaQuery` hook for the responsive breakpoint; no new dependencies or CSS files

## Test plan

- [ ] Open homepage on a desktop-width viewport (≥720px) — Articles & Guides and Recently Added should appear side by side
- [ ] Resize browser below 720px — sections should stack vertically
- [ ] Verify all four themes render correctly in two-column layout
- [ ] Confirm `npm run format:check` passes

https://claude.ai/code/session_01LUE3A8HcQUDoJpn5XnkMfu