### PR TITLE
Reorder mobile homepage: Recent Lenses above Articles & Guides

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -83,11 +83,11 @@ export default function HomePage() {
         <HeroSection theme={t} />
         <QuickNavCards theme={t} />
         <div style={isDesktop ? { display: "flex", gap: "2rem", alignItems: "flex-start" } : {}}>
-          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0 } : {}}>
-            <ArticleList articles={displayedArticles} theme={t} showMoreLink={showMoreLink} />
-          </div>
-          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0 } : {}}>
+          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0, order: 1 } : {}}>
             <RecentLenses entries={RECENT_LENS_KEYS} theme={t} />
+          </div>
+          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0, order: 0 } : {}}>
+            <ArticleList articles={displayedArticles} theme={t} showMoreLink={showMoreLink} />
           </div>
         </div>
         <HomeFooter theme={t} />


### PR DESCRIPTION
On mobile (< 720px), DOM order now puts RecentLenses before ArticleList. On desktop, CSS flex `order` properties restore ArticleList on the left and RecentLenses on the right, preserving the original desktop layout.

https://claude.ai/code/session_01V6rBR5fJL3kUvmf9A1Dg3e