### PR TITLE
Adjust Nikon Nikkor Z 100-400mm lens optical parameters

### DIFF
--- a/src/lens-data/NikonNikkorZ100400f4556.data.ts
+++ b/src/lens-data/NikonNikkorZ100400f4556.data.ts
@@ -53,8 +53,8 @@ const LENS_DATA = {
   maxFstop: 32,
 
   scFill: 0.48,
-  yScFill: 0.3,
-  maxAspectRatio: 2.2,
+  yScFill: 0.42,
+  maxAspectRatio: 1.6,
   lensShiftFrac: 0.06,
 
   elements: [


### PR DESCRIPTION
## Summary
Updated optical rendering parameters for the Nikon Nikkor Z 100-400mm f/4.5-5.6 lens to improve visual accuracy.

## Changes
- Increased `yScFill` from 0.3 to 0.42 to adjust vertical scale fill
- Decreased `maxAspectRatio` from 2.2 to 1.6 to constrain maximum aspect ratio

## Details
These parameter adjustments refine how the lens is rendered optically, affecting the vertical scaling and aspect ratio constraints used in lens simulation calculations.

https://claude.ai/code/session_01JGD8QqP4UFkEwWS57jzvqE