### PR TITLE
Tune semi-diameters for Nikon AF-S NIKKOR 28mm f/1.4E ED

### DIFF
--- a/src/lens-data/NikonAFS28f14E.data.ts
+++ b/src/lens-data/NikonAFS28f14E.data.ts
@@ -18,9 +18,12 @@ import type { LensDataInput } from "../types/optics.js";
  * ║                                                                        ║
  * ║  NOTE ON SEMI-DIAMETERS:                                               ║
  * ║    SDs estimated from paraxial marginal + chief ray trace at full      ║
- * ║    field (2ω = 75.42°) with ~8% mechanical clearance.  Patent does     ║
- * ║    not list semi-diameters.  Rear-group SDs reflect expected           ║
- * ║    natural vignetting at f/1.4.                                        ║
+ * ║    field (2ω = 75.42°) with ~8% mechanical clearance, then tuned      ║
+ * ║    to match the production lens cross-section profile.  Patent does    ║
+ * ║    not list semi-diameters.  L11 front (S1 = 33 mm) is consistent     ║
+ * ║    with the 77 mm filter-thread specification.  S6/S7 (L13) are       ║
+ * ║    constrained to 26.0 mm by the 4.85 mm cross-gap to the LS doublet. ║
+ * ║    Rear-group SDs reflect expected natural vignetting at f/1.4.       ║
  * ╚══════════════════════════════════════════════════════════════════════════╝
  */
 
@@ -259,9 +262,9 @@ const LENS_DATA = {
    */
   surfaces: [
     // ── Gr1: Front group (fixed) ──
-    { label: "1", R: 70.017, d: 2.5, nd: 1.68893, elemId: 1, sd: 30.5 }, // L11 front
-    { label: "2", R: 29.64, d: 10.58, nd: 1.0, elemId: 0, sd: 25.5 }, // L11 rear → air (sd<0.9×R to avoid TIR)
-    { label: "3", R: 94.105, d: 2.4, nd: 1.713, elemId: 2, sd: 29.0 }, // L12 glass front
+    { label: "1", R: 70.017, d: 2.5, nd: 1.68893, elemId: 1, sd: 33.0 }, // L11 front
+    { label: "2", R: 29.64, d: 10.58, nd: 1.0, elemId: 0, sd: 26.5 }, // L11 rear → air (sd<0.9×R to avoid TIR)
+    { label: "3", R: 94.105, d: 2.4, nd: 1.713, elemId: 2, sd: 31.0 }, // L12 glass front
     { label: "4", R: 31.773, d: 0.05, nd: 1.5138, elemId: 3, sd: 25.5 }, // L12 glass→resin junction
     { label: "5A", R: 27.197, d: 9.49, nd: 1.0, elemId: 0, sd: 20.5 }, // L12 resin rear → air (asph; sd<0.9×R)
     { label: "6", R: 164.736, d: 4.94, nd: 1.84666, elemId: 4, sd: 26.0 }, // L13 front
@@ -269,15 +272,15 @@ const LENS_DATA = {
     { label: "8", R: -46.832, d: 2.15, nd: 1.56883, elemId: 5, sd: 27.5 }, // L14 front (LS doublet)
     { label: "9", R: 134.737, d: 4.17, nd: 1.883, elemId: 6, sd: 27.5 }, // L14→L15 cemented junction
     { label: "10", R: -366.912, d: 3.03, nd: 1.0, elemId: 0, sd: 28.0 }, // L15 rear → air
-    { label: "11", R: 70.316, d: 7.09, nd: 1.7725, elemId: 7, sd: 24.0 }, // L16 front
-    { label: "12", R: -99.338, d: 7.7, nd: 1.0, elemId: 0, sd: 22.5 }, // L16 rear → air [VARIABLE: Gr1→Gr2]
+    { label: "11", R: 70.316, d: 7.09, nd: 1.7725, elemId: 7, sd: 25.0 }, // L16 front
+    { label: "12", R: -99.338, d: 7.7, nd: 1.0, elemId: 0, sd: 23.0 }, // L16 rear → air [VARIABLE: Gr1→Gr2]
 
     // ── Gr2: Rear group (focusing, moves as unit toward object) ──
-    { label: "13", R: 55.349, d: 4.2, nd: 1.72916, elemId: 8, sd: 23.5 }, // L21 front
-    { label: "14", R: 289.177, d: 0.15, nd: 1.0, elemId: 0, sd: 21.5 }, // L21 rear → air
-    { label: "15", R: 111.31, d: 4.0, nd: 1.6968, elemId: 9, sd: 21.0 }, // L22 front
+    { label: "13", R: 55.349, d: 4.2, nd: 1.72916, elemId: 8, sd: 22.5 }, // L21 front
+    { label: "14", R: 289.177, d: 0.15, nd: 1.0, elemId: 0, sd: 21.0 }, // L21 rear → air
+    { label: "15", R: 111.31, d: 4.0, nd: 1.6968, elemId: 9, sd: 20.5 }, // L22 front
     { label: "16", R: -158.345, d: 0.15, nd: 1.0, elemId: 0, sd: 19.0 }, // L22 rear → air
-    { label: "17", R: 322.096, d: 5.79, nd: 1.59282, elemId: 10, sd: 19.0 }, // L23 front (ED, D1 doublet)
+    { label: "17", R: 322.096, d: 5.79, nd: 1.59282, elemId: 10, sd: 18.5 }, // L23 front (ED, D1 doublet)
     { label: "18", R: -37.124, d: 1.5, nd: 1.738, elemId: 11, sd: 15.5 }, // L23→L24 cemented junction
     { label: "19", R: 37.221, d: 5.6, nd: 1.0, elemId: 0, sd: 14.5 }, // L24 rear → air
 
@@ -288,10 +291,10 @@ const LENS_DATA = {
     { label: "21", R: -24.127, d: 1.3, nd: 1.8061, elemId: 12, sd: 11.5 }, // L25 front (D2 doublet)
     { label: "22", R: 47.257, d: 5.35, nd: 1.8322, elemId: 13, sd: 12.5 }, // L25→L26 cemented junction
     { label: "23A", R: -131.725, d: 0.3, nd: 1.0, elemId: 0, sd: 14.5 }, // L26 rear → air (asph)
-    { label: "24", R: 64.397, d: 8.98, nd: 1.59282, elemId: 14, sd: 15.0 }, // L27 front (ED)
-    { label: "25", R: -28.781, d: 0.15, nd: 1.0, elemId: 0, sd: 18.5 }, // L27 rear → air
-    { label: "26A", R: -280.388, d: 3.71, nd: 1.6935, elemId: 15, sd: 18.5 }, // L28 front (asph)
-    { label: "27A", R: -55.502, d: 38.47, nd: 1.0, elemId: 0, sd: 19.0 }, // L28 rear → image (asph) [VARIABLE: BF]
+    { label: "24", R: 64.397, d: 8.98, nd: 1.59282, elemId: 14, sd: 16.0 }, // L27 front (ED)
+    { label: "25", R: -28.781, d: 0.15, nd: 1.0, elemId: 0, sd: 19.0 }, // L27 rear → air
+    { label: "26A", R: -280.388, d: 3.71, nd: 1.6935, elemId: 15, sd: 19.0 }, // L28 front (asph)
+    { label: "27A", R: -55.502, d: 38.47, nd: 1.0, elemId: 0, sd: 20.0 }, // L28 rear → image (asph) [VARIABLE: BF]
   ],
 
   /* ── Aspherical coefficients ──


### PR DESCRIPTION
Adjust SDs to better match the production lens cross-section profile:

- S1 (L11 front): 30.5 → 33.0 mm — consistent with 77 mm filter thread;
  makes L11 clearly the largest element as in the official Nikon diagram
- S2 (L11 rear): 25.5 → 26.5 mm — near the sd/|R| = 0.894 limit
- S3 (L12 glass front): 29.0 → 31.0 mm — L12c compound element wider
- S11 (L16 front): 24.0 → 25.0 mm, S12 (rear): 22.5 → 23.0 mm
- S13 (L21 front): 23.5 → 22.5 mm — creates clean visual break at Gr1/Gr2 gap
- S14/S15 (L21 rear, L22 front): 21.5/21.0 → 21.0/20.5 mm
- S17 (L23 front): 19.0 → 18.5 mm — tighter D1 pre-stop taper
- S24/S25 (L27 front/rear): 15.0/18.5 → 16.0/19.0 mm — L27 slightly wider
- S26A/S27A (L28 front/rear): 18.5/19.0 → 19.0/20.0 mm — L28 slightly wider

S6/S7 (L13) remain at 26.0 mm — constrained by the 4.85 mm cross-gap to
the LS doublet which only allows ~0.06 mm margin before validation fails.

All sd/|R| ratios, SD consistency ratios (max/min ≤ 1.25), edge-thickness
checks, and cross-gap overlap checks continue to pass (639 tests green).

https://claude.ai/code/session_01WLnJsGF8xBVF6GfKNjPLfB