### PR TITLE
Strip frontmatter from overlay markdown using shared utility

### DIFF
--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -31,12 +31,13 @@ import BreadcrumbBar from "./BreadcrumbBar.js";
 import ViewToggleBar from "./ViewToggleBar.js";
 import SingleLensContent from "./SingleLensContent.js";
 import DescriptionPanel from "./DescriptionPanel.js";
-import ABOUT_ME_MD from "../../content/AboutMe.md?raw";
-import ABOUT_SITE_MD from "../../content/AboutSite.md?raw";
-import OPTICS_PRIMER_SIMPLE_MD from "../../content/OpticsPrimerSimple.md?raw";
-import OPTICS_PRIMER_INTERMEDIATE_MD from "../../content/OpticsPrimerIntermediate.md?raw";
-import ABERRATIONS_PRIMER_SIMPLE_MD from "../../content/AberrationsPrimerSimple.md?raw";
-import ABERRATIONS_PRIMER_INTERMEDIATE_MD from "../../content/AberrationsPrimerIntermediate.md?raw";
+import _ABOUT_ME_MD from "../../content/AboutMe.md?raw";
+import _ABOUT_SITE_MD from "../../content/AboutSite.md?raw";
+import _OPTICS_PRIMER_SIMPLE_MD from "../../content/OpticsPrimerSimple.md?raw";
+import _OPTICS_PRIMER_INTERMEDIATE_MD from "../../content/OpticsPrimerIntermediate.md?raw";
+import _ABERRATIONS_PRIMER_SIMPLE_MD from "../../content/AberrationsPrimerSimple.md?raw";
+import _ABERRATIONS_PRIMER_INTERMEDIATE_MD from "../../content/AberrationsPrimerIntermediate.md?raw";
+import { stripFrontmatter } from "../../utils/homepageContent.js";
 import AboutFooter from "../display/AboutFooter.js";
 import useLensState from "../../utils/useLensState.js";
 import useMediaQuery from "../../utils/useMediaQuery.js";
@@ -45,6 +46,13 @@ import useComparisonOrchestration from "../../comparison/useComparisonOrchestrat
 import ComparisonContent from "../../comparison/ComparisonContent.js";
 import useOverlays from "../hooks/useOverlays.js";
 import PrimerToggleButton from "./PrimerToggleButton.js";
+
+const ABOUT_ME_MD = stripFrontmatter(_ABOUT_ME_MD);
+const ABOUT_SITE_MD = stripFrontmatter(_ABOUT_SITE_MD);
+const OPTICS_PRIMER_SIMPLE_MD = stripFrontmatter(_OPTICS_PRIMER_SIMPLE_MD);
+const OPTICS_PRIMER_INTERMEDIATE_MD = stripFrontmatter(_OPTICS_PRIMER_INTERMEDIATE_MD);
+const ABERRATIONS_PRIMER_SIMPLE_MD = stripFrontmatter(_ABERRATIONS_PRIMER_SIMPLE_MD);
+const ABERRATIONS_PRIMER_INTERMEDIATE_MD = stripFrontmatter(_ABERRATIONS_PRIMER_INTERMEDIATE_MD);
 
 /* =====================================================================
  * §2  COMPONENT — State, effects, and orchestration logic

--- a/src/utils/homepageContent.ts
+++ b/src/utils/homepageContent.ts
@@ -53,6 +53,11 @@ export const HOMEPAGE_ARTICLE_LIMIT = 5;
 
 /* ── Auto-discovered markdown content ──────────────────────────────── */
 
+/** Strip YAML frontmatter (---...---) from the top of a markdown string. */
+export function stripFrontmatter(raw: string): string {
+  return raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n*/, "");
+}
+
 const _mdModules = import.meta.glob<string>("../content/*.md", {
   eager: true,
   query: "?raw",
@@ -63,8 +68,7 @@ const _mdModules = import.meta.glob<string>("../content/*.md", {
 const MD_BY_FILE: Record<string, string> = {};
 for (const [path, raw] of Object.entries(_mdModules)) {
   const file = path.replace("../content/", "");
-  // Strip YAML frontmatter before storing
-  MD_BY_FILE[file] = raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n*/, "");
+  MD_BY_FILE[file] = stripFrontmatter(raw);
 }
 
 /* ── Articles (auto-generated from build metadata) ─────────────────── */


### PR DESCRIPTION
Extracts the frontmatter-stripping regex from homepageContent.ts into
an exported stripFrontmatter() helper and applies it to all six raw
markdown imports in LensViewer (about site, about author, both optics
primer levels, both aberrations primer levels) so YAML metadata no
longer renders visibly in the about/primer overlays.

https://claude.ai/code/session_018KJiRPKfMxb59Mb9ncuLVw