### PR TITLE
fix: complete error-reporting pipeline — componentStack, write-side ref race, and silently-swallowed computation errors

### DIFF
--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -123,8 +123,8 @@
 |--------|----------|---------|
 | `ClientOnly.tsx` | `src/components/` | SSR-safe wrapper that renders children only after hydration |
 | `SEOHead.tsx` | `src/components/` | Per-page meta tags (title, OG, Twitter Card, JSON-LD) via react-helmet-async |
-| `ErrorBoundary.tsx` | `src/components/errors/` | Error boundary + reusable ErrorDisplay |
-| `PanelErrorBoundary.tsx` | `src/components/errors/` | Panel-level error boundary, resets on lens change |
+| `ErrorBoundary.tsx` | `src/components/errors/` | Error boundary + reusable `ErrorDisplay`. `ErrorDisplay` builds a pre-filled GitHub issue URL via `buildIssueURL`, including the error message, stack trace, React component stack, lens key, and browser UA |
+| `PanelErrorBoundary.tsx` | `src/components/errors/` | Panel-level error boundary, resets on lens change; stores `componentStack` from `ErrorInfo` and passes it through to `ErrorDisplay` |
 
 ### Optics Engine
 
@@ -154,7 +154,7 @@
 | `comparisonSliders.ts` | `src/utils/` | Shared slider math for comparison mode (focus, aperture, zoom) |
 | `parseComparisonParams.ts` | `src/utils/` | URL deep-link parsing, `encodeSliderParams()` (shared slider→URL encoding), and slider state persistence |
 | `featureFlags.ts` | `src/utils/` | Feature flag controls |
-| `errorReporting.ts` | `src/utils/` | GitHub issue URL builder |
+| `errorReporting.ts` | `src/utils/` | `buildIssueURL(error, context)` — builds a pre-filled GitHub `/issues/new` URL. `IssueContext` fields: `component`, `lensKey`, `componentStack` (React component tree from `ErrorInfo`), `extra` |
 | `useMediaQuery.ts` | `src/utils/` | Responsive breakpoint hook |
 | `preferences.ts` | `src/utils/` | localStorage load/save |
 | `lensReducer.ts` | `src/utils/` | Pure reducer: sliced state shape + action types |
@@ -215,19 +215,27 @@ State is provided to children via `LensStateContext` (state + theme + isWide) an
 Orchestrates sub-components and custom hooks. Owns only hover/selection state and structural layout wiring.
 
 Extracted hooks (all in `src/components/hooks/`):
-- **`useLensComputation.ts`** — Hook: lens building, layout, coordinate transforms, element shapes, aperture calculations
-- **`useRayTracing.ts`** — Hook: orchestrates ray sub-hooks (useOnAxisRays, useOffAxisRays, useChromaticRays)
-- **`useOnAxisRays.ts`** — Hook: on-axis ray fan computation + coordinate transform
-- **`useOffAxisRays.ts`** — Hook: off-axis field ray computation with trueAngle/edge projection modes
-- **`useChromaticRays.ts`** — Hook: chromatic tracing across R/G/B channels + LCA/TCA spread computation
+- **`useLensComputation.ts`** — Hook: lens building, layout, coordinate transforms, element shapes, aperture calculations. Returns `buildError` (thrown by `buildLens`) and `shapeError` (thrown by `computeElementShapes`) separately so the panel can surface both via `ErrorDisplay`
+- **`useRayTracing.ts`** — Hook: orchestrates ray sub-hooks (useOnAxisRays, useOffAxisRays, useChromaticRays). Aggregates errors from all three into a single `rayError` (first non-null)
+- **`useOnAxisRays.ts`** — Hook: on-axis ray fan computation + coordinate transform. Returns `{ segments, error }` — caught errors are surfaced rather than silently dropped
+- **`useOffAxisRays.ts`** — Hook: off-axis field ray computation with trueAngle/edge projection modes. Returns `{ segments, error }`
+- **`useChromaticRays.ts`** — Hook: chromatic tracing across R/G/B channels + LCA/TCA spread computation. Returns `{ chromaticRays, chromSpread, error }`
 - **`useFlashOverlay.ts`** — Hook: two-phase flash animation state machine for sticky slider feedback
 - **`useSideLayoutDetection.ts`** — Hook: ResizeObserver-based overflow detection with hysteresis for side-by-side layout
 - **`useDispatchAdapters.ts`** — Hook: reads context dispatch and returns named callback adapters for child components
 - **`useOverlayState.ts`** — Hook: Abbe/LCA/Petzval overlay open/close state with lensKey reset
 - **`useHeaderHeight.ts`** — Hook: header ResizeObserver height tracking for multi-panel alignment
 
+**Error display tiers** (in render order — first truthy wins):
+1. `buildError` — `buildLens()` threw (bad lens data); shown via `ErrorDisplay`
+2. `shapeError` — `computeElementShapes()` threw; shown via `ErrorDisplay`
+3. `rayError` — any ray-trace sub-hook threw; shown via `ErrorDisplay`
+4. `PanelErrorBoundary` — catches any render-phase error not caught above
+
+All `ErrorDisplay` instances include a pre-filled "Report Issue on GitHub" link built by `buildIssueURL` with component name, lens key, and (for render errors) the React component stack.
+
 Sub-components:
-- **`PanelErrorBoundary.tsx`** (`src/components/errors/`) — Panel-level error boundary that resets automatically on lens change
+- **`PanelErrorBoundary.tsx`** (`src/components/errors/`) — Panel-level error boundary that resets automatically on lens change; captures React's `componentStack` and forwards it to `buildIssueURL`
 - **`DiagramHeader.tsx`** (`src/components/controls/`) — Title, specs, composes RayToggles + ChromaticControls (uses `forwardRef` for height measurement)
   - **`RayToggles.tsx`** — On-axis/off-axis toggle buttons with off-axis cycling logic and feature flag awareness
   - **`ChromaticControls.tsx`** — COLOR master toggle + individual R/G/B channel buttons

--- a/src/components/errors/ErrorBoundary.tsx
+++ b/src/components/errors/ErrorBoundary.tsx
@@ -20,7 +20,7 @@ import { buildIssueURL, REPO_URL } from "../../utils/errorReporting.js";
 
 interface ErrorDisplayProps {
   error: Error | null;
-  context: Record<string, string>;
+  context: Record<string, string | undefined>;
   onRetry?: () => void;
   title?: string;
 }
@@ -200,7 +200,10 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
       <div style={BOUNDARY_WRAPPER}>
         <ErrorDisplay
           error={this.state.error}
-          context={{ component: "ErrorBoundary (top-level)" }}
+          context={{
+            component: "ErrorBoundary (top-level)",
+            componentStack: this.state.componentStack || undefined,
+          }}
           title="Rendering Error"
           onRetry={() => this.setState({ error: null, componentStack: null })}
         />

--- a/src/components/errors/PanelErrorBoundary.tsx
+++ b/src/components/errors/PanelErrorBoundary.tsx
@@ -13,21 +13,24 @@ interface PanelErrorBoundaryProps {
 
 interface PanelErrorBoundaryState {
   error: Error | null;
+  componentStack: string | null;
 }
 
 export default class PanelErrorBoundary extends Component<PanelErrorBoundaryProps, PanelErrorBoundaryState> {
   constructor(props: PanelErrorBoundaryProps) {
     super(props);
-    this.state = { error: null };
+    this.state = { error: null, componentStack: null };
   }
   static getDerivedStateFromError(error: Error): Partial<PanelErrorBoundaryState> {
     return { error };
   }
   componentDidCatch(error: Error, info: ErrorInfo): void {
-    console.error(`[LensDiagramPanel] Render error for lens "${this.props.lensKey}":`, error, info?.componentStack);
+    const stack = info?.componentStack || null;
+    console.error(`[LensDiagramPanel] Render error for lens "${this.props.lensKey}":`, error, stack);
+    this.setState({ componentStack: stack });
   }
   componentDidUpdate(prevProps: PanelErrorBoundaryProps): void {
-    if (prevProps.lensKey !== this.props.lensKey) this.setState({ error: null });
+    if (prevProps.lensKey !== this.props.lensKey) this.setState({ error: null, componentStack: null });
   }
   render() {
     if (!this.state.error) return this.props.children;
@@ -35,9 +38,13 @@ export default class PanelErrorBoundary extends Component<PanelErrorBoundaryProp
       <div style={{ display: "flex", justifyContent: "center", padding: 24 }}>
         <ErrorDisplay
           error={this.state.error}
-          context={{ component: "LensDiagramPanel", lensKey: this.props.lensKey }}
+          context={{
+            component: "LensDiagramPanel",
+            lensKey: this.props.lensKey,
+            componentStack: this.state.componentStack || undefined,
+          }}
           title="Diagram Rendering Error"
-          onRetry={() => this.setState({ error: null })}
+          onRetry={() => this.setState({ error: null, componentStack: null })}
         />
       </div>
     );

--- a/src/components/hooks/useChromaticRays.ts
+++ b/src/components/hooks/useChromaticRays.ts
@@ -44,6 +44,7 @@ interface UseChromaticRaysParams {
 interface UseChromaticRaysResult {
   chromaticRays: ChromaticRaySegment[];
   chromSpread: ChromaticSpread | null;
+  error: unknown;
 }
 
 export default function useChromaticRays({
@@ -65,10 +66,13 @@ export default function useChromaticRays({
   chromB,
   lensKey,
 }: UseChromaticRaysParams): UseChromaticRaysResult {
-  const chromaticRays = useMemo((): ChromaticRaySegment[] => {
-    if (!L || !showChromatic) return [];
+  /* Separate ref to surface a caught error from the chromatic useMemo to the
+   * combined return value (useMemo cannot return a tuple with a separate
+   * error field without restructuring, so we pair the error here). */
+  const chromaticResult = useMemo((): { segments: ChromaticRaySegment[]; error: unknown } => {
+    if (!L || !showChromatic) return { segments: [], error: null };
     const channels = filterChannels(chromR, chromG, chromB);
-    if (channels.length === 0) return [];
+    if (channels.length === 0) return { segments: [], error: null };
     try {
       const out: ChromaticRaySegment[] = [];
       for (const f of CHROM_FRACS) {
@@ -89,10 +93,10 @@ export default function useChromaticRays({
           out.push({ ...seg, channel: ch, y: result.y, u: result.u, clipped: result.clipped });
         }
       }
-      return out;
+      return { segments: out, error: null };
     } catch (e) {
       console.error(`[useChromaticRays] Chromatic ray trace failed for "${lensKey}":`, e);
-      return [];
+      return { segments: [], error: e };
     }
   }, [
     showChromatic,
@@ -114,6 +118,8 @@ export default function useChromaticRays({
     zoomT,
   ]);
 
+  const chromaticRays = chromaticResult.segments;
+
   /* Compute LCA (longitudinal chromatic aberration) and TCA (transverse)
    * from the marginal chromatic rays. Requires at least 2 active channels. */
   const chromSpread = useMemo((): ChromaticSpread | null => {
@@ -131,5 +137,5 @@ export default function useChromaticRays({
     return computeChromaticSpread(marginalRays, IMG_MM, zPos[L.N - 1]);
   }, [showChromatic, chromR, chromG, chromB, chromaticRays, IMG_MM, zPos, L]);
 
-  return { chromaticRays, chromSpread };
+  return { chromaticRays, chromSpread, error: chromaticResult.error };
 }

--- a/src/components/hooks/useLensComputation.ts
+++ b/src/components/hooks/useLensComputation.ts
@@ -47,6 +47,7 @@ interface UseLensComputationResult {
   IX: number;
   effectiveSC: number;
   shapes: ElementShape[];
+  shapeError: unknown;
   stopZ: number;
   currentFOPEN: number;
   fNumber: number;
@@ -116,15 +117,18 @@ export default function useLensComputation({
   );
 
   /* ── Element shapes ── */
-  const shapes = useMemo((): ElementShape[] => {
-    if (!L) return [];
+  const shapesResult = useMemo((): { shapes: ElementShape[]; error: unknown } => {
+    if (!L) return { shapes: [], error: null };
     try {
-      return computeElementShapes(L, zPos, sx, sy);
+      return { shapes: computeElementShapes(L, zPos, sx, sy), error: null };
     } catch (e) {
       console.error(`[useLensComputation] Element shape computation failed for "${lensKey}":`, e);
-      return [];
+      return { shapes: [], error: e };
     }
   }, [L, zPos, sx, sy, lensKey]);
+
+  const shapes = shapesResult.shapes;
+  const shapeError = shapesResult.error;
 
   /* ── Aperture ──
    * Compute the current f-number and physical stop/entrance-pupil diameters
@@ -174,6 +178,7 @@ export default function useLensComputation({
     IX,
     effectiveSC,
     shapes,
+    shapeError,
     stopZ,
     currentFOPEN,
     fNumber,

--- a/src/components/hooks/useOffAxisRays.ts
+++ b/src/components/hooks/useOffAxisRays.ts
@@ -30,6 +30,11 @@ interface UseOffAxisRaysParams {
   lensKey: string;
 }
 
+interface UseOffAxisRaysResult {
+  segments: RaySegment[];
+  error: unknown;
+}
+
 export default function useOffAxisRays({
   L,
   zPos,
@@ -45,9 +50,9 @@ export default function useOffAxisRays({
   focusK,
   showOffAxis,
   lensKey,
-}: UseOffAxisRaysParams): RaySegment[] {
-  return useMemo((): RaySegment[] => {
-    if (!L || showOffAxis === "off") return [];
+}: UseOffAxisRaysParams): UseOffAxisRaysResult {
+  return useMemo((): UseOffAxisRaysResult => {
+    if (!L || showOffAxis === "off") return { segments: [], error: null };
     try {
       const out: RaySegment[] = [];
       /* Zoom-aware field angle and chief ray entry position.
@@ -96,10 +101,10 @@ export default function useOffAxisRays({
           ),
         );
       }
-      return out;
+      return { segments: out, error: null };
     } catch (e) {
       console.error(`[useOffAxisRays] Off-axis ray trace failed for "${lensKey}":`, e);
-      return [];
+      return { segments: [], error: e };
     }
   }, [
     showOffAxis,

--- a/src/components/hooks/useOnAxisRays.ts
+++ b/src/components/hooks/useOnAxisRays.ts
@@ -32,6 +32,11 @@ interface UseOnAxisRaysParams {
   lensKey: string;
 }
 
+interface UseOnAxisRaysResult {
+  segments: RaySegment[];
+  error: unknown;
+}
+
 export default function useOnAxisRays({
   L,
   zPos,
@@ -46,9 +51,9 @@ export default function useOnAxisRays({
   rayTracksF,
   focusK,
   lensKey,
-}: UseOnAxisRaysParams): RaySegment[] {
-  return useMemo((): RaySegment[] => {
-    if (!L) return [];
+}: UseOnAxisRaysParams): UseOnAxisRaysResult {
+  return useMemo((): UseOnAxisRaysResult => {
+    if (!L) return { segments: [], error: null };
     try {
       const out: RaySegment[] = [];
       for (const f of L.rayFractions) {
@@ -59,10 +64,10 @@ export default function useOnAxisRays({
           compileRaySegment(result.pts, result.ghostPts, result.u, result.clipped, sx, sy, clampedRayEnd, IMG_MM),
         );
       }
-      return out;
+      return { segments: out, error: null };
     } catch (e) {
       console.error(`[useOnAxisRays] On-axis ray trace failed for "${lensKey}":`, e);
-      return [];
+      return { segments: [], error: e };
     }
   }, [
     zPos,

--- a/src/components/hooks/useRayTracing.ts
+++ b/src/components/hooks/useRayTracing.ts
@@ -41,6 +41,8 @@ interface UseRayTracingResult {
   offAxisRays: RaySegment[];
   chromaticRays: ChromaticRaySegment[];
   chromSpread: ChromaticSpread | null;
+  /** First ray-trace error across all three sub-hooks, or null if all succeeded. */
+  rayError: unknown;
 }
 
 export default function useRayTracing({
@@ -66,7 +68,7 @@ export default function useRayTracing({
    * ray mode; 0 when rays arrive from infinity. */
   const focusK = useMemo(() => (L && rayTracksF ? conjugateK(focusT, zoomT, L) : 0), [focusT, zoomT, rayTracksF, L]);
 
-  const rays = useOnAxisRays({
+  const { segments: rays, error: onAxisError } = useOnAxisRays({
     L,
     zPos,
     IMG_MM,
@@ -82,7 +84,7 @@ export default function useRayTracing({
     lensKey,
   });
 
-  const offAxisRays = useOffAxisRays({
+  const { segments: offAxisRays, error: offAxisError } = useOffAxisRays({
     L,
     zPos,
     IMG_MM,
@@ -99,7 +101,11 @@ export default function useRayTracing({
     lensKey,
   });
 
-  const { chromaticRays, chromSpread } = useChromaticRays({
+  const {
+    chromaticRays,
+    chromSpread,
+    error: chromaticError,
+  } = useChromaticRays({
     L,
     zPos,
     IMG_MM,
@@ -119,5 +125,7 @@ export default function useRayTracing({
     lensKey,
   });
 
-  return { focusK, rays, offAxisRays, chromaticRays, chromSpread };
+  const rayError = onAxisError ?? offAxisError ?? chromaticError ?? null;
+
+  return { focusK, rays, offAxisRays, chromaticRays, chromSpread, rayError };
 }

--- a/src/components/hooks/useViewBoxZoom.ts
+++ b/src/components/hooks/useViewBoxZoom.ts
@@ -82,6 +82,11 @@ export default function useViewBoxZoom(svgW: number, svgH: number, active: boole
   const [state, setState] = useState<ViewBoxState>(() => defaultState(svgW, svgH));
   const [isPanning, setIsPanning] = useState(false);
 
+  /* Always-current snapshot of state for use in event-handler callbacks without
+   * adding state fields to dependency arrays. Updated on every render. */
+  const latestState = useRef(state);
+  latestState.current = state;
+
   /* Refs for drag tracking */
   const dragStart = useRef<{ x: number; y: number; vbX: number; vbY: number } | null>(null);
 
@@ -141,11 +146,11 @@ export default function useViewBoxZoom(svgW: number, svgH: number, active: boole
     (e: React.PointerEvent<SVGSVGElement>) => {
       if (!active || e.button !== 0) return;
       e.currentTarget.setPointerCapture(e.pointerId);
+      /* Capture current vbX/vbY via latestState ref — avoids a side-effect-in-updater
+       * and removes the unnecessary setState call that was only used to read prev state. */
+      const { vbX, vbY } = latestState.current;
+      dragStart.current = { x: e.clientX, y: e.clientY, vbX, vbY };
       setIsPanning(true);
-      setState((prev) => {
-        dragStart.current = { x: e.clientX, y: e.clientY, vbX: prev.vbX, vbY: prev.vbY };
-        return prev;
-      });
     },
     [active],
   );
@@ -204,16 +209,9 @@ export default function useViewBoxZoom(svgW: number, svgH: number, active: boole
           midY: (e.touches[0].clientY + e.touches[1].clientY) / 2,
         };
       } else if (e.touches.length === 1) {
+        const { vbX, vbY } = latestState.current;
+        dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY, vbX, vbY };
         setIsPanning(true);
-        setState((prev) => {
-          dragStart.current = {
-            x: e.touches[0].clientX,
-            y: e.touches[0].clientY,
-            vbX: prev.vbX,
-            vbY: prev.vbY,
-          };
-          return prev;
-        });
       }
     },
     [active, state.zoom],

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -132,6 +132,7 @@ export default function LensDiagramPanel({
     IX,
     effectiveSC,
     shapes,
+    shapeError,
     stopZ,
     currentFOPEN,
     fNumber,
@@ -159,7 +160,7 @@ export default function LensDiagramPanel({
   const info = act && L ? L.elements.find((e) => e.id === act) : null;
 
   /* ── Ray tracing (on-axis, off-axis, chromatic) ── */
-  const { rays, offAxisRays, chromaticRays, chromSpread } = useRayTracing({
+  const { rays, offAxisRays, chromaticRays, chromSpread, rayError } = useRayTracing({
     L,
     zPos,
     IMG_MM,
@@ -187,6 +188,22 @@ export default function LensDiagramPanel({
             error={buildError instanceof Error ? buildError : new Error(String(buildError))}
             context={{ component: "LensDiagramPanel (buildLens)", lensKey }}
             title="Failed to build lens"
+          />
+        </div>
+      ) : shapeError ? (
+        <div style={{ display: "flex", justifyContent: "center", padding: 24 }}>
+          <ErrorDisplay
+            error={shapeError instanceof Error ? shapeError : new Error(String(shapeError))}
+            context={{ component: "LensDiagramPanel (element shapes)", lensKey }}
+            title="Failed to compute lens element shapes"
+          />
+        </div>
+      ) : rayError ? (
+        <div style={{ display: "flex", justifyContent: "center", padding: 24 }}>
+          <ErrorDisplay
+            error={rayError instanceof Error ? rayError : new Error(String(rayError))}
+            context={{ component: "LensDiagramPanel (ray tracing)", lensKey }}
+            title="Ray tracing failed"
           />
         </div>
       ) : L ? (

--- a/src/utils/errorReporting.ts
+++ b/src/utils/errorReporting.ts
@@ -10,6 +10,8 @@ const MAX_BODY_LENGTH: number = 6000;
 interface IssueContext {
   component?: string;
   lensKey?: string;
+  /** React component stack from ErrorInfo.componentStack */
+  componentStack?: string;
   extra?: string;
 }
 
@@ -29,6 +31,18 @@ export function buildIssueURL(error: Error, context: IssueContext = {}): string 
 
   if (error?.stack) {
     sections.push("", "<details><summary>Stack trace</summary>", "", "```", error.stack, "```", "</details>");
+  }
+
+  if (context.componentStack) {
+    sections.push(
+      "",
+      "<details><summary>Component stack</summary>",
+      "",
+      "```",
+      context.componentStack.trim(),
+      "```",
+      "</details>",
+    );
   }
 
   sections.push("", "## Context", `- **Component:** ${comp}`);


### PR DESCRIPTION
## Summary

Follow-on to #357, which fixed the read-side ref/setState race in `useViewBoxZoom`. This PR closes the remaining gaps in error reporting so that any crash — render, shape computation, or ray trace — produces a pre-filled GitHub issue link with enough context to actually diagnose it.

### 1. Write-side ref/setState race (`useViewBoxZoom.ts`)

`handlePointerDown` and `handleTouchStart` were writing `dragStart.current` *inside* `setState` callbacks — a side effect in a pure updater, the mirror image of the bug #357 fixed. In React Strict Mode, updaters are called twice to catch exactly this kind of violation.

Introduces a `latestState` ref (synced to current state on every render) so both handlers write `dragStart.current` directly and the `setState` calls that existed only to read `prev` state are eliminated entirely.

### 2. React `componentStack` missing from GitHub issue reports

Both error boundaries captured React's `componentStack` from `ErrorInfo` (the component tree that led to the crash — the most useful debugging signal) but never forwarded it:
- `ErrorBoundary` stored it in component state but passed only `component: "ErrorBoundary (top-level)"` to `buildIssueURL`
- `PanelErrorBoundary` didn't even store it

Adds `componentStack?: string` to `IssueContext`, renders it as a collapsible `<details>` section in the issue body, and wires it through both boundaries.

### 3. Silently-swallowed computation errors

Four `catch` blocks were logging to `console.error`, returning empty results, and moving on with no user-visible feedback:

| Hook | Was | Now |
|---|---|---|
| `useOnAxisRays` | `console.error` + return `[]` | returns `{ segments, error }` |
| `useOffAxisRays` | `console.error` + return `[]` | returns `{ segments, error }` |
| `useChromaticRays` | `console.error` + return `[]` | adds `error` to existing return object |
| `useLensComputation` (shapes) | `console.error` + return `[]` | exposes `shapeError` alongside `buildError` |

`useRayTracing` aggregates the three ray errors into a single `rayError`. `LensDiagramPanel` now has explicit render tiers for `shapeError` and `rayError` matching the existing `buildError` pattern — each shows `ErrorDisplay` with a pre-filled GitHub issue link.

### 4. Docs

`agent_docs/architecture.md` updated to document the complete error propagation chain: hook-level error returns, the four render tiers in `LensDiagramPanel`, `componentStack` threading, and the `IssueContext` fields now included in issue URLs.

## Test plan

- [ ] Typecheck passes (`npm run typecheck`) — zero new errors
- [ ] Format passes (`npm run format:check`)
- [ ] Lint passes (`npm run lint`)
- [ ] Tests pass (`npm run test`) — same pre-existing failures only (missing generated `build-metadata.json`)
- [ ] Manually trigger a ray-trace error (e.g. corrupt lens data) and confirm `ErrorDisplay` appears with a working "Report Issue on GitHub" link
- [ ] Confirm the pre-filled issue body includes the error stack trace and (for render errors) the React component stack

https://claude.ai/code/session_019FGvJLQz1jjWTcPQzUHDBE