### PR TITLE
Enlarge CA diagram inset width

### DIFF
--- a/src/components/diagram/LCAInsetWidget.tsx
+++ b/src/components/diagram/LCAInsetWidget.tsx
@@ -47,7 +47,7 @@ export default function LCAInsetWidget({
   onClick,
   fontScale = 1,
 }: LCAInsetWidgetProps) {
-  const insetW = width ?? 90;
+  const insetW = width ?? 110;
   const insetH = height ?? 100;
   const gRef = chromSpread.intercepts.G ?? IMG_MM;
   const viewWidthPx = insetW - 24;


### PR DESCRIPTION
## Summary

- Increases the default LCA inset widget width from 90px to 110px for better readability in the lens diagram

## Test plan

- [ ] Open any lens with chromatic aberration enabled — verify the LCA inset appears wider and readable
- [ ] Confirm the inset still positions correctly relative to the image plane marker
- [ ] Confirm the larger overlay (opened by clicking the inset) is unaffected

Closes #201