### PR TITLE
add sagittal coma and chromatic field curvature UI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The catalog is auto-registered from `src/lens-data/*.data.ts`, so the README no 
 - **Spherical aberration model**: combines a real-ray transverse fan at the solved best-focus plane with a true near-axis reference for the headline longitudinal SA diagnostic
 - **Coma point-cloud preview**: traces a fixed circular pupil pattern with the skew-ray core and plots chief-ray-centered tangential and sagittal image heights directly in millimeters
 - **Meridional coma model**: samples a dense off-axis ray fan across the current entrance pupil and reports the asymmetric image-plane span for the current focus, aperture, and zoom state; this detailed diagnostic is retained below the point-cloud preview
+- **Sagittal coma model**: traces a sagittal pupil fan orthogonal to the meridional plane and reports the x-intercept spread, displayed in its own collapsible section below the meridional coma view
+- **Chromatic field curvature**: per-wavelength (R/G/B) tangential and sagittal best-focus traces across the field, with a chromatic focus spread metric; displayed as a third chart inside the field curvature section
 - **Chromatic analysis**: RGB ray tracing, longitudinal chromatic spread, and enlarged LCA overlay
 - **Glass inspection**: element metadata, Abbe-number plotting, APD tagging, and lens role annotations
 - **SEO-friendly multipage app**: prerendered routes for lenses, makers, articles, comparison pages, and static content

--- a/__tests__/AberrationsPanel.test.tsx
+++ b/__tests__/AberrationsPanel.test.tsx
@@ -10,12 +10,14 @@ const {
   mockComputeSphericalAberration,
   mockComputeSAProfile,
   mockComputeMeridionalComa,
+  mockComputeSagittalComa,
   mockComputeComaPreview,
   mockComputeFieldCurvature,
 } = vi.hoisted(() => ({
   mockComputeSphericalAberration: vi.fn(),
   mockComputeSAProfile: vi.fn(),
   mockComputeMeridionalComa: vi.fn(),
+  mockComputeSagittalComa: vi.fn(),
   mockComputeComaPreview: vi.fn(),
   mockComputeFieldCurvature: vi.fn(),
 }));
@@ -24,6 +26,7 @@ vi.mock("../src/optics/aberrationAnalysis.js", () => ({
   computeSphericalAberration: mockComputeSphericalAberration,
   computeSAProfile: mockComputeSAProfile,
   computeMeridionalComa: mockComputeMeridionalComa,
+  computeSagittalComa: mockComputeSagittalComa,
   computeComaPointCloudPreview: mockComputeComaPreview,
   computeFieldCurvature: mockComputeFieldCurvature,
 }));
@@ -65,6 +68,7 @@ describe("AberrationsPanel", () => {
     mockComputeSphericalAberration.mockReset();
     mockComputeSAProfile.mockReset();
     mockComputeMeridionalComa.mockReset();
+    mockComputeSagittalComa.mockReset();
     mockComputeComaPreview.mockReset();
     mockComputeFieldCurvature.mockReset();
     mockComputeSAProfile.mockReturnValue([
@@ -176,6 +180,7 @@ describe("AberrationsPanel", () => {
       maxAstigmaticDifferenceUm: 120,
       edgeTangentialShiftMm: -0.45,
       edgeSagittalShiftMm: -0.21,
+      chromaticFocusSpreadMm: null,
       fields: [
         {
           fieldFraction: 0,
@@ -193,6 +198,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: 0,
           astigmaticDifferenceMm: 0,
           astigmaticDifferenceUm: 0,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -211,6 +217,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -0.075,
           astigmaticDifferenceMm: 0.05,
           astigmaticDifferenceUm: 50,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -229,6 +236,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -0.15,
           astigmaticDifferenceMm: 0.1,
           astigmaticDifferenceUm: 100,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -247,6 +255,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -0.29,
           astigmaticDifferenceMm: 0.12,
           astigmaticDifferenceUm: 120,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -265,6 +274,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -0.33,
           astigmaticDifferenceMm: 0.24,
           astigmaticDifferenceUm: 240,
+          chromaticFieldShifts: null,
           usable: true,
         },
       ],
@@ -364,6 +374,7 @@ describe("AberrationsPanel", () => {
       maxAstigmaticDifferenceUm: 30000,
       edgeTangentialShiftMm: -25,
       edgeSagittalShiftMm: 5,
+      chromaticFocusSpreadMm: null,
       fields: [
         {
           fieldFraction: 0,
@@ -381,6 +392,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: 0,
           astigmaticDifferenceMm: 0,
           astigmaticDifferenceUm: 0,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -399,6 +411,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -13,
           astigmaticDifferenceMm: 6,
           astigmaticDifferenceUm: 6000,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -417,6 +430,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -19,
           astigmaticDifferenceMm: 12,
           astigmaticDifferenceUm: 12000,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -435,6 +449,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -24,
           astigmaticDifferenceMm: 18,
           astigmaticDifferenceUm: 18000,
+          chromaticFieldShifts: null,
           usable: true,
         },
         {
@@ -453,6 +468,7 @@ describe("AberrationsPanel", () => {
           petzvalShiftMm: -30,
           astigmaticDifferenceMm: 30,
           astigmaticDifferenceUm: 30000,
+          chromaticFieldShifts: null,
           usable: true,
         },
       ],
@@ -526,7 +542,7 @@ describe("AberrationsPanel", () => {
     mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
 
     render(<AberrationsPanel {...baseProps} />);
-    fireEvent.click(screen.getAllByText("LESS")[3].closest("button")!);
+    fireEvent.click(screen.getAllByText("LESS")[4].closest("button")!);
 
     expect(screen.queryByText(/The first chart strips the problem down to field curvature only/i)).toBeNull();
     expect(screen.getAllByText("MORE").length).toBeGreaterThan(0);
@@ -540,7 +556,7 @@ describe("AberrationsPanel", () => {
     ]);
 
     const { rerender } = render(<AberrationsPanel {...baseProps} expanded={true} />);
-    expect(screen.getAllByText("LESS").length).toBe(4);
+    expect(screen.getAllByText("LESS").length).toBe(5);
     expect(screen.getByText(/Real-ray transverse SA at best focus/i)).toBeTruthy();
     expect(screen.getByText(/The first chart strips the problem down to field curvature only/i)).toBeTruthy();
 

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -92,7 +92,9 @@
 | `ElementInspector.tsx` | `src/components/display/` | Selected element property display |
 | `DiagramLegend.tsx` | `src/components/display/` | Legend with swatches, ray descriptions, aberration readouts |
 | `AberrationsPanel.tsx` | `src/components/display/` | Thin aberrations container that wires the shared panel-data hook into the extracted section components |
-| `aberrations/` | `src/components/display/aberrations/` | Presentational aberration sections (`SphericalAberrationSection`, `ComaPreviewSection`, `MeridionalComaSection`), `SADiagram`, formatting helpers, and `useAberrationsPanelData` |
+| `aberrations/` | `src/components/display/aberrations/` | Presentational aberration sections (`SphericalAberrationSection`, `ComaPreviewSection`, `MeridionalComaSection`, `SagittalComaSection`), `SADiagram`, formatting helpers, and `useAberrationsPanelData` |
+| `SagittalComaPlot.tsx` | `src/components/display/` | SVG chart plotting sagittal fan x-intercepts against pupil fraction with dashed lines and square markers |
+| `ChromaticFieldCurvaturePlot.tsx` | `src/components/display/` | SVG chart showing per-wavelength (R/G/B) tangential and sagittal best-focus traces across the field |
 | `DistortionTab.tsx` | `src/components/display/` | Distortion curve tab content; memoizes computation and renders DistortionChart |
 | `DistortionChart.tsx` | `src/components/display/` | Reusable SVG line chart: distortion % vs field angle with zero line, sample dots, axis labels |
 | `FocusBreathingTab.tsx` | `src/components/display/` | Focus breathing tab content; reports dynamic focal-length change across focus |

--- a/agent_docs/records/skew-ray-audit-improvements.md
+++ b/agent_docs/records/skew-ray-audit-improvements.md
@@ -22,6 +22,14 @@
 - Added chromatic field curvature: per-wavelength (R/G/B) tangential and sagittal focus shifts per field position, `chromaticFocusSpreadMm` summary metric, backward-compatible `chromatic=false` default.
 - Added `computeSagittalComa` with `SagittalComaResult` and `SagittalComaSample` types: traces sagittal pupil fan and extracts x-intercept spread, complementing meridional coma.
 
+### Phase 4: UI Components
+- Added `SagittalComaPlot.tsx`: SVG chart plotting sagittal fan x-intercepts against pupil fraction, using dashed lines and square markers to visually distinguish from the meridional (tangential) trace.
+- Added `SagittalComaSection.tsx`: collapsible section in the Aberrations drawer with help tooltip, description, chart, and COMA SPAN / FIELD / VALID readouts.
+- Added `ChromaticFieldCurvaturePlot.tsx`: SVG chart rendering R/G/B tangential (solid) and sagittal (dashed) best-focus traces across the field with per-channel markers and legend.
+- Integrated chromatic plot and CHROM SPREAD metric into the existing `FieldCurvatureSection`, shown when chromatic data is available.
+- Updated `useAberrationsPanelData` to compute `sagittalComaResult` and `chromaticFieldCurvatureResult` alongside existing monochromatic metrics.
+- Updated `AberrationsPanel` to render `SagittalComaSection` after `MeridionalComaSection` and pass chromatic field curvature result to `FieldCurvatureSection`.
+
 ## Verification
 - `npm run typecheck` — passed (pre-existing build-metadata errors only)
 - `npm run format:check` — passed
@@ -29,6 +37,5 @@
 - `npm run test` — 120 tests across 4 aberration/ray test files, all passing
 
 ## Follow-ups
-- Wire chromatic field curvature and sagittal coma into UI analysis drawer tabs.
 - Consider adaptive circular-pupil sample count for very fast wide-angle designs.
 - Consider adding a dedicated multi-field spot-diagram view using the shared skew-ray core.

--- a/src/components/display/AberrationsPanel.tsx
+++ b/src/components/display/AberrationsPanel.tsx
@@ -12,6 +12,7 @@ import type { Theme } from "../../types/theme.js";
 import ComaPreviewSection from "./aberrations/ComaPreviewSection.js";
 import FieldCurvatureSection from "./aberrations/FieldCurvatureSection.js";
 import MeridionalComaSection from "./aberrations/MeridionalComaSection.js";
+import SagittalComaSection from "./aberrations/SagittalComaSection.js";
 import SphericalAberrationSection from "./aberrations/SphericalAberrationSection.js";
 import useAberrationsPanelData from "./aberrations/useAberrationsPanelData.js";
 
@@ -38,7 +39,15 @@ export default function AberrationsPanel({
   expanded,
   onExpandedChange,
 }: AberrationsPanelProps) {
-  const { saResult, saProfile, comaResult, comaPreviewResult, fieldCurvatureResult } = useAberrationsPanelData({
+  const {
+    saResult,
+    saProfile,
+    comaResult,
+    sagittalComaResult,
+    comaPreviewResult,
+    fieldCurvatureResult,
+    chromaticFieldCurvatureResult,
+  } = useAberrationsPanelData({
     L,
     zPos,
     focusT,
@@ -50,6 +59,7 @@ export default function AberrationsPanel({
   const [saChartExpanded, setSaChartExpanded] = useState(expanded);
   const [comaPreviewExpanded, setComaPreviewExpanded] = useState(true);
   const [comaExpanded, setComaExpanded] = useState(true);
+  const [sagittalComaExpanded, setSagittalComaExpanded] = useState(true);
   const [fieldCurvatureExpanded, setFieldCurvatureExpanded] = useState(true);
 
   useEffect(() => {
@@ -85,8 +95,15 @@ export default function AberrationsPanel({
           theme={t}
         />
 
+        <SagittalComaSection
+          result={sagittalComaResult}
+          expanded={sagittalComaExpanded}
+          onToggle={() => setSagittalComaExpanded((value) => !value)}
+          theme={t}
+        />
+
         <FieldCurvatureSection
-          result={fieldCurvatureResult}
+          result={chromaticFieldCurvatureResult ?? fieldCurvatureResult}
           expanded={fieldCurvatureExpanded}
           onToggle={() => setFieldCurvatureExpanded((value) => !value)}
           theme={t}

--- a/src/components/display/ChromaticFieldCurvaturePlot.tsx
+++ b/src/components/display/ChromaticFieldCurvaturePlot.tsx
@@ -1,0 +1,214 @@
+/**
+ * ChromaticFieldCurvaturePlot — SVG chart showing per-wavelength (R/G/B)
+ * tangential and sagittal focus shifts across the field.
+ *
+ * Renders three pairs of tangential (solid) + sagittal (dashed) traces,
+ * one per chromatic channel, to visualize how lateral color shifts the
+ * best-focus surface at each field position.
+ */
+
+import type { FieldCurvatureResult } from "../../optics/aberrationAnalysis.js";
+import type { Theme } from "../../types/theme.js";
+
+interface ChromaticFieldCurvaturePlotProps {
+  result: FieldCurvatureResult;
+  t: Theme;
+}
+
+const VB_W = 320;
+const VB_H = 224;
+const ML = 42;
+const MR = 18;
+const MT = 20;
+const MB = 60;
+const PW = VB_W - ML - MR;
+const PH = VB_H - MT - MB;
+
+function formatShiftMm(value: number): string {
+  if (Math.abs(value) < 1e-9) return "0";
+  if (Math.abs(value) >= 1) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFieldCurvaturePlotProps) {
+  const usableFields = result.fields.filter((field) => field.usable && field.chromaticFieldShifts !== null);
+  if (usableFields.length < 2) return null;
+
+  // Compute y-range from all chromatic shifts
+  let maxShift = 0.1;
+  for (const field of usableFields) {
+    for (const shift of field.chromaticFieldShifts!) {
+      maxShift = Math.max(maxShift, Math.abs(shift.tangentialShiftMm), Math.abs(shift.sagittalShiftMm));
+    }
+  }
+  const imageCircleRadiusMm = Math.max(...usableFields.map((field) => Math.abs(field.chiefImageHeight)), 0);
+  const yHalfRange = Math.max(0.1, Math.min(maxShift * 1.1, imageCircleRadiusMm || maxShift * 1.1));
+
+  const xScale = (fieldFraction: number) => ML + fieldFraction * PW;
+  const yScale = (shiftMm: number) => MT + PH / 2 - (shiftMm / yHalfRange) * (PH / 2);
+  const zeroY = yScale(0);
+  const tickMm = yHalfRange >= 2 ? 1 : yHalfRange >= 1 ? 0.5 : yHalfRange >= 0.4 ? 0.2 : 0.1;
+  const tickValues = Array.from(new Set([-yHalfRange, -tickMm, 0, tickMm, yHalfRange]));
+
+  const channelColors: Record<string, string> = {
+    R: t.rayChromR,
+    G: t.rayChromG,
+    B: t.rayChromB,
+  };
+
+  const channels = ["R", "G", "B"] as const;
+
+  function buildPolyline(
+    channel: string,
+    accessor: (s: { tangentialShiftMm: number; sagittalShiftMm: number }) => number,
+  ) {
+    return usableFields
+      .map((field) => {
+        const shift = field.chromaticFieldShifts!.find((s) => s.channel === channel);
+        if (!shift) return null;
+        return `${xScale(field.fieldFraction).toFixed(1)},${yScale(accessor(shift)).toFixed(1)}`;
+      })
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  return (
+    <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
+      <title>
+        Chromatic field curvature. R, G, and B tangential (solid) and sagittal (dashed) best-focus traces show how
+        dispersion shifts the focal surface per wavelength across the field.
+      </title>
+      <rect x={ML} y={MT} width={PW} height={PH} rx={3} fill={t.panelBg} stroke={t.panelBorder} strokeWidth={0.75} />
+
+      <line x1={ML} y1={zeroY} x2={ML + PW} y2={zeroY} stroke={t.axis} strokeWidth={0.75} strokeDasharray="3,3" />
+      <text x={ML + PW - 4} y={zeroY - 5} textAnchor="end" fill={t.muted} fontSize={8} fontFamily="inherit">
+        Current plane
+      </text>
+
+      {tickValues.map((tick) => {
+        const y = yScale(tick);
+        return (
+          <g key={tick}>
+            <line x1={ML - 4} y1={y} x2={ML} y2={y} stroke={t.muted} strokeWidth={0.75} />
+            <text x={ML - 7} y={y + 4} textAnchor="end" fill={t.muted} fontSize={9} fontFamily="inherit">
+              {formatShiftMm(tick)}
+            </text>
+          </g>
+        );
+      })}
+
+      {[0, 0.25, 0.5, 0.75, 1].map((tick) => {
+        const x = xScale(tick);
+        return (
+          <g key={tick}>
+            <line x1={x} y1={MT + PH} x2={x} y2={MT + PH + 4} stroke={t.muted} strokeWidth={0.75} />
+            <text x={x} y={VB_H - 12} textAnchor="middle" fill={t.muted} fontSize={8} fontFamily="inherit">
+              {tick === 0 ? "C" : `${Math.round(tick * 100)}%`}
+            </text>
+          </g>
+        );
+      })}
+
+      <text
+        textAnchor="middle"
+        fill={t.muted}
+        fontSize={9.5}
+        fontFamily="inherit"
+        transform={`rotate(-90) translate(${-(MT + PH / 2)}, 12)`}
+      >
+        Best-focus shift (mm)
+      </text>
+      <text x={ML + PW - 4} y={MT - 6} textAnchor="end" fill={t.muted} fontSize={8} fontFamily="inherit">
+        Toward lens
+      </text>
+      <text x={ML + PW - 4} y={MT + PH + 16} textAnchor="end" fill={t.muted} fontSize={8} fontFamily="inherit">
+        Toward sensor
+      </text>
+      <text x={ML + PW / 2} y={VB_H - 2} textAnchor="middle" fill={t.muted} fontSize={9.5} fontFamily="inherit">
+        Field position across current half-field
+      </text>
+
+      {/* Tangential traces (solid) and sagittal traces (dashed) per channel */}
+      {channels.map((channel) => {
+        const color = channelColors[channel];
+        const tangentialPts = buildPolyline(channel, (s) => s.tangentialShiftMm);
+        const sagittalPts = buildPolyline(channel, (s) => s.sagittalShiftMm);
+        return (
+          <g key={channel}>
+            {tangentialPts && (
+              <polyline
+                points={tangentialPts}
+                fill="none"
+                stroke={color}
+                strokeWidth={1.8}
+                strokeLinejoin="round"
+                opacity={0.85}
+              />
+            )}
+            {sagittalPts && (
+              <polyline
+                points={sagittalPts}
+                fill="none"
+                stroke={color}
+                strokeWidth={1.8}
+                strokeLinejoin="round"
+                strokeDasharray="5,3"
+                opacity={0.85}
+              />
+            )}
+          </g>
+        );
+      })}
+
+      {/* Data point markers per channel */}
+      {channels.map((channel) => {
+        const color = channelColors[channel];
+        return usableFields.map((field) => {
+          const shift = field.chromaticFieldShifts!.find((s) => s.channel === channel);
+          if (!shift) return null;
+          return (
+            <g key={`${channel}-${field.fieldFraction}`}>
+              <circle cx={xScale(field.fieldFraction)} cy={yScale(shift.tangentialShiftMm)} r={2} fill={color} />
+              <rect
+                x={xScale(field.fieldFraction) - 1.8}
+                y={yScale(shift.sagittalShiftMm) - 1.8}
+                width={3.6}
+                height={3.6}
+                fill={color}
+                rx={0.6}
+              />
+            </g>
+          );
+        });
+      })}
+
+      {/* Legend */}
+      <g transform={`translate(${ML + 6}, ${MT + 12})`}>
+        {channels.map((channel, i) => {
+          const color = channelColors[channel];
+          const xOff = i * 72;
+          return (
+            <g key={channel} transform={`translate(${xOff}, 0)`}>
+              <line x1={0} y1={0} x2={12} y2={0} stroke={color} strokeWidth={1.8} />
+              <circle cx={16} cy={0} r={2} fill={color} />
+              <text x={22} y={3} fill={t.muted} fontSize={8} fontFamily="inherit">
+                {channel} T/S
+              </text>
+            </g>
+          );
+        })}
+      </g>
+
+      <g transform={`translate(${ML + 6}, ${MT + 26})`}>
+        <line x1={0} y1={0} x2={12} y2={0} stroke={t.muted} strokeWidth={1.5} />
+        <text x={18} y={3} fill={t.muted} fontSize={8} fontFamily="inherit">
+          Solid = tangential
+        </text>
+        <line x1={100} y1={0} x2={112} y2={0} stroke={t.muted} strokeWidth={1.5} strokeDasharray="5,3" />
+        <text x={118} y={3} fill={t.muted} fontSize={8} fontFamily="inherit">
+          Dashed = sagittal
+        </text>
+      </g>
+    </svg>
+  );
+}

--- a/src/components/display/SagittalComaPlot.tsx
+++ b/src/components/display/SagittalComaPlot.tsx
@@ -1,0 +1,140 @@
+/**
+ * SagittalComaPlot — Compact sagittal coma visualization for the Aberrations drawer.
+ *
+ * Plots x-coordinate image-plane intercepts against pupil fraction for the
+ * sagittal fan. Mirrors the structure of MeridionalComaPlot but uses sagittal
+ * (x-axis) data instead of tangential (y-axis).
+ */
+
+import type { SagittalComaResult } from "../../optics/aberrationAnalysis.js";
+import type { Theme } from "../../types/theme.js";
+
+interface SagittalComaPlotProps {
+  result: SagittalComaResult;
+  t: Theme;
+}
+
+const VB_W = 300;
+const VB_H = 216;
+const ML = 44;
+const MR = 16;
+const MT = 20;
+const MB = 40;
+const PW = VB_W - ML - MR;
+const PH = VB_H - MT - MB;
+const MIN_Y_RANGE_MM = 0.02;
+
+export function formatSagittalComaSpan(spanUm: number): string {
+  const abs = Math.abs(spanUm);
+  if (abs >= 1000) return `${(spanUm / 1000).toFixed(2)} mm`;
+  if (abs >= 100) return `${spanUm.toFixed(0)} µm`;
+  if (abs >= 10) return `${spanUm.toFixed(1)} µm`;
+  return `${spanUm.toFixed(2)} µm`;
+}
+
+export default function SagittalComaPlot({ result, t }: SagittalComaPlotProps) {
+  const yHalfRange = Math.max(
+    MIN_Y_RANGE_MM,
+    Math.max(Math.abs(result.minIntercept), Math.abs(result.maxIntercept)) * 1.1,
+  );
+  const zeroY = MT + PH / 2;
+
+  const xScale = (pupilFraction: number) => ML + ((pupilFraction + 1) / 2) * PW;
+  const yScale = (imageX: number) => zeroY - (imageX / yHalfRange) * (PH / 2);
+
+  const validSamples = result.samples.filter(
+    (sample): sample is typeof sample & { imageX: number } => sample.imageX !== null && !sample.clipped,
+  );
+
+  const polylinePoints = validSamples
+    .map((sample) => `${xScale(sample.pupilFraction).toFixed(1)},${yScale(sample.imageX).toFixed(1)}`)
+    .join(" ");
+
+  const tickMm = yHalfRange >= 1 ? 1 : yHalfRange >= 0.2 ? 0.2 : yHalfRange >= 0.05 ? 0.05 : 0.01;
+  const tickValues = [-tickMm, 0, tickMm];
+
+  const sagittalColor = t.rayChromB ?? "#38bdf8";
+
+  return (
+    <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
+      <title>
+        Sagittal coma view. Dense off-axis sagittal pupil samples show x-intercept spread on the image plane.
+      </title>
+      <rect x={ML} y={MT} width={PW} height={PH} rx={3} fill={t.panelBg} stroke={t.panelBorder} strokeWidth={0.75} />
+
+      <line x1={ML} y1={zeroY} x2={ML + PW} y2={zeroY} stroke={t.axis} strokeWidth={0.75} strokeDasharray="3,3" />
+      <line
+        x1={ML + PW / 2}
+        y1={MT}
+        x2={ML + PW / 2}
+        y2={MT + PH}
+        stroke={t.axis}
+        strokeWidth={0.75}
+        strokeDasharray="3,3"
+      />
+
+      {tickValues.map((tick) => {
+        const y = yScale(tick);
+        return (
+          <g key={tick}>
+            <line x1={ML - 4} y1={y} x2={ML} y2={y} stroke={t.muted} strokeWidth={0.75} />
+            <text x={ML - 7} y={y + 4} textAnchor="end" fill={t.muted} fontSize={9} fontFamily="inherit">
+              {tick === 0 ? "0" : tick.toFixed(tickMm < 0.1 ? 2 : 1)}
+            </text>
+          </g>
+        );
+      })}
+
+      <text
+        textAnchor="middle"
+        fill={t.muted}
+        fontSize={9.5}
+        fontFamily="inherit"
+        transform={`rotate(-90) translate(${-(MT + PH / 2)}, 12)`}
+      >
+        Image plane x (mm)
+      </text>
+
+      {polylinePoints && (
+        <polyline
+          points={polylinePoints}
+          fill="none"
+          stroke={sagittalColor}
+          strokeWidth={2}
+          strokeLinejoin="round"
+          strokeDasharray="5,3"
+        />
+      )}
+
+      {validSamples.map((sample) => (
+        <rect
+          key={sample.index}
+          x={xScale(sample.pupilFraction) - 2.2}
+          y={yScale(sample.imageX) - 2.2}
+          width={4.4}
+          height={4.4}
+          rx={0.8}
+          fill={Math.abs(sample.pupilFraction) < 1e-9 ? t.label : sagittalColor}
+        />
+      ))}
+
+      {result.samples
+        .filter((sample) => sample.clipped)
+        .map((sample) => (
+          <line
+            key={`clipped-${sample.index}`}
+            x1={xScale(sample.pupilFraction) - 3}
+            y1={MT + PH - 10}
+            x2={xScale(sample.pupilFraction) + 3}
+            y2={MT + PH - 4}
+            stroke={t.muted}
+            strokeWidth={1}
+          />
+        ))}
+
+      <text x={ML + PW / 2} y={VB_H - 4} textAnchor="middle" fill={t.muted} fontSize={9.5} fontFamily="inherit">
+        Pupil fraction (−1 to +1)
+      </text>
+    </svg>
+  );
+}

--- a/src/components/display/aberrations/FieldCurvatureSection.tsx
+++ b/src/components/display/aberrations/FieldCurvatureSection.tsx
@@ -1,3 +1,4 @@
+import ChromaticFieldCurvaturePlot from "../ChromaticFieldCurvaturePlot.js";
 import FieldCurvatureMeanPlot from "../FieldCurvatureMeanPlot.js";
 import FieldCurvaturePlot from "../FieldCurvaturePlot.js";
 import type { FieldCurvatureResult } from "../../../optics/aberrationAnalysis.js";
@@ -50,6 +51,15 @@ export default function FieldCurvatureSection({ result, expanded, onToggle, them
               <span style={{ fontSize: 8.5, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
                 Tangential versus real sagittal diagnostic. The gap between the two traces is the astigmatic split.
               </span>
+              {result.chromaticFocusSpreadMm !== null ? (
+                <>
+                  <ChromaticFieldCurvaturePlot result={result} t={theme} />
+                  <span style={{ fontSize: 8.5, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
+                    Per-wavelength focus shift. Each color shows its own tangential (solid) and sagittal (dashed) best
+                    focus across the field. Wider R/B separation indicates stronger chromatic field curvature.
+                  </span>
+                </>
+              ) : null}
               <div
                 style={{
                   display: "flex",
@@ -112,6 +122,29 @@ export default function FieldCurvatureSection({ result, expanded, onToggle, them
                     T {formatSignedMm(result.edgeTangentialShiftMm)} / S {formatSignedMm(result.edgeSagittalShiftMm)}
                   </span>
                 </div>
+                {result.chromaticFocusSpreadMm !== null ? (
+                  <div
+                    style={{ display: "flex", alignItems: "center", gap: 8 }}
+                    title="Maximum chromatic focus spread: the largest R-to-B tangential or sagittal best-focus separation across all sampled field positions."
+                  >
+                    <span
+                      style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}
+                    >
+                      CHROM SPREAD
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 600,
+                        color: theme.value,
+                        fontVariantNumeric: "tabular-nums",
+                        transition: "color 0.3s",
+                      }}
+                    >
+                      {formatSignedMm(result.chromaticFocusSpreadMm)}
+                    </span>
+                  </div>
+                ) : null}
               </div>
             </>
           ) : (

--- a/src/components/display/aberrations/SagittalComaSection.tsx
+++ b/src/components/display/aberrations/SagittalComaSection.tsx
@@ -1,0 +1,113 @@
+import SagittalComaPlot, { formatSagittalComaSpan } from "../SagittalComaPlot.js";
+import type { SagittalComaResult } from "../../../optics/aberrationAnalysis.js";
+import type { Theme } from "../../../types/theme.js";
+import SectionHeader from "./SectionHeader.js";
+
+interface SagittalComaSectionProps {
+  result: SagittalComaResult | null;
+  expanded: boolean;
+  onToggle: () => void;
+  theme: Theme;
+}
+
+export default function SagittalComaSection({ result, expanded, onToggle, theme }: SagittalComaSectionProps) {
+  return (
+    <div
+      style={{
+        borderTop: `1px solid ${theme.panelBorder}`,
+        paddingTop: 14,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      <SectionHeader
+        title="Sagittal Coma"
+        helpLabel="Sagittal coma help"
+        helpText="Sagittal coma shows how an off-axis point spreads in the sagittal (x) direction across the image plane. The sagittal coma span helps show how much the left and right pupil zones fail to converge at the same x-intercept. Compare with the meridional coma span above to see the directional asymmetry."
+        expanded={expanded}
+        onToggle={onToggle}
+        theme={theme}
+      />
+
+      {expanded ? (
+        <>
+          <span style={{ fontSize: 9, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
+            Sagittal coma view using a dense off-axis sagittal ray fan. This shows x-intercept spread orthogonal to the
+            meridional plane.
+          </span>
+
+          {result ? (
+            <>
+              <SagittalComaPlot result={result} t={theme} />
+              <div
+                style={{
+                  display: "flex",
+                  gap: 14,
+                  flexWrap: "wrap",
+                  fontSize: 9.5,
+                }}
+              >
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: 8 }}
+                  title="Sagittal coma span: right outer valid x-intercept minus left outer valid x-intercept."
+                >
+                  <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
+                    COMA SPAN
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: theme.value,
+                      fontVariantNumeric: "tabular-nums",
+                      transition: "color 0.3s",
+                    }}
+                  >
+                    {formatSagittalComaSpan(result.spanUm)}
+                  </span>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
+                    FIELD
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: theme.value,
+                      fontVariantNumeric: "tabular-nums",
+                      transition: "color 0.3s",
+                    }}
+                  >
+                    {result.fieldAngleDeg.toFixed(1)}°
+                  </span>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
+                    VALID
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: theme.value,
+                      fontVariantNumeric: "tabular-nums",
+                      transition: "color 0.3s",
+                    }}
+                  >
+                    {result.validSampleCount}/{result.sampleCount}
+                  </span>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div style={{ color: theme.muted, fontSize: 10, lineHeight: 1.5, transition: "color 0.3s" }}>
+              Unable to compute a usable sagittal coma view for this lens state.
+            </div>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/display/aberrations/useAberrationsPanelData.ts
+++ b/src/components/display/aberrations/useAberrationsPanelData.ts
@@ -3,6 +3,7 @@ import {
   computeComaPointCloudPreview,
   computeFieldCurvature,
   computeMeridionalComa,
+  computeSagittalComa,
   computeSphericalAberration,
   computeSAProfile,
 } from "../../../optics/aberrationAnalysis.js";
@@ -29,15 +30,27 @@ export default function useAberrationsPanelData({
     const saResult = computeSphericalAberration(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
     const saProfile = computeSAProfile(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
     const comaResult = computeMeridionalComa(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
+    const sagittalComaResult = computeSagittalComa(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
     const comaPreviewResult = computeComaPointCloudPreview(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
     const fieldCurvatureResult = computeFieldCurvature(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
+    const chromaticFieldCurvatureResult = computeFieldCurvature(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      true,
+    );
 
     return {
       saResult,
       saProfile,
       comaResult,
+      sagittalComaResult,
       comaPreviewResult,
       fieldCurvatureResult,
+      chromaticFieldCurvatureResult,
     };
   }, [L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD]);
 }

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -23,12 +23,12 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-03-28",
     type: "feature",
-    summary: "Added chromatic field curvature analysis with per-wavelength focus shifts",
+    summary: "Added chromatic field curvature chart with per-wavelength R/G/B focus traces",
   },
   {
     date: "2026-03-28",
     type: "feature",
-    summary: "Added sagittal coma metric complementing the existing meridional coma analysis",
+    summary: "Added sagittal coma section with x-intercept fan chart to aberrations drawer",
   },
   {
     date: "2026-03-28",


### PR DESCRIPTION
New UI sections in the Aberrations drawer:

- SagittalComaPlot: SVG chart plotting sagittal fan x-intercepts against pupil fraction, using dashed lines and square markers to distinguish from the meridional (tangential) trace above it.
- SagittalComaSection: collapsible section with header, description, chart, and COMA SPAN / FIELD / VALID metrics.
- ChromaticFieldCurvaturePlot: SVG chart showing R/G/B tangential (solid) and sagittal (dashed) best-focus traces across the field.
- Integrated chromatic plot and CHROM SPREAD metric into the existing FieldCurvatureSection, shown when chromatic data is available.

Data hook now computes sagittalComaResult and chromaticFieldCurvatureResult alongside the existing monochromatic metrics.

https://claude.ai/code/session_01WQSLzTupekdzX9u7gCnB49