### PR TITLE
Clear hover state when deselecting element in lens diagram

### DIFF
--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -225,7 +225,14 @@ export default function LensDiagramPanel({
                 showPupils={showPupils}
                 act={act}
                 onHover={setHov}
-                onSelect={(eid) => setSel(sel === eid ? null : eid)}
+                onSelect={(eid) => {
+                  if (sel === eid) {
+                    setSel(null);
+                    setHov(null);
+                  } else {
+                    setSel(eid);
+                  }
+                }}
                 sel={sel}
                 maxSvgHeight={maxSvgHeight}
                 useSideLayout={useSideLayout}


### PR DESCRIPTION
## Summary
Updated the element selection handler in LensDiagramPanel to clear the hover state when deselecting an element, improving the UI state consistency.

## Key Changes
- Modified the `onSelect` callback to explicitly clear both selection and hover state when deselecting an element
- Previously, only the selection state was cleared when clicking a selected element
- Now when an element is deselected, the hover state (`setHov(null)`) is also reset

## Implementation Details
The selection logic was expanded from a ternary operator to a full conditional block to accommodate the additional hover state cleanup. This ensures that when a user clicks on a selected element to deselect it, any lingering hover styling or state is also removed, providing a cleaner UI experience.

https://claude.ai/code/session_01TavsbrYYa5nZ9Z6ZQjQSyU