### PR TITLE
Add GoatCounter analytics with SPA navigation tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          VITE_GOATCOUNTER_URL: ${{ vars.GOATCOUNTER_URL }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/index.html
+++ b/index.html
@@ -28,6 +28,9 @@
       content="Explore real camera lens designs with interactive cross-section diagrams, ray tracing, focus and aperture adjustment, element inspection, and chromatic aberration analysis. Built from optical patent data."
     />
 
+    <!-- GoatCounter analytics — auto-tracks initial page load; SPA navigations tracked in main.tsx -->
+    <script data-goatcounter="%VITE_GOATCOUNTER_URL%" async src="//gc.zgo.at/count.js"></script>
+
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       body { font-family: system-ui, -apple-system, sans-serif; }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,19 @@ import { HelmetProvider } from "react-helmet-async";
 import ErrorBoundary from "./components/errors/ErrorBoundary.js";
 import router from "./router.js";
 
+// Track SPA navigations in GoatCounter. The script tag in index.html handles the
+// initial page view automatically; this subscription fires only on subsequent
+// client-side route changes.
+let _gcInitialSkipped = false;
+router.subscribe((state) => {
+  if (!_gcInitialSkipped) {
+    _gcInitialSkipped = true;
+    return;
+  }
+  if (!import.meta.env.PROD || !window.goatcounter?.count) return;
+  window.goatcounter.count({ path: state.location.pathname + state.location.search });
+});
+
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary>
     <HelmetProvider>

--- a/src/types/goatcounter.d.ts
+++ b/src/types/goatcounter.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Ambient type declaration for the GoatCounter analytics global.
+ * Injected by the GoatCounter script tag in index.html.
+ */
+interface GoatCounter {
+  count(opts: { path: string; title?: string; referrer?: string; event?: boolean }): void;
+}
+
+interface Window {
+  goatcounter?: GoatCounter;
+}


### PR DESCRIPTION
- Add GoatCounter script tag to index.html (auto-tracks initial page load)
- Subscribe to router in main.tsx to track client-side navigations (PROD only)
- Add window.goatcounter ambient TypeScript declaration
- Inject VITE_GOATCOUNTER_URL from GOATCOUNTER_URL repo variable in deploy.yml

https://claude.ai/code/session_012e6BsMUKQ3VGu6i7MsNYZ9