### PR TITLE
Fix Nikon AF‑S 105/2.8G lens geometry to satisfy validation

### DIFF
--- a/src/lens-data/NikonAFS105f28G.data.ts
+++ b/src/lens-data/NikonAFS105f28G.data.ts
@@ -225,18 +225,18 @@ const LENS_DATA = {
   surfaces: [
     // ── G1 ──────────────────────────────────────────────────
     { label: "1", R: 135.481, d: 4.8268, nd: 1.7725, elemId: 1, sd: 29.0 },
-    { label: "2", R: -190.5454, d: 0.2, nd: 1.0, elemId: 0, sd: 28.0 },
+    { label: "2", R: -190.5454, d: 0.2, nd: 1.0, elemId: 0, sd: 27.5 },
     { label: "3", R: 49.725, d: 5.0443, nd: 1.61272, elemId: 2, sd: 27.5 },
-    { label: "4", R: 328.1282, d: 3.2512, nd: 1.0, elemId: 0, sd: 24.5 },
+    { label: "4", R: 328.1282, d: 3.2512, nd: 1.0, elemId: 0, sd: 23.0 },
     { label: "5", R: -301.4048, d: 1.3, nd: 1.71736, elemId: 3, sd: 22.5 },
     { label: "6", R: 36.6648, d: 0.2601, nd: 1.0, elemId: 0, sd: 21.5 },
-    { label: "7", R: 39.1876, d: 5.0203, nd: 1.7725, elemId: 4, sd: 21.5 },
-    { label: "8", R: 1e15, d: 3.0, nd: 1.0, elemId: 0, sd: 20.0 }, // D8 (variable)
+    { label: "7", R: 39.1876, d: 5.0203, nd: 1.7725, elemId: 4, sd: 15.0 },
+    { label: "8", R: 1e15, d: 3.0, nd: 1.0, elemId: 0, sd: 18.0 }, // D8 (variable)
     // ── G2 ──────────────────────────────────────────────────
     { label: "9", R: -184.4593, d: 1.1, nd: 1.58267, elemId: 5, sd: 17.5 },
-    { label: "10", R: 27.3895, d: 4.0524, nd: 1.0, elemId: 0, sd: 16.5 },
-    { label: "11", R: -173.3863, d: 1.2519, nd: 1.53172, elemId: 6, sd: 16.0 }, // L6 (D1 front)
-    { label: "12", R: 26.3938, d: 4.0212, nd: 1.80518, elemId: 7, sd: 15.5 }, // L6→L7 junction
+    { label: "10", R: 27.3895, d: 4.0524, nd: 1.0, elemId: 0, sd: 14.0 },
+    { label: "11", R: -173.3863, d: 1.2519, nd: 1.53172, elemId: 6, sd: 12.0 }, // L6 (D1 front)
+    { label: "12", R: 26.3938, d: 4.0212, nd: 1.80518, elemId: 7, sd: 15.0 }, // L6→L7 junction
     { label: "13", R: 89.6909, d: 21.449, nd: 1.0, elemId: 0, sd: 14.5 }, // D13 (variable)
     // ── Aperture stop ───────────────────────────────────────
     { label: "STO", R: 1e15, d: 14.484, nd: 1.0, elemId: 0, sd: 12.9 }, // D14 (variable)


### PR DESCRIPTION
### Motivation
- The newly added Nikon AF‑S 105mm lens triggered geometry validation errors (negative edge thickness, overlapping gaps, and front/rear SD ratio violations) that block building runtime lenses.
- The intent is to adjust the prescription's semi‑diameters so the model passes the existing `validateLensData` checks without altering optical prescription values.

### Description
- Adjusted semi‑diameter (`sd`) values in `src/lens-data/NikonAFS105f28G.data.ts` for the surfaces that caused the failures. 
- Changed the `sd` on surfaces `2`, `4`, `7`, `8`, `10`, `11`, and `12` to eliminate negative edge thickness, air‑gap overlap, and front/rear SD ratio violations while leaving radii/thickness/glass/power unchanged.
- No changes were made to element powers, radii, glass identifiers, variable gaps, or any other optical parameters to preserve the design intent.

### Testing
- Ran metadata generation with `npm run generate:metadata` and it completed successfully (build metadata written). 
- Reproduced the initial failure: `npm test -- __tests__/lensCatalog.test.ts` initially reported 5 validation errors for `nikon-afs-105f28-vr-micro`. 
- After the `sd` adjustments, `npm test -- __tests__/lensCatalog.test.ts` passed (10 tests passed) and `npm test -- __tests__/validateLensData.test.ts` passed (46 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d4b4cf588326b01ec9755d9d703f)