### PR TITLE
Add `article` changelog type and fix SSR article title assertion

### DIFF
--- a/__tests__/entryServer.test.ts
+++ b/__tests__/entryServer.test.ts
@@ -249,7 +249,8 @@ describe("SSR render — article page /articles/:slug", () => {
 
   it("title contains the article title", () => {
     const { helmet } = render(url);
-    expect(helmet.title.toString()).toContain(TEST_ARTICLE.title);
+    const encodedTitle = TEST_ARTICLE.title.replaceAll("'", "&#x27;");
+    expect(helmet.title.toString()).toContain(encodedTitle);
   });
 
   it("includes the default social image tags", () => {

--- a/agent_docs/changelog.md
+++ b/agent_docs/changelog.md
@@ -39,6 +39,7 @@ Add an entry when merging a PR that does any of the following:
 | `fix` | red-orange (`#c65`) | Corrects incorrect behavior or rendering |
 | `lens` | green (`#2a7`) | New lens added to the catalog |
 | `improvement` | amber (`#c84`) | Enhancement to an existing feature, SEO, or performance |
+| `article` | purple (`#a5c`) | New article or guide published in Articles & Guides |
 
 ---
 

--- a/src/components/homepage/ChangelogBox.tsx
+++ b/src/components/homepage/ChangelogBox.tsx
@@ -19,6 +19,7 @@ const ENTRY_TYPE_COLORS: Record<ChangelogEntryType, string> = {
   fix: "#c65",
   lens: "#2a7",
   improvement: "#c84",
+  article: "#a5c",
 };
 
 const ENTRY_TYPE_LABELS: Record<ChangelogEntryType, string> = {
@@ -26,6 +27,7 @@ const ENTRY_TYPE_LABELS: Record<ChangelogEntryType, string> = {
   fix: "fix",
   lens: "lens",
   improvement: "improved",
+  article: "article",
 };
 
 function formatDate(iso: string): string {

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -7,7 +7,7 @@
  * maintenance guide.
  */
 
-export type ChangelogEntryType = "feature" | "fix" | "lens" | "improvement";
+export type ChangelogEntryType = "feature" | "fix" | "lens" | "improvement" | "article";
 
 export interface ChangelogEntry {
   /** ISO date string (YYYY-MM-DD) matching the PR merge date */


### PR DESCRIPTION
### Motivation
- The curated `CHANGELOG` included an entry with `type: "article"` which violated the existing `ChangelogEntryType` union and caused type-check/test failures; the changelog UI also needed a badge mapping for that new type. 
- An SSR test for article pages failed because Helmet renders the `<title>` with HTML-entity escaping (apostrophes become `&#x27;`), so the assertion needed to match the escaped output.

### Description
- Added `article` to the `ChangelogEntryType` union in `src/utils/changelogData.ts` so article entries are type-safe. 
- Extended `ENTRY_TYPE_COLORS` and `ENTRY_TYPE_LABELS` in `src/components/homepage/ChangelogBox.tsx` to include a color and label for the `article` type. 
- Updated documentation in `agent_docs/changelog.md` to list the new `article` entry type. 
- Adjusted the SSR test in `__tests__/entryServer.test.ts` to assert against the HTML-escaped title (`TEST_ARTICLE.title.replaceAll("'", "&#x27;")`) to match Helmet output.

### Testing
- Ran metadata generation with `npm run generate:metadata` to populate `src/generated/build-metadata.json` which resolved missing-type issues; this command completed successfully. 
- Ran formatting and lint checks with `npm run format:check` and `npm run lint`, both passed without formatting or lint errors. 
- Ran type checks with `npm run typecheck`, which passed after the `article` type and metadata generation fixes were applied. 
- Ran the test suite with `npm test` (Vitest); after the fixes all tests passed (`Test Files 58 passed, Tests 922 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9597b87608326bd8e64014b1adbda)