### PR TITLE
[codex] Stabilize spherical aberration real-ray chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The catalog is auto-registered from `src/lens-data/*.data.ts`, so the README no 
 
 - **Interactive optical state**: focus, aperture, zoom, ray mode, chromatic channels, and comparison scale mode all update live
 - **Analysis drawer**: dedicated tabs for aberrations, distortion, breathing, and vignetting, including a dense 2D meridional coma view inside the Aberrations tab
-- **Spherical aberration model**: uses a true paraxial reference and current-state entrance pupil geometry, with sign conventions aligned to the in-app optics primer
+- **Spherical aberration model**: combines a real-ray transverse fan at the solved best-focus plane with a true near-axis reference for the headline longitudinal SA diagnostic
 - **Meridional coma model**: samples a dense off-axis ray fan across the current entrance pupil and reports the asymmetric image-plane span for the current focus, aperture, and zoom state
 - **Chromatic analysis**: RGB ray tracing, longitudinal chromatic spread, and enlarged LCA overlay
 - **Glass inspection**: element metadata, Abbe-number plotting, APD tagging, and lens role annotations

--- a/__tests__/aberrationAnalysis.test.ts
+++ b/__tests__/aberrationAnalysis.test.ts
@@ -297,20 +297,19 @@ describe("computeSAProfile", () => {
     }
   });
 
-  it("all best-focus profile values are finite", () => {
+  it("all signed transverse profile values are finite", () => {
     const L = build(ApoLantharRaw);
     const { z: zPos } = doLayout(0, 0, L);
     const { currentEPSD, currentPhysStopSD } = apertureAt(L, 0, 0);
 
     const profile = computeSAProfile(L, zPos, 0, 0, currentEPSD, currentPhysStopSD);
-    for (const { imageHeightMm } of profile) {
-      expect(isFinite(imageHeightMm)).toBe(true);
-      expect(imageHeightMm).toBeGreaterThanOrEqual(0);
+    for (const { transverseSaMm } of profile) {
+      expect(isFinite(transverseSaMm)).toBe(true);
     }
   });
 
-  it("profile values stay within the best-focus peak spread", () => {
-    const L = build(ApoLantharRaw);
+  it("profile values stay within twice the best-focus peak spread", () => {
+    const L = build(Sonnar50f15Raw);
     const { z: zPos } = doLayout(0, 0, L);
     const { currentEPSD, currentPhysStopSD } = apertureAt(L, 0, 0);
 
@@ -319,20 +318,43 @@ describe("computeSAProfile", () => {
 
     expect(result).not.toBeNull();
     expect(profile.length).toBeGreaterThan(0);
-    const maxProfileHeight = Math.max(...profile.map((point) => point.imageHeightMm * 1000));
-    expect(maxProfileHeight).toBeLessThanOrEqual(result!.bestFocusPeakUm + 1e-6);
+    const maxProfileHeight = Math.max(...profile.map((point) => Math.abs(point.transverseSaMm * 1000)));
+    expect(maxProfileHeight).toBeLessThanOrEqual(result!.bestFocusPeakUm * 2 + 1e-6);
   });
 
-  it("inner zones have less best-focus blur than outer zones", () => {
+  it("near-axis profile sample is close to zero at best focus", () => {
     const L = build(Sonnar50f15Raw);
     const { z: zPos } = doLayout(0, 0, L);
     const { currentEPSD, currentPhysStopSD } = apertureAt(L, 0, 0);
 
     const profile = computeSAProfile(L, zPos, 0, 0, currentEPSD, currentPhysStopSD);
+    expect(profile.length).toBeGreaterThan(0);
+    expect(profile[0].fraction).toBe(NEAR_AXIS_REAL_FRAC);
+    expect(Math.abs(profile[0].transverseSaMm)).toBeLessThan(0.01);
+  });
+
+  it("simple positive element profile goes negative toward the margin", () => {
+    const L = mkSingleElement();
+    const zPos = [0, 5];
+
+    const profile = computeSAProfile(L, zPos, 0, 0, 12, 15);
     expect(profile.length).toBeGreaterThan(1);
-    const inner = profile[0].imageHeightMm;
-    const outer = profile[profile.length - 1].imageHeightMm;
-    expect(outer).toBeGreaterThan(inner);
+    expect(Math.abs(profile[0].transverseSaMm)).toBeLessThan(0.01);
+    expect(profile[profile.length - 1].transverseSaMm).toBeLessThan(0);
+  });
+
+  it("profile marginal value matches the spherical aberration sign convention", () => {
+    const L = build(Sonnar50f15Raw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const { currentEPSD, currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const result = computeSphericalAberration(L, zPos, 0, 0, currentEPSD, currentPhysStopSD);
+    const profile = computeSAProfile(L, zPos, 0, 0, currentEPSD, currentPhysStopSD);
+
+    expect(result).not.toBeNull();
+    expect(profile.length).toBeGreaterThan(0);
+    const marginalPoint = profile[profile.length - 1];
+    expect(Math.sign(marginalPoint.transverseSaMm)).toBe(Math.sign(result!.longitudinalSaMm));
   });
 
   /* ── Edge cases ── */

--- a/src/components/display/AberrationsPanel.tsx
+++ b/src/components/display/AberrationsPanel.tsx
@@ -39,6 +39,12 @@ function formatSaUm(saUm: number): string {
   return "< 0.1 µm";
 }
 
+function formatSignedSaUm(saUm: number): string {
+  if (Math.abs(saUm) < 0.1) return "0 µm";
+  const rounded = Math.abs(saUm) >= 1 ? saUm.toFixed(0) : saUm.toFixed(1);
+  return `${rounded} µm`;
+}
+
 const VB_W = 280;
 const VB_H = 200;
 const ML = 44;
@@ -49,11 +55,11 @@ const PW = VB_W - ML - MR;
 const PH = VB_H - MT - MB;
 const MIN_X_RANGE_UM = 5;
 
-function buildPolylinePoints(profile: SAProfilePoint[], xRangeUm: number): string {
+function buildPolylinePoints(profile: SAProfilePoint[], xMaxAbsUm: number): string {
   return profile
-    .map(({ fraction, imageHeightMm }) => {
-      const blurUm = imageHeightMm * 1000;
-      const px = ML + (blurUm / xRangeUm) * PW;
+    .map(({ fraction, transverseSaMm }) => {
+      const saUm = transverseSaMm * 1000;
+      const px = ML + PW / 2 + (saUm / xMaxAbsUm) * (PW / 2);
       const py = MT + PH * (1 - fraction);
       return `${px.toFixed(1)},${py.toFixed(1)}`;
     })
@@ -61,24 +67,30 @@ function buildPolylinePoints(profile: SAProfilePoint[], xRangeUm: number): strin
 }
 
 function SADiagram({ profile, t }: { profile: SAProfilePoint[]; t: Theme }) {
-  const maxBlurUm = Math.max(...profile.map((p) => Math.abs(p.imageHeightMm * 1000)));
-  const xRangeUm = Math.max(MIN_X_RANGE_UM, maxBlurUm * 1.2);
-  const rawTick = xRangeUm / 2;
+  const maxSaUm = Math.max(...profile.map((p) => Math.abs(p.transverseSaMm * 1000)));
+  const xMaxAbsUm = Math.max(MIN_X_RANGE_UM, maxSaUm * 1.2);
+  const halfTickRaw = xMaxAbsUm / 2;
   const tickUm =
-    rawTick >= 50 ? Math.round(rawTick / 25) * 25 : rawTick >= 10 ? Math.round(rawTick / 5) * 5 : Math.round(rawTick);
-  const tickX = ML + (tickUm / xRangeUm) * PW;
+    halfTickRaw >= 50
+      ? Math.round(halfTickRaw / 25) * 25
+      : halfTickRaw >= 10
+        ? Math.round(halfTickRaw / 5) * 5
+        : Math.max(1, Math.round(halfTickRaw));
+  const centerX = ML + PW / 2;
+  const leftTickX = centerX - (tickUm / xMaxAbsUm) * (PW / 2);
+  const rightTickX = centerX + (tickUm / xMaxAbsUm) * (PW / 2);
   const yTicks = [
     { frac: 0, label: "0" },
     { frac: 0.5, label: "0.5" },
     { frac: 1, label: "1" },
   ];
-  const polylinePoints = buildPolylinePoints(profile, xRangeUm);
+  const polylinePoints = buildPolylinePoints(profile, xMaxAbsUm);
 
   return (
     <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
       <title>
-        Best-focus spherical-aberration profile: blur radius at the best-fit image plane vs. pupil zone. Smaller values
-        and flatter curves indicate a tighter on-axis bundle.
+        Real-ray transverse spherical-aberration profile at the common best-focus plane versus pupil zone, referenced to
+        the near-axis real ray.
       </title>
       <rect x={ML} y={MT} width={PW} height={PH} rx={3} fill={t.panelBg} stroke={t.panelBorder} strokeWidth={0.75} />
 
@@ -104,25 +116,33 @@ function SADiagram({ profile, t }: { profile: SAProfilePoint[]; t: Theme }) {
         Pupil zone
       </text>
 
-      <line x1={ML} y1={MT} x2={ML} y2={MT + PH} stroke={t.axis} strokeWidth={0.75} strokeDasharray="3,3" />
+      <line x1={centerX} y1={MT} x2={centerX} y2={MT + PH} stroke={t.axis} strokeWidth={0.75} strokeDasharray="3,3" />
       <polyline points={polylinePoints} fill="none" stroke={t.value} strokeWidth={2} strokeLinejoin="round" />
 
       <line x1={ML} y1={MT + PH} x2={ML} y2={MT + PH + 4} stroke={t.muted} strokeWidth={0.75} />
-      <line x1={tickX} y1={MT + PH} x2={tickX} y2={MT + PH + 4} stroke={t.muted} strokeWidth={0.75} />
+      <line x1={leftTickX} y1={MT + PH} x2={leftTickX} y2={MT + PH + 4} stroke={t.muted} strokeWidth={0.75} />
+      <line x1={centerX} y1={MT + PH} x2={centerX} y2={MT + PH + 4} stroke={t.muted} strokeWidth={0.75} />
+      <line x1={rightTickX} y1={MT + PH} x2={rightTickX} y2={MT + PH + 4} stroke={t.muted} strokeWidth={0.75} />
       <line x1={ML + PW} y1={MT + PH} x2={ML + PW} y2={MT + PH + 4} stroke={t.muted} strokeWidth={0.75} />
 
       <text x={ML} y={MT + PH + 15} textAnchor="middle" fill={t.muted} fontSize={9} fontFamily="inherit">
+        {formatSignedSaUm(-xMaxAbsUm)}
+      </text>
+      <text x={leftTickX} y={MT + PH + 15} textAnchor="middle" fill={t.muted} fontSize={9} fontFamily="inherit">
+        {formatSignedSaUm(-tickUm)}
+      </text>
+      <text x={centerX} y={MT + PH + 15} textAnchor="middle" fill={t.muted} fontSize={9} fontFamily="inherit">
         0
       </text>
-      <text x={tickX} y={MT + PH + 15} textAnchor="middle" fill={t.muted} fontSize={9} fontFamily="inherit">
-        {`${tickUm}`}
+      <text x={rightTickX} y={MT + PH + 15} textAnchor="middle" fill={t.muted} fontSize={9} fontFamily="inherit">
+        {formatSignedSaUm(tickUm)}
       </text>
       <text x={ML + PW} y={MT + PH + 15} textAnchor="middle" fill={t.muted} fontSize={9} fontFamily="inherit">
-        {`${Math.round(xRangeUm)}`}
+        {formatSignedSaUm(xMaxAbsUm)}
       </text>
 
       <text x={ML + PW / 2} y={VB_H - 4} textAnchor="middle" fill={t.muted} fontSize={9.5} fontFamily="inherit">
-        Best-focus blur radius (&micro;m)
+        Real-ray transverse SA at best focus (&micro;m)
       </text>
     </svg>
   );
@@ -169,7 +189,7 @@ export default function AberrationsPanel({
           <HelpTooltipButton
             theme={t}
             label="Spherical aberration help"
-            text="Best-focus spread shows how tightly on-axis rays from different pupil zones come together after refocusing to the best-fit image plane. Smaller values mean the lens is bringing center and edge zones into a tighter common focus."
+            text="The curve shows the real-ray transverse aberration fan at the common best-focus plane, referenced to the near-axis real ray. Because it stays in image space, it remains stable near the pupil edge while still showing the signed fan shape of the on-axis bundle. The spread metric below still shows the residual bundle size at best focus."
           />
           <CollapseButton
             expanded={saChartExpanded}

--- a/src/content/AberrationsPrimerIntermediate.md
+++ b/src/content/AberrationsPrimerIntermediate.md
@@ -101,7 +101,7 @@ Correcting aberrations is fundamentally a problem of balancing positive and nega
 
 The paraxial ray-trace model used by this site captures the first-order aberration behavior — spherical aberration, chromatic aberration, and the gross structure of coma and vignetting — faithfully enough to distinguish well-corrected designs from poorly corrected ones. A few practical observations for reading the diagrams:
 
-When on-axis marginal rays converge noticeably ahead of or behind the image plane, the lens has residual spherical aberration. The sign tells you the type: if marginal rays focus short of the image plane (toward the lens), the aberration is *under-corrected*; if they focus beyond it, it is *over-corrected*.
+The Aberrations tab shows spherical aberration in two complementary ways. The main curve is a real-ray transverse fan evaluated at the solved best-focus plane and referenced to the near-axis real ray, so you can see how the outer pupil zones deviate across the image plane without the numerical instability of an axial-intercept plot. When the optional longitudinal SA readout is enabled, it reports the axial focus shift of the marginal real ray relative to the near-axis reference ray. If the marginal focus falls short of the paraxial focus (toward the lens), the aberration is *under-corrected*; if it falls beyond it, it is *over-corrected*.
 
 When the off-axis ray bundle is asymmetric — spreading more on one side of the chief ray than the other — the lens has residual coma. A tight, symmetric off-axis bundle indicates good coma correction.
 

--- a/src/optics/aberrationAnalysis.ts
+++ b/src/optics/aberrationAnalysis.ts
@@ -13,12 +13,12 @@
 import { bAtZoom, halfFieldAtZoom, traceRay, yRatioAtZoom } from "./optics.js";
 import type { RuntimeLens } from "../types/optics.js";
 
-/** One sample point on the longitudinal SA profile curve. */
+/** One sample point on the real-ray transverse SA profile curve. */
 export interface SAProfilePoint {
   /** Normalised pupil zone fraction (0 = paraxial axis, 1 = full entrance-pupil edge). */
   fraction: number;
-  /** Best-focus blur radius at this zone in mm. */
-  imageHeightMm: number;
+  /** Signed real-ray transverse SA at this zone in mm at the common best-focus plane. */
+  transverseSaMm: number;
 }
 
 /** Result of a spherical aberration computation. */
@@ -390,12 +390,13 @@ const PROFILE_FRACS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95] as con
 export const MERIDIONAL_COMA_SAMPLE_COUNT = 51;
 
 /**
- * Compute a best-focus on-axis blur profile across the pupil aperture.
+ * Compute a real-ray on-axis transverse SA profile across the pupil aperture.
  *
- * Traces ±Y rays at each PROFILE_FRACS fraction of the entrance pupil and
- * evaluates their blur radius at the best-fit real-ray image plane for the
- * current state. This makes the default chart practical and focus-responsive
- * rather than a pure longitudinal-intercept diagnostic.
+ * Traces real rays through the system, solves a common best-focus plane from
+ * the full symmetric bundle, then plots the positive-branch ray height at that
+ * plane relative to the near-axis positive-branch reference ray. This keeps
+ * the chart in image space, avoids the axial-intercept blow-up near the pupil
+ * edge, and still reflects over/under-correction through the signed fan shape.
  */
 export function computeSAProfile(
   L: RuntimeLens,
@@ -439,16 +440,20 @@ export function computeSAProfile(
   if (hits.length < 4) return [];
 
   const bestFocusZ = bestFocusPlane(hits, lastSurfZ);
+  const nearAxisPlusHit = hits.find((hit) => hit.signedFraction === NEAR_AXIS_REAL_FRAC) ?? null;
+  if (nearAxisPlusHit === null) return [];
+  const nearAxisHeightAtBestFocus = nearAxisPlusHit.y + nearAxisPlusHit.u * (bestFocusZ - lastSurfZ);
+
   const points: SAProfilePoint[] = [];
 
   for (const fraction of PROFILE_FRACS) {
     const plusHit = hits.find((hit) => hit.signedFraction === fraction) ?? null;
-    const minusHit = hits.find((hit) => hit.signedFraction === -fraction) ?? null;
-    if (!plusHit || !minusHit) continue;
+    if (plusHit === null) continue;
 
-    const plusHeight = Math.abs(plusHit.y + plusHit.u * (bestFocusZ - lastSurfZ));
-    const minusHeight = Math.abs(minusHit.y + minusHit.u * (bestFocusZ - lastSurfZ));
-    points.push({ fraction, imageHeightMm: (plusHeight + minusHeight) / 2 });
+    points.push({
+      fraction,
+      transverseSaMm: plusHit.y + plusHit.u * (bestFocusZ - lastSurfZ) - nearAxisHeightAtBestFocus,
+    });
   }
 
   return points.length >= 2 ? points : [];


### PR DESCRIPTION
## Summary
Fixes the spherical aberration chart so the plotted curve is a stable real-ray transverse fan at the solved best-focus plane instead of an absolute blur-only view or an unstable axial-intercept plot.

## What Changed
- switched the spherical aberration profile to a true real-ray transverse best-focus fan referenced to the near-axis real ray
- kept the signed chart presentation while avoiding the marginal-ray longitudinal intercept blow-up near pupil fraction 1
- updated chart labels and help text to describe the real-ray transverse SA view accurately
- refreshed the aberrations primer and README to match the current UI behavior
- updated the focused SA tests to cover the new profile semantics and bounds

## Why
The previous absolute-value chart hid over/under-correction. A direct longitudinal real-ray plot preserved sign but produced irrational mm-scale edge values because axial intercepts become unstable as exit slopes approach zero. The new chart keeps the profile in image space, which is stable and visually meaningful, while still reflecting the real-ray fan shape.

## Validation
- `npm run format`
- `npx vitest run __tests__/aberrationAnalysis.test.ts __tests__/AberrationsPanel.test.tsx`
- `npm run typecheck`