### PR TITLE
Improve readability of diagram panel labels

### DIFF
--- a/src/components/diagram/ApertureStop.tsx
+++ b/src/components/diagram/ApertureStop.tsx
@@ -55,7 +55,7 @@ export default function ApertureStop({
         y={sy(-stopHousingSD - lyStoPad)}
         textAnchor="middle"
         fill={t.stopLabel}
-        fontSize={7.5}
+        fontSize={9.5}
         fontFamily="inherit"
         style={{ letterSpacing: "0.1em" }}
       >

--- a/src/components/diagram/DiagramSVG.tsx
+++ b/src/components/diagram/DiagramSVG.tsx
@@ -257,7 +257,7 @@ export default function DiagramSVG({
             y={labelY}
             textAnchor="middle"
             fill={t.asphLabel}
-            fontSize={6.5}
+            fontSize={9}
             fontFamily="inherit"
             fontWeight={500}
             style={{ pointerEvents: "none", letterSpacing: "0.06em" }}
@@ -295,7 +295,7 @@ export default function DiagramSVG({
         y={sy(L.lyImgLabel)}
         textAnchor="middle"
         fill={t.imgLabel}
-        fontSize={7.5}
+        fontSize={9.5}
         fontFamily="inherit"
         style={{ letterSpacing: "0.12em" }}
       >

--- a/src/components/diagram/ElementAnnotations.tsx
+++ b/src/components/diagram/ElementAnnotations.tsx
@@ -39,7 +39,7 @@ export default function ElementAnnotations({
             y={sy(L.lyElemNum)}
             textAnchor="middle"
             fill={on ? t.elemNumActive : t.elemNum(e)}
-            fontSize={7}
+            fontSize={9}
             fontFamily="inherit"
             fontWeight={on ? 700 : 400}
           >
@@ -81,7 +81,7 @@ export default function ElementAnnotations({
           x={sx((zPos[fromSurface] + zPos[toSurface]) / 2)}
           y={sy(L.lyGroup)}
           fill={t.groupLabel}
-          fontSize={7}
+          fontSize={9}
           fontFamily="inherit"
           textAnchor="middle"
           style={{ letterSpacing: "0.08em" }}
@@ -98,7 +98,7 @@ export default function ElementAnnotations({
           y={sy(L.lyDoublet)}
           textAnchor="middle"
           fill={t.doubletLabel}
-          fontSize={7}
+          fontSize={9}
           fontFamily="inherit"
         >
           {text}


### PR DESCRIPTION
## Summary

- Increases font sizes across all SVG diagram labels for improved legibility
- Aspheric "A" labels: 6.5 → 9; element numbers, group labels, doublet labels: 7 → 9; STO and IMG labels: 7.5 → 9.5

## Test plan

- [ ] Open a lens with group labels (e.g. a zoom lens) and verify group text is clearly readable
- [ ] Open a lens with aspheric surfaces and verify the "A" labels are visibly larger
- [ ] Verify STO and IMG labels are legible in all four themes
- [ ] Verify doublet labels render correctly when present

Closes #200

https://claude.ai/code/session_015SzmNZvYeGaRgVZf9g38ZH