### PR TITLE
Improve aberration visualizations with higher fidelity and industry-standard displays

### DIFF
--- a/__tests__/AberrationsPanel.test.tsx
+++ b/__tests__/AberrationsPanel.test.tsx
@@ -80,6 +80,7 @@ describe("AberrationsPanel", () => {
       usableFieldCount: 4,
       sharedTangentialHalfRangeMm: 0.06,
       sharedSagittalHalfRangeMm: 0.03,
+      airyDiskRadiusMm: 0.002,
       fields: [
         {
           fieldFraction: 0,

--- a/__tests__/ComaPreviewGrid.test.tsx
+++ b/__tests__/ComaPreviewGrid.test.tsx
@@ -103,6 +103,7 @@ function pointCloudResult(): ComaPointCloudPreviewResult {
     usableFieldCount: 3,
     sharedTangentialHalfRangeMm: 0.2,
     sharedSagittalHalfRangeMm: 0.1,
+    airyDiskRadiusMm: 0.002,
     fields: [
       {
         fieldFraction: 0,
@@ -188,7 +189,7 @@ describe("ComaPreviewGrid", () => {
   it("renders point-cloud tiles with shared axis copy", () => {
     render(<ComaPreviewGrid result={pointCloudResult()} t={theme} mode="pointCloud" />);
 
-    expect(screen.getAllByText("Real 2D point cloud").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Spot diagram").length).toBeGreaterThan(0);
     expect(screen.getByText("Tangential / sagittal image height relative to the chief ray (mm)")).toBeTruthy();
   });
 
@@ -202,8 +203,10 @@ describe("ComaPreviewGrid", () => {
 
     const centerAxisX = verticalAxisX(centerTile!);
     const quarterAxisX = verticalAxisX(quarterTile!);
-    const centerPointX = Number(centerTile!.querySelector("circle")!.getAttribute("cx"));
-    const quarterPointX = Number(quarterTile!.querySelector("circle")!.getAttribute("cx"));
+    const centerDataCircles = centerTile!.querySelectorAll("circle:not([stroke-dasharray])");
+    const quarterDataCircles = quarterTile!.querySelectorAll("circle:not([stroke-dasharray])");
+    const centerPointX = Number(centerDataCircles[0]!.getAttribute("cx"));
+    const quarterPointX = Number(quarterDataCircles[0]!.getAttribute("cx"));
 
     const centerOffset = Math.abs(centerPointX - centerAxisX);
     const quarterOffset = Math.abs(quarterPointX - quarterAxisX);

--- a/__tests__/aberrationAnalysis.test.ts
+++ b/__tests__/aberrationAnalysis.test.ts
@@ -931,7 +931,15 @@ describe("computeFieldCurvature", () => {
       0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1,
     ]);
     expect(result!.fields.map((field) => field.label)).toEqual([
-      "Center", "12.5%", "25%", "37.5%", "50%", "62.5%", "75%", "87.5%", "100%",
+      "Center",
+      "12.5%",
+      "25%",
+      "37.5%",
+      "50%",
+      "62.5%",
+      "75%",
+      "87.5%",
+      "100%",
     ]);
     expect(result!.usableFieldCount).toBeGreaterThanOrEqual(2);
     expect(result!.sharedFocusShiftHalfRangeMm).toBeGreaterThan(0);

--- a/__tests__/aberrationAnalysis.test.ts
+++ b/__tests__/aberrationAnalysis.test.ts
@@ -920,8 +920,12 @@ describe("computeFieldCurvature", () => {
     const result = computeFieldCurvature(L, zPos, 0, 0, currentEPSD, currentPhysStopSD);
     expect(result).not.toBeNull();
     expect(result!.fieldFractions).toEqual(FIELD_CURVATURE_FIELD_FRACTIONS);
-    expect(result!.fields.map((field) => field.fieldFraction)).toEqual([0, 0.25, 0.5, 0.75, 1]);
-    expect(result!.fields.map((field) => field.label)).toEqual(["Center", "25%", "50%", "75%", "100%"]);
+    expect(result!.fields.map((field) => field.fieldFraction)).toEqual([
+      0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1,
+    ]);
+    expect(result!.fields.map((field) => field.label)).toEqual([
+      "Center", "12.5%", "25%", "37.5%", "50%", "62.5%", "75%", "87.5%", "100%",
+    ]);
     expect(result!.usableFieldCount).toBeGreaterThanOrEqual(2);
     expect(result!.sharedFocusShiftHalfRangeMm).toBeGreaterThan(0);
   });

--- a/__tests__/aberrationAnalysis.test.ts
+++ b/__tests__/aberrationAnalysis.test.ts
@@ -20,7 +20,14 @@ import {
   traceCircularOffAxisBundle,
   traceOrthogonalOffAxisBundle,
 } from "../src/optics/aberration/offAxis.js";
-import { doLayout, entrancePupilAtState, epAtZoom, fopenAtZoom, traceRay } from "../src/optics/optics.js";
+import {
+  doLayout,
+  entrancePupilAtState,
+  epAtZoom,
+  FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
+  fopenAtZoom,
+  traceRay,
+} from "../src/optics/optics.js";
 import buildLens from "../src/optics/buildLens.js";
 import LENS_DEFAULTS from "../src/lens-data/defaults.js";
 import ApoLantharRaw from "../src/lens-data/VoigtlanderApoLanthar50f2.data.js";
@@ -959,7 +966,7 @@ describe("computeFieldCurvature", () => {
 
     const tangentialBundle = traceOrthogonalOffAxisBundle(
       "tangential",
-      MERIDIONAL_COMA_SAMPLE_COUNT,
+      FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
       geometry!,
       L,
       0,
@@ -969,7 +976,7 @@ describe("computeFieldCurvature", () => {
     );
     const sagittalBundle = traceOrthogonalOffAxisBundle(
       "sagittal",
-      MERIDIONAL_COMA_SAMPLE_COUNT,
+      FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
       geometry!,
       L,
       0,

--- a/__tests__/aberrationInternals.test.ts
+++ b/__tests__/aberrationInternals.test.ts
@@ -3,6 +3,7 @@ import {
   axialIntercept,
   bestFocusPlane,
   bestRelativeFocusPlane,
+  bestRelativeFocusPlaneWeighted,
   peakAtPlane,
   rmsAtPlane,
   type RealRayHit,
@@ -83,5 +84,43 @@ describe("aberration shared helpers", () => {
 
     expect(bestFocusPlane(hits, 7)).toBe(7);
     expect(bestRelativeFocusPlane(hits, hits[0], 7)).toBe(7);
+  });
+
+  it("weighted best-focus agrees with unweighted for uniform pupil fractions", () => {
+    const referenceHit: TransverseFocusHit = { coordinate: 0, slope: 0 };
+    const hits: TransverseFocusHit[] = [
+      { coordinate: 0.1, slope: -0.05 },
+      { coordinate: -0.1, slope: 0.05 },
+      { coordinate: -0.2, slope: 0.1 },
+    ];
+    const pupilFractions = [0, 0, 0];
+
+    const unweighted = bestRelativeFocusPlane(hits, referenceHit, 4);
+    const weighted = bestRelativeFocusPlaneWeighted(hits, referenceHit, 4, pupilFractions, 0.7);
+    expect(weighted).toBeCloseTo(unweighted, 6);
+  });
+
+  it("weighted best-focus emphasizes central pupil rays", () => {
+    const referenceHit: TransverseFocusHit = { coordinate: 0, slope: 0 };
+    const hits: TransverseFocusHit[] = [
+      { coordinate: 0.01, slope: -0.01 },
+      { coordinate: 0.02, slope: -0.02 },
+      { coordinate: 0.5, slope: -0.1 },
+    ];
+    const pupilFractions = [0.1, 0.3, 0.95];
+
+    const unweighted = bestRelativeFocusPlane(hits, referenceHit, 10);
+    const weighted = bestRelativeFocusPlaneWeighted(hits, referenceHit, 10, pupilFractions, 0.7);
+    expect(weighted).not.toBe(unweighted);
+    expect(isFinite(weighted)).toBe(true);
+  });
+
+  it("weighted best-focus falls back to unweighted on mismatched lengths", () => {
+    const referenceHit: TransverseFocusHit = { coordinate: 0, slope: 0 };
+    const hits: TransverseFocusHit[] = [{ coordinate: 0.1, slope: -0.05 }];
+
+    const result = bestRelativeFocusPlaneWeighted(hits, referenceHit, 4, [], 0.7);
+    const unweighted = bestRelativeFocusPlane(hits, referenceHit, 4);
+    expect(result).toBeCloseTo(unweighted, 6);
   });
 });

--- a/__tests__/analysisDisplayTabs.test.ts
+++ b/__tests__/analysisDisplayTabs.test.ts
@@ -51,7 +51,7 @@ describe("analysis display tabs", () => {
     ];
 
     const html = renderToStaticMarkup(React.createElement(DistortionChart, { samples, t: themes.dark }));
-    expect(html).toContain("Image height (% of edge)");
+    expect(html).toContain("Relative image height (%)");
     expect(html).toContain("100%");
     expect(html).not.toContain("Field angle (°)");
   });
@@ -106,11 +106,11 @@ describe("analysis display tabs", () => {
 
     expect(html).toContain("Spherical Aberration");
     expect(html).toContain("Field Curvature");
-    expect(html).not.toContain("Coma Preview");
+    expect(html).not.toContain("Spot Diagram");
     expect(html).not.toContain("Meridional Coma");
   });
 
-  it("ComaTab renders coma preview and meridional coma content", () => {
+  it("ComaTab renders spot diagram and meridional coma content", () => {
     const L = build(Sonnar50f15Raw);
     const focusT = 0;
     const zoomT = 0;
@@ -129,8 +129,8 @@ describe("analysis display tabs", () => {
       }),
     );
 
-    expect(html).toContain("Coma Preview");
-    expect(html).toContain("Real 2D coma point cloud");
+    expect(html).toContain("Spot Diagram");
+    expect(html).toContain("Spot diagram");
     expect(html).toContain("Center");
     expect(html).toContain("25%");
     expect(html).toContain("50%");

--- a/__tests__/distortionAnalysis.test.ts
+++ b/__tests__/distortionAnalysis.test.ts
@@ -172,7 +172,19 @@ describe("computeDistortionCurve", () => {
 describe("computeDistortionGrid", () => {
   it("returns null for fewer than 2 samples", () => {
     expect(computeDistortionGrid([])).toBeNull();
-    expect(computeDistortionGrid([{ fieldAngleDeg: 0, normalizedImageHeight: 0, imageHeight: 0, distortionPercent: 0, realHeight: 0, idealHeight: 0, idealFieldAngleDeg: 0 }])).toBeNull();
+    expect(
+      computeDistortionGrid([
+        {
+          fieldAngleDeg: 0,
+          normalizedImageHeight: 0,
+          imageHeight: 0,
+          distortionPercent: 0,
+          realHeight: 0,
+          idealHeight: 0,
+          idealFieldAngleDeg: 0,
+        },
+      ]),
+    ).toBeNull();
   });
 
   it("produces the correct number of grid lines", () => {

--- a/__tests__/distortionAnalysis.test.ts
+++ b/__tests__/distortionAnalysis.test.ts
@@ -239,6 +239,24 @@ describe("computeDistortionGrid", () => {
     }
   });
 
+  it("grid corners stay within the image circle (inscribed square)", () => {
+    const L = build(Sonnar50f15Raw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const dynamicEFL = eflAtFocus(0, 0, L);
+    const { currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 0, 0, dynamicEFL, currentPhysStopSD);
+    const grid = computeDistortionGrid(samples, 11);
+    expect(grid).not.toBeNull();
+
+    for (const line of [...grid!.horizontalLines, ...grid!.verticalLines]) {
+      for (const pt of line) {
+        const r = Math.sqrt(pt.x * pt.x + pt.y * pt.y);
+        expect(r).toBeLessThanOrEqual(1.1);
+      }
+    }
+  });
+
   it("maxDistortionPercent matches the distortion curve edge", () => {
     const L = build(Sonnar50f15Raw);
     const { z: zPos } = doLayout(0, 0, L);

--- a/__tests__/distortionAnalysis.test.ts
+++ b/__tests__/distortionAnalysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeDistortionCurve } from "../src/optics/distortionAnalysis.js";
+import { computeDistortionCurve, computeDistortionGrid } from "../src/optics/distortionAnalysis.js";
 import { doLayout, eflAtFocus, fopenAtZoom, halfFieldAtZoom } from "../src/optics/optics.js";
 import buildLens from "../src/optics/buildLens.js";
 import LENS_DEFAULTS from "../src/lens-data/defaults.js";
@@ -166,5 +166,78 @@ describe("computeDistortionCurve", () => {
     const samples = computeDistortionCurve(L, zPos, 1, 1, dynamicEFL, currentPhysStopSD);
     const maxAbs = samples.reduce((m, s) => Math.max(m, Math.abs(s.distortionPercent)), 0);
     expect(maxAbs).toBeLessThan(15);
+  });
+});
+
+describe("computeDistortionGrid", () => {
+  it("returns null for fewer than 2 samples", () => {
+    expect(computeDistortionGrid([])).toBeNull();
+    expect(computeDistortionGrid([{ fieldAngleDeg: 0, normalizedImageHeight: 0, imageHeight: 0, distortionPercent: 0, realHeight: 0, idealHeight: 0, idealFieldAngleDeg: 0 }])).toBeNull();
+  });
+
+  it("produces the correct number of grid lines", () => {
+    const L = build(Sonnar50f15Raw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const dynamicEFL = eflAtFocus(0, 0, L);
+    const { currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 0, 0, dynamicEFL, currentPhysStopSD);
+    const grid = computeDistortionGrid(samples, 9);
+    expect(grid).not.toBeNull();
+    expect(grid!.horizontalLines).toHaveLength(9);
+    expect(grid!.verticalLines).toHaveLength(9);
+    expect(grid!.gridSize).toBe(9);
+  });
+
+  it("center point is undistorted", () => {
+    const L = build(Sonnar50f15Raw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const dynamicEFL = eflAtFocus(0, 0, L);
+    const { currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 0, 0, dynamicEFL, currentPhysStopSD);
+    const grid = computeDistortionGrid(samples, 11);
+    expect(grid).not.toBeNull();
+
+    const centerH = grid!.horizontalLines[5];
+    const centerV = grid!.verticalLines[5];
+    const hMid = centerH[Math.floor(centerH.length / 2)];
+    const vMid = centerV[Math.floor(centerV.length / 2)];
+    expect(Math.abs(hMid.x)).toBeLessThan(1e-9);
+    expect(Math.abs(hMid.y)).toBeLessThan(1e-9);
+    expect(Math.abs(vMid.x)).toBeLessThan(1e-9);
+    expect(Math.abs(vMid.y)).toBeLessThan(1e-9);
+  });
+
+  it("grid points are finite for a real lens", () => {
+    const L = build(ApoLantharRaw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const dynamicEFL = eflAtFocus(0, 0, L);
+    const { currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 0, 0, dynamicEFL, currentPhysStopSD);
+    const grid = computeDistortionGrid(samples);
+    expect(grid).not.toBeNull();
+
+    for (const line of [...grid!.horizontalLines, ...grid!.verticalLines]) {
+      for (const pt of line) {
+        expect(isFinite(pt.x)).toBe(true);
+        expect(isFinite(pt.y)).toBe(true);
+      }
+    }
+  });
+
+  it("maxDistortionPercent matches the distortion curve edge", () => {
+    const L = build(Sonnar50f15Raw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const dynamicEFL = eflAtFocus(0, 0, L);
+    const { currentPhysStopSD } = apertureAt(L, 0, 0);
+
+    const samples = computeDistortionCurve(L, zPos, 0, 0, dynamicEFL, currentPhysStopSD);
+    const grid = computeDistortionGrid(samples);
+    expect(grid).not.toBeNull();
+
+    const curveMax = Math.max(...samples.map((s) => Math.abs(s.distortionPercent)));
+    expect(grid!.maxDistortionPercent).toBeCloseTo(curveMax, 6);
   });
 });

--- a/src/components/display/ChromaticFieldCurvaturePlot.tsx
+++ b/src/components/display/ChromaticFieldCurvaturePlot.tsx
@@ -82,7 +82,7 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
 
       <line x1={ML} y1={zeroY} x2={ML + PW} y2={zeroY} stroke={t.axis} strokeWidth={0.75} strokeDasharray="3,3" />
       <text x={ML + PW - 4} y={zeroY - 5} textAnchor="end" fill={t.muted} fontSize={8} fontFamily="inherit">
-        Current plane
+        Image plane
       </text>
 
       {tickValues.map((tick) => {
@@ -125,7 +125,7 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
         Toward sensor
       </text>
       <text x={ML + PW / 2} y={VB_H - 2} textAnchor="middle" fill={t.muted} fontSize={9.5} fontFamily="inherit">
-        Field position across current half-field
+        Relative field height
       </text>
 
       {/* Tangential traces (solid) and sagittal traces (dashed) per channel */}

--- a/src/components/display/ComaPreviewGrid.tsx
+++ b/src/components/display/ComaPreviewGrid.tsx
@@ -24,6 +24,8 @@ interface ComaPreviewGridProps {
 
 const VB_W = 320;
 const VB_H = 268;
+const REF_PANEL_H = 64;
+const VB_H_WITH_REF = VB_H + REF_PANEL_H;
 const OUTER_PAD_X = 18;
 const OUTER_PAD_Y = 18;
 const COL_GAP = 14;
@@ -304,15 +306,116 @@ function renderPointCloudTile(
   );
 }
 
+function renderDiffractionReferencePanel(
+  airyDiskRadiusMm: number,
+  sharedTangentialHalfRangeMm: number,
+  sharedSagittalHalfRangeMm: number,
+  t: Theme,
+) {
+  const refY = VB_H - 6;
+  const refPlotSize = REF_PANEL_H - 20;
+  const refCenterX = OUTER_PAD_X + refPlotSize / 2 + 8;
+  const refCenterY = refY + 10 + refPlotSize / 2;
+  const airyPixelR = Math.max(1, (airyDiskRadiusMm / sharedTangentialHalfRangeMm) * (PLOT_W / 2));
+  const maxR = refPlotSize / 2 - 2;
+  const displayR = Math.min(airyPixelR, maxR);
+  const airyDiameterUm = airyDiskRadiusMm * 2000;
+
+  return (
+    <g data-ref-panel="diffraction-limit">
+      <rect
+        x={OUTER_PAD_X}
+        y={refY}
+        width={VB_W - OUTER_PAD_X * 2}
+        height={REF_PANEL_H - 8}
+        rx={4}
+        fill={t.panelBg}
+        stroke={t.panelBorder}
+        strokeWidth={0.75}
+      />
+      <rect
+        x={refCenterX - refPlotSize / 2}
+        y={refCenterY - refPlotSize / 2}
+        width={refPlotSize}
+        height={refPlotSize}
+        rx={3}
+        fill="none"
+        stroke={t.panelBorder}
+        strokeWidth={0.5}
+      />
+      <line
+        x1={refCenterX - refPlotSize / 2}
+        y1={refCenterY}
+        x2={refCenterX + refPlotSize / 2}
+        y2={refCenterY}
+        stroke={t.axis}
+        strokeWidth={0.5}
+        strokeDasharray="2,2"
+      />
+      <line
+        x1={refCenterX}
+        y1={refCenterY - refPlotSize / 2}
+        x2={refCenterX}
+        y2={refCenterY + refPlotSize / 2}
+        stroke={t.axis}
+        strokeWidth={0.5}
+        strokeDasharray="2,2"
+      />
+      <circle
+        cx={refCenterX}
+        cy={refCenterY}
+        r={displayR}
+        fill={t.axis}
+        fillOpacity={0.08}
+        stroke={t.axis}
+        strokeWidth={0.75}
+        strokeDasharray="3,2"
+      />
+      <text
+        x={OUTER_PAD_X + refPlotSize + 22}
+        y={refCenterY - 8}
+        fill={t.label}
+        fontSize={9}
+        fontFamily="inherit"
+      >
+        Diffraction limit (Airy disk)
+      </text>
+      <text
+        x={OUTER_PAD_X + refPlotSize + 22}
+        y={refCenterY + 4}
+        fill={t.muted}
+        fontSize={8}
+        fontFamily="inherit"
+      >
+        {`\u00d8 ${airyDiameterUm.toFixed(1)} \u00b5m at ${sharedTangentialHalfRangeMm > 0 ? "shared" : "current"} scale`}
+      </text>
+      <text
+        x={OUTER_PAD_X + refPlotSize + 22}
+        y={refCenterY + 16}
+        fill={t.muted}
+        fontSize={7.5}
+        fontFamily="inherit"
+      >
+        Same scale as spot diagrams above
+      </text>
+    </g>
+  );
+}
+
 export default function ComaPreviewGrid({ result, t, mode = "meridional" }: ComaPreviewGridProps) {
   if (mode === "pointCloud") {
     const pointCloudResult = result as ComaPointCloudPreviewResult;
+    const hasAiry = pointCloudResult.airyDiskRadiusMm > 0;
+    const vbHeight = hasAiry ? VB_H_WITH_REF : VB_H;
 
     return (
-      <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
+      <svg
+        viewBox={`0 0 ${VB_W} ${vbHeight}`}
+        style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}
+      >
         <title>
-          Real 2D coma point cloud. Each tile traces a fixed circular pupil pattern and plots the chief-ray-centered
-          tangential and sagittal image heights directly.
+          Spot diagram with diffraction-limited Airy disk reference. Each tile traces a circular pupil pattern and plots
+          the chief-ray-centered tangential and sagittal image heights.
         </title>
         {pointCloudResult.fields.map((field, index) =>
           renderPointCloudTile(
@@ -324,7 +427,22 @@ export default function ComaPreviewGrid({ result, t, mode = "meridional" }: Coma
             pointCloudResult.airyDiskRadiusMm,
           ),
         )}
-        <text x={VB_W / 2} y={VB_H - 2} textAnchor="middle" fill={t.muted} fontSize={8.5} fontFamily="inherit">
+        {hasAiry
+          ? renderDiffractionReferencePanel(
+              pointCloudResult.airyDiskRadiusMm,
+              pointCloudResult.sharedTangentialHalfRangeMm,
+              pointCloudResult.sharedSagittalHalfRangeMm,
+              t,
+            )
+          : null}
+        <text
+          x={VB_W / 2}
+          y={vbHeight - 2}
+          textAnchor="middle"
+          fill={t.muted}
+          fontSize={8.5}
+          fontFamily="inherit"
+        >
           Tangential / sagittal image height relative to the chief ray (mm)
         </text>
       </svg>

--- a/src/components/display/ComaPreviewGrid.tsx
+++ b/src/components/display/ComaPreviewGrid.tsx
@@ -371,31 +371,13 @@ function renderDiffractionReferencePanel(
         strokeWidth={0.75}
         strokeDasharray="3,2"
       />
-      <text
-        x={OUTER_PAD_X + refPlotSize + 22}
-        y={refCenterY - 8}
-        fill={t.label}
-        fontSize={9}
-        fontFamily="inherit"
-      >
+      <text x={OUTER_PAD_X + refPlotSize + 22} y={refCenterY - 8} fill={t.label} fontSize={9} fontFamily="inherit">
         Diffraction limit (Airy disk)
       </text>
-      <text
-        x={OUTER_PAD_X + refPlotSize + 22}
-        y={refCenterY + 4}
-        fill={t.muted}
-        fontSize={8}
-        fontFamily="inherit"
-      >
+      <text x={OUTER_PAD_X + refPlotSize + 22} y={refCenterY + 4} fill={t.muted} fontSize={8} fontFamily="inherit">
         {`\u00d8 ${airyDiameterUm.toFixed(1)} \u00b5m at ${sharedTangentialHalfRangeMm > 0 ? "shared" : "current"} scale`}
       </text>
-      <text
-        x={OUTER_PAD_X + refPlotSize + 22}
-        y={refCenterY + 16}
-        fill={t.muted}
-        fontSize={7.5}
-        fontFamily="inherit"
-      >
+      <text x={OUTER_PAD_X + refPlotSize + 22} y={refCenterY + 16} fill={t.muted} fontSize={7.5} fontFamily="inherit">
         Same scale as spot diagrams above
       </text>
     </g>
@@ -435,14 +417,7 @@ export default function ComaPreviewGrid({ result, t, mode = "meridional" }: Coma
               t,
             )
           : null}
-        <text
-          x={VB_W / 2}
-          y={vbHeight - 2}
-          textAnchor="middle"
-          fill={t.muted}
-          fontSize={8.5}
-          fontFamily="inherit"
-        >
+        <text x={VB_W / 2} y={vbHeight - 2} textAnchor="middle" fill={t.muted} fontSize={8.5} fontFamily="inherit">
           Tangential / sagittal image height relative to the chief ray (mm)
         </text>
       </svg>

--- a/src/components/display/ComaPreviewGrid.tsx
+++ b/src/components/display/ComaPreviewGrid.tsx
@@ -275,9 +275,9 @@ function renderPointCloudTile(
             key={`${field.label}-${point.index}`}
             cx={xScale(point.tangentialImageHeight)}
             cy={yScale(point.sagittalImageHeight)}
-            r={1.3 + (point.weight / maxWeight) * 0.8}
+            r={0.8 + (point.weight / maxWeight) * 0.6}
             fill={t.value}
-            opacity={Math.max(0.12, Math.min(0.85, point.weight / maxWeight))}
+            opacity={Math.max(0.15, Math.min(0.9, point.weight / maxWeight))}
           />
         ))
       ) : (

--- a/src/components/display/ComaPreviewGrid.tsx
+++ b/src/components/display/ComaPreviewGrid.tsx
@@ -238,7 +238,7 @@ function renderPointCloudTile(
       geometry={geometry}
       label={field.label}
       angleLabel={field.usable ? `${field.fieldAngleDeg.toFixed(1)}°` : "Unavailable"}
-      footerLabel="Real 2D point cloud"
+      footerLabel="Spot diagram"
       t={t}
     >
       <line

--- a/src/components/display/ComaPreviewGrid.tsx
+++ b/src/components/display/ComaPreviewGrid.tsx
@@ -220,6 +220,7 @@ function renderPointCloudTile(
   sharedTangentialHalfRangeMm: number,
   sharedSagittalHalfRangeMm: number,
   t: Theme,
+  airyDiskRadiusMm: number,
 ) {
   const geometry = tileGeometry(index);
   const { plotX, plotY, zeroX, zeroY } = geometry;
@@ -270,16 +271,30 @@ function renderPointCloudTile(
       })}
 
       {field.usable ? (
-        field.points.map((point) => (
-          <circle
-            key={`${field.label}-${point.index}`}
-            cx={xScale(point.tangentialImageHeight)}
-            cy={yScale(point.sagittalImageHeight)}
-            r={0.8 + (point.weight / maxWeight) * 0.6}
-            fill={t.value}
-            opacity={Math.max(0.15, Math.min(0.9, point.weight / maxWeight))}
-          />
-        ))
+        <>
+          {airyDiskRadiusMm > 0 ? (
+            <circle
+              cx={zeroX}
+              cy={zeroY}
+              r={Math.max(1, (airyDiskRadiusMm / sharedTangentialHalfRangeMm) * (PLOT_W / 2))}
+              fill="none"
+              stroke={t.axis}
+              strokeWidth={0.6}
+              strokeDasharray="2,2"
+              opacity={0.5}
+            />
+          ) : null}
+          {field.points.map((point) => (
+            <circle
+              key={`${field.label}-${point.index}`}
+              cx={xScale(point.tangentialImageHeight)}
+              cy={yScale(point.sagittalImageHeight)}
+              r={0.8 + (point.weight / maxWeight) * 0.6}
+              fill={t.value}
+              opacity={Math.max(0.15, Math.min(0.9, point.weight / maxWeight))}
+            />
+          ))}
+        </>
       ) : (
         <text x={zeroX} y={zeroY + 3} textAnchor="middle" fill={t.muted} fontSize={8.5} fontFamily="inherit">
           Insufficient data
@@ -306,6 +321,7 @@ export default function ComaPreviewGrid({ result, t, mode = "meridional" }: Coma
             pointCloudResult.sharedTangentialHalfRangeMm,
             pointCloudResult.sharedSagittalHalfRangeMm,
             t,
+            pointCloudResult.airyDiskRadiusMm,
           ),
         )}
         <text x={VB_W / 2} y={VB_H - 2} textAnchor="middle" fill={t.muted} fontSize={8.5} fontFamily="inherit">

--- a/src/components/display/DistortionChart.tsx
+++ b/src/components/display/DistortionChart.tsx
@@ -187,7 +187,7 @@ export default function DistortionChart({ samples, t, width = 320, height = 220 
         fontFamily="inherit"
         letterSpacing="0.05em"
       >
-        Image height (% of edge)
+        Relative image height (%)
       </text>
       <text
         x={10}

--- a/src/components/display/DistortionGridOverlay.tsx
+++ b/src/components/display/DistortionGridOverlay.tsx
@@ -1,0 +1,126 @@
+/**
+ * DistortionGridOverlay — SVG component rendering a standard TV distortion
+ * grid showing the ideal rectilinear grid vs the distorted grid.
+ *
+ * The ideal grid is drawn as dashed light lines, with the distorted grid
+ * overlaid in solid themed color, showing barrel/pincushion bowing.
+ */
+
+import type { Theme } from "../../types/theme.js";
+import type { DistortionGridResult } from "../../optics/distortionAnalysis.js";
+
+interface DistortionGridOverlayProps {
+  grid: DistortionGridResult;
+  t: Theme;
+  size?: number;
+}
+
+const MARGIN = 20;
+
+function pointsToPath(points: { x: number; y: number }[], scale: number, offset: number): string {
+  return points
+    .map((pt, i) => {
+      const px = offset + pt.x * scale;
+      const py = offset - pt.y * scale;
+      return `${i === 0 ? "M" : "L"}${px.toFixed(1)},${py.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+export default function DistortionGridOverlay({ grid, t, size = 280 }: DistortionGridOverlayProps) {
+  const plotSize = size - MARGIN * 2;
+  const scale = plotSize / 2;
+  const center = size / 2;
+  const gridSize = grid.gridSize;
+
+  return (
+    <svg viewBox={`0 0 ${size} ${size}`} style={{ display: "block", width: "100%", maxWidth: size, height: "auto" }}>
+      <title>
+        TV distortion grid overlay. Dashed lines show the ideal rectilinear grid; solid lines show the distorted grid.
+      </title>
+
+      <rect x={MARGIN} y={MARGIN} width={plotSize} height={plotSize} rx={3} fill={t.panelBg} stroke={t.panelBorder} />
+
+      {/* Ideal rectilinear grid (straight dashed lines) */}
+      {Array.from({ length: gridSize }, (_, i) => {
+        const pos = MARGIN + (i / (gridSize - 1)) * plotSize;
+        return (
+          <g key={`ideal-${i}`}>
+            <line
+              x1={MARGIN}
+              y1={pos}
+              x2={MARGIN + plotSize}
+              y2={pos}
+              stroke={t.panelBorder}
+              strokeWidth={0.5}
+              strokeDasharray="3,3"
+              opacity={0.5}
+            />
+            <line
+              x1={pos}
+              y1={MARGIN}
+              x2={pos}
+              y2={MARGIN + plotSize}
+              stroke={t.panelBorder}
+              strokeWidth={0.5}
+              strokeDasharray="3,3"
+              opacity={0.5}
+            />
+          </g>
+        );
+      })}
+
+      {/* Distorted grid (solid colored lines) */}
+      {grid.horizontalLines.map((line, i) => (
+        <path
+          key={`h-${i}`}
+          d={pointsToPath(line, scale, center)}
+          fill="none"
+          stroke={t.sliderAccent}
+          strokeWidth={1}
+          opacity={0.85}
+        />
+      ))}
+      {grid.verticalLines.map((line, i) => (
+        <path
+          key={`v-${i}`}
+          d={pointsToPath(line, scale, center)}
+          fill="none"
+          stroke={t.sliderAccent}
+          strokeWidth={1}
+          opacity={0.85}
+        />
+      ))}
+
+      {/* Center crosshair */}
+      <line
+        x1={center - 4}
+        y1={center}
+        x2={center + 4}
+        y2={center}
+        stroke={t.muted}
+        strokeWidth={0.75}
+        opacity={0.5}
+      />
+      <line
+        x1={center}
+        y1={center - 4}
+        x2={center}
+        y2={center + 4}
+        stroke={t.muted}
+        strokeWidth={0.75}
+        opacity={0.5}
+      />
+
+      {/* Corner labels */}
+      <text x={MARGIN + 4} y={MARGIN - 6} fill={t.muted} fontSize={8} fontFamily="inherit">
+        Ideal (dashed) vs distorted (solid)
+      </text>
+      {grid.maxDistortionPercent > 0.01 ? (
+        <text x={size - MARGIN} y={size - 6} textAnchor="end" fill={t.muted} fontSize={7.5} fontFamily="inherit">
+          {`Max: ${grid.maxDistortionPercent.toFixed(2)}%`}
+        </text>
+      ) : null}
+    </svg>
+  );
+}

--- a/src/components/display/DistortionGridOverlay.tsx
+++ b/src/components/display/DistortionGridOverlay.tsx
@@ -93,24 +93,8 @@ export default function DistortionGridOverlay({ grid, t, size = 280 }: Distortio
       ))}
 
       {/* Center crosshair */}
-      <line
-        x1={center - 4}
-        y1={center}
-        x2={center + 4}
-        y2={center}
-        stroke={t.muted}
-        strokeWidth={0.75}
-        opacity={0.5}
-      />
-      <line
-        x1={center}
-        y1={center - 4}
-        x2={center}
-        y2={center + 4}
-        stroke={t.muted}
-        strokeWidth={0.75}
-        opacity={0.5}
-      />
+      <line x1={center - 4} y1={center} x2={center + 4} y2={center} stroke={t.muted} strokeWidth={0.75} opacity={0.5} />
+      <line x1={center} y1={center - 4} x2={center} y2={center + 4} stroke={t.muted} strokeWidth={0.75} opacity={0.5} />
 
       {/* Corner labels */}
       <text x={MARGIN + 4} y={MARGIN - 6} fill={t.muted} fontSize={8} fontFamily="inherit">

--- a/src/components/display/DistortionGridOverlay.tsx
+++ b/src/components/display/DistortionGridOverlay.tsx
@@ -16,6 +16,8 @@ interface DistortionGridOverlayProps {
 }
 
 const MARGIN = 20;
+/** Must match INSCRIBED_HALF in distortionAnalysis.ts (1/√2). */
+const INSCRIBED_HALF = 1 / Math.sqrt(2);
 
 function pointsToPath(points: { x: number; y: number }[], scale: number, offset: number): string {
   return points
@@ -29,7 +31,8 @@ function pointsToPath(points: { x: number; y: number }[], scale: number, offset:
 
 export default function DistortionGridOverlay({ grid, t, size = 280 }: DistortionGridOverlayProps) {
   const plotSize = size - MARGIN * 2;
-  const scale = plotSize / 2;
+  /* Scale so the inscribed grid fills the plot area. */
+  const scale = plotSize / (2 * INSCRIBED_HALF);
   const center = size / 2;
   const gridSize = grid.gridSize;
 
@@ -41,15 +44,19 @@ export default function DistortionGridOverlay({ grid, t, size = 280 }: Distortio
 
       <rect x={MARGIN} y={MARGIN} width={plotSize} height={plotSize} rx={3} fill={t.panelBg} stroke={t.panelBorder} />
 
-      {/* Ideal rectilinear grid (straight dashed lines) */}
+      {/* Ideal rectilinear grid (straight dashed lines, inscribed within image circle) */}
       {Array.from({ length: gridSize }, (_, i) => {
-        const pos = MARGIN + (i / (gridSize - 1)) * plotSize;
+        const frac = i / (gridSize - 1);
+        const coord = -INSCRIBED_HALF + 2 * INSCRIBED_HALF * frac;
+        const pos = center + coord * scale;
+        const lo = center - INSCRIBED_HALF * scale;
+        const hi = center + INSCRIBED_HALF * scale;
         return (
           <g key={`ideal-${i}`}>
             <line
-              x1={MARGIN}
+              x1={lo}
               y1={pos}
-              x2={MARGIN + plotSize}
+              x2={hi}
               y2={pos}
               stroke={t.panelBorder}
               strokeWidth={0.5}
@@ -58,9 +65,9 @@ export default function DistortionGridOverlay({ grid, t, size = 280 }: Distortio
             />
             <line
               x1={pos}
-              y1={MARGIN}
+              y1={lo}
               x2={pos}
-              y2={MARGIN + plotSize}
+              y2={hi}
               stroke={t.panelBorder}
               strokeWidth={0.5}
               strokeDasharray="3,3"

--- a/src/components/display/DistortionTab.tsx
+++ b/src/components/display/DistortionTab.tsx
@@ -6,9 +6,10 @@
  */
 
 import { useMemo } from "react";
-import { computeDistortionCurve } from "../../optics/distortionAnalysis.js";
+import { computeDistortionCurve, computeDistortionGrid } from "../../optics/distortionAnalysis.js";
 import { eflAtZoom } from "../../optics/optics.js";
 import DistortionChart from "./DistortionChart.js";
+import DistortionGridOverlay from "./DistortionGridOverlay.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
 
@@ -36,6 +37,8 @@ export default function DistortionTab({
     [L, zPos, focusT, zoomT, dynamicEFL, currentPhysStopSD],
   );
 
+  const grid = useMemo(() => computeDistortionGrid(samples), [samples]);
+
   if (samples.length < 2) {
     return (
       <div style={{ color: t.muted, fontSize: 10, padding: "8px 0", transition: "color 0.3s" }}>
@@ -61,6 +64,16 @@ export default function DistortionTab({
         </span>
       </div>
       <DistortionChart samples={samples} t={t} />
+      {grid ? (
+        <div style={{ marginTop: 12 }}>
+          <span style={{ fontSize: 10, color: t.muted, transition: "color 0.3s" }}>
+            TV distortion grid (uncorrected field approximation)
+          </span>
+          <div style={{ marginTop: 4 }}>
+            <DistortionGridOverlay grid={grid} t={t} />
+          </div>
+        </div>
+      ) : null}
       <div
         style={{
           display: "flex",

--- a/src/components/display/FieldCurvatureMeanPlot.tsx
+++ b/src/components/display/FieldCurvatureMeanPlot.tsx
@@ -60,7 +60,7 @@ export default function FieldCurvatureMeanPlot({ result, t }: FieldCurvatureMean
 
       <line x1={ML} y1={zeroY} x2={ML + PW} y2={zeroY} stroke={t.axis} strokeWidth={0.75} strokeDasharray="3,3" />
       <text x={ML + PW - 4} y={zeroY - 5} textAnchor="end" fill={t.muted} fontSize={8} fontFamily="inherit">
-        Focused plane
+        Image plane
       </text>
 
       {tickValues.map((tick) => {

--- a/src/components/display/FieldCurvaturePlot.tsx
+++ b/src/components/display/FieldCurvaturePlot.tsx
@@ -56,7 +56,7 @@ export default function FieldCurvaturePlot({ result, t }: FieldCurvaturePlotProp
 
       <line x1={ML} y1={zeroY} x2={ML + PW} y2={zeroY} stroke={t.axis} strokeWidth={0.75} strokeDasharray="3,3" />
       <text x={ML + PW - 4} y={zeroY - 5} textAnchor="end" fill={t.muted} fontSize={8} fontFamily="inherit">
-        Current plane
+        Image plane
       </text>
 
       {tickValues.map((tick) => {
@@ -99,7 +99,7 @@ export default function FieldCurvaturePlot({ result, t }: FieldCurvaturePlotProp
         Toward sensor
       </text>
       <text x={ML + PW / 2} y={VB_H - 2} textAnchor="middle" fill={t.muted} fontSize={9.5} fontFamily="inherit">
-        Field position across current half-field
+        Relative field height
       </text>
 
       {usableFields.map((field) => {

--- a/src/components/display/aberrations/ComaPreviewSection.tsx
+++ b/src/components/display/aberrations/ComaPreviewSection.tsx
@@ -23,9 +23,9 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
       }}
     >
       <SectionHeader
-        title="Coma Preview"
-        helpLabel="Coma preview help"
-        helpText="This real 2D coma point cloud traces a fixed circular pupil pattern at the center and at 25%, 50%, and 75% of the current half-field. Each sample is projected to the image plane and plotted as chief-ray-centered tangential and sagittal image height in millimeters. It is a compact real-ray diagnostic rather than a diffraction-aware spot model."
+        title="Spot Diagram"
+        helpLabel="Spot diagram help"
+        helpText="This spot diagram traces a circular pupil pattern at the center and at 25%, 50%, and 75% of the current half-field. Each ray is projected to the image plane and plotted as chief-ray-centered tangential and sagittal image height in millimeters. The dashed circle shows the diffraction-limited Airy disk for scale reference."
         expanded={expanded}
         onToggle={onToggle}
         theme={theme}
@@ -34,8 +34,8 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
       {expanded ? (
         <>
           <span style={{ fontSize: 9, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-            Real 2D coma point cloud at center, 25%, 50%, and 75% of the current half-field. Both axes show
-            chief-ray-centered image height in millimeters from a fixed circular pupil sample pattern.
+            Spot diagram at center, 25%, 50%, and 75% of the current half-field. Both axes show chief-ray-centered
+            image height in millimeters. Dashed circle = Airy disk (diffraction limit).
           </span>
 
           {result ? (
@@ -88,7 +88,7 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
             </>
           ) : (
             <div style={{ color: theme.muted, fontSize: 10, lineHeight: 1.5, transition: "color 0.3s" }}>
-              Unable to compute a usable 2D coma point cloud for this lens state.
+              Unable to compute spot diagrams for this lens state.
             </div>
           )}
         </>

--- a/src/components/display/aberrations/ComaPreviewSection.tsx
+++ b/src/components/display/aberrations/ComaPreviewSection.tsx
@@ -34,8 +34,8 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
       {expanded ? (
         <>
           <span style={{ fontSize: 9, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-            Spot diagram at center, 25%, 50%, and 75% of the current half-field. Both axes show chief-ray-centered
-            image height in millimeters. Dashed circle = Airy disk (diffraction limit).
+            Spot diagram at center, 25%, 50%, and 75% of the current half-field. Both axes show chief-ray-centered image
+            height in millimeters. Dashed circle = Airy disk (diffraction limit).
           </span>
 
           {result ? (

--- a/src/components/layout/lensDiagram/analysisTabs.ts
+++ b/src/components/layout/lensDiagram/analysisTabs.ts
@@ -2,7 +2,7 @@ import type { AnalysisTab } from "../AnalysisDrawer.js";
 
 export const ANALYSIS_TABS: AnalysisTab[] = [
   { id: "aberrations", label: "ABERRATIONS" },
-  { id: "coma", label: "COMA" },
+  { id: "coma", label: "SPOT DIAGRAM" },
   { id: "distortion", label: "DISTORTION" },
   { id: "breathing", label: "BREATHING" },
   { id: "vignetting", label: "VIGNETTING" },

--- a/src/optics/aberration/coma.ts
+++ b/src/optics/aberration/coma.ts
@@ -22,6 +22,16 @@ import { computeOffAxisFieldGeometry, traceCircularOffAxisBundle, traceOrthogona
 const COMA_PREVIEW_MIN_SHARED_HALF_RANGE_MM = 0.01;
 const COMA_POINT_CLOUD_MIN_VALID_SAMPLES = 5;
 
+/** d-line wavelength in mm (587.6 nm). */
+const D_LINE_WAVELENGTH_MM = 0.0005876;
+
+/** Compute the Airy disk first-zero radius: 1.22 * lambda * f_working. */
+function airyDiskRadius(efl: number, currentEPSD: number): number {
+  if (currentEPSD <= 0 || !isFinite(efl) || Math.abs(efl) < 1e-9) return 0;
+  const fNumber = Math.abs(efl) / (2 * currentEPSD);
+  return 1.22 * D_LINE_WAVELENGTH_MM * fNumber;
+}
+
 const COMA_PREVIEW_FIELD_LABELS: Record<(typeof COMA_PREVIEW_FIELD_FRACTIONS)[number], string> = {
   0: "Center",
   0.25: "25%",
@@ -543,5 +553,6 @@ export function computeComaPointCloudPreview(
     sharedTangentialHalfRangeMm,
     sharedSagittalHalfRangeMm,
     usableFieldCount: usableFields.length,
+    airyDiskRadiusMm: airyDiskRadius(L.EFL, currentEPSD),
   };
 }

--- a/src/optics/aberration/fieldCurvature.ts
+++ b/src/optics/aberration/fieldCurvature.ts
@@ -1,6 +1,7 @@
 import type { ChromaticChannel, RuntimeLens } from "../../types/optics.js";
 import type { ChromaticFieldShift, FieldCurvatureFieldResult, FieldCurvatureResult } from "./types.js";
-import { FIELD_CURVATURE_FIELD_FRACTIONS, MERIDIONAL_COMA_SAMPLE_COUNT } from "./types.js";
+import { FIELD_CURVATURE_FIELD_FRACTIONS } from "./types.js";
+import { FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT } from "../optics.js";
 import { bestFocusPlaneForDirection, computeOffAxisFieldGeometry, traceOrthogonalOffAxisBundle } from "./offAxis.js";
 
 const FIELD_CURVATURE_MIN_SHARED_HALF_RANGE_MM = 0.1;
@@ -34,9 +35,9 @@ function emptyFieldCurvatureFieldResult({ fieldFraction, label }: FieldCurvature
     fieldFraction,
     label,
     fieldAngleDeg: 0,
-    sampleCount: MERIDIONAL_COMA_SAMPLE_COUNT,
+    sampleCount: FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
     validSampleCount: 0,
-    clippedSampleCount: MERIDIONAL_COMA_SAMPLE_COUNT,
+    clippedSampleCount: FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
     chiefImageHeight: 0,
     tangentialBestFocusZ: 0,
     sagittalBestFocusZ: 0,
@@ -77,7 +78,7 @@ function computeChromaticFieldShifts(
   for (const channel of CHROMATIC_CHANNELS) {
     const tangentialBundle = traceOrthogonalOffAxisBundle(
       "tangential",
-      MERIDIONAL_COMA_SAMPLE_COUNT,
+      FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
       geometry,
       L,
       focusT,
@@ -88,7 +89,7 @@ function computeChromaticFieldShifts(
     );
     const sagittalBundle = traceOrthogonalOffAxisBundle(
       "sagittal",
-      MERIDIONAL_COMA_SAMPLE_COUNT,
+      FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
       geometry,
       L,
       focusT,
@@ -130,7 +131,7 @@ function computeFieldCurvatureField(
 
   const tangentialBundle = traceOrthogonalOffAxisBundle(
     "tangential",
-    MERIDIONAL_COMA_SAMPLE_COUNT,
+    FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
     geometry,
     L,
     focusT,
@@ -140,7 +141,7 @@ function computeFieldCurvatureField(
   );
   const sagittalBundle = traceOrthogonalOffAxisBundle(
     "sagittal",
-    MERIDIONAL_COMA_SAMPLE_COUNT,
+    FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
     geometry,
     L,
     focusT,
@@ -167,9 +168,9 @@ function computeFieldCurvatureField(
     fieldFraction: meta.fieldFraction,
     label: meta.label,
     fieldAngleDeg: geometry.fieldAngleDeg,
-    sampleCount: MERIDIONAL_COMA_SAMPLE_COUNT,
+    sampleCount: FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT,
     validSampleCount,
-    clippedSampleCount: MERIDIONAL_COMA_SAMPLE_COUNT - validSampleCount,
+    clippedSampleCount: FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT - validSampleCount,
     chiefImageHeight,
     tangentialBestFocusZ,
     sagittalBestFocusZ,

--- a/src/optics/aberration/fieldCurvature.ts
+++ b/src/optics/aberration/fieldCurvature.ts
@@ -7,9 +7,13 @@ const FIELD_CURVATURE_MIN_SHARED_HALF_RANGE_MM = 0.1;
 
 const FIELD_CURVATURE_FIELD_LABELS: Record<(typeof FIELD_CURVATURE_FIELD_FRACTIONS)[number], string> = {
   0: "Center",
+  0.125: "12.5%",
   0.25: "25%",
+  0.375: "37.5%",
   0.5: "50%",
+  0.625: "62.5%",
   0.75: "75%",
+  0.875: "87.5%",
   1: "100%",
 };
 

--- a/src/optics/aberration/offAxis.ts
+++ b/src/optics/aberration/offAxis.ts
@@ -13,7 +13,7 @@ import {
   type SkewRayTraceResult,
 } from "../optics.js";
 import type { ChromaticChannel, RuntimeLens } from "../../types/optics.js";
-import { bestRelativeFocusPlane, type TransverseFocusHit } from "./shared.js";
+import { bestRelativeFocusPlane, bestRelativeFocusPlaneWeighted, type TransverseFocusHit } from "./shared.js";
 
 export type OffAxisFanOrientation = "tangential" | "sagittal";
 export type OffAxisDirection = "tangential" | "sagittal";
@@ -306,5 +306,6 @@ export function transverseFocusHitsForDirection(
 
 export function bestFocusPlaneForDirection(bundle: OffAxisBundle, direction: OffAxisDirection): number {
   const { hits, referenceHit } = transverseFocusHitsForDirection(bundle, direction);
-  return bestRelativeFocusPlane(hits, referenceHit, bundle.geometry.lastSurfZ);
+  const pupilFractions = bundle.samples.map((s) => s.pupilFraction ?? 0);
+  return bestRelativeFocusPlaneWeighted(hits, referenceHit, bundle.geometry.lastSurfZ, pupilFractions);
 }

--- a/src/optics/aberration/offAxis.ts
+++ b/src/optics/aberration/offAxis.ts
@@ -13,7 +13,7 @@ import {
   type SkewRayTraceResult,
 } from "../optics.js";
 import type { ChromaticChannel, RuntimeLens } from "../../types/optics.js";
-import { bestRelativeFocusPlane, bestRelativeFocusPlaneWeighted, type TransverseFocusHit } from "./shared.js";
+import { bestRelativeFocusPlaneWeighted, type TransverseFocusHit } from "./shared.js";
 
 export type OffAxisFanOrientation = "tangential" | "sagittal";
 export type OffAxisDirection = "tangential" | "sagittal";

--- a/src/optics/aberration/shared.ts
+++ b/src/optics/aberration/shared.ts
@@ -156,3 +156,37 @@ export function bestRelativeFocusPlane(
 
   return lastSurfZ - numer / denom;
 }
+
+/**
+ * Weighted least-squares best-focus plane relative to a reference ray.
+ *
+ * Applies Gaussian weighting centered on the pupil axis (sigma ~0.7)
+ * to emphasize central pupil rays for more stable astigmatic focus
+ * determination, matching industry-standard practice.
+ */
+export function bestRelativeFocusPlaneWeighted(
+  hits: TransverseFocusHit[],
+  referenceHit: TransverseFocusHit,
+  lastSurfZ: number,
+  pupilFractions: number[],
+  sigma = 0.7,
+): number {
+  if (hits.length !== pupilFractions.length) {
+    return bestRelativeFocusPlane(hits, referenceHit, lastSurfZ);
+  }
+
+  const invTwoSigmaSq = 1 / (2 * sigma * sigma);
+  let denomW = 0;
+  let numerW = 0;
+
+  for (let i = 0; i < hits.length; i++) {
+    const w = Math.exp(-(pupilFractions[i] * pupilFractions[i]) * invTwoSigmaSq);
+    const du = hits[i].slope - referenceHit.slope;
+    const dy = hits[i].coordinate - referenceHit.coordinate;
+    denomW += w * du * du;
+    numerW += w * dy * du;
+  }
+
+  if (denomW <= 1e-12) return lastSurfZ;
+  return lastSurfZ - numerW / denomW;
+}

--- a/src/optics/aberration/types.ts
+++ b/src/optics/aberration/types.ts
@@ -138,6 +138,8 @@ export interface ComaPointCloudPreviewResult {
   sharedTangentialHalfRangeMm: number;
   sharedSagittalHalfRangeMm: number;
   usableFieldCount: number;
+  /** Airy disk first-zero radius in mm for the current working f-number (d-line, 587.6 nm). */
+  airyDiskRadiusMm: number;
 }
 
 /** Per-channel chromatic focus shift at a single field position. */

--- a/src/optics/aberration/types.ts
+++ b/src/optics/aberration/types.ts
@@ -201,5 +201,5 @@ export const COMA_PREVIEW_POINT_CLOUD_SAMPLE_COUNT = COMA_PREVIEW_CIRCULAR_PUPIL
 /** Fixed field positions shown in the representative coma preview grid. */
 export const COMA_PREVIEW_FIELD_FRACTIONS = [0, 0.25, 0.5, 0.75] as const;
 
-/** Fixed field positions shown in the field-curvature / astigmatism chart. */
-export const FIELD_CURVATURE_FIELD_FRACTIONS = [0, 0.25, 0.5, 0.75, 1] as const;
+/** Fixed field positions shown in the field-curvature / astigmatism chart (9-point for smooth curves). */
+export const FIELD_CURVATURE_FIELD_FRACTIONS = [0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1] as const;

--- a/src/optics/aberration/types.ts
+++ b/src/optics/aberration/types.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_CIRCULAR_PUPIL_RING_SAMPLES, DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT } from "../optics.js";
+import {
+  DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT,
+  HIGH_RES_CIRCULAR_PUPIL_RING_SAMPLES,
+} from "../optics.js";
 
 /** One sample point on the real-ray transverse SA profile curve. */
 export interface SAProfilePoint {
@@ -186,8 +189,8 @@ export const NEAR_AXIS_REAL_FRAC = 0.1;
 export const ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT = DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT;
 export const MERIDIONAL_COMA_SAMPLE_COUNT = ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT;
 
-/** Fixed equal-area circular pupil pattern reused by real 2D coma preview sampling. */
-export const COMA_PREVIEW_CIRCULAR_PUPIL_RING_SAMPLES = DEFAULT_CIRCULAR_PUPIL_RING_SAMPLES;
+/** High-resolution equal-area circular pupil pattern for spot diagram sampling. */
+export const COMA_PREVIEW_CIRCULAR_PUPIL_RING_SAMPLES = HIGH_RES_CIRCULAR_PUPIL_RING_SAMPLES;
 export const COMA_PREVIEW_POINT_CLOUD_SAMPLE_COUNT = COMA_PREVIEW_CIRCULAR_PUPIL_RING_SAMPLES.reduce(
   (sum, count) => sum + count,
   0,

--- a/src/optics/aberration/types.ts
+++ b/src/optics/aberration/types.ts
@@ -1,7 +1,4 @@
-import {
-  DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT,
-  HIGH_RES_CIRCULAR_PUPIL_RING_SAMPLES,
-} from "../optics.js";
+import { DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT, HIGH_RES_CIRCULAR_PUPIL_RING_SAMPLES } from "../optics.js";
 
 /** One sample point on the real-ray transverse SA profile curve. */
 export interface SAProfilePoint {

--- a/src/optics/distortionAnalysis.ts
+++ b/src/optics/distortionAnalysis.ts
@@ -117,3 +117,98 @@ export function computeDistortionCurve(
 
   return samples;
 }
+
+/** A 2D point in normalized image-plane coordinates (-1..+1). */
+export interface DistortionGridPoint {
+  x: number;
+  y: number;
+}
+
+/** Result of computing a 2D distorted grid for visualization. */
+export interface DistortionGridResult {
+  /** Horizontal lines: each is an array of distorted {x, y} points. */
+  horizontalLines: DistortionGridPoint[][];
+  /** Vertical lines: each is an array of distorted {x, y} points. */
+  verticalLines: DistortionGridPoint[][];
+  /** Maximum absolute distortion at edge (%). */
+  maxDistortionPercent: number;
+  /** Grid line count per axis (including edges). */
+  gridSize: number;
+}
+
+/** Number of interpolation sub-points along each grid line for smooth curves. */
+const GRID_LINE_SUBDIVISIONS = 31;
+
+/**
+ * Interpolate distortion percentage at a given normalized radius from a
+ * distortion curve. Uses linear interpolation between sample points.
+ */
+function interpolateDistortion(normalizedRadius: number, samples: DistortionSample[]): number {
+  if (samples.length < 2 || normalizedRadius <= 0) return 0;
+  if (normalizedRadius >= 1) return samples[samples.length - 1].distortionPercent;
+
+  for (let i = 1; i < samples.length; i++) {
+    if (samples[i].normalizedImageHeight >= normalizedRadius) {
+      const prev = samples[i - 1];
+      const curr = samples[i];
+      const range = curr.normalizedImageHeight - prev.normalizedImageHeight;
+      if (range < 1e-12) return curr.distortionPercent;
+      const t = (normalizedRadius - prev.normalizedImageHeight) / range;
+      return prev.distortionPercent + t * (curr.distortionPercent - prev.distortionPercent);
+    }
+  }
+
+  return samples[samples.length - 1].distortionPercent;
+}
+
+/**
+ * Apply radial distortion to a 2D normalized point.
+ *
+ * Given an ideal point (x, y) in normalized coordinates (-1..+1),
+ * compute the distorted position using the radially symmetric distortion
+ * function interpolated from the distortion curve.
+ */
+function distortPoint(x: number, y: number, samples: DistortionSample[]): DistortionGridPoint {
+  const r = Math.sqrt(x * x + y * y);
+  if (r < 1e-12) return { x: 0, y: 0 };
+
+  const distortionPct = interpolateDistortion(r, samples);
+  const scale = 1 + distortionPct / 100;
+  return { x: x * scale, y: y * scale };
+}
+
+/**
+ * Compute a 2D distorted grid for the standard TV-distortion overlay.
+ *
+ * Maps an ideal rectilinear grid through the lens's radial distortion
+ * function (interpolated from the distortion curve samples) to produce
+ * the characteristic barrel/pincushion bowing pattern.
+ *
+ * @param samples   — distortion curve from computeDistortionCurve()
+ * @param gridSize  — number of lines per axis (default 11 for a 10×10 grid)
+ */
+export function computeDistortionGrid(samples: DistortionSample[], gridSize = 11): DistortionGridResult | null {
+  if (samples.length < 2) return null;
+
+  const maxDistortionPercent = Math.max(...samples.map((s) => Math.abs(s.distortionPercent)));
+  const horizontalLines: DistortionGridPoint[][] = [];
+  const verticalLines: DistortionGridPoint[][] = [];
+
+  for (let i = 0; i < gridSize; i++) {
+    const linePos = -1 + (2 * i) / (gridSize - 1);
+
+    const hLine: DistortionGridPoint[] = [];
+    const vLine: DistortionGridPoint[] = [];
+
+    for (let j = 0; j < GRID_LINE_SUBDIVISIONS; j++) {
+      const t = -1 + (2 * j) / (GRID_LINE_SUBDIVISIONS - 1);
+      hLine.push(distortPoint(t, linePos, samples));
+      vLine.push(distortPoint(linePos, t, samples));
+    }
+
+    horizontalLines.push(hLine);
+    verticalLines.push(vLine);
+  }
+
+  return { horizontalLines, verticalLines, maxDistortionPercent, gridSize };
+}

--- a/src/optics/distortionAnalysis.ts
+++ b/src/optics/distortionAnalysis.ts
@@ -139,40 +139,71 @@ export interface DistortionGridResult {
 /** Number of interpolation sub-points along each grid line for smooth curves. */
 const GRID_LINE_SUBDIVISIONS = 31;
 
-/**
- * Interpolate distortion percentage at a given normalized radius from a
- * distortion curve. Uses linear interpolation between sample points.
- */
-function interpolateDistortion(normalizedRadius: number, samples: DistortionSample[]): number {
-  if (samples.length < 2 || normalizedRadius <= 0) return 0;
-  if (normalizedRadius >= 1) return samples[samples.length - 1].distortionPercent;
+/** Half-width of the inscribed square (corners touch the image circle at r=1). */
+const INSCRIBED_HALF = 1 / Math.sqrt(2);
 
-  for (let i = 1; i < samples.length; i++) {
-    if (samples[i].normalizedImageHeight >= normalizedRadius) {
-      const prev = samples[i - 1];
-      const curr = samples[i];
-      const range = curr.normalizedImageHeight - prev.normalizedImageHeight;
+/** An ideal-height-indexed distortion lookup entry. */
+interface IdealDistortionEntry {
+  normalizedIdealHeight: number;
+  distortionPercent: number;
+}
+
+/**
+ * Build a lookup table indexed by normalized IDEAL image height from the
+ * distortion curve (which is indexed by real/distorted height). This
+ * corrects the reference frame so grid points — which are ideal
+ * coordinates — look up distortion at the right key.
+ */
+function buildIdealLookup(samples: DistortionSample[]): IdealDistortionEntry[] {
+  if (samples.length < 2) return [];
+
+  const edgeIdeal = Math.abs(samples[samples.length - 1].idealHeight);
+  if (edgeIdeal < 1e-12) {
+    return samples.map((s) => ({
+      normalizedIdealHeight: s.normalizedImageHeight,
+      distortionPercent: s.distortionPercent,
+    }));
+  }
+
+  return samples.map((s) => ({
+    normalizedIdealHeight: Math.abs(s.idealHeight) / edgeIdeal,
+    distortionPercent: s.distortionPercent,
+  }));
+}
+
+/**
+ * Interpolate distortion percentage at a given normalized IDEAL radius.
+ * Uses the ideal-indexed lookup table for correct reference frame.
+ */
+function interpolateIdealDistortion(normalizedRadius: number, lookup: IdealDistortionEntry[]): number {
+  if (lookup.length < 2 || normalizedRadius <= 0) return 0;
+  if (normalizedRadius >= 1) return lookup[lookup.length - 1].distortionPercent;
+
+  for (let i = 1; i < lookup.length; i++) {
+    if (lookup[i].normalizedIdealHeight >= normalizedRadius) {
+      const prev = lookup[i - 1];
+      const curr = lookup[i];
+      const range = curr.normalizedIdealHeight - prev.normalizedIdealHeight;
       if (range < 1e-12) return curr.distortionPercent;
-      const t = (normalizedRadius - prev.normalizedImageHeight) / range;
+      const t = (normalizedRadius - prev.normalizedIdealHeight) / range;
       return prev.distortionPercent + t * (curr.distortionPercent - prev.distortionPercent);
     }
   }
 
-  return samples[samples.length - 1].distortionPercent;
+  return lookup[lookup.length - 1].distortionPercent;
 }
 
 /**
- * Apply radial distortion to a 2D normalized point.
+ * Apply radial distortion to a 2D normalized ideal point.
  *
- * Given an ideal point (x, y) in normalized coordinates (-1..+1),
- * compute the distorted position using the radially symmetric distortion
- * function interpolated from the distortion curve.
+ * Given an ideal point (x, y) in inscribed-grid coordinates, compute the
+ * distorted position using the ideal-indexed distortion lookup.
  */
-function distortPoint(x: number, y: number, samples: DistortionSample[]): DistortionGridPoint {
+function distortPoint(x: number, y: number, lookup: IdealDistortionEntry[]): DistortionGridPoint {
   const r = Math.sqrt(x * x + y * y);
   if (r < 1e-12) return { x: 0, y: 0 };
 
-  const distortionPct = interpolateDistortion(r, samples);
+  const distortionPct = interpolateIdealDistortion(r, lookup);
   const scale = 1 + distortionPct / 100;
   return { x: x * scale, y: y * scale };
 }
@@ -180,9 +211,9 @@ function distortPoint(x: number, y: number, samples: DistortionSample[]): Distor
 /**
  * Compute a 2D distorted grid for the standard TV-distortion overlay.
  *
- * Maps an ideal rectilinear grid through the lens's radial distortion
- * function (interpolated from the distortion curve samples) to produce
- * the characteristic barrel/pincushion bowing pattern.
+ * The grid is inscribed within the image circle (corners touch r=1) per
+ * industry convention. Uses an ideal-height-indexed lookup table so that
+ * the distortion percentage is applied in the correct reference frame.
  *
  * @param samples   — distortion curve from computeDistortionCurve()
  * @param gridSize  — number of lines per axis (default 11 for a 10×10 grid)
@@ -190,20 +221,23 @@ function distortPoint(x: number, y: number, samples: DistortionSample[]): Distor
 export function computeDistortionGrid(samples: DistortionSample[], gridSize = 11): DistortionGridResult | null {
   if (samples.length < 2) return null;
 
+  const lookup = buildIdealLookup(samples);
+  if (lookup.length < 2) return null;
+
   const maxDistortionPercent = Math.max(...samples.map((s) => Math.abs(s.distortionPercent)));
   const horizontalLines: DistortionGridPoint[][] = [];
   const verticalLines: DistortionGridPoint[][] = [];
 
   for (let i = 0; i < gridSize; i++) {
-    const linePos = -1 + (2 * i) / (gridSize - 1);
+    const linePos = -INSCRIBED_HALF + (2 * INSCRIBED_HALF * i) / (gridSize - 1);
 
     const hLine: DistortionGridPoint[] = [];
     const vLine: DistortionGridPoint[] = [];
 
     for (let j = 0; j < GRID_LINE_SUBDIVISIONS; j++) {
-      const t = -1 + (2 * j) / (GRID_LINE_SUBDIVISIONS - 1);
-      hLine.push(distortPoint(t, linePos, samples));
-      vLine.push(distortPoint(linePos, t, samples));
+      const t = -INSCRIBED_HALF + (2 * INSCRIBED_HALF * j) / (GRID_LINE_SUBDIVISIONS - 1);
+      hLine.push(distortPoint(t, linePos, lookup));
+      vLine.push(distortPoint(linePos, t, lookup));
     }
 
     horizontalLines.push(hLine);

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -68,6 +68,7 @@ const BISECT_ITERATIONS: number = 30; /* bisection steps for gapTrimHeight — y
 export const FOCUS_INFINITY_THRESHOLD: number = 0.003; /* focusT values below this are treated as infinity focus */
 export const DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT = 51;
 export const DEFAULT_CIRCULAR_PUPIL_RING_SAMPLES = [1, 6, 12, 18, 24] as const;
+export const HIGH_RES_CIRCULAR_PUPIL_RING_SAMPLES = [1, 6, 12, 18, 24, 30, 36, 42, 48] as const;
 
 /* =====================================================================
  * §4  RENDERING HELPERS — Sag, layout, and shape utilities

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -67,6 +67,7 @@ const SVG_PATH_SUBDIVISIONS: number = 48; /* arc segments per surface when build
 const BISECT_ITERATIONS: number = 30; /* bisection steps for gapTrimHeight — yields ~1e-9 mm precision */
 export const FOCUS_INFINITY_THRESHOLD: number = 0.003; /* focusT values below this are treated as infinity focus */
 export const DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT = 51;
+export const FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT = 101;
 export const DEFAULT_CIRCULAR_PUPIL_RING_SAMPLES = [1, 6, 12, 18, 24] as const;
 export const HIGH_RES_CIRCULAR_PUPIL_RING_SAMPLES = [1, 6, 12, 18, 24, 30, 36, 42, 48] as const;
 


### PR DESCRIPTION
## Summary

- **Spot diagrams**: Increase sampling from 61 to 217 rays (9-ring circular pupil pattern), add Airy disk reference circle overlay on each tile, and add a dedicated diffraction-limit reference panel showing the ideal PSF at shared scale
- **Field curvature**: Increase field positions from 5 to 9 for smoother T/S/Petzval curves, increase pupil fan from 51 to 101 samples for better least-squares focus estimation, and add Gaussian-weighted best-focus (sigma=0.7) for more accurate astigmatic focus determination
- **Distortion**: Add `computeDistortionGrid()` function and `DistortionGridOverlay` SVG component showing the standard TV distortion grid (ideal rectilinear vs distorted) for an intuitive barrel/pincushion visualization
- **Terminology**: Standardize labels to industry conventions — "spot diagram" (not "point cloud"), "Image plane" (consistent across all FC plots), rename COMA tab to SPOT DIAGRAM, update axis labels to "Relative field height" and "Relative image height (%)"

## Changes by area

### Optics engine (`src/optics/`)
- `optics.ts`: Add `HIGH_RES_CIRCULAR_PUPIL_RING_SAMPLES` and `FIELD_CURVATURE_PUPIL_FAN_SAMPLE_COUNT` constants
- `aberration/types.ts`: Update sampling constants, add `airyDiskRadiusMm` to `ComaPointCloudPreviewResult`
- `aberration/coma.ts`: Compute Airy disk radius (1.22 × λ × f/#), use high-res sampling
- `aberration/fieldCurvature.ts`: Use dedicated 101-sample pupil fan, 9 field fractions with labels
- `aberration/offAxis.ts`: Use weighted best-focus via `bestRelativeFocusPlaneWeighted()`
- `aberration/shared.ts`: Add `bestRelativeFocusPlaneWeighted()` with Gaussian pupil weighting
- `distortionAnalysis.ts`: Add `computeDistortionGrid()` with radial distortion mapping and interpolation

### UI components (`src/components/`)
- `ComaPreviewGrid.tsx`: Smaller point radius for density, Airy disk circle per tile, diffraction-limit reference panel
- `DistortionGridOverlay.tsx`: New SVG component for TV distortion grid overlay
- `DistortionTab.tsx`: Integrate grid overlay below the percentage chart
- `FieldCurvaturePlot.tsx`, `FieldCurvatureMeanPlot.tsx`, `ChromaticFieldCurvaturePlot.tsx`: Standardize "Image plane" and "Relative field height" labels
- `DistortionChart.tsx`: Update to "Relative image height (%)"
- `ComaPreviewSection.tsx`: Rename to "Spot Diagram", update help text
- `analysisTabs.ts`: Rename COMA → SPOT DIAGRAM

### Tests (`__tests__/`)
- Updated: `aberrationAnalysis.test.ts`, `aberrationInternals.test.ts`, `distortionAnalysis.test.ts`, `ComaPreviewGrid.test.tsx`, `AberrationsPanel.test.tsx`, `analysisDisplayTabs.test.ts`
- 8 new tests added (weighted best-focus, distortion grid computation, Airy disk)

## Test plan

- [x] `npm run typecheck` — no new errors (pre-existing build-metadata errors only)
- [x] `npm run format:check` — all files formatted
- [x] `npm run lint` — no lint errors
- [x] `npm run test` — 765 passing (up from 757), 1 pre-existing failure unchanged

https://claude.ai/code/session_01NttYhC1JRqrbJKHrcGztVz