### PR TITLE
feat: add changelog box to homepage

### DIFF
--- a/agent_docs/changelog.md
+++ b/agent_docs/changelog.md
@@ -1,0 +1,119 @@
+# Changelog — Maintenance Guide
+
+## Overview
+
+The homepage changelog is a manually curated list of user-facing changes
+displayed in the `ChangelogBox` section on the home page. The data lives in
+`src/utils/changelogData.ts` as a flat array of `ChangelogEntry` objects.
+
+The component (`src/components/homepage/ChangelogBox.tsx`) groups entries by
+date automatically and renders them with color-coded type badges. No other
+file needs to be updated when adding entries.
+
+---
+
+## When to Add Entries
+
+Add an entry when merging a PR that does any of the following:
+
+- Adds a new lens to the catalog
+- Adds or changes a user-visible feature (new analysis tab, new control, new chart)
+- Fixes a visible bug or incorrect rendering
+- Improves performance, SEO, or UI in a way the user would notice
+
+**Do not add entries for:**
+
+- Internal refactors with no behavior change
+- Test additions or test infrastructure changes
+- Build tooling updates (Vite config, scripts, CI)
+- Dependency bumps (unless they fix a user-visible issue)
+- Documentation-only PRs
+
+---
+
+## Entry Types
+
+| Type | Color | Use for |
+|------|-------|---------|
+| `feature` | blue (`#58c`) | New capability the user can interact with |
+| `fix` | red-orange (`#c65`) | Corrects incorrect behavior or rendering |
+| `lens` | green (`#2a7`) | New lens added to the catalog |
+| `improvement` | amber (`#c84`) | Enhancement to an existing feature, SEO, or performance |
+
+---
+
+## Writing Summaries
+
+- Write from the user's perspective, not the developer's
+- Use past tense: "Added X", "Fixed Y", "Improved Z"
+- Avoid PR jargon: "implement", "refactor", "hook into", "wire up"
+- Keep to one sentence, under ~90 characters
+- Name the specific lens, tab, or feature affected when helpful
+
+**Good:** `"Added coma analysis with 2D point-cloud preview to aberrations drawer"`
+**Bad:** `"Implement coma computation module and integrate with aberration panel"`
+
+---
+
+## Adding an Entry
+
+Open `src/utils/changelogData.ts` and **prepend** a new object to the top of
+the `CHANGELOG` array (before the first existing entry):
+
+```ts
+{
+  date: "2026-04-10",         // ISO merge date (YYYY-MM-DD)
+  type: "feature",            // see table above
+  summary: "Added chromatic aberration chart to analysis drawer",
+},
+```
+
+The array must remain sorted **newest-first**. The component handles grouping
+by date — no other code needs updating.
+
+---
+
+## Consolidating Multiple PRs
+
+When several small PRs address the same conceptual change, write one entry
+describing the combined outcome rather than one per PR.
+
+> **Example:** PRs #308–318 all adjusted Nikon Z semidiameter values →
+> one entry: `"Corrected semi-diameter values across the Nikon Z lens lineup"`
+
+When two PRs implement the same feature in stages (initial engine + UI), write
+one entry describing what the user can now do.
+
+---
+
+## Pruning Old Entries
+
+The changelog renders with a `max-height: 28rem` scrollable container and does
+not paginate. There is no hard expiry policy, but entries older than ~60 days
+can be removed if the list grows unwieldy. Prune from the **bottom** of the array
+(oldest entries first).
+
+---
+
+## Existing History (seeded from PRs #291–#350)
+
+The initial entries cover **2026-03-26 through 2026-03-28** and include:
+
+- **2026-03-28**: Real sagittal ray analysis; field curvature and astigmatic difference analysis
+- **2026-03-27**: SEO improvements; Fujifilm maker + lenses; Canon and Nikon lens additions;
+  full aberrations analysis suite (spherical aberration engine, analysis drawer, coma,
+  distortion, vignetting, longitudinal SA chart); Nikon Z semidiameter fixes
+- **2026-03-26**: Variable-aperture zoom lens support; Nikon Z close-focus collision fixes
+
+---
+
+## Component Reference
+
+| File | Role |
+|------|------|
+| `src/utils/changelogData.ts` | Data — `CHANGELOG` array, `ChangelogEntry` type |
+| `src/components/homepage/ChangelogBox.tsx` | UI — renders grouped entries with badges |
+| `src/pages/HomePage.tsx` | Layout — places ChangelogBox in right column (desktop) or page bottom (mobile) |
+
+**Desktop layout**: ChangelogBox appears in the right column below "Recently Added".
+**Mobile layout**: ChangelogBox appears below "Articles & Guides", before the footer.

--- a/src/components/homepage/ChangelogBox.tsx
+++ b/src/components/homepage/ChangelogBox.tsx
@@ -1,0 +1,122 @@
+/**
+ * ChangelogBox — homepage section showing recent site updates.
+ *
+ * Entries are manually curated in src/utils/changelogData.ts.
+ * Grouped by date (newest first) with color-coded type badges.
+ * Non-interactive: changelog items do not correspond to routable pages.
+ */
+
+import type { Theme } from "../../types/theme.js";
+import { CHANGELOG } from "../../utils/changelogData.js";
+import type { ChangelogEntry, ChangelogEntryType } from "../../utils/changelogData.js";
+
+interface ChangelogBoxProps {
+  theme: Theme;
+}
+
+const ENTRY_TYPE_COLORS: Record<ChangelogEntryType, string> = {
+  feature: "#58c",
+  fix: "#c65",
+  lens: "#2a7",
+  improvement: "#c84",
+};
+
+const ENTRY_TYPE_LABELS: Record<ChangelogEntryType, string> = {
+  feature: "new",
+  fix: "fix",
+  lens: "lens",
+  improvement: "improved",
+};
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default function ChangelogBox({ theme: t }: ChangelogBoxProps) {
+  // Group flat entries into a date-keyed Map, preserving newest-first insertion order.
+  const grouped = new Map<string, ChangelogEntry[]>();
+  for (const entry of CHANGELOG) {
+    const bucket = grouped.get(entry.date) ?? [];
+    bucket.push(entry);
+    grouped.set(entry.date, bucket);
+  }
+
+  return (
+    <section style={{ marginBottom: "2.5rem" }}>
+      <h2
+        style={{
+          fontSize: "1.125rem",
+          fontWeight: 600,
+          color: t.body,
+          marginBottom: "1rem",
+          paddingBottom: "0.25rem",
+          borderBottom: `1px solid ${t.panelBorder}`,
+        }}
+      >
+        Changelog
+      </h2>
+
+      <div style={{ maxHeight: "28rem", overflowY: "auto" }}>
+        {Array.from(grouped.entries()).map(([date, entries]) => (
+          <div key={date} style={{ marginBottom: "0.75rem" }}>
+            <div
+              style={{
+                fontSize: "0.7rem",
+                color: t.label,
+                fontWeight: 600,
+                letterSpacing: "0.05em",
+                textTransform: "uppercase",
+                marginBottom: "0.4rem",
+              }}
+            >
+              {formatDate(date)}
+            </div>
+
+            {entries.map((entry, i) => (
+              <div
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: "0.5rem",
+                  padding: "0.5rem 0.75rem",
+                  marginBottom: "0.35rem",
+                  borderRadius: 6,
+                  border: `1px solid ${t.panelBorder}`,
+                  background: t.panelBg,
+                }}
+              >
+                <span
+                  style={{
+                    flexShrink: 0,
+                    fontSize: "0.6rem",
+                    padding: "1px 6px",
+                    borderRadius: 3,
+                    background: `${ENTRY_TYPE_COLORS[entry.type]}22`,
+                    color: ENTRY_TYPE_COLORS[entry.type],
+                    letterSpacing: "0.06em",
+                    textTransform: "uppercase",
+                    fontWeight: 600,
+                    marginTop: "0.15rem",
+                  }}
+                >
+                  {ENTRY_TYPE_LABELS[entry.type]}
+                </span>
+                <span
+                  style={{
+                    fontSize: "0.8rem",
+                    color: t.body,
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {entry.summary}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ import HeroSection from "../components/homepage/HeroSection.js";
 import QuickNavCards from "../components/homepage/QuickNavCards.js";
 import ArticleList from "../components/homepage/ArticleList.js";
 import RecentLenses from "../components/homepage/RecentLenses.js";
+import ChangelogBox from "../components/homepage/ChangelogBox.js";
 import HomeFooter from "../components/homepage/HomeFooter.js";
 import { CATALOG_KEYS, RECENT_LENS_KEYS } from "../utils/lensCatalog.js";
 import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
@@ -85,12 +86,22 @@ export default function HomePage() {
         <HeroSection theme={t} />
         <QuickNavCards theme={t} />
         <div style={isDesktop ? { display: "flex", gap: "2rem", alignItems: "flex-start" } : {}}>
+          {/* Right column on desktop — RecentLenses + ChangelogBox stacked vertically.
+              On mobile this div has no styles, so its children stack in normal flow. */}
           <div style={isDesktop ? { flex: "1 1 0", minWidth: 0, order: 1 } : {}}>
             <RecentLenses entries={RECENT_LENS_KEYS} theme={t} />
+            {/* Desktop copy: shown only on desktop so it sits under RecentLenses in the right column. */}
+            <div style={{ display: isDesktop ? "block" : "none" }}>
+              <ChangelogBox theme={t} />
+            </div>
           </div>
           <div style={isDesktop ? { flex: "1 1 0", minWidth: 0, order: 0 } : {}}>
             <ArticleList articles={displayedArticles} theme={t} showMoreLink={showMoreLink} />
           </div>
+        </div>
+        {/* Mobile copy: shown only on mobile so it appears below ArticleList, before the footer. */}
+        <div style={{ display: isDesktop ? "none" : "block" }}>
+          <ChangelogBox theme={t} />
         </div>
         <HomeFooter theme={t} />
       </div>

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -1,0 +1,137 @@
+/**
+ * changelogData — manually curated list of user-facing site changes.
+ *
+ * Entries are ordered newest-first. The ChangelogBox component groups them
+ * by date automatically. Add new entries at the top of the CHANGELOG array
+ * when merging a user-facing PR; see agent_docs/changelog.md for the full
+ * maintenance guide.
+ */
+
+export type ChangelogEntryType = "feature" | "fix" | "lens" | "improvement";
+
+export interface ChangelogEntry {
+  /** ISO date string (YYYY-MM-DD) matching the PR merge date */
+  date: string;
+  /** Category tag for badge display */
+  type: ChangelogEntryType;
+  /** User-facing one-liner in past tense, e.g. "Added X" or "Fixed Y" */
+  summary: string;
+}
+
+export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-03-28 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-03-28",
+    type: "feature",
+    summary: "Added real sagittal ray analysis across aberration views",
+  },
+  {
+    date: "2026-03-28",
+    type: "feature",
+    summary: "Added field curvature and astigmatic difference analysis",
+  },
+
+  // ── 2026-03-27 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-03-27",
+    type: "improvement",
+    summary: "Strengthened SEO metadata, sitemap freshness, and social card data",
+  },
+  {
+    date: "2026-03-27",
+    type: "lens",
+    summary: "Added Fujifilm as a maker — XF 80mm f/2.8 Macro OIS WR and XF 50mm f/1.0 R WR",
+  },
+  {
+    date: "2026-03-27",
+    type: "lens",
+    summary: "Added Canon standard and telephoto zoom lenses",
+  },
+  {
+    date: "2026-03-27",
+    type: "lens",
+    summary: "Added Nikon AF-S Micro NIKKOR 105mm f/2.8G IF-ED",
+  },
+  {
+    date: "2026-03-27",
+    type: "feature",
+    summary: "Added coma analysis with 2D point-cloud preview to aberrations drawer",
+  },
+  {
+    date: "2026-03-27",
+    type: "feature",
+    summary: "Added meridional coma field footprint analysis to aberrations drawer",
+  },
+  {
+    date: "2026-03-27",
+    type: "feature",
+    summary: "Separated distortion analysis into its own dedicated drawer tab",
+  },
+  {
+    date: "2026-03-27",
+    type: "feature",
+    summary: "Added vignetting and relative illumination analysis tab",
+  },
+  {
+    date: "2026-03-27",
+    type: "feature",
+    summary: "Added longitudinal spherical aberration profile chart",
+  },
+  {
+    date: "2026-03-27",
+    type: "feature",
+    summary: "Introduced analysis drawer — slide-out panel for optical aberration analysis",
+  },
+  {
+    date: "2026-03-27",
+    type: "feature",
+    summary: "Added spherical aberration computation engine with real-ray tracing",
+  },
+  {
+    date: "2026-03-27",
+    type: "improvement",
+    summary: "Made analysis drawer tab rail scrollable on narrow screens",
+  },
+  {
+    date: "2026-03-27",
+    type: "improvement",
+    summary: "Relocated analysis button to lower-left corner of lens diagram",
+  },
+  {
+    date: "2026-03-27",
+    type: "fix",
+    summary: "Fixed optical surface overlap in Canon RF lenses",
+  },
+  {
+    date: "2026-03-27",
+    type: "fix",
+    summary: "Fixed geometry validation errors in Nikon AF-S 105mm f/2.8G",
+  },
+  {
+    date: "2026-03-27",
+    type: "fix",
+    summary: "Stabilized spherical aberration real-ray chart rendering",
+  },
+  {
+    date: "2026-03-27",
+    type: "fix",
+    summary: "Fixed distortion calculation to correctly project chief ray to image plane",
+  },
+  {
+    date: "2026-03-27",
+    type: "fix",
+    summary: "Corrected semi-diameter values across the Nikon Z lens lineup",
+  },
+
+  // ── 2026-03-26 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-03-26",
+    type: "feature",
+    summary: "Added support for variable-aperture zoom lenses (e.g. f/4.5–5.6)",
+  },
+  {
+    date: "2026-03-26",
+    type: "fix",
+    summary: "Fixed glass interpenetration in Nikon Z lenses at close-focus distances",
+  },
+];


### PR DESCRIPTION
Adds a Changelog section to the home page showing recent site updates
grouped by date with color-coded type badges (new/fix/lens/improved).

- src/utils/changelogData.ts — static ChangelogEntry[] seeded from
  PRs #291–350 (Mar 26–28, 2026); internal refactors excluded
- src/components/homepage/ChangelogBox.tsx — new section component
  matching RecentLenses/ArticleList visual style; scrollable at 28rem
- src/pages/HomePage.tsx — ChangelogBox placed below RecentLenses in
  the right column on desktop and below ArticleList on mobile; uses
  display:none/block to avoid SSR hydration mismatches
- agent_docs/changelog.md — maintenance guide covering when/how to
  add entries, type definitions, consolidation rules, and pruning

https://claude.ai/code/session_01DG9xYgtibahcSSqCcqw8JH