### PR TITLE
Split coma sections into dedicated COMA tab in analysis drawer

### DIFF
--- a/__tests__/AberrationsPanel.test.tsx
+++ b/__tests__/AberrationsPanel.test.tsx
@@ -331,27 +331,13 @@ describe("AberrationsPanel", () => {
     expect(screen.getByText(/Real-ray transverse SA at best focus/i)).toBeTruthy();
   });
 
-  it("renders meridional coma copy and span metric", () => {
+  it("renders spherical aberration and field curvature content", () => {
     mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
 
     render(<AberrationsPanel {...baseProps} />);
-    expect(screen.getAllByText("Coma Preview").length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Real 2D coma point cloud/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Center").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("25%").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("50%").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("75%").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("FIELDS").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("4/4").length).toBeGreaterThan(0);
     expect(screen.getAllByText("BEST-FOCUS SPREAD").length).toBeGreaterThan(0);
     expect(screen.getAllByText("3 µm").length).toBeGreaterThan(0);
     expect(screen.getAllByText("(peak 5 µm, shift -0.80 mm)").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Meridional Coma").length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/2D meridional coma view/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText("COMA SPAN").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("300 µm").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("VALID").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("47/51").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Field Curvature & Astigmatic Difference").length).toBeGreaterThan(0);
     expect(screen.getByText(/The first chart strips the problem down to field curvature only/i)).toBeTruthy();
     expect(screen.getByText(/Field curvature only\. Negative values are fore of the focused plane/i)).toBeTruthy();
@@ -478,22 +464,6 @@ describe("AberrationsPanel", () => {
     expect(screen.getAllByText(/Scale capped to image circle/i).length).toBe(2);
   });
 
-  it("shows fallback copy when preview computation fails", () => {
-    mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
-    mockComputeComaPreview.mockReturnValue(null);
-
-    render(<AberrationsPanel {...baseProps} />);
-    expect(screen.getByText(/Unable to compute a usable 2D coma point cloud/i)).toBeTruthy();
-  });
-
-  it("shows fallback copy when coma computation fails", () => {
-    mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
-    mockComputeMeridionalComa.mockReturnValue(null);
-
-    render(<AberrationsPanel {...baseProps} />);
-    expect(screen.getByText(/Unable to compute a usable 2D meridional coma view/i)).toBeTruthy();
-  });
-
   it("shows fallback copy when field-curvature computation fails", () => {
     mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
     mockComputeFieldCurvature.mockReturnValue(null);
@@ -518,31 +488,11 @@ describe("AberrationsPanel", () => {
     expect(screen.getAllByText("MORE").length).toBeGreaterThan(0);
   });
 
-  it("toggles the coma preview section body independently", () => {
-    mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
-
-    render(<AberrationsPanel {...baseProps} />);
-    fireEvent.click(screen.getAllByText("LESS")[1].closest("button")!);
-
-    expect(screen.queryByText(/Real 2D coma point cloud at center/i)).toBeNull();
-    expect(screen.getAllByText("MORE").length).toBeGreaterThan(0);
-  });
-
-  it("toggles the meridional coma section body independently", () => {
-    mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
-
-    render(<AberrationsPanel {...baseProps} />);
-    fireEvent.click(screen.getAllByText("LESS")[2].closest("button")!);
-
-    expect(screen.queryByText(/2D meridional coma view using a dense off-axis ray fan/i)).toBeNull();
-    expect(screen.getAllByText("MORE").length).toBeGreaterThan(0);
-  });
-
   it("toggles the field-curvature section body independently", () => {
     mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
 
     render(<AberrationsPanel {...baseProps} />);
-    fireEvent.click(screen.getAllByText("LESS")[4].closest("button")!);
+    fireEvent.click(screen.getAllByText("LESS")[1].closest("button")!);
 
     expect(screen.queryByText(/The first chart strips the problem down to field curvature only/i)).toBeNull();
     expect(screen.getAllByText("MORE").length).toBeGreaterThan(0);
@@ -556,7 +506,7 @@ describe("AberrationsPanel", () => {
     ]);
 
     const { rerender } = render(<AberrationsPanel {...baseProps} expanded={true} />);
-    expect(screen.getAllByText("LESS").length).toBe(5);
+    expect(screen.getAllByText("LESS").length).toBe(2);
     expect(screen.getByText(/Real-ray transverse SA at best focus/i)).toBeTruthy();
     expect(screen.getByText(/The first chart strips the problem down to field curvature only/i)).toBeTruthy();
 

--- a/__tests__/analysisDisplayTabs.test.ts
+++ b/__tests__/analysisDisplayTabs.test.ts
@@ -5,6 +5,7 @@ import buildLens from "../src/optics/buildLens.js";
 import LENS_DEFAULTS from "../src/lens-data/defaults.js";
 import { doLayout, eflAtFocus, epAtZoom, fopenAtZoom } from "../src/optics/optics.js";
 import AberrationsPanel from "../src/components/display/AberrationsPanel.js";
+import ComaTab from "../src/components/display/ComaTab.js";
 import DistortionChart from "../src/components/display/DistortionChart.js";
 import DistortionTab from "../src/components/display/DistortionTab.js";
 import FocusBreathingTab from "../src/components/display/FocusBreathingTab.js";
@@ -83,7 +84,7 @@ describe("analysis display tabs", () => {
     expect(html).not.toContain(">FIELD<");
   });
 
-  it("AberrationsPanel renders spherical aberration and meridional coma content together", () => {
+  it("AberrationsPanel renders spherical aberration and field curvature content", () => {
     const L = build(Sonnar50f15Raw);
     const focusT = 0;
     const zoomT = 0;
@@ -104,6 +105,30 @@ describe("analysis display tabs", () => {
     );
 
     expect(html).toContain("Spherical Aberration");
+    expect(html).toContain("Field Curvature");
+    expect(html).not.toContain("Coma Preview");
+    expect(html).not.toContain("Meridional Coma");
+  });
+
+  it("ComaTab renders coma preview and meridional coma content", () => {
+    const L = build(Sonnar50f15Raw);
+    const focusT = 0;
+    const zoomT = 0;
+    const { z: zPos } = doLayout(focusT, zoomT, L);
+    const { currentPhysStopSD, currentEPSD } = apertureAt(L, zoomT, 0);
+
+    const html = renderToStaticMarkup(
+      React.createElement(ComaTab, {
+        L,
+        t: themes.dark,
+        zPos,
+        focusT,
+        zoomT,
+        currentEPSD,
+        currentPhysStopSD,
+      }),
+    );
+
     expect(html).toContain("Coma Preview");
     expect(html).toContain("Real 2D coma point cloud");
     expect(html).toContain("Center");
@@ -113,7 +138,8 @@ describe("analysis display tabs", () => {
     expect(html).toContain("Meridional Coma");
     expect(html).toContain("2D meridional coma view");
     expect(html).toContain("COMA SPAN");
-    expect(html).toContain("fixed circular pupil sample pattern");
+    expect(html).not.toContain("Spherical Aberration");
+    expect(html).not.toContain("Field Curvature");
   });
 
   it("FocusBreathingTab renders the breathing chart and summary metrics", () => {

--- a/src/components/display/AberrationsPanel.tsx
+++ b/src/components/display/AberrationsPanel.tsx
@@ -9,10 +9,7 @@
 import { useEffect, useState } from "react";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
-import ComaPreviewSection from "./aberrations/ComaPreviewSection.js";
 import FieldCurvatureSection from "./aberrations/FieldCurvatureSection.js";
-import MeridionalComaSection from "./aberrations/MeridionalComaSection.js";
-import SagittalComaSection from "./aberrations/SagittalComaSection.js";
 import SphericalAberrationSection from "./aberrations/SphericalAberrationSection.js";
 import useAberrationsPanelData from "./aberrations/useAberrationsPanelData.js";
 
@@ -39,15 +36,7 @@ export default function AberrationsPanel({
   expanded,
   onExpandedChange,
 }: AberrationsPanelProps) {
-  const {
-    saResult,
-    saProfile,
-    comaResult,
-    sagittalComaResult,
-    comaPreviewResult,
-    fieldCurvatureResult,
-    chromaticFieldCurvatureResult,
-  } = useAberrationsPanelData({
+  const { saResult, saProfile, fieldCurvatureResult, chromaticFieldCurvatureResult } = useAberrationsPanelData({
     L,
     zPos,
     focusT,
@@ -57,9 +46,6 @@ export default function AberrationsPanel({
   });
 
   const [saChartExpanded, setSaChartExpanded] = useState(expanded);
-  const [comaPreviewExpanded, setComaPreviewExpanded] = useState(true);
-  const [comaExpanded, setComaExpanded] = useState(true);
-  const [sagittalComaExpanded, setSagittalComaExpanded] = useState(true);
   const [fieldCurvatureExpanded, setFieldCurvatureExpanded] = useState(true);
 
   useEffect(() => {
@@ -78,27 +64,6 @@ export default function AberrationsPanel({
             setSaChartExpanded(next);
             onExpandedChange?.(next);
           }}
-          theme={t}
-        />
-
-        <ComaPreviewSection
-          result={comaPreviewResult}
-          expanded={comaPreviewExpanded}
-          onToggle={() => setComaPreviewExpanded((value) => !value)}
-          theme={t}
-        />
-
-        <MeridionalComaSection
-          result={comaResult}
-          expanded={comaExpanded}
-          onToggle={() => setComaExpanded((value) => !value)}
-          theme={t}
-        />
-
-        <SagittalComaSection
-          result={sagittalComaResult}
-          expanded={sagittalComaExpanded}
-          onToggle={() => setSagittalComaExpanded((value) => !value)}
           theme={t}
         />
 

--- a/src/components/display/ComaTab.tsx
+++ b/src/components/display/ComaTab.tsx
@@ -1,0 +1,66 @@
+/**
+ * ComaTab — Analysis drawer tab content for coma aberration analysis.
+ *
+ * Shows a 2×2 coma point-cloud preview across the field, plus detailed
+ * meridional and sagittal coma fan plots with numeric readouts.
+ */
+
+import { useState } from "react";
+import type { RuntimeLens } from "../../types/optics.js";
+import type { Theme } from "../../types/theme.js";
+import ComaPreviewSection from "./aberrations/ComaPreviewSection.js";
+import MeridionalComaSection from "./aberrations/MeridionalComaSection.js";
+import SagittalComaSection from "./aberrations/SagittalComaSection.js";
+import useAberrationsPanelData from "./aberrations/useAberrationsPanelData.js";
+
+interface ComaTabProps {
+  L: RuntimeLens;
+  t: Theme;
+  zPos: number[];
+  focusT: number;
+  zoomT: number;
+  currentEPSD: number;
+  currentPhysStopSD: number;
+}
+
+export default function ComaTab({ L, t, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD }: ComaTabProps) {
+  const { comaResult, sagittalComaResult, comaPreviewResult } = useAberrationsPanelData({
+    L,
+    zPos,
+    focusT,
+    zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+  });
+
+  const [comaPreviewExpanded, setComaPreviewExpanded] = useState(true);
+  const [comaExpanded, setComaExpanded] = useState(true);
+  const [sagittalComaExpanded, setSagittalComaExpanded] = useState(true);
+
+  return (
+    <div style={{ padding: "8px 0" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 16, fontSize: 9.5 }}>
+        <ComaPreviewSection
+          result={comaPreviewResult}
+          expanded={comaPreviewExpanded}
+          onToggle={() => setComaPreviewExpanded((v) => !v)}
+          theme={t}
+        />
+
+        <MeridionalComaSection
+          result={comaResult}
+          expanded={comaExpanded}
+          onToggle={() => setComaExpanded((v) => !v)}
+          theme={t}
+        />
+
+        <SagittalComaSection
+          result={sagittalComaResult}
+          expanded={sagittalComaExpanded}
+          onToggle={() => setSagittalComaExpanded((v) => !v)}
+          theme={t}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
+++ b/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
@@ -1,4 +1,5 @@
 import AberrationsPanel from "../../display/AberrationsPanel.js";
+import ComaTab from "../../display/ComaTab.js";
 import DistortionTab from "../../display/DistortionTab.js";
 import FocusBreathingTab from "../../display/FocusBreathingTab.js";
 import VignettingTab from "../../display/VignettingTab.js";
@@ -44,6 +45,20 @@ export default function AnalysisDrawerContent({
         currentPhysStopSD={currentPhysStopSD}
         expanded={aberrationsExpanded}
         onExpandedChange={onAberrationsExpandedChange}
+      />
+    );
+  }
+
+  if (activeTab === "coma") {
+    return (
+      <ComaTab
+        L={L}
+        t={t}
+        zPos={zPos}
+        focusT={focusT}
+        zoomT={zoomT}
+        currentEPSD={currentEPSD}
+        currentPhysStopSD={currentPhysStopSD}
       />
     );
   }

--- a/src/components/layout/lensDiagram/analysisTabs.ts
+++ b/src/components/layout/lensDiagram/analysisTabs.ts
@@ -2,6 +2,7 @@ import type { AnalysisTab } from "../AnalysisDrawer.js";
 
 export const ANALYSIS_TABS: AnalysisTab[] = [
   { id: "aberrations", label: "ABERRATIONS" },
+  { id: "coma", label: "COMA" },
   { id: "distortion", label: "DISTORTION" },
   { id: "breathing", label: "BREATHING" },
   { id: "vignetting", label: "VIGNETTING" },


### PR DESCRIPTION
Moves ComaPreviewSection, MeridionalComaSection, and SagittalComaSection
out of the overloaded Aberrations tab into a new COMA tab, reducing
Aberrations from 5 sections to 2 (Spherical Aberration + Field Curvature).
Adds ComaTab.tsx as the new tab component and updates tests accordingly.

https://claude.ai/code/session_01CKpoUDNpc2ZUa5nwkAZ5cc