### PR TITLE
[codex] Separate distortion analysis from focus breathing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Read the relevant file before starting work on that area:
 - **`agent_docs/architecture.md`** — Module responsibilities, component data flow, API surface
 - **`agent_docs/adding_a_lens.md`** — Lens data creation workflow and troubleshooting
 - **`agent_docs/workflow.md`** — Commit style, pre-commit checks, and deployment pipeline
+- **`agent_docs/record_keeping.md`** — How to maintain branch/task records without bloating `CLAUDE.md`
 - **`agent_docs/code_conventions.md`** — Naming, TypeScript, formatting, and architecture constraints
 - **`agent_docs/commenting_guide.md`** — Code commenting standards and best practices
 - **`agent_docs/gotchas.md`** — Common pitfalls and non-obvious constraints
@@ -87,7 +88,7 @@ Read the relevant file before starting work on that area:
 - Shared utilities and components reduce duplication — check `architecture.md` before creating new ones
 - **Unified route pipeline** — `generate-build-metadata.mjs` is the single source of truth for all concrete routes; `prerender.mjs` validates routes against the React Router manifest; `generate-sitemap.mjs` and `seo-audit.mjs` consume the same route list from `build-metadata.json`
 - **Aberration analysis** — slider-state-dependent metrics (SA, distortion, vignetting) live in `src/optics/aberrationAnalysis.ts` and `src/optics/distortionAnalysis.ts` as pure helpers, memoized from current state in the Analysis Drawer tabs; they must NOT go in `buildLens()` which is build-time only
-- **Analysis Drawer** — sliding panel that overlays the SVG viewport with tabbed analysis views (aberrations, distortion). Opened via "ANALYSIS" button in `DiagramControlPanel`; state managed via `analysisDrawerOpen` / `analysisDrawerTab` in the panels slice. Desktop: vertical tabs on the left; mobile: horizontal tabs on top. New analysis tabs are added by extending `ANALYSIS_TABS` in `LensDiagramPanel.tsx` and creating a tab content component in `src/components/display/`
+- **Analysis Drawer** — sliding panel that overlays the SVG viewport with tabbed analysis views (aberrations, distortion, breathing, vignetting). Opened via the "ABERRATIONS & DISTORTIONS" button in `LensDiagramPanel.tsx`; state managed via `analysisDrawerOpen` / `analysisDrawerTab` in the panels slice. Desktop: vertical tabs on the left; mobile: horizontal tabs on top. New analysis tabs are added by extending `ANALYSIS_TABS` in `LensDiagramPanel.tsx` and creating a tab content component in `src/components/display/`
 - See `agent_docs/architecture.md` for full component relationships and data flow
 
 ## Adding a New Lens

--- a/__tests__/analysisDisplayTabs.test.ts
+++ b/__tests__/analysisDisplayTabs.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import buildLens from "../src/optics/buildLens.js";
+import LENS_DEFAULTS from "../src/lens-data/defaults.js";
+import { doLayout, eflAtFocus, fopenAtZoom } from "../src/optics/optics.js";
+import DistortionChart from "../src/components/display/DistortionChart.js";
+import DistortionTab from "../src/components/display/DistortionTab.js";
+import FocusBreathingTab from "../src/components/display/FocusBreathingTab.js";
+import themes from "../src/utils/themes.js";
+import Sonnar50f15Raw from "../src/lens-data/ZeissSonnar50f15.data.js";
+import type { DistortionSample } from "../src/optics/distortionAnalysis.js";
+import type { LensData, RuntimeLens } from "../src/types/optics.js";
+
+function build(raw: object): RuntimeLens {
+  return buildLens({ ...LENS_DEFAULTS, ...raw } as LensData);
+}
+
+function apertureAt(L: RuntimeLens, zoomT: number, stopdownT: number) {
+  const currentFOPEN = fopenAtZoom(zoomT, L);
+  const rawFNumber = L.FOPEN * Math.pow(L.maxFstop / L.FOPEN, stopdownT);
+  const fNumber = Math.max(rawFNumber, currentFOPEN);
+  const currentPhysStopSD = (L.stopPhysSD * L.FOPEN) / fNumber;
+  return { currentPhysStopSD };
+}
+
+describe("analysis display tabs", () => {
+  it("DistortionChart labels the x-axis as image height percentage", async () => {
+    const samples: DistortionSample[] = [
+      {
+        fieldAngleDeg: 0,
+        normalizedImageHeight: 0,
+        imageHeight: 0,
+        distortionPercent: 0,
+        realHeight: 0,
+        idealHeight: 0,
+        idealFieldAngleDeg: 0,
+      },
+      {
+        fieldAngleDeg: 12,
+        normalizedImageHeight: 1,
+        imageHeight: -20,
+        distortionPercent: 1.25,
+        realHeight: -20,
+        idealHeight: -19.75,
+        idealFieldAngleDeg: 11.9,
+      },
+    ];
+
+    const html = renderToStaticMarkup(React.createElement(DistortionChart, { samples, t: themes.dark }));
+    expect(html).toContain("Image height (% of edge)");
+    expect(html).toContain("100%");
+    expect(html).not.toContain("Field angle (°)");
+  });
+
+  it("DistortionTab renders rectilinear distortion copy and separate breathing metric", () => {
+    const L = build(Sonnar50f15Raw);
+    const focusT = 0.5;
+    const zoomT = 0;
+    const { z: zPos } = doLayout(focusT, zoomT, L);
+    const dynamicEFL = eflAtFocus(focusT, zoomT, L);
+    const { currentPhysStopSD } = apertureAt(L, zoomT, 0);
+
+    const html = renderToStaticMarkup(
+      React.createElement(DistortionTab, {
+        L,
+        t: themes.dark,
+        zPos,
+        focusT,
+        zoomT,
+        dynamicEFL,
+        currentPhysStopSD,
+      }),
+    );
+
+    expect(html).toContain("Rectilinear distortion");
+    expect(html).toContain("fixed image height");
+    expect(html).toContain("BREATHING");
+    expect(html).toContain("HEIGHT");
+    expect(html).toContain("ANGLE");
+    expect(html).not.toContain(">FIELD<");
+  });
+
+  it("FocusBreathingTab renders the breathing chart and summary metrics", () => {
+    const L = build(Sonnar50f15Raw);
+    const focusT = 0.5;
+    const zoomT = 0;
+    const dynamicEFL = eflAtFocus(focusT, zoomT, L);
+
+    const html = renderToStaticMarkup(
+      React.createElement(FocusBreathingTab, {
+        L,
+        t: themes.dark,
+        focusT,
+        zoomT,
+        dynamicEFL,
+      }),
+    );
+
+    expect(html).toContain("Focus breathing");
+    expect(html).toContain("Effective focal length shift");
+    expect(html).toContain("CURRENT");
+    expect(html).toContain("EFL");
+    expect(html).toContain("FOCUS");
+    expect(html).toContain("CLOSE");
+    expect(html).toContain("EFL change (%)");
+  });
+});

--- a/__tests__/distortionAnalysis.test.ts
+++ b/__tests__/distortionAnalysis.test.ts
@@ -6,6 +6,8 @@ import LENS_DEFAULTS from "../src/lens-data/defaults.js";
 import Sonnar50f15Raw from "../src/lens-data/ZeissSonnar50f15.data.js";
 import ApoLantharRaw from "../src/lens-data/VoigtlanderApoLanthar50f2.data.js";
 import NikkorZ70200Raw from "../src/lens-data/NikonNikkorZ70200f28.data.js";
+import NikonZ135Raw from "../src/lens-data/NikonZ135f18.data.js";
+import NikonZ100400Raw from "../src/lens-data/NikonNikkorZ100400f4556.data.js";
 import type { RuntimeLens, LensData } from "../src/types/optics.js";
 
 /* ── Helpers ── */
@@ -46,7 +48,7 @@ describe("computeDistortionCurve", () => {
     expect(samples[0].distortionPercent).toBe(0);
   });
 
-  it("field angles span from 0 to the half-field edge", () => {
+  it("field angles span from 0 to near the current field edge", () => {
     const L = build(ApoLantharRaw);
     const { z: zPos } = doLayout(0, 0, L);
     const dynamicEFL = eflAtFocus(0, 0, L);
@@ -57,8 +59,9 @@ describe("computeDistortionCurve", () => {
 
     const halfField = halfFieldAtZoom(0, L);
     const lastAngle = samples[samples.length - 1].fieldAngleDeg;
-    /* Last sample should be at or very near the half-field edge */
-    expect(lastAngle).toBeCloseTo(halfField, 1);
+    expect(lastAngle).toBeGreaterThan(0);
+    expect(lastAngle).toBeLessThanOrEqual(halfField);
+    expect(lastAngle).toBeGreaterThan(halfField * 0.9);
   });
 
   it("all samples have finite values", () => {
@@ -73,18 +76,21 @@ describe("computeDistortionCurve", () => {
       expect(isFinite(s.distortionPercent)).toBe(true);
       expect(isFinite(s.realHeight)).toBe(true);
       expect(isFinite(s.idealHeight)).toBe(true);
+      expect(isFinite(s.imageHeight)).toBe(true);
+      expect(isFinite(s.normalizedImageHeight)).toBe(true);
+      expect(isFinite(s.idealFieldAngleDeg)).toBe(true);
     }
   });
 
   /* ── Edge cases ── */
 
-  it("returns empty array when dynamicEFL is 0", () => {
+  it("ignores the legacy dynamicEFL input and still computes the curve", () => {
     const L = build(Sonnar50f15Raw);
     const { z: zPos } = doLayout(0, 0, L);
     const { currentPhysStopSD } = apertureAt(L, 0, 0);
 
     const samples = computeDistortionCurve(L, zPos, 0, 0, 0, currentPhysStopSD);
-    expect(samples).toEqual([]);
+    expect(samples.length).toBeGreaterThanOrEqual(9);
   });
 
   /* ── Zoom lens ── */
@@ -125,5 +131,40 @@ describe("computeDistortionCurve", () => {
     for (let i = 1; i < samples.length; i++) {
       expect(samples[i].fieldAngleDeg).toBeGreaterThan(samples[i - 1].fieldAngleDeg);
     }
+  });
+
+  it("image heights are monotonically increasing in magnitude", () => {
+    const L = build(Sonnar50f15Raw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const dynamicEFL = eflAtFocus(0, 0, L);
+    const { currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 0, 0, dynamicEFL, currentPhysStopSD);
+    for (let i = 1; i < samples.length; i++) {
+      expect(Math.abs(samples[i].imageHeight)).toBeGreaterThan(Math.abs(samples[i - 1].imageHeight));
+      expect(samples[i].normalizedImageHeight).toBeGreaterThan(samples[i - 1].normalizedImageHeight);
+    }
+  });
+
+  it("keeps close-focus distortion bounded for Nikon Z 135mm f/1.8", () => {
+    const L = build(NikonZ135Raw);
+    const { z: zPos } = doLayout(1, 0, L);
+    const dynamicEFL = eflAtFocus(1, 0, L);
+    const { currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 1, 0, dynamicEFL, currentPhysStopSD);
+    const maxAbs = samples.reduce((m, s) => Math.max(m, Math.abs(s.distortionPercent)), 0);
+    expect(maxAbs).toBeLessThan(10);
+  });
+
+  it("keeps tele close-focus distortion bounded for Nikon Z 100-400mm", () => {
+    const L = build(NikonZ100400Raw);
+    const { z: zPos } = doLayout(1, 1, L);
+    const dynamicEFL = eflAtFocus(1, 1, L);
+    const { currentPhysStopSD } = apertureAt(L, 1, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 1, 1, dynamicEFL, currentPhysStopSD);
+    const maxAbs = samples.reduce((m, s) => Math.max(m, Math.abs(s.distortionPercent)), 0);
+    expect(maxAbs).toBeLessThan(15);
   });
 });

--- a/__tests__/lensReducer.test.ts
+++ b/__tests__/lensReducer.test.ts
@@ -284,6 +284,11 @@ describe("lensReducer", () => {
       const next = lensReducer(state, { type: SET_ANALYSIS_TAB, tab: "distortion" });
       expect(next.panels.analysisDrawerTab).toBe("distortion");
     });
+
+    it("accepts the breathing analysis tab", () => {
+      const next = lensReducer(state, { type: SET_ANALYSIS_TAB, tab: "breathing" });
+      expect(next.panels.analysisDrawerTab).toBe("breathing");
+    });
   });
 
   /* ── Overlays ── */

--- a/agent_docs/record_keeping.md
+++ b/agent_docs/record_keeping.md
@@ -1,0 +1,55 @@
+# Record Keeping — LensVisualizer
+
+## Purpose
+
+Keep a lightweight, durable record of branch work so future sessions can recover context quickly without bloating `CLAUDE.md`.
+
+## What To Record
+
+Record only information that will matter after context is gone:
+
+- Current branch purpose
+- Meaningful user-facing or architectural changes
+- New analysis tabs, controls, or workflow changes
+- Commands run for verification and whether they passed
+- Open follow-ups, known limitations, or deferred work
+- PR-ready summary points when a branch is approaching review
+
+Do **not** copy large diffs, command transcripts, or code snippets here.
+
+## Where To Record It
+
+- Keep durable process guidance in docs like this one
+- Keep branch-specific notes in a short markdown file under `agent_docs/records/`
+- Prefer one file per branch or task, with a descriptive name such as:
+  - `agent_docs/records/focus-breathing-distortion-overhaul.md`
+  - `agent_docs/records/pr-123-followups.md`
+
+## Recommended Template
+
+```md
+# <Task or Branch Name>
+
+## Summary
+- Short description of the goal
+
+## Changes
+- High-signal bullets only
+
+## Verification
+- `npm run typecheck` — passed
+- `npx vitest run ...` — passed
+
+## Follow-ups
+- Remaining UI polish, edge cases, or cleanup
+```
+
+## Updating Records
+
+- Update the branch record at the end of each substantial stage, not every tiny edit
+- Before opening a PR, make sure the record reflects the final scope and verification status
+- When work is merged and no longer useful for active context, the record can be pruned or replaced by the PR itself
+
+## Governing Principle
+
+Prefer short, high-signal notes that help the next session restart work confidently.

--- a/agent_docs/records/focus-breathing-distortion-overhaul.md
+++ b/agent_docs/records/focus-breathing-distortion-overhaul.md
@@ -1,0 +1,26 @@
+# Focus Breathing / Distortion Overhaul
+
+## Summary
+
+- Branch: `ronbuening/codex_analyze_distortion`
+- Goal: separate focus breathing from distortion, stabilize close-focus distortion analysis, and expose breathing in the analysis drawer
+
+## Changes
+
+- Reworked distortion analysis to sample fixed image heights and solve back to object-space field angle
+- Added focus-aware field geometry helpers in the optics layer
+- Updated the distortion UI to reflect image-height-based rectilinear distortion
+- Added a dedicated breathing tab with a focus-range chart and current-state summary metrics
+- Renamed the lens-diagram launch button to `ABERRATIONS & DISTORTIONS`
+- Added display/reducer tests covering the new distortion semantics and breathing tab
+
+## Verification
+
+- `npx vitest run __tests__/distortionAnalysis.test.ts` — passed
+- `npx vitest run __tests__/analysisDisplayTabs.test.ts __tests__/lensReducer.test.ts` — passed
+- `npm run typecheck` — passed
+
+## Follow-ups
+
+- Consider a dedicated UI test around `LensDiagramPanel` tab visibility if full component rendering coverage expands
+- Consider PR notes/screenshots showing the distortion and breathing tabs side by side

--- a/agent_docs/workflow.md
+++ b/agent_docs/workflow.md
@@ -5,12 +5,20 @@
 - **Small, focused commits** — one logical change per commit (add a type, fix a bug, update a component, add a test)
 - **Commit and push frequently** — after each working stage, not only at the end
 - **Break larger tasks into stages** — commit at the end of each stage before moving to the next
+- **Update branch records at stage boundaries** — keep a short high-signal note in `agent_docs/records/` following `agent_docs/record_keeping.md`
 
 Typical stage breakdown:
 1. Types / interfaces → commit
 2. Optics/utils logic + tests → commit
 3. UI components → commit
 4. Final typecheck + lint + format pass → commit
+
+## Branch Records
+
+- For multi-step work, keep a concise branch/task record in `agent_docs/records/`
+- Record scope, meaningful changes, verification commands, and follow-ups
+- Before opening a PR, make sure the record reflects the final branch state
+- See `agent_docs/record_keeping.md` for the preferred format and pruning rules
 
 ## Pre-Commit Checks
 

--- a/src/components/display/DistortionChart.tsx
+++ b/src/components/display/DistortionChart.tsx
@@ -1,6 +1,6 @@
 /**
  * DistortionChart — Reusable SVG line chart plotting distortion %
- * versus field angle. Shows a zero reference line, sample dots,
+ * versus normalized image height. Shows a zero reference line, sample dots,
  * barrel/pincushion labels, and axis annotations.
  */
 
@@ -30,7 +30,6 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
   const plotH = height - MARGIN.top - MARGIN.bottom;
 
   /* ── Axis ranges ── */
-  const maxAngle = samples[samples.length - 1].fieldAngleDeg;
   const distortions = samples.map((s) => s.distortionPercent);
   const minD = Math.min(0, ...distortions);
   const maxD = Math.max(0, ...distortions);
@@ -40,13 +39,14 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
   const yMax = dRange * 1.2;
 
   /* ── Scale helpers ── */
-  const xScale = (angle: number) => MARGIN.left + (angle / maxAngle) * plotW;
+  const xScale = (normalizedImageHeight: number) => MARGIN.left + normalizedImageHeight * plotW;
   const yScale = (d: number) => MARGIN.top + ((yMax - d) / (yMax - yMin)) * plotH;
 
   /* ── Curve path ── */
   const pathD = samples
     .map(
-      (s, i) => `${i === 0 ? "M" : "L"}${xScale(s.fieldAngleDeg).toFixed(1)},${yScale(s.distortionPercent).toFixed(1)}`,
+      (s, i) =>
+        `${i === 0 ? "M" : "L"}${xScale(s.normalizedImageHeight).toFixed(1)},${yScale(s.distortionPercent).toFixed(1)}`,
     )
     .join(" ");
 
@@ -62,7 +62,7 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
   const yTicks = generateTicks(yMin, yMax);
 
   /* ── X-axis tick values ── */
-  const xTicks = generateAngleTicks(maxAngle);
+  const xTicks = generateImageHeightTicks();
 
   return (
     <svg viewBox={`0 0 ${width} ${height}`} width="100%" style={{ maxWidth: width, display: "block" }}>
@@ -111,22 +111,22 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
       {xTicks.map((tick) => (
         <g key={`x-${tick}`}>
           <line
-            x1={xScale(tick)}
+            x1={xScale(tick / 100)}
             y1={MARGIN.top + plotH}
-            x2={xScale(tick)}
+            x2={xScale(tick / 100)}
             y2={MARGIN.top + plotH + 4}
             stroke={t.muted}
             strokeWidth={0.5}
           />
           <text
-            x={xScale(tick)}
+            x={xScale(tick / 100)}
             y={MARGIN.top + plotH + 14}
             textAnchor="middle"
             fill={t.muted}
             fontSize={8}
             fontFamily="inherit"
           >
-            {tick.toFixed(0)}°
+            {tick.toFixed(0)}%
           </text>
         </g>
       ))}
@@ -156,7 +156,7 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
       {samples.map((s, i) => (
         <circle
           key={i}
-          cx={xScale(s.fieldAngleDeg)}
+          cx={xScale(s.normalizedImageHeight)}
           cy={yScale(s.distortionPercent)}
           r={2.5}
           fill={t.sliderAccent}
@@ -166,7 +166,7 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
 
       {/* ── Edge value annotation ── */}
       <text
-        x={xScale(edgeSample.fieldAngleDeg)}
+        x={xScale(edgeSample.normalizedImageHeight)}
         y={yScale(edgeSample.distortionPercent) + (edgeSample.distortionPercent >= 0 ? -10 : 14)}
         textAnchor="end"
         fill={t.value}
@@ -187,7 +187,7 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
         fontFamily="inherit"
         letterSpacing="0.05em"
       >
-        Field angle (°)
+        Image height (% of edge)
       </text>
       <text
         x={10}
@@ -235,18 +235,9 @@ function generateTicks(yMin: number, yMax: number): number[] {
   return ticks;
 }
 
-/** Generate x-axis tick values. */
-function generateAngleTicks(maxAngle: number): number[] {
-  const rawStep = maxAngle / 5;
-  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
-  const niceSteps = [1, 2, 5, 10];
-  const step = niceSteps.find((s) => s * mag >= rawStep)! * mag;
-
-  const ticks: number[] = [];
-  for (let v = 0; v <= maxAngle; v += step) {
-    ticks.push(v);
-  }
-  return ticks;
+/** Generate x-axis tick values in percent of edge image height. */
+function generateImageHeightTicks(): number[] {
+  return [0, 20, 40, 60, 80, 100];
 }
 
 /** Format a tick value, avoiding unnecessary decimals. */

--- a/src/components/display/DistortionTab.tsx
+++ b/src/components/display/DistortionTab.tsx
@@ -7,6 +7,7 @@
 
 import { useMemo } from "react";
 import { computeDistortionCurve } from "../../optics/distortionAnalysis.js";
+import { eflAtZoom } from "../../optics/optics.js";
 import DistortionChart from "./DistortionChart.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
@@ -46,11 +47,18 @@ export default function DistortionTab({
   const edgeSample = samples[samples.length - 1];
   const directionLabel =
     edgeSample.distortionPercent > 0.01 ? "barrel" : edgeSample.distortionPercent < -0.01 ? "pincushion" : "negligible";
+  const infinityEFL = L.isZoom ? eflAtZoom(zoomT, L) : L.EFL;
+  const breathingPercent = Math.abs(infinityEFL) > 1e-9 ? (100 * (dynamicEFL - infinityEFL)) / infinityEFL : 0;
+  const breathingLabel =
+    Math.abs(breathingPercent) < 0.05 ? "negligible" : breathingPercent < 0 ? "narrower FOV" : "wider FOV";
 
   return (
     <div>
-      <div style={{ marginBottom: 8 }}>
-        <span style={{ fontSize: 10.5, color: t.muted, transition: "color 0.3s" }}>Distortion</span>
+      <div style={{ marginBottom: 8, display: "grid", gap: 4 }}>
+        <span style={{ fontSize: 10.5, color: t.muted, transition: "color 0.3s" }}>Rectilinear distortion</span>
+        <span style={{ fontSize: 9, color: t.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
+          Measured at fixed image height. Focus breathing is reported separately from distortion.
+        </span>
       </div>
       <DistortionChart samples={samples} t={t} />
       <div
@@ -79,7 +87,21 @@ export default function DistortionTab({
           <span style={{ fontSize: 9, color: t.muted, transition: "color 0.3s" }}>({directionLabel})</span>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>FIELD</span>
+          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>HEIGHT</span>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: t.value,
+              fontVariantNumeric: "tabular-nums",
+              transition: "color 0.3s",
+            }}
+          >
+            {Math.abs(edgeSample.imageHeight).toFixed(1)} mm
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>ANGLE</span>
           <span
             style={{
               fontSize: 13,
@@ -91,6 +113,24 @@ export default function DistortionTab({
           >
             {edgeSample.fieldAngleDeg.toFixed(1)}°
           </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
+            BREATHING
+          </span>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: t.value,
+              fontVariantNumeric: "tabular-nums",
+              transition: "color 0.3s",
+            }}
+          >
+            {breathingPercent >= 0 ? "+" : ""}
+            {breathingPercent.toFixed(1)}%
+          </span>
+          <span style={{ fontSize: 9, color: t.muted, transition: "color 0.3s" }}>({breathingLabel})</span>
         </div>
       </div>
     </div>

--- a/src/components/display/FocusBreathingTab.tsx
+++ b/src/components/display/FocusBreathingTab.tsx
@@ -1,0 +1,351 @@
+/**
+ * FocusBreathingTab — Analysis drawer tab content for focus breathing.
+ *
+ * Shows how effective focal length changes across the focus range at the
+ * current zoom position, with the current focus point highlighted.
+ */
+
+import { useMemo } from "react";
+import { eflAtFocus, eflAtZoom, formatDist } from "../../optics/optics.js";
+import type { RuntimeLens } from "../../types/optics.js";
+import type { Theme } from "../../types/theme.js";
+
+interface FocusBreathingTabProps {
+  L: RuntimeLens;
+  t: Theme;
+  focusT: number;
+  zoomT: number;
+  dynamicEFL: number;
+}
+
+interface BreathingSample {
+  focusT: number;
+  efl: number;
+  breathingPercent: number;
+  distanceLabel: string;
+}
+
+const SAMPLE_COUNT = 21;
+const MARGIN = { top: 24, right: 20, bottom: 42, left: 48 };
+
+function buildBreathingSamples(L: RuntimeLens, zoomT: number, currentFocusT: number): BreathingSample[] {
+  const infinityEFL = L.isZoom ? eflAtZoom(zoomT, L) : L.EFL;
+  const points = new Set<number>([0, 1, currentFocusT]);
+  for (let i = 0; i < SAMPLE_COUNT; i++) points.add(i / (SAMPLE_COUNT - 1));
+
+  return [...points]
+    .sort((a, b) => a - b)
+    .map((focusT) => {
+      const efl = eflAtFocus(focusT, zoomT, L);
+      const breathingPercent = Math.abs(infinityEFL) > 1e-9 ? (100 * (efl - infinityEFL)) / infinityEFL : 0;
+      return {
+        focusT,
+        efl,
+        breathingPercent,
+        distanceLabel: formatDist(focusT, L),
+      };
+    });
+}
+
+function FocusBreathingChart({
+  samples,
+  currentFocusT,
+  t,
+  width = 320,
+  height = 220,
+}: {
+  samples: BreathingSample[];
+  currentFocusT: number;
+  t: Theme;
+  width?: number;
+  height?: number;
+}) {
+  const plotW = width - MARGIN.left - MARGIN.right;
+  const plotH = height - MARGIN.top - MARGIN.bottom;
+  const breathingValues = samples.map((s) => s.breathingPercent);
+  const minB = Math.min(0, ...breathingValues);
+  const maxB = Math.max(0, ...breathingValues);
+  const bRange = Math.max(Math.abs(minB), Math.abs(maxB), 0.5);
+  const yMin = -bRange * 1.2;
+  const yMax = bRange * 1.2;
+
+  const xScale = (focusT: number) => MARGIN.left + focusT * plotW;
+  const yScale = (value: number) => MARGIN.top + ((yMax - value) / (yMax - yMin)) * plotH;
+
+  const pathD = samples
+    .map((s, i) => `${i === 0 ? "M" : "L"}${xScale(s.focusT).toFixed(1)},${yScale(s.breathingPercent).toFixed(1)}`)
+    .join(" ");
+
+  const currentSample =
+    samples.find((s) => Math.abs(s.focusT - currentFocusT) < 1e-9) ??
+    samples.reduce((best, sample) =>
+      Math.abs(sample.focusT - currentFocusT) < Math.abs(best.focusT - currentFocusT) ? sample : best,
+    );
+
+  const yTicks = generateTicks(yMin, yMax);
+  const xTicks = [
+    { focusT: 0, label: "∞" },
+    { focusT: 0.5, label: "mid" },
+    { focusT: 1, label: samples[samples.length - 1].distanceLabel },
+  ];
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} width="100%" style={{ maxWidth: width, display: "block" }}>
+      <rect x={MARGIN.left} y={MARGIN.top} width={plotW} height={plotH} fill="none" />
+
+      <line
+        x1={MARGIN.left}
+        y1={yScale(0)}
+        x2={MARGIN.left + plotW}
+        y2={yScale(0)}
+        stroke={t.muted}
+        strokeWidth={1}
+        strokeDasharray="4,3"
+        opacity={0.6}
+      />
+
+      {yTicks.map((tick) => (
+        <g key={`y-${tick}`}>
+          <line
+            x1={MARGIN.left}
+            y1={yScale(tick)}
+            x2={MARGIN.left + plotW}
+            y2={yScale(tick)}
+            stroke={t.panelBorder}
+            strokeWidth={0.5}
+            opacity={0.4}
+          />
+          <text
+            x={MARGIN.left - 6}
+            y={yScale(tick)}
+            textAnchor="end"
+            dominantBaseline="central"
+            fill={t.muted}
+            fontSize={8}
+            fontFamily="inherit"
+          >
+            {tick === 0 ? "0" : `${tick > 0 ? "+" : ""}${formatTick(tick)}%`}
+          </text>
+        </g>
+      ))}
+
+      {xTicks.map((tick) => (
+        <g key={`x-${tick.label}`}>
+          <line
+            x1={xScale(tick.focusT)}
+            y1={MARGIN.top + plotH}
+            x2={xScale(tick.focusT)}
+            y2={MARGIN.top + plotH + 4}
+            stroke={t.muted}
+            strokeWidth={0.5}
+          />
+          <text
+            x={xScale(tick.focusT)}
+            y={MARGIN.top + plotH + 14}
+            textAnchor="middle"
+            fill={t.muted}
+            fontSize={8}
+            fontFamily="inherit"
+          >
+            {tick.label}
+          </text>
+        </g>
+      ))}
+
+      <line
+        x1={MARGIN.left}
+        y1={MARGIN.top}
+        x2={MARGIN.left}
+        y2={MARGIN.top + plotH}
+        stroke={t.panelBorder}
+        strokeWidth={1}
+      />
+      <line
+        x1={MARGIN.left}
+        y1={MARGIN.top + plotH}
+        x2={MARGIN.left + plotW}
+        y2={MARGIN.top + plotH}
+        stroke={t.panelBorder}
+        strokeWidth={1}
+      />
+
+      <path d={pathD} fill="none" stroke={t.sliderAccent} strokeWidth={1.5} strokeLinejoin="round" />
+
+      {samples.map((s, i) => (
+        <circle
+          key={i}
+          cx={xScale(s.focusT)}
+          cy={yScale(s.breathingPercent)}
+          r={2.2}
+          fill={t.sliderAccent}
+          opacity={0.75}
+        />
+      ))}
+
+      <line
+        x1={xScale(currentSample.focusT)}
+        y1={MARGIN.top}
+        x2={xScale(currentSample.focusT)}
+        y2={MARGIN.top + plotH}
+        stroke={t.value}
+        strokeWidth={0.9}
+        strokeDasharray="3,3"
+        opacity={0.8}
+      />
+      <circle cx={xScale(currentSample.focusT)} cy={yScale(currentSample.breathingPercent)} r={3.6} fill={t.value} />
+
+      <text
+        x={xScale(currentSample.focusT)}
+        y={yScale(currentSample.breathingPercent) + (currentSample.breathingPercent >= 0 ? -10 : 14)}
+        textAnchor="middle"
+        fill={t.value}
+        fontSize={9}
+        fontWeight={600}
+        fontFamily="inherit"
+      >
+        {currentSample.breathingPercent >= 0 ? "+" : ""}
+        {currentSample.breathingPercent.toFixed(1)}%
+      </text>
+
+      <text
+        x={MARGIN.left + plotW / 2}
+        y={height - 4}
+        textAnchor="middle"
+        fill={t.muted}
+        fontSize={8.5}
+        fontFamily="inherit"
+        letterSpacing="0.05em"
+      >
+        Focus position
+      </text>
+      <text
+        x={10}
+        y={MARGIN.top + plotH / 2}
+        textAnchor="middle"
+        fill={t.muted}
+        fontSize={8.5}
+        fontFamily="inherit"
+        letterSpacing="0.05em"
+        transform={`rotate(-90, 10, ${MARGIN.top + plotH / 2})`}
+      >
+        EFL change (%)
+      </text>
+    </svg>
+  );
+}
+
+export default function FocusBreathingTab({ L, t, focusT, zoomT, dynamicEFL }: FocusBreathingTabProps) {
+  const samples = useMemo(() => buildBreathingSamples(L, zoomT, focusT), [L, zoomT, focusT]);
+  const infinityEFL = L.isZoom ? eflAtZoom(zoomT, L) : L.EFL;
+  const currentBreathingPercent = Math.abs(infinityEFL) > 1e-9 ? (100 * (dynamicEFL - infinityEFL)) / infinityEFL : 0;
+  const closeSample = samples[samples.length - 1];
+  const breathingLabel =
+    Math.abs(currentBreathingPercent) < 0.05
+      ? "negligible"
+      : currentBreathingPercent < 0
+        ? "narrower FOV"
+        : "wider FOV";
+
+  return (
+    <div>
+      <div style={{ marginBottom: 8, display: "grid", gap: 4 }}>
+        <span style={{ fontSize: 10.5, color: t.muted, transition: "color 0.3s" }}>Focus breathing</span>
+        <span style={{ fontSize: 9, color: t.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
+          Effective focal length shift across the focus range at the current zoom position.
+        </span>
+      </div>
+      <FocusBreathingChart samples={samples} currentFocusT={focusT} t={t} />
+      <div
+        style={{
+          display: "flex",
+          gap: 14,
+          flexWrap: "wrap",
+          fontSize: 9.5,
+          marginTop: 10,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
+            CURRENT
+          </span>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: t.value,
+              fontVariantNumeric: "tabular-nums",
+              transition: "color 0.3s",
+            }}
+          >
+            {currentBreathingPercent >= 0 ? "+" : ""}
+            {currentBreathingPercent.toFixed(1)}%
+          </span>
+          <span style={{ fontSize: 9, color: t.muted, transition: "color 0.3s" }}>({breathingLabel})</span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>EFL</span>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: t.value,
+              fontVariantNumeric: "tabular-nums",
+              transition: "color 0.3s",
+            }}
+          >
+            {dynamicEFL.toFixed(1)} mm
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>FOCUS</span>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: t.value,
+              fontVariantNumeric: "tabular-nums",
+              transition: "color 0.3s",
+            }}
+          >
+            {formatDist(focusT, L)}
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>CLOSE</span>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: t.value,
+              fontVariantNumeric: "tabular-nums",
+              transition: "color 0.3s",
+            }}
+          >
+            {closeSample.breathingPercent >= 0 ? "+" : ""}
+            {closeSample.breathingPercent.toFixed(1)}%
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function generateTicks(yMin: number, yMax: number): number[] {
+  const range = yMax - yMin;
+  const rawStep = range / 6;
+  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const niceSteps = [1, 2, 5, 10];
+  const step = niceSteps.find((s) => s * mag >= rawStep)! * mag;
+
+  const ticks: number[] = [];
+  for (let v = Math.ceil(yMin / step) * step; v <= yMax; v += step) {
+    ticks.push(Math.round(v * 1e6) / 1e6);
+  }
+  return ticks;
+}
+
+function formatTick(v: number): string {
+  if (Number.isInteger(v)) return v.toString();
+  if (Math.abs(v) >= 1) return v.toFixed(1);
+  return v.toFixed(2);
+}

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -36,6 +36,7 @@ import AnalysisDrawer from "./AnalysisDrawer.js";
 import type { AnalysisTab } from "./AnalysisDrawer.js";
 import AberrationsPanel from "../display/AberrationsPanel.js";
 import DistortionTab from "../display/DistortionTab.js";
+import FocusBreathingTab from "../display/FocusBreathingTab.js";
 import VignettingTab from "../display/VignettingTab.js";
 import AbbeDiagram from "../display/AbbeDiagram.js";
 import LCAOverlayContent from "../diagram/LCAOverlayContent.js";
@@ -47,6 +48,7 @@ import useMediaQuery from "../../utils/useMediaQuery.js";
 const ANALYSIS_TABS: AnalysisTab[] = [
   { id: "aberrations", label: "ABERRATIONS" },
   { id: "distortion", label: "DISTORTION" },
+  { id: "breathing", label: "BREATHING" },
   { id: "vignetting", label: "VIGNETTING" },
 ];
 
@@ -302,7 +304,7 @@ export default function LensDiagramPanel({
                     color: t.muted,
                   }}
                 >
-                  <span>ABERRATIONS</span>
+                  <span>ABERRATIONS &amp; DISTORTIONS</span>
                   <span style={{ fontSize: 11, lineHeight: 1 }}>{"\u25B8"}</span>
                 </button>
               )}
@@ -339,6 +341,9 @@ export default function LensDiagramPanel({
                     dynamicEFL={dynamicEFL}
                     currentPhysStopSD={currentPhysStopSD}
                   />
+                )}
+                {analysisDrawerTab === "breathing" && (
+                  <FocusBreathingTab L={L} t={t} focusT={focusT} zoomT={zoomT} dynamicEFL={dynamicEFL} />
                 )}
                 {analysisDrawerTab === "vignetting" && (
                   <VignettingTab

--- a/src/optics/distortionAnalysis.ts
+++ b/src/optics/distortionAnalysis.ts
@@ -1,27 +1,34 @@
 /**
  * Distortion analysis — pure function for computing a distortion curve
- * across the field for the current lens state.
+ * across the current image height for the active lens state.
  *
- * Traces chief rays at sampled field angles, compares real image height
- * to the rectilinear ideal (EFL × tan θ), and returns distortion %.
+ * Samples fixed image heights from center to the current field edge,
+ * solves the object-space field angle that lands at each height, and
+ * compares the traced image height to the current rectilinear ideal.
  *
  * No React dependencies — fully testable in isolation. Memoize from
  * current state in a hook rather than embedding in a component.
  */
 
-import { traceRay, halfFieldAtZoom, bAtZoom, yRatioAtZoom, thick } from "./optics.js";
+import { chiefRayImageHeight, computeFieldGeometryAtState, solveFieldAngleForImageHeight } from "./optics.js";
 import type { RuntimeLens } from "../types/optics.js";
 
 /** A single sample point on the distortion curve. */
 export interface DistortionSample {
-  /** Field angle in degrees (0 = on-axis). */
+  /** Object-space field angle in degrees (0 = on-axis). */
   fieldAngleDeg: number;
+  /** Normalized image height from center to current edge (0..1). */
+  normalizedImageHeight: number;
+  /** Current image height on the sensor/image plane (mm, signed). */
+  imageHeight: number;
   /** Distortion as a percentage: 100 × (real − ideal) / ideal. */
   distortionPercent: number;
   /** Traced chief-ray image height (mm, signed). */
   realHeight: number;
   /** Ideal rectilinear image height: EFL × tan(θ) (mm, signed). */
   idealHeight: number;
+  /** Ideal rectilinear object angle for this image height at current scale. */
+  idealFieldAngleDeg: number;
 }
 
 /** Number of evenly-spaced field samples (including center and edge). */
@@ -30,21 +37,18 @@ const SAMPLE_COUNT = 11;
 /**
  * Compute a distortion curve for the current lens state.
  *
- * Samples the field from center (0°) to the current half-field edge at
- * SAMPLE_COUNT evenly-spaced angles. At each angle a chief ray is traced
- * through the system and the real image height is compared against the
- * ideal rectilinear projection.
- *
- * The chief-ray launch convention matches the off-axis display rays:
- *   uField = −tan(θ)
- *   yChief = −(B / yRatio) × uField
+ * Samples the image plane from center to the current traced field edge at
+ * SAMPLE_COUNT evenly-spaced image heights. At each height, solves the
+ * object-space field angle that reaches that point, then compares the
+ * actual image height to an ideal rectilinear mapping derived from the
+ * current near-axis scale.
  *
  * @param L               — runtime lens object
  * @param zPos            — surface z-positions for current focus/zoom
  * @param focusT          — focus slider [0..1]
  * @param zoomT           — zoom slider [0..1]
- * @param dynamicEFL      — effective focal length for current focus/zoom (mm)
- * @param currentPhysStopSD — current physical stop semi-diameter (mm)
+ * @param dynamicEFL      — retained for compatibility with existing callers
+ * @param currentPhysStopSD — retained for compatibility with existing callers
  * @returns                  array of DistortionSample, or empty if tracing fails
  */
 export function computeDistortionCurve(
@@ -52,53 +56,62 @@ export function computeDistortionCurve(
   zPos: number[],
   focusT: number,
   zoomT: number,
-  dynamicEFL: number,
+  _dynamicEFL: number,
   _currentPhysStopSD: number,
 ): DistortionSample[] {
-  if (L.N < 1 || dynamicEFL === 0) return [];
+  if (L.N < 1) return [];
 
-  const halfFieldDeg = halfFieldAtZoom(zoomT, L);
-  if (halfFieldDeg <= 0 || !isFinite(halfFieldDeg)) return [];
+  const geometry = computeFieldGeometryAtState(focusT, zoomT, L);
+  if (geometry.halfFieldDeg <= 0 || !isFinite(geometry.halfFieldDeg)) return [];
 
-  const bVal = bAtZoom(zoomT, L);
-  const yRatio = yRatioAtZoom(zoomT, L);
-  if (yRatio === 0) return [];
+  const edgeImageHeight = chiefRayImageHeight(geometry.halfFieldDeg, zPos, focusT, zoomT, L, geometry);
+  if (!isFinite(edgeImageHeight) || Math.abs(edgeImageHeight) < 1e-9) return [];
+
+  const scaleProbeAngleDeg = Math.min(Math.max(geometry.halfFieldDeg * 0.02, 0.05), 0.25);
+  const probeImageHeight = chiefRayImageHeight(scaleProbeAngleDeg, zPos, focusT, zoomT, L, geometry);
+  const probeTan = Math.tan((scaleProbeAngleDeg * Math.PI) / 180);
+  if (!isFinite(probeImageHeight) || Math.abs(probeTan) < 1e-12) return [];
+
+  const rectilinearScale = -probeImageHeight / probeTan;
+  if (!isFinite(rectilinearScale) || Math.abs(rectilinearScale) < 1e-9) return [];
 
   const samples: DistortionSample[] = [];
+  const edgeAbsHeight = Math.abs(edgeImageHeight);
 
   for (let i = 0; i < SAMPLE_COUNT; i++) {
-    const fieldAngleDeg = (i / (SAMPLE_COUNT - 1)) * halfFieldDeg;
-
-    /* Center sample: distortion is 0 by definition */
+    const normalizedImageHeight = i / (SAMPLE_COUNT - 1);
     if (i === 0) {
-      samples.push({ fieldAngleDeg: 0, distortionPercent: 0, realHeight: 0, idealHeight: 0 });
+      samples.push({
+        fieldAngleDeg: 0,
+        normalizedImageHeight: 0,
+        imageHeight: 0,
+        distortionPercent: 0,
+        realHeight: 0,
+        idealHeight: 0,
+        idealFieldAngleDeg: 0,
+      });
       continue;
     }
 
+    const realHeight = -edgeAbsHeight * normalizedImageHeight;
+    const fieldAngleDeg = solveFieldAngleForImageHeight(realHeight, zPos, focusT, zoomT, L, geometry);
+    if (fieldAngleDeg == null || !isFinite(fieldAngleDeg)) continue;
+
     const thetaRad = (fieldAngleDeg * Math.PI) / 180;
-    const uField = -Math.tan(thetaRad);
-    const yChief = -(bVal / yRatio) * uField;
-
-    /* Trace chief ray (no stop clipping — chief ray passes through stop center) */
-    const trace = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L);
-
-    /* Project from the last optical surface to the image plane by propagating
-     * through the final air gap (BFD).  thick(N-1, ...) gives the current
-     * back-focal distance accounting for focus and zoom. */
-    const realHeight = trace.y + trace.u * thick(L.N - 1, focusT, zoomT, L);
-
-    /* Ideal rectilinear height: negative because the image is inverted */
-    const idealHeight = -(dynamicEFL * Math.tan(thetaRad));
-
-    if (!isFinite(realHeight) || !isFinite(idealHeight) || idealHeight === 0) continue;
+    const idealHeight = -(rectilinearScale * Math.tan(thetaRad));
+    if (!isFinite(idealHeight) || idealHeight === 0) continue;
 
     const distortionPercent = (100 * (realHeight - idealHeight)) / idealHeight;
+    const idealFieldAngleDeg = (Math.atan(Math.abs(realHeight) / rectilinearScale) * 180) / Math.PI;
 
     samples.push({
       fieldAngleDeg,
+      normalizedImageHeight,
+      imageHeight: realHeight,
       distortionPercent: isFinite(distortionPercent) ? distortionPercent : 0,
       realHeight,
       idealHeight,
+      idealFieldAngleDeg,
     });
   }
 

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -14,6 +14,20 @@ import type {
   AsphericCoefficients,
 } from "../types/optics.js";
 
+interface StateSurfaceTraceResult {
+  y: number;
+  u: number;
+  clipped: boolean;
+  heights: number[] | null;
+}
+
+export interface FieldGeometryState {
+  halfFieldDeg: number;
+  yRatio: number;
+  b: number;
+  epRatio: number;
+}
+
 /* ── Named constants ── */
 export const FLAT_R_THRESHOLD: number = 1e10; /* surfaces with |R| above this are treated as flat (plano) */
 const SVG_PATH_SUBDIVISIONS: number = 48; /* arc segments per surface when building SVG paths */
@@ -208,6 +222,179 @@ export function doLayout(focusT: number, zoomT: number, L: RuntimeLens): LayoutR
   const z = [0];
   for (let i = 0; i < th.length - 1; i++) z.push(z[i] + th[i]);
   return { z, th, imgZ: z[z.length - 1] + th[th.length - 1] };
+}
+
+function stateSurfaces(focusT: number, zoomT: number, L: RuntimeLens) {
+  return L.S.map((s, i) => ({ ...s, d: thick(i, focusT, zoomT, L) }));
+}
+
+function traceStateSurfacesParaxial(
+  S: RuntimeLens["S"],
+  y0: number,
+  u0: number,
+  {
+    stopAt,
+    skipLastTransfer = false,
+    recordHeights = false,
+  }: { stopAt?: number; skipLastTransfer?: boolean; recordHeights?: boolean } = {},
+): StateSurfaceTraceResult {
+  const N = stopAt !== undefined ? stopAt : S.length;
+  const total = S.length;
+  const heights: number[] | null = recordHeights ? [] : null;
+  let y = y0,
+    u = u0,
+    n = 1.0;
+  for (let i = 0; i < N; i++) {
+    if (recordHeights) heights!.push(y);
+    const { R, nd, d } = S[i];
+    const nn = nd === 1.0 ? 1.0 : nd;
+    if (nn !== n) u = Math.abs(R) < FLAT_R_THRESHOLD ? (n * u - (y * (nn - n)) / R) / nn : (n * u) / nn;
+    n = nn;
+    const isLast = i === N - 1;
+    if (isLast && skipLastTransfer) {
+      /* skip */
+    } else if (i < total - 1) {
+      y += d * u;
+    }
+  }
+  return { y, u, clipped: false, heights };
+}
+
+function traceStateSurfacesReal(
+  S: RuntimeLens["S"],
+  asphByIdx: RuntimeLens["asphByIdx"],
+  y0: number,
+  u0: number,
+  stopAt?: number,
+): StateSurfaceTraceResult {
+  const N = stopAt !== undefined ? stopAt : S.length;
+  let y = y0,
+    U = Math.atan(u0),
+    n = 1.0;
+  let clipped = false;
+  for (let i = 0; i < N; i++) {
+    const { R, nd, d, sd } = S[i];
+    if (Math.abs(y) > sd) clipped = true;
+    const nn = nd === 1.0 ? 1.0 : nd;
+    if (nn !== n) {
+      const absY = Math.abs(y);
+      const slope = sagSlopeRaw(absY, R, asphByIdx[i]);
+      const alpha = y >= 0 ? -Math.atan(slope) : Math.atan(slope);
+      const sinIp = (n / nn) * Math.sin(U - alpha);
+      if (Math.abs(sinIp) > 1.0) return { y: NaN, u: NaN, clipped: true, heights: null };
+      U = alpha + Math.asin(sinIp);
+    }
+    n = nn;
+    if (i < N - 1) y += d * Math.tan(U);
+  }
+  return { y, u: Math.tan(U), clipped, heights: null };
+}
+
+export function computeFieldGeometryAtState(focusT: number, zoomT: number, L: RuntimeLens): FieldGeometryState {
+  const S = stateSurfaces(focusT, zoomT, L);
+  const stopIdx = L.stopIdx;
+  const delta = 1e-4;
+
+  const paraxMarg = traceStateSurfacesParaxial(S, 1, 0, { stopAt: stopIdx });
+  const paraxChief = traceStateSurfacesParaxial(S, 0, 1, { stopAt: stopIdx });
+  const realMarg = traceStateSurfacesReal(S, L.asphByIdx, delta, 0, stopIdx);
+  const realChief = traceStateSurfacesReal(S, L.asphByIdx, 0, delta, stopIdx);
+
+  const yRatio = isFinite(realMarg.y) ? realMarg.y / delta : paraxMarg.y;
+  const b = isFinite(realChief.y) ? realChief.y / delta : paraxChief.y;
+  const epRatio = Math.abs(yRatio) > 1e-9 ? b / yRatio : 0;
+
+  const hA = traceStateSurfacesParaxial(S, 1, 0, { skipLastTransfer: true, recordHeights: true }).heights!;
+  const hB = traceStateSurfacesParaxial(S, 0, 1, { skipLastTransfer: true, recordHeights: true }).heights!;
+  const r = Math.abs(hA[stopIdx]) > 1e-15 ? hB[stopIdx] / hA[stopIdx] : 0;
+  let minU = Infinity;
+  for (let i = 0; i < L.N; i++) {
+    if (i === stopIdx) continue;
+    const coeff = Math.abs(hB[i] - r * hA[i]);
+    if (coeff > 1e-8) {
+      const uMax = S[i].sd / coeff;
+      if (uMax < minU) minU = uMax;
+    }
+  }
+  let halfFieldDeg = (Math.atan(minU) * 180) / Math.PI;
+
+  const testChief = (deg: number): boolean => {
+    const uField = -Math.tan((deg * Math.PI) / 180);
+    const yChiefIn = -epRatio * uField;
+    const trace = traceStateSurfacesReal(S, L.asphByIdx, yChiefIn, uField);
+    return isFinite(trace.y) && !trace.clipped;
+  };
+
+  if (isFinite(halfFieldDeg) && halfFieldDeg > 0 && !testChief(halfFieldDeg)) {
+    let lo = 0,
+      hi = halfFieldDeg;
+    for (let i = 0; i < 20; i++) {
+      const mid = (lo + hi) / 2;
+      if (testChief(mid)) lo = mid;
+      else hi = mid;
+    }
+    halfFieldDeg = lo;
+  }
+
+  return { halfFieldDeg, yRatio, b, epRatio };
+}
+
+export function traceChiefRayAtAngle(
+  fieldAngleDeg: number,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  L: RuntimeLens,
+  geometry?: FieldGeometryState,
+): RayTraceResult {
+  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L);
+  const thetaRad = (fieldAngleDeg * Math.PI) / 180;
+  const uField = -Math.tan(thetaRad);
+  const yChief = -geom.epRatio * uField;
+  return traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L);
+}
+
+export function chiefRayImageHeight(
+  fieldAngleDeg: number,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  L: RuntimeLens,
+  geometry?: FieldGeometryState,
+): number {
+  const trace = traceChiefRayAtAngle(fieldAngleDeg, zPos, focusT, zoomT, L, geometry);
+  return trace.y + trace.u * thick(L.N - 1, focusT, zoomT, L);
+}
+
+export function solveFieldAngleForImageHeight(
+  targetImageHeight: number,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  L: RuntimeLens,
+  geometry?: FieldGeometryState,
+): number | null {
+  if (!isFinite(targetImageHeight) || Math.abs(targetImageHeight) < 1e-12) return 0;
+  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L);
+  if (!isFinite(geom.halfFieldDeg) || geom.halfFieldDeg <= 0) return null;
+
+  const target = -Math.abs(targetImageHeight);
+  let lo = 0;
+  let hi = geom.halfFieldDeg;
+  const yLo = chiefRayImageHeight(lo, zPos, focusT, zoomT, L, geom);
+  const yHi = chiefRayImageHeight(hi, zPos, focusT, zoomT, L, geom);
+  if (!isFinite(yLo) || !isFinite(yHi)) return null;
+  if (target > yLo || target < yHi) return null;
+
+  for (let i = 0; i < 32; i++) {
+    const mid = (lo + hi) / 2;
+    const yMid = chiefRayImageHeight(mid, zPos, focusT, zoomT, L, geom);
+    if (!isFinite(yMid)) return null;
+    if (Math.abs(yMid - target) < 1e-4) return mid;
+    if (yMid > target) lo = mid;
+    else hi = mid;
+  }
+  return (lo + hi) / 2;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR separates focus breathing from distortion in the analysis workflow and adds a dedicated breathing view in the analysis drawer.

## What changed

- rewrote distortion analysis to sample fixed image heights and solve back to object-space angle instead of conflating breathing with distortion
- added focus-aware field-geometry helpers in the optics layer to support the new distortion model
- updated the distortion chart and tab copy to present rectilinear distortion at fixed image height
- added a dedicated focus breathing tab with an EFL-change chart and summary metrics
- renamed the lens-diagram launcher button to `ABERRATIONS & DISTORTIONS`
- added regression and display tests for the new distortion semantics, breathing tab, and analysis-tab state
- added record-keeping guidance plus a branch record for this work

## Why

Close-focus internal-focus lenses, especially telephoto zooms and floating-focus designs, were producing distortion results that were not representative of actual lenses. The old analysis path was effectively mixing focus breathing with distortion by reusing infinity-focus field geometry and normalizing against a breathed focal length.

This change isolates breathing as its own metric and makes the distortion view more physically meaningful.

## User impact

- close-focus distortion curves should remain stable and believable for lenses that previously went out of range
- the distortion tab now communicates its measurement basis more clearly
- users can inspect focus breathing directly from a dedicated analysis tab

## Validation

- `npm run format:check`
- `npm run lint` (passes with one existing warning in `src/optics/buildLens.ts`)
- `npm run test`
- `npm run typecheck`

## Notes

- branch record: `agent_docs/records/focus-breathing-distortion-overhaul.md`
- PR is opened as draft for review of the new analysis presentation and wording
