### PR TITLE
Add explicit metadata fields to LensData and all lens files

### DIFF
--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -65,6 +65,13 @@ These must be specified in every lens file — they have no defaults.
 | `visible` | `boolean` | `true` | Controls whether the lens appears in the UI catalog. Set to `false` to hide a lens from the dropdown without removing its data file. |
 | `subtitle` | `string` | | Patent reference shown in UI header |
 | `specs` | `string[]` | | Spec strings displayed in header |
+| `focalLengthMarketing` | `number \| [number, number]` | | Marketed/nominal focal length in mm. Single number for primes (e.g. `50`); `[wide, tele]` tuple for zooms (e.g. `[70, 200]`). |
+| `focalLengthDesign` | `number \| [number, number]` | | Design/patent focal length in mm (computed EFL). Single number for primes; `[wide, tele]` for zooms. May differ from marketing value. |
+| `apertureMarketing` | `number` | | Marketed/nominal maximum f-number (e.g. `1.8` for an "f/1.8" lens). |
+| `apertureDesign` | `number` | | Design/patent maximum f-number (precise computed value, e.g. `1.85`). May differ from marketing value. |
+| `patentYear` | `number` | | Year the patent was published or granted (e.g. `2019`). |
+| `elementCount` | `number` | | Total number of glass elements in the design. |
+| `groupCount` | `number` | | Total number of air-separated groups in the design. |
 | `focusDescription` | `string` | | Human-readable focus mechanism description |
 | `asph` | `object` | | Aspherical coefficients (see below) |
 | `var` | `object` | | Variable air gaps for focus (see below) |

--- a/src/lens-data/Nikon58f14GDesignCandidate.data.ts
+++ b/src/lens-data/Nikon58f14GDesignCandidate.data.ts
@@ -46,6 +46,14 @@ const LENS_DATA = {
     "2 ASPHERICAL SURFACES",
   ],
 
+  focalLengthMarketing: 58,
+  focalLengthDesign: 58.0,
+  apertureMarketing: 1.4,
+  apertureDesign: 1.4,
+  patentYear: 2013,
+  elementCount: 9,
+  groupCount: 5,
+
   /* ── Elements ──
    *  9 elements, front to rear. Patent group designations noted.
    *  Glass identifications are INFERENTIAL from nd/νd catalog matching.

--- a/src/lens-data/Nikon85f14AIS.data.ts
+++ b/src/lens-data/Nikon85f14AIS.data.ts
@@ -36,6 +36,14 @@ const LENS_DATA = {
   subtitle: "US 4,396,256 Embodiment 1 — Nippon Kogaku / Fujie",
   specs: ["7 ELEMENTS / 5 GROUPS", "f ≈ 85.0 mm", "F/1.4", "2ω ≈ 28.5°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 85,
+  focalLengthDesign: 85.0,
+  apertureMarketing: 1.4,
+  apertureDesign: 1.4,
+  patentYear: 1983,
+  elementCount: 7,
+  groupCount: 5,
+
   /* ── Elements ──
    *  7 elements in 5 groups: L1, L2, L3(a+b cemented), L4(a+b cemented), L5
    */

--- a/src/lens-data/Nikon85f14D.data.ts
+++ b/src/lens-data/Nikon85f14D.data.ts
@@ -25,6 +25,14 @@ const LENS_DATA = {
   subtitle: "US 5,640,277 Example 2 — Nikon / Koichi Ohshita",
   specs: ["9 ELEMENTS / 8 GROUPS", "f = 85.0 mm", "F/1.4", "2ω = 28°30'", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 85,
+  focalLengthDesign: 85.0,
+  apertureMarketing: 1.4,
+  apertureDesign: 1.43,
+  patentYear: 1997,
+  elementCount: 9,
+  groupCount: 8,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/NikonAF28f14D.data.ts
+++ b/src/lens-data/NikonAF28f14D.data.ts
@@ -33,6 +33,14 @@ const LENS_DATA = {
   subtitle: "US 5,315,441 EXAMPLE 1 — NIKON / HORI & TATSUNO",
   specs: ["11 ELEMENTS / 8 GROUPS", "f ≈ 28.6 mm", "F/1.4", "2ω ≈ 75.4°", "1 ASPHERICAL SURFACE (GROUND GLASS)"],
 
+  focalLengthMarketing: 28,
+  focalLengthDesign: 28.6,
+  apertureMarketing: 1.4,
+  apertureDesign: 1.4,
+  patentYear: 1994,
+  elementCount: 11,
+  groupCount: 8,
+
   /* ── Elements ──
    *  11 physical glass elements in 8 air-spaced groups (4 functional macro-groups).
    *  Three cemented doublets: L4 (G2), L6 (G3), L8 (G4).

--- a/src/lens-data/NikonAFS28f14E.data.ts
+++ b/src/lens-data/NikonAFS28f14E.data.ts
@@ -39,6 +39,14 @@ const LENS_DATA = {
     "2 ED ELEMENTS (S-FPM2)",
   ],
 
+  focalLengthMarketing: 28,
+  focalLengthDesign: 28.4,
+  apertureMarketing: 1.4,
+  apertureDesign: 1.45,
+  patentYear: 2017,
+  elementCount: 14,
+  groupCount: 11,
+
   /* ── Elements ──
    *  15 entries for 14 patent elements (L12 compound asphere = 2 entries).
    *  Glass identifications: inferential, matched by nd/νd against OHARA catalog.

--- a/src/lens-data/NikonAFSMicroNikkor60f28G.data.ts
+++ b/src/lens-data/NikonAFSMicroNikkor60f28G.data.ts
@@ -41,6 +41,14 @@ const LENS_DATA = {
     "1 ED ELEMENT (L7)",
   ],
 
+  focalLengthMarketing: 60,
+  focalLengthDesign: 58.0,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.88,
+  patentYear: 2011,
+  elementCount: 12,
+  groupCount: 9,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/NikonNikkor105f14E.data.ts
+++ b/src/lens-data/NikonNikkor105f14E.data.ts
@@ -26,6 +26,14 @@ const LENS_DATA = {
   subtitle: "WO2019/116563 A1 Example 3 — Nikon / Yamashita, Ito et al.",
   specs: ["14 ELEMENTS / 9 GROUPS", "f ≈ 102.1 mm", "F/1.45", "2ω ≈ 23.8°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 105,
+  focalLengthDesign: 102.1,
+  apertureMarketing: 1.4,
+  apertureDesign: 1.45,
+  patentYear: 2019,
+  elementCount: 14,
+  groupCount: 9,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/NikonNikkor85f14G.data.ts
+++ b/src/lens-data/NikonNikkor85f14G.data.ts
@@ -27,6 +27,14 @@ const LENS_DATA = {
   subtitle: "US 8,767,319 B2 EXAMPLE 1 — KONICA MINOLTA / NIKON",
   specs: ["10 ELEMENTS / 9 GROUPS", "f = 85.0 mm", "F/1.4", "2ω ≈ 28.6°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 85,
+  focalLengthDesign: 85.0,
+  apertureMarketing: 1.4,
+  apertureDesign: 1.45,
+  patentYear: 2014,
+  elementCount: 10,
+  groupCount: 9,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/NikonNikkorAuto24f28.data.ts
+++ b/src/lens-data/NikonNikkorAuto24f28.data.ts
@@ -47,6 +47,14 @@ const LENS_DATA = {
   subtitle: "US 3,622,227 Example I — Nippon Kogaku / Yoshiyuki Shimizu",
   specs: ["9 ELEMENTS / 7 GROUPS", "f ≈ 24.0 mm", "F/2.8", "2ω ≈ 84°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 24,
+  focalLengthDesign: 24.0,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.8,
+  patentYear: 1971,
+  elementCount: 9,
+  groupCount: 7,
+
   /* ── Elements ──
    *  9 elements, front to rear. Five glass types.
    *  L4+L5 cemented (doublet D1), L7+L8 cemented (doublet D2).

--- a/src/lens-data/NikonNikkorZ50f12.data.ts
+++ b/src/lens-data/NikonNikkorZ50f12.data.ts
@@ -34,6 +34,14 @@ const LENS_DATA = {
   subtitle: "WO 2021/241230 A1 EXAMPLE 1 — NIKON / HARADA Hiroki",
   specs: ["17 ELEMENTS / 15 GROUPS", "f = 51.29 mm", "F/1.23", "2ω ≈ 45.6°", "3 ASPHERICAL SURFACES"],
 
+  focalLengthMarketing: 50,
+  focalLengthDesign: 51.29,
+  apertureMarketing: 1.2,
+  apertureDesign: 1.23,
+  patentYear: 2021,
+  elementCount: 17,
+  groupCount: 15,
+
   /* ── Elements ──
    *  17 optical elements + 1 filter plate, front to rear.
    *  Patent element labels: L11–L19 (front group A), L21–L22 (F1),

--- a/src/lens-data/NikonNikkorZ50f18S.data.ts
+++ b/src/lens-data/NikonNikkorZ50f18S.data.ts
@@ -16,6 +16,14 @@ const LENS_DATA = {
   subtitle: "Patent WO2019/220618 A1 — Example 9",
   specs: ["12 elements / 9 groups", "EFL 51.6 mm", "f/1.85", "2ω = 45.8°", "2 Asph · 2 ED", "MFD 0.4 m"],
 
+  focalLengthMarketing: 50,
+  focalLengthDesign: 51.6,
+  apertureMarketing: 1.8,
+  apertureDesign: 1.85,
+  patentYear: 2019,
+  elementCount: 12,
+  groupCount: 9,
+
   // §2 — Elements (front-to-rear, one per physical glass element)
   //
   // elemId mapping notes:

--- a/src/lens-data/NikonNikkorZ70200f28.data.ts
+++ b/src/lens-data/NikonNikkorZ70200f28.data.ts
@@ -32,6 +32,14 @@ const LENS_DATA = {
   subtitle: "WO2020/105104 EXAMPLE 1 — NIKON / KEN UEHARA",
   specs: ["21 ELEMENTS / 18 GROUPS", "f = 71.5–196 mm", "F/2.88", "2ω = 33.8°–12.3°", "2 ASPHERICAL SURFACES"],
 
+  focalLengthMarketing: [70, 200],
+  focalLengthDesign: [71.5, 196],
+  apertureMarketing: 2.8,
+  apertureDesign: 2.88,
+  patentYear: 2020,
+  elementCount: 21,
+  groupCount: 18,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/NikonZ105f28.data.ts
+++ b/src/lens-data/NikonZ105f28.data.ts
@@ -28,6 +28,14 @@ const LENS_DATA = {
   subtitle: "WO 2022/097401 A1 EXAMPLE 1 — NIKON / KURIBAYASHI",
   specs: ["16 ELEMENTS / 11 GROUPS", "f ≈ 102.9 mm", "F/2.89", "2ω ≈ 24.1°", "1 ASPHERICAL SURFACE"],
 
+  focalLengthMarketing: 105,
+  focalLengthDesign: 102.9,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.89,
+  patentYear: 2022,
+  elementCount: 16,
+  groupCount: 11,
+
   /* ── Elements ── */
   elements: [
     // ── G1: Front positive group (f = +56.05 mm) ──

--- a/src/lens-data/NikonZ135f18.data.ts
+++ b/src/lens-data/NikonZ135f18.data.ts
@@ -26,6 +26,14 @@ const LENS_DATA = {
   subtitle: "WO 2024/147268 A1 Example 1 — NIKON / MURATANI",
   specs: ["16 ELEMENTS / 14 GROUPS", "f ≈ 132.3 mm", "F/1.85", "2ω ≈ 18.6°", "1 ASPHERICAL SURFACE"],
 
+  focalLengthMarketing: 135,
+  focalLengthDesign: 132.3,
+  apertureMarketing: 1.8,
+  apertureDesign: 1.85,
+  patentYear: 2024,
+  elementCount: 16,
+  groupCount: 14,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/NikonZ2470f28.data.ts
+++ b/src/lens-data/NikonZ2470f28.data.ts
@@ -28,6 +28,14 @@ const LENS_DATA = {
   subtitle: "WO2020/136749 A1 EXAMPLE 1 — NIKON / MACHIDA, GOMIBUCHI",
   specs: ["17 ELEMENTS / 15 GROUPS", "f = 24.8–67.9 mm", "F/2.92", "2ω = 85.10°–33.84°", "4 ASPHERICAL SURFACES"],
 
+  focalLengthMarketing: [24, 70],
+  focalLengthDesign: [24.8, 67.9],
+  apertureMarketing: 2.8,
+  apertureDesign: 2.92,
+  patentYear: 2020,
+  elementCount: 17,
+  groupCount: 15,
+
   /* ── Elements ── */
   elements: [
     // ── Group 1 — Front Positive (f = +119.1 mm) ──

--- a/src/lens-data/NikonZ26f28.data.ts
+++ b/src/lens-data/NikonZ26f28.data.ts
@@ -33,6 +33,14 @@ const LENS_DATA = {
   subtitle: "WO 2023/190222 A1 Example 1 — NIKON / MAKIDA",
   specs: ["8 ELEMENTS / 4 GROUPS", "f = 26.78 mm", "F/2.8", "2ω ≈ 80.6°", "4 ASPHERICAL SURFACES"],
 
+  focalLengthMarketing: 26,
+  focalLengthDesign: 26.78,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.8,
+  patentYear: 2023,
+  elementCount: 8,
+  groupCount: 4,
+
   /* ── Elements ──
    *  L8 is physically one composite element (resin + glass) per patent §0199.
    *  Modeled as L8a (resin) + L8b (glass body) for the renderer.

--- a/src/lens-data/NikonZ28f28.data.ts
+++ b/src/lens-data/NikonZ28f28.data.ts
@@ -29,6 +29,14 @@ const LENS_DATA = {
   subtitle: "WO 2022/071249 A1 Example 2 — Nikon / SHIMADA",
   specs: ["9 ELEMENTS / 8 GROUPS", "f ≈ 28.8 mm", "F/2.8", "2ω ≈ 76.1°", "3 ASPHERICAL SURFACES"],
 
+  focalLengthMarketing: 28,
+  focalLengthDesign: 28.8,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.8,
+  patentYear: 2022,
+  elementCount: 9,
+  groupCount: 8,
+
   /* ── Elements ──
    *  Nikon counts 9 physical elements in 8 groups.
    *  The data format requires separate entries for the L24 glass body and resin

--- a/src/lens-data/NikonZ85f18S.data.ts
+++ b/src/lens-data/NikonZ85f18S.data.ts
@@ -40,6 +40,14 @@ const LENS_DATA = {
     "ALL SPHERICAL · 2 ED ELEMENTS",
   ],
 
+  focalLengthMarketing: 85,
+  focalLengthDesign: 83.0,
+  apertureMarketing: 1.8,
+  apertureDesign: 1.85,
+  patentYear: 2020,
+  elementCount: 12,
+  groupCount: 8,
+
   /* ── Elements ──
    *  12 glass elements, front to rear.
    *  Gr1 (positive, fixed): L11, L12, L13+L14 cemented doublet

--- a/src/lens-data/RicohGR28f28.data.ts
+++ b/src/lens-data/RicohGR28f28.data.ts
@@ -29,6 +29,14 @@ const LENS_DATA = {
   subtitle: "US 5,760,973 EXAMPLE 1 — RICOH / KAWAMURA",
   specs: ["7 ELEMENTS / 4 GROUPS", "f ≈ 28.1 mm", "F/2.86", "2ω ≈ 74.4°", "2 ASPHERICAL SURFACES"],
 
+  focalLengthMarketing: 28,
+  focalLengthDesign: 28.1,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.86,
+  patentYear: 1998,
+  elementCount: 7,
+  groupCount: 4,
+
   /* ── Elements ──
    *  Patent notation: L(I,J) = J-th element in I-th component.
    *  L1 = component 1 (negative), L2 = component 2 (positive doublet),

--- a/src/lens-data/RicohGR328f28.data.ts
+++ b/src/lens-data/RicohGR328f28.data.ts
@@ -39,6 +39,14 @@ const LENS_DATA = {
     "3 ASPHERICAL SURFACES (2 PGM ELEMENTS)",
   ],
 
+  focalLengthMarketing: 18.3,
+  focalLengthDesign: 18.3,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.87,
+  patentYear: 2019,
+  elementCount: 6,
+  groupCount: 4,
+
   /* ── Elements ──
    *  Front group LO: L11 (singlet), L12+L13 (cemented doublet)
    *  Rear group LI:  L21+L22 (cemented doublet), L23 (singlet)

--- a/src/lens-data/RicohGR428f28.data.ts
+++ b/src/lens-data/RicohGR428f28.data.ts
@@ -34,6 +34,14 @@ const LENS_DATA = {
   subtitle: "JP2025-069516A EXAMPLE 2 — RICOH / NAKAYAMA",
   specs: ["7 ELEMENTS / 5 GROUPS", "f ≈ 18.35 mm", "F/2.89", "2ω ≈ 76.0°", "5 ASPHERICAL SURFACES (3 ELEMENTS)"],
 
+  focalLengthMarketing: 18.3,
+  focalLengthDesign: 18.35,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.89,
+  patentYear: 2025,
+  elementCount: 7,
+  groupCount: 5,
+
   /* ── Elements ──
    *  Patent nomenclature: G1 = L11 + (L12–L13), G2 = (L21–L22) + L23, G3 = L31.
    *  Production "5 groups" counts air-separated groups:

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -42,6 +42,26 @@ const LENS_DATA = {
     "N ASPHERICAL SURFACES",
   ],
 
+  /* ── Explicit metadata fields ──
+   *  focalLengthMarketing  Marketed/nominal focal length in mm.
+   *                        Single number for primes (e.g. 50); [wide, tele] tuple for zooms (e.g. [70, 200]).
+   *  focalLengthDesign     Patent/computed EFL in mm. Same format as focalLengthMarketing.
+   *                        Omit if identical to focalLengthMarketing.
+   *  apertureMarketing     Marketed/nominal max f-number (e.g. 1.8 for an "f/1.8" lens).
+   *  apertureDesign        Patent/computed max f-number (precise value, e.g. 1.85).
+   *                        Omit if identical to apertureMarketing.
+   *  patentYear            Year the patent was published or granted (e.g. 2019).
+   *  elementCount          Total number of glass elements.
+   *  groupCount            Total number of air-separated groups.
+   */
+  focalLengthMarketing: 50,             // or [70, 200] for zooms
+  focalLengthDesign:    51.2,           // omit if same as focalLengthMarketing
+  apertureMarketing:    1.8,
+  apertureDesign:       1.85,           // omit if same as apertureMarketing
+  patentYear:           2019,
+  elementCount:         12,
+  groupCount:           9,
+
   /* ── Elements ──
    *  One entry per physical glass element, front to rear.
    *  Each element must have a unique `id` and be referenced by at least one surface.

--- a/src/lens-data/VoigtlanderApoLanthar50f2.data.ts
+++ b/src/lens-data/VoigtlanderApoLanthar50f2.data.ts
@@ -37,6 +37,14 @@ const LENS_DATA = {
     "5 APD ELEMENTS (Z/E-MOUNT)",
   ],
 
+  focalLengthMarketing: 50,
+  focalLengthDesign: 49.3,
+  apertureMarketing: 2.0,
+  apertureDesign: 1.93,
+  patentYear: 2021,
+  elementCount: 10,
+  groupCount: 8,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/VoigtlanderHeliar.data.ts
+++ b/src/lens-data/VoigtlanderHeliar.data.ts
@@ -41,6 +41,14 @@ const LENS_DATA = {
   visible: true,
   specs: ["5 ELEMENTS / 3 GROUPS", "f = 100 (normalized)", "F/4.0", "2ω ≈ 43.6°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 100,
+  focalLengthDesign: 100.0,
+  apertureMarketing: 4.0,
+  apertureDesign: 4.0,
+  patentYear: 1902,
+  elementCount: 5,
+  groupCount: 3,
+
   /* ── Elements ──
    *  Five elements: front cemented doublet (a + b), central biconcave (c),
    *  rear cemented doublet (b′ + a′). Symmetric about the aperture stop.

--- a/src/lens-data/VoigtlanderNokton50f1.data.ts
+++ b/src/lens-data/VoigtlanderNokton50f1.data.ts
@@ -31,6 +31,14 @@ const LENS_DATA = {
   subtitle: "JP2023063766A EXAMPLE 1 — COSINA / OGINO",
   specs: ["9 ELEMENTS / 7 GROUPS", "f ≈ 50.0 mm", "F/1.0", "2ω ≈ 46.8°", "3 ASPHERICAL SURFACES"],
 
+  focalLengthMarketing: 50,
+  focalLengthDesign: 50.0,
+  apertureMarketing: 1.0,
+  apertureDesign: 1.0,
+  patentYear: 2023,
+  elementCount: 9,
+  groupCount: 7,
+
   /* ── Elements ── */
   elements: [
     {

--- a/src/lens-data/ZeissJenaSonnar50f2.data.ts
+++ b/src/lens-data/ZeissJenaSonnar50f2.data.ts
@@ -31,6 +31,14 @@ const LENS_DATA = {
   subtitle: "US 1,998,704 EXAMPLE I — BERTELE / ZEISS IKON (1932) — SCALED 0.5× TO 50mm",
   specs: ["6 ELEMENTS / 3 GROUPS", "f ≈ 50.0 mm (scaled from 100mm patent)", "F/2.0", "2ω ≈ 46.8°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 50,
+  focalLengthDesign: 50.0,
+  apertureMarketing: 2.0,
+  apertureDesign: 2.0,
+  patentYear: 1935,
+  elementCount: 6,
+  groupCount: 3,
+
   /* ── Elements ──
    *  Six elements in three groups: 1-3-2 (singlet, cemented triplet, cemented doublet).
    *  Focal lengths are half the patent values.

--- a/src/lens-data/ZeissSonnar50f15.data.ts
+++ b/src/lens-data/ZeissSonnar50f15.data.ts
@@ -33,6 +33,14 @@ const LENS_DATA = {
   subtitle: "US 1,975,678 — ZEISS IKON / LUDWIG BERTELE (1932)",
   specs: ["7 ELEMENTS / 3 GROUPS", "f ≈ 50.2 mm", "F/1.5", "2ω ≈ 46.8°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 50,
+  focalLengthDesign: 50.2,
+  apertureMarketing: 1.5,
+  apertureDesign: 1.5,
+  patentYear: 1934,
+  elementCount: 7,
+  groupCount: 3,
+
   /* ── Elements ──
    *  Prescription scaled from patent (f=100) to production (f≈50) by ×0.5.
    *  Glass identifications are inferential — see analysis document.

--- a/src/lens-data/ZeissTessar144f55.data.ts
+++ b/src/lens-data/ZeissTessar144f55.data.ts
@@ -40,6 +40,14 @@ const LENS_DATA = {
   visible: true,
   specs: ["4 ELEMENTS / 3 GROUPS", "f ≈ 144 mm (scaled from normalized patent)", "F/5.5", "2ω ≈ 60°", "ALL SPHERICAL"],
 
+  focalLengthMarketing: 144,
+  focalLengthDesign: 144.0,
+  apertureMarketing: 5.5,
+  apertureDesign: 5.5,
+  patentYear: 1903,
+  elementCount: 4,
+  groupCount: 3,
+
   /* ── Elements ──
    *  Four elements in three groups.  Front group: L1 (positive singlet) +
    *  L2 (negative singlet) separated by air.  Rear group: L3 + L4 cemented

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -67,6 +67,13 @@ export interface LensData {
   name: string;
   subtitle?: string;
   specs?: string[];
+  focalLengthMarketing?: number | [number, number];
+  focalLengthDesign?: number | [number, number];
+  apertureMarketing?: number;
+  apertureDesign?: number;
+  patentYear?: number;
+  elementCount?: number;
+  groupCount?: number;
   visible?: boolean;
   nominalFno?: number;
   closeFocusM: number;


### PR DESCRIPTION
Adds 7 new optional fields to `LensData` / `LensDataInput`:
  - `focalLengthMarketing` — marketed nominal focal length (number for primes,
    [wide, tele] tuple for zooms)
  - `focalLengthDesign`    — patent/computed EFL (same format)
  - `apertureMarketing`    — marketed nominal f-number
  - `apertureDesign`       — patent/computed f-number (precise value)
  - `patentYear`           — patent publication/grant year
  - `elementCount`         — total glass elements
  - `groupCount`           — total air-separated groups

All 27 existing lens data files are populated with values derived from
their `specs` strings, analysis documents, and patent records.
Zoom lenses (Z 70-200 f/2.8, Z 24-70 f/2.8) use `[wide, tele]` tuples.

Also updates `LENS_DATA_SPEC.md` and `TEMPLATE.data.ts.template` so
future lenses can include these fields from the start.

Closes #271.

https://claude.ai/code/session_01JpCdZLDXXe2hwiHa1CtJFD