### PR TITLE
Add focal length grouping option to lens index page

### DIFF
--- a/src/pages/LensIndexPage.tsx
+++ b/src/pages/LensIndexPage.tsx
@@ -146,11 +146,11 @@ export default function LensIndexPage() {
     padding: "0.25rem 0.75rem",
     fontSize: "0.8rem",
     fontFamily: "inherit",
-    border: `1px solid ${t.panelBorder}`,
+    border: `1px solid ${active ? t.toggleActiveBorder : t.toggleBorder}`,
     borderRadius: 4,
     cursor: "pointer",
-    backgroundColor: active ? t.accent : t.bg,
-    color: active ? t.bg : t.body,
+    backgroundColor: active ? t.toggleActiveBg : t.toggleBg,
+    color: active ? t.toggleActiveText : t.toggleInactiveText,
     fontWeight: active ? 600 : 400,
   });
 


### PR DESCRIPTION
## Summary
Added an alternative grouping mode to the lens index page that allows users to browse lenses by focal length instead of just by maker. Users can toggle between "By Maker" and "By Focal Length" views using new toggle buttons.

## Key Changes
- Added state management with `useState` hook to track the active grouping mode ("maker" or "focal")
- Implemented focal length classification system with 6 predefined buckets (Ultrawide, Wide, Normal, Short Tele, Mid Tele, Ultra Tele)
- Created `groupByFocalLength()` function that organizes lenses into focal length buckets, further subdivided by lens type (Primes vs Zooms)
- Added helper functions:
  - `focalBucketLabel()` - classifies a focal length into the appropriate bucket
  - `groupingFl()` - extracts the representative focal length for grouping (uses minimum for zoom ranges)
  - `isZoomLens()` - determines if a lens is a zoom or prime
- Added toggle button UI with styling that switches between grouping modes
- Restructured the page layout to display either maker groups or focal length sections based on the selected mode
- Focal length view displays a two-level hierarchy: Prime/Zoom sections → Focal length buckets → Individual lenses
- Updated page documentation to reflect the new grouping capability

## Implementation Details
- For zoom lenses, the grouping uses the wider (smaller) end of the focal length range to provide more intuitive categorization
- Focal buckets are ordered and filtered to only show non-empty categories
- Lens counts are displayed at multiple hierarchy levels for both grouping modes
- The toggle buttons use the existing theme system for consistent styling with active/inactive states

https://claude.ai/code/session_01Gued3bwqg9dHazPDGV35GE