### PR TITLE
Add three new lens optical prescriptions with detailed analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `49` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
+- `52` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Nikon, Zeiss, Voigtlander, Canon, Ricoh, and Vivitar
 - Lens pages pair interactive diagrams with long-form optical analysis markdown
 

--- a/src/lens-data/FujifilmXF56mmf12.analysis.md
+++ b/src/lens-data/FujifilmXF56mmf12.analysis.md
@@ -1,0 +1,127 @@
+# Fujinon XF 56mm F1.2 R — Patent Analysis
+
+## Patent & Lens Identification
+
+**Patent:** US 2015/0212302 A1, "Imaging Lens and Imaging Apparatus"
+**Inventor:** Takashi Suzuki (Fujifilm Corporation)
+**Filed:** January 27, 2015 (priority: JP 2014-015509, January 30, 2014)
+**Production lens:** Fujinon XF56mmF1.2 R (announced January 6, 2014)
+**Embodiment:** Example 3
+
+The identification of Example 3 as the production embodiment rests on convergent evidence. The production lens is specified by Fujifilm as having 11 elements in 8 groups, with two extra-low dispersion (ED) elements and one double-sided aspherical element. Examples 1, 4, and 5 of the patent contain only 10 elements (five in G1 and five in G2), while Examples 2 and 3 each contain 11 elements — matching the production count. Example 3's computed effective focal length of 56.99 mm and design f-number of 1.25 are consistent with the marketed 56 mm f/1.2 specification, as is its half-angle of view of 14.0° (total 28.0°, closely matching the published 28.5° angle of view on the APS-C format). All five examples share the same f/1.25 design aperture, but Example 3's 11-element count, two S-FPL51 ED elements, and single double-sided aspherical element collectively match the published optical formula.
+
+## Lens Overview
+
+The XF56mmF1.2 R is a fast normal-to-short-telephoto prime designed for Fujifilm's APS-C X-mount mirrorless cameras, yielding an 85 mm full-frame equivalent field of view. It was one of the fastest autofocusing native mirrorless lenses at the time of its release and was widely regarded as a benchmark portrait lens for the X system.
+
+The optical design is a modified Gaussian type: a positive front group (G1) ahead of the aperture stop followed by a positive rear group (G2). The Gaussian heritage is visible in the "two successive positive lenses plus a negative lens with a concave surface toward the image side" structure of G1, but the design departs substantially from a classical Gaussian by placing a cemented doublet and an additional negative meniscus in G1, and by using an aspherical element and a cemented triplet in G2.
+
+### Specifications (Patent Example 3)
+
+| Parameter | Value |
+|---|---|
+| Effective focal length | 56.99 mm (patent-computed) |
+| Marketing focal length | 56 mm |
+| Design f-number (Fno) | 1.25 |
+| Marketing f-number | f/1.2 |
+| Back focus (BF) | 16.53 mm |
+| Total angle of view (2ω) | 28.0° |
+| Elements / Groups | 11 / 8 |
+| Aspherical surfaces | 2 (both surfaces of L21) |
+| ED elements | 2 (L12, L13) |
+| Filter size | 62 mm |
+| Minimum focus distance | 0.7 m |
+| Diaphragm blades | 7 (rounded) |
+| Weight | 405 g |
+
+---
+
+## Optical Construction
+
+### Group 1 — Front Group (positive, f ≈ 112.9 mm)
+
+G1 contains six elements in five air-spaced groups: three individually mounted positive meniscus lenses (L11, L12, L13), a cemented positive doublet (L14 + L15), and a negative meniscus (L16). G1 is fixed during focusing.
+
+**L11 — Positive Meniscus (convex to object)**
+nd = 1.48749, νd = 70.2. Glass: S-FSL5 (OHARA). f = +385.2 mm.
+A weak positive collector element at the front of the lens. Its low refractive index and gentle curvatures minimize surface reflections and contribute very little chromatic aberration. L11 gently pre-converges the incoming beam, reducing the angles of incidence on the more strongly curved surfaces of L12 and L13 that follow.
+
+**L12 — Positive Meniscus (convex to object)**
+nd = 1.49700, νd = 81.6. Glass: S-FPL51 (OHARA) — ED glass. f = +78.7 mm.
+The first of the two ED elements. S-FPL51 is OHARA's flagship fluorophosphate crown glass, characterized by very low dispersion (νd = 81.6) and anomalous partial dispersion (θgF = 0.5375). This element carries a substantial share of G1's positive power while introducing minimal primary and secondary chromatic aberration.
+
+**L13 — Positive Meniscus (convex to object)**
+nd = 1.49700, νd = 81.6, θgF = 0.5375. Glass: S-FPL51 (OHARA) — ED glass. f = +139.8 mm.
+The second ED element. Paired with L12, it allows the front group to achieve high positive power while keeping both primary and secondary longitudinal chromatic aberration under control. The patent's conditional expressions (3) and (4) specifically require θgF1p − 0.6415 + 0.001618 × νd1p > 0.01 and νd1p > 60, confirming the use of anomalous-dispersion glass in G1 for secondary spectrum correction.
+
+**L14 + L15 — Cemented Doublet D1**
+L14: nd = 1.88300, νd = 40.8. Glass: S-LAH66 (OHARA). f = +66.4 mm.
+L15: nd = 1.75211, νd = 25.1. Glass: Dense flint (752/251, uncertain). f = −90.4 mm.
+This cemented doublet is a weak positive achromatic corrector. L14 uses S-LAH66, a high-index lanthanum glass (nd = 1.883), which provides strong positive power without excessive surface curvatures. L15 is a dense flint glass with very low Abbe number (25.1), creating a large dispersion difference across the cemented interface for chromatic correction.
+
+**L16 — Negative Meniscus (convex to object)**
+nd = 1.67300, νd = 38.2. Glass: Flint (673/382, uncertain). f = −29.1 mm.
+The strongest single element in G1 and the "negative lens having a concave surface toward the image side" referenced throughout the patent claims. Its concave image-side surface creates a powerful diverging action that balances the combined positive power of L11–L14/L15. L16's strong negative power also contributes significantly to reducing the Petzval sum.
+
+### Aperture Stop
+
+Located in the air space between G1 and G2. The seven-blade rounded diaphragm sits roughly at the midpoint of the optical track, which is typical for Gaussian-derived designs where the stop position is chosen to balance the symmetry of aberration correction between the front and rear groups.
+
+### Group 2 — Rear Group (positive, f ≈ 35.0 mm)
+
+G2 contains five elements in three air-spaced groups: the aspherical singlet L21, the cemented triplet (L22 + L23 + L24), and the positive biconvex L25.
+
+**L21 — Biconcave Negative (double-sided aspherical)**
+nd = 1.58313, νd = 59.4. Glass: L-BAL42 (OHARA) — PGM glass (probable). f = −91.1 mm.
+The sole aspherical element in the design, with both surfaces carrying aspherical departures (surfaces *13 and *14 in the patent). The "L-" prefix on the OHARA designation indicates a low-softening-temperature glass designed specifically for precision glass molding (PGM). The aspherical sag equation used in the patent includes both odd-order (A3, A5, A7, …) and even-order (A4, A6, A8, …) polynomial coefficients. Because the renderer supports only even-order terms through A14, the visualization uses an approximation; see the data file header for omitted coefficients. Positioned immediately behind the aperture stop, L21 intercepts the marginal ray bundle where the aspherical correction is most effective for spherical aberration.
+
+**L22 + L23 + L24 — Cemented Triplet T1**
+L22: nd = 1.88300, νd = 40.8. Glass: S-LAH66 (OHARA). f = +16.6 mm.
+L23: nd = 1.66680, νd = 33.0. Glass: S-TIF6 (OHARA). f = −14.0 mm.
+L24: nd = 1.88300, νd = 40.8. Glass: S-LAH66 (OHARA). f = +22.7 mm.
+The optical heart of the rear group. Its positive/negative/positive structure with all three elements cemented eliminates air-glass interfaces, which is critical at f/1.2 where even small surface reflections can generate visible ghost images and flare. The two positive elements both use S-LAH66 (nd = 1.883), giving the triplet high positive power in a compact package.
+
+**L25 — Symmetric Biconvex Positive**
+nd = 1.48749, νd = 70.2. Glass: S-FSL5 (OHARA). f = +297.6 mm.
+A weak positive field lens placed at the rear of the optical system. L25 serves primarily to fine-tune the image-side telecentricity. During focusing, L25 is fixed relative to the image plane, acting as a stationary rear element that maintains consistent image-side ray geometry regardless of focus position.
+
+---
+
+## Focusing Mechanism
+
+The patent describes an inner-focusing scheme in which G1 and L25 remain fixed relative to the image plane during focusing from infinity to the minimum object distance of 0.7 m. Focusing is performed by moving the subassembly consisting of L21, L22, L23, and L24 (the aspherical element and the cemented triplet) toward the object side.
+
+Paraxial ray-trace computation gives a required group movement of approximately 6.20 mm for focusing from infinity to 0.7 m. The stop-to-L21 air gap decreases from 11.59 mm (infinity) to 5.39 mm (close focus), while the L24-to-L25 gap increases from 0.90 mm to 7.10 mm. The effective focal length shortens from 56.99 mm at infinity to approximately 53.35 mm at close focus — roughly 6.4% focus breathing, which is typical for inner-focus designs of this era.
+
+---
+
+## Glass Selection and Aberration Correction
+
+The glass map spans a wide range of refractive indices and dispersions, from the anomalous-dispersion fluorophosphate S-FPL51 (nd = 1.497, νd = 81.6) to the high-index lanthanum S-LAH66 (nd = 1.883, νd = 40.8).
+
+**ED glasses (S-FPL51) in the front group** correct secondary longitudinal chromatic aberration. At f/1.2, the longitudinal color spread at the paraxial focus is a dominant image quality limiter; without anomalous-dispersion glasses, the secondary spectrum would produce visible color fringing in high-contrast transitions.
+
+**High-index lanthanum glasses (S-LAH66) in both groups** allow strong positive power with moderate surface curvatures, reducing higher-order spherical aberration and coma. Using three elements of the same glass type (L14, L22, L24) also simplifies manufacturing logistics.
+
+**PGM glass (L-BAL42) for the molded asphere** ensures that the aspherical element can be manufactured economically by precision glass molding rather than expensive single-point diamond turning.
+
+The Petzval sum for the complete lens is 0.00345, corresponding to a Petzval radius of approximately 289 mm. Field flatness is achieved through *astigmatic balancing* — the deliberate introduction of controlled astigmatism that opposes the Petzval curvature. The negative elements L16 (f = −29.1 mm) and L23 (f = −14.0 mm) contribute the most to reducing the Petzval sum.
+
+---
+
+## Summary of Glass Identifications
+
+| Element | nd | νd | Code | Catalog Match | Confidence |
+|---|---|---|---|---|---|
+| L11 | 1.48749 | 70.2 | 487/702 | S-FSL5 (OHARA) | Exact |
+| L12 | 1.49700 | 81.6 | 497/816 | S-FPL51 (OHARA) — ED | Exact |
+| L13 | 1.49700 | 81.6 | 497/816 | S-FPL51 (OHARA) — ED | Exact |
+| L14 | 1.88300 | 40.8 | 883/408 | S-LAH66 (OHARA) | Exact |
+| L15 | 1.75211 | 25.1 | 752/251 | Dense flint (uncertain) | Uncertain |
+| L16 | 1.67300 | 38.2 | 673/382 | Flint (uncertain) | Uncertain |
+| L21 | 1.58313 | 59.4 | 583/594 | L-BAL42 (OHARA) — PGM | Probable |
+| L22 | 1.88300 | 40.8 | 883/408 | S-LAH66 (OHARA) | Exact |
+| L23 | 1.66680 | 33.0 | 667/330 | S-TIF6 (OHARA) | Exact |
+| L24 | 1.88300 | 40.8 | 883/408 | S-LAH66 (OHARA) | Exact |
+| L25 | 1.48749 | 70.2 | 487/702 | S-FSL5 (OHARA) | Exact |
+| PP | 1.51680 | 64.2 | 517/642 | S-BSL7 (OHARA) / N-BK7 | Cover glass |

--- a/src/lens-data/FujifilmXF56mmf12.data.ts
+++ b/src/lens-data/FujifilmXF56mmf12.data.ts
@@ -1,0 +1,290 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — FUJINON XF 56mm F1.2 R                      ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2015/0212302 A1 Example 3 (Suzuki / Fujifilm).   ║
+ * ║  Modified Gaussian, 11 elements / 8 groups, 2 aspherical surfaces.║
+ * ║  Focus: inner focus — L21 + cemented triplet (L22–L24) move       ║
+ * ║         toward object; G1 and L25 fixed to image plane.           ║
+ * ║                                                                    ║
+ * ║  NOTE ON ASPHERICAL SURFACES:                                      ║
+ * ║    The patent specifies odd-order polynomial terms (A3, A5, A7,   ║
+ * ║    A9, A11, A13, A15, A17, A19) in addition to even-order terms.  ║
+ * ║    The renderer supports only even-order coefficients (A4–A14).   ║
+ * ║    Odd-order terms and A16–A20 are OMITTED. This affects the      ║
+ * ║    aspherical sag profile, particularly at intermediate zones.    ║
+ * ║    The odd-order A3 coefficient is the largest in magnitude       ║
+ * ║    (~3.8×10⁻⁴ for S13A) and its omission slightly alters the     ║
+ * ║    rendered element shape and ray trace near the rim.             ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list semi-diameters. Values estimated from     ║
+ * ║    marginal + chief ray trace at f/1.25 design aperture, with     ║
+ * ║    ~8% mechanical clearance. Front elements constrained by 62 mm  ║
+ * ║    filter thread (SD ≤ 29 mm). All SDs validated for sd/|R|<0.90, ║
+ * ║    edge thickness ≥ 0.5 mm, cemented pair consistency, and        ║
+ * ║    cross-gap sag clearance.                                       ║
+ * ║                                                                    ║
+ * ║  NOTE ON COVER GLASS:                                              ║
+ * ║    Patent specifies PP: nd=1.5168, t=2.80 mm, plus 10.00 mm air  ║
+ * ║    gap from L25 rear. PP excluded from surfaces; air-equivalent   ║
+ * ║    BFD = 16.53 mm from L25 rear to image.                        ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "fujinon-xf56f12r",
+  maker: "Fujifilm",
+  name: "FUJINON XF 56mm F1.2 R",
+  subtitle: "US 2015/0212302 A1 Example 3 — Fujifilm / Suzuki",
+  specs: ["11 ELEMENTS / 8 GROUPS", "f ≈ 56.99 mm", "F/1.25", "2ω ≈ 28.0°", "2 ASPHERICAL SURFACES (even-order only)"],
+
+  focalLengthMarketing: 56,
+  focalLengthDesign: 56.99,
+  apertureMarketing: 1.2,
+  apertureDesign: 1.25,
+  patentYear: 2015,
+  elementCount: 11,
+  groupCount: 8,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L11",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 385.2,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      role: "Weak positive collector; gentle pre-convergence of incoming beam",
+    },
+    {
+      id: 2,
+      name: "L12",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 78.7,
+      glass: "S-FPL51 (OHARA) — ED",
+      apd: "patent",
+      apdNote: "θgF = 0.5375 (patent-listed)",
+      role: "First ED element; primary positive power in G1 with minimal chromatic contribution",
+    },
+    {
+      id: 3,
+      name: "L13",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 139.8,
+      glass: "S-FPL51 (OHARA) — ED",
+      apd: "patent",
+      apdNote: "θgF = 0.5375 (patent-listed)",
+      role: "Second ED element; paired with L12 for secondary spectrum correction",
+    },
+    {
+      id: 4,
+      name: "L14",
+      label: "Element 4",
+      type: "Positive Meniscus",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 66.4,
+      glass: "S-LAH66 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "High-index positive element in achromatizing doublet D1",
+    },
+    {
+      id: 5,
+      name: "L15",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.75211,
+      vd: 25.1,
+      fl: -90.4,
+      glass: "Dense flint (752/251, uncertain)",
+      apd: false,
+      cemented: "D1",
+      role: "Dense flint corrector in doublet D1; chromatic correction via dispersion contrast",
+    },
+    {
+      id: 6,
+      name: "L16",
+      label: "Element 6",
+      type: "Negative Meniscus",
+      nd: 1.673,
+      vd: 38.2,
+      fl: -29.1,
+      glass: "Flint (673/382, uncertain)",
+      apd: false,
+      role: "Strong negative meniscus; Gaussian-type spherical aberration corrector and Petzval flattener",
+    },
+    {
+      id: 7,
+      name: "L21",
+      label: "Element 7",
+      type: "Biconcave Neg. (2× Asph)",
+      nd: 1.58313,
+      vd: 59.4,
+      fl: -91.1,
+      glass: "L-BAL42 (OHARA) — PGM",
+      apd: false,
+      role: "Molded double-asphere; corrects spherical aberration post-stop without strong concave surface",
+    },
+    {
+      id: 8,
+      name: "L22",
+      label: "Element 8",
+      type: "Positive Meniscus",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 16.6,
+      glass: "S-LAH66 (OHARA)",
+      apd: false,
+      cemented: "T1",
+      role: "Front positive of cemented triplet; convex-to-image meniscus redirects converging beam",
+    },
+    {
+      id: 9,
+      name: "L23",
+      label: "Element 9",
+      type: "Biconcave Negative",
+      nd: 1.6668,
+      vd: 33.0,
+      fl: -14.0,
+      glass: "S-TIF6 (OHARA)",
+      apd: false,
+      cemented: "T1",
+      role: "Central negative of triplet; chromatic and spherical aberration corrector",
+    },
+    {
+      id: 10,
+      name: "L24",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 22.7,
+      glass: "S-LAH66 (OHARA)",
+      apd: false,
+      cemented: "T1",
+      role: "Rear positive of triplet; shares aberration-correction burden with L22",
+    },
+    {
+      id: 11,
+      name: "L25",
+      label: "Element 11",
+      type: "Biconvex Positive",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 297.6,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      role: "Weak positive field lens; fixed to image plane, maintains image-side telecentricity",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    { label: "1", R: 163.41, d: 2.59, nd: 1.48749, elemId: 1, sd: 27.5 },
+    { label: "2", R: 1252.6, d: 0.15, nd: 1.0, elemId: 0, sd: 27.5 },
+    { label: "3", R: 32.582, d: 9.16, nd: 1.497, elemId: 2, sd: 23.5 },
+    { label: "4", R: 177.38, d: 0.15, nd: 1.0, elemId: 0, sd: 23.5 },
+    { label: "5", R: 31.661, d: 4.54, nd: 1.497, elemId: 3, sd: 21.0 },
+    { label: "6", R: 55.403, d: 0.4, nd: 1.0, elemId: 0, sd: 21.0 },
+    { label: "7", R: 28.432, d: 3.99, nd: 1.883, elemId: 4, sd: 18.5 },
+    { label: "8", R: 51.536, d: 1.3, nd: 1.75211, elemId: 5, sd: 18.5 },
+    { label: "9", R: 28.992, d: 2.96, nd: 1.0, elemId: 0, sd: 18.5 },
+    { label: "10", R: 89.503, d: 1.21, nd: 1.673, elemId: 6, sd: 14.0 },
+    { label: "11", R: 15.974, d: 6.22, nd: 1.0, elemId: 0, sd: 14.0 },
+    { label: "STO", R: 1e15, d: 11.59, nd: 1.0, elemId: 0, sd: 11.3 },
+    { label: "13A", R: -187.802, d: 1.5, nd: 1.58313, elemId: 7, sd: 6.0 },
+    { label: "14A", R: 74.266, d: 0.39, nd: 1.0, elemId: 0, sd: 6.0 },
+    { label: "15", R: -193.91, d: 6.96, nd: 1.883, elemId: 8, sd: 11.5 },
+    { label: "16", R: -13.865, d: 1.21, nd: 1.6668, elemId: 9, sd: 11.5 },
+    { label: "17", R: 29.688, d: 6.63, nd: 1.883, elemId: 10, sd: 11.5 },
+    { label: "18", R: -55.427, d: 0.9, nd: 1.0, elemId: 0, sd: 11.5 },
+    { label: "19", R: 289.87, d: 1.81, nd: 1.48749, elemId: 11, sd: 14.0 },
+    { label: "20", R: -289.87, d: 16.53, nd: 1.0, elemId: 0, sd: 14.0 },
+  ],
+
+  /* ── Aspherical coefficients ──
+   *  Even-order only (A4–A14). Patent specifies odd-order terms A3–A19
+   *  and higher-order A16–A20 which are unsupported by the renderer.
+   *  Omitted coefficients for surface 13A: A3=3.8394e-4, A5=1.4778e-4,
+   *    A7=-4.3589e-6, A9=-8.1702e-9, A11=1.8896e-9, A13=-3.5277e-12,
+   *    A15=-7.1519e-13, A17=9.4964e-15, A19=-3.5657e-17.
+   *  Omitted coefficients for surface 14A: A3=3.2574e-4, A5=1.1259e-4,
+   *    A7=-3.6581e-6, A9=-8.9862e-8, A11=4.6428e-9, A13=-4.8041e-11,
+   *    A15=-5.5600e-14, A17=3.3642e-15, A19=-1.2834e-17.
+   *  Higher-order (A16–A20) also omitted for both surfaces.
+   */
+  asph: {
+    "13A": {
+      K: 0,
+      A4: -6.2592552e-4,
+      A6: -1.4352983e-5,
+      A8: 1.1550101e-6,
+      A10: -2.0799721e-8,
+      A12: -7.7228059e-11,
+      A14: 5.669064e-12,
+    },
+    "14A": {
+      K: 0,
+      A4: -5.1485989e-4,
+      A6: -1.045219e-5,
+      A8: 1.2413561e-6,
+      A10: -1.9808269e-8,
+      A12: -2.0450812e-10,
+      A14: 6.9487622e-12,
+    },
+  },
+
+  /* ── Variable air spacings (inner focus) ──
+   *  G1 and L25 fixed to image plane. Moving group: L21 + L22 + L23 + L24.
+   *  Focus shift δ ≈ 6.20 mm at MFD (0.7 m).
+   */
+  var: {
+    STO: [11.59, 5.39],
+    "18": [0.9, 7.1],
+  },
+  varLabels: [
+    ["STO", "D(STO)"],
+    ["18", "BF(G2)"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+)", fromSurface: "1", toSurface: "11" },
+    { text: "G2 (+)", fromSurface: "13A", toSurface: "20" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "7", toSurface: "9" },
+    { text: "T1", fromSurface: "15", toSurface: "18" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.7,
+  focusDescription: "Inner focus — L21 through L24 move toward object; G1 and L25 fixed.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 1.2,
+  fstopSeries: [1.2, 1.4, 2, 2.8, 4, 5.6, 8, 11, 16],
+  apertureBlades: 7,
+  apertureBladeRoundedness: 0.7,
+
+  /* ── Layout tuning ── */
+  scFill: 0.52,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/FujifilmXF90mmf2.analysis.md
+++ b/src/lens-data/FujifilmXF90mmf2.analysis.md
@@ -1,0 +1,134 @@
+# Fujifilm Fujinon XF 90mm f/2 R LM WR — Patent Analysis
+
+**Patent:** US 2016/0274335 A1 — *Imaging Lens and Imaging Apparatus*
+**Inventor:** Daiki Kawamura (Fujifilm Corporation)
+**Filed:** March 8, 2016 | **Priority:** JP 2015-052258, March 16, 2015
+**Production Embodiment:** Example 1
+
+---
+
+## 1. Embodiment Identification
+
+Fujifilm's published specifications for the XF 90mm f/2 R LM WR state the lens comprises **11 elements in 8 groups**, including **three ED (extra-low dispersion) elements**, with a maximum aperture of f/2, a minimum focus distance of 0.6 m, and a 62 mm filter thread. The lens uses a Quad Linear Motor (LM) inner-focus system and is weather-sealed (WR).
+
+Example 1 of the patent matches the production lens on every convergent criterion: 11 elements in 8 groups arranged as G1 (4 elements) / Stop / G2 (2 elements, cemented) / G3 (5 elements), with an f/2.06 design aperture and an 87.5 mm design focal length. Fujifilm markets the lens as 90 mm, and the stated 137 mm full-frame equivalent derives from 90 × 1.52 (Fujifilm's published crop factor for the 23.5 × 15.6 mm X-Trans sensor). No aspherical surfaces are present in Example 1, consistent with Fujifilm's specifications, which make no mention of aspherical elements. Inner focusing is performed by movement of G2 alone.
+
+Examples 2, 3, and 6 share the same 11-in-8 configuration as Example 1 (Example 6 is identical to Example 1 with the addition of an apodization filter). Example 4 has 12 elements in 8 groups, and Example 5 has 11 elements in 7 groups with two aspherical surfaces. The production lens is therefore unambiguously identified with **Example 1**.
+
+---
+
+## 2. OCR Correction — Surface 1 Radius
+
+The PDF OCR of Table 1 renders the first surface radius as "134,542.19". In US number formatting the comma is a thousands separator, which would give R₁ ≈ 134.5 m — an essentially flat surface. However, a paraxial ray trace with R₁ = 134542 yields EFL ≈ 107 mm, far from the patent-stated f = 87.495 mm, and all seven conditional formulae (Table 14) fail.
+
+Interpreting the value as **R₁ = 134.54219 mm** (the decimal point corrupted to a comma during OCR) recovers EFL = 87.50 mm and satisfies every conditional formula to the patent's stated precision:
+
+| Formula | Computed | Patent |
+|---|---|---|
+| TL/f | 1.315 | 1.315 |
+| \|f2\|/f | 0.549 | 0.549 |
+| Bf/f | 0.282 | 0.282 |
+| D23/TL | 0.163 | 0.163 |
+
+The same OCR corruption appears in Example 2 (surface 2: "18334.01582" likely representing a value with a misplaced decimal) and in Example 6 (identical to Example 1). All data in the accompanying `.data.ts` file uses the corrected R₁ = 134.54219 mm.
+
+---
+
+## 3. Optical Configuration
+
+The lens is a three-group telephoto-type design:
+
+| Group | Elements | Power | Role |
+|---|---|---|---|
+| G1 | L11, L12, L13, L14 | Positive (f = +70.4 mm) | Front objective — collects and converges light |
+| G2 | L21, L22 (cemented) | Negative (f = −48.1 mm) | Inner-focus group — moves 8.1 mm toward image during infinity→close focus |
+| G3 | L31, L32+L33, L34, L35 | Positive (f = +57.5 mm) | Rear relay — corrects off-axis aberrations and sets back focus |
+
+The aperture stop is located between G1 and G2, fixed relative to the image plane during focusing. This placement is a key design choice: by positioning the stop ahead of the focusing group (rather than behind it, as in many competing designs), the front element diameters are reduced and the focus throw space is naturally available in the gap between G1 and G3.
+
+The telephoto ratio is TL/f = 1.315, meaning the physical length (115.1 mm from front vertex to image plane) is about 31.5% longer than the focal length. This is a moderately compact telephoto arrangement.
+
+---
+
+## 4. Aspherical Surfaces
+
+**Example 1 has no aspherical surfaces.** All 20 optical surfaces (plus the flat aperture stop) are spherical. This is confirmed by the absence of any asterisk markings in Table 1 of the patent, and by the absence of any aspherical coefficient table for Example 1.
+
+This is noteworthy for a modern f/2 medium-telephoto design. The designer achieved satisfactory aberration correction using only spherical surfaces, relying instead on a generous element count (11 lenses), judicious glass selection (three ED materials and two ultra-high-dispersion glasses), and careful power distribution across the three groups.
+
+For comparison, Example 5 in the same patent *does* use aspherical surfaces (on surfaces 12 and 13, the front element of G3), but it has a different group structure (7 groups vs. 8) and was not selected for production.
+
+---
+
+## 5. Glass Identification
+
+The patent provides nd, vd, and θgF for each element. Matching these against the OHARA, HOYA, and Schott catalogs yields the following identifications:
+
+| Element | nd | vd | θgF | Glass ID | Six-Digit Code | Confidence |
+|---|---|---|---|---|---|---|
+| L11 | 1.51633 | 64.14 | 0.53531 | S-BSL7 (OHARA) | 516/641 | Exact |
+| L12 | 1.49700 | 81.61 | 0.53887 | FCD1 (HOYA) | 497/816 | Exact (nd/vd/θgF) |
+| L13 | 1.59522 | 67.73 | 0.54426 | S-FPM2 (OHARA) | 595/677 | Exact |
+| L14 | 1.74950 | 35.33 | 0.58189 | S-NBH53 (OHARA) | 750/353 | Exact |
+| L21 | 1.92286 | 18.90 | 0.64960 | S-NPH2 (OHARA) | 923/189 | Exact |
+| L22 | 1.63854 | 55.38 | 0.54858 | S-BAM4 (OHARA) | 639/554 | Exact (nd/vd) |
+| L31 | 1.59522 | 67.73 | 0.54426 | S-FPM2 (OHARA) | 595/677 | Exact (same as L13) |
+| L32 | 1.83481 | 42.72 | 0.56486 | S-LAH55VS (OHARA) | 835/427 | Exact |
+| L33 | 1.67270 | 32.10 | 0.59891 | S-TIM22 (OHARA) | 673/321 | Exact |
+| L34 | 1.71300 | 53.87 | 0.54587 | S-LAM60 (OHARA) | 713/539 | Exact |
+| L35 | 1.51742 | 52.43 | 0.55649 | S-NSL3 (OHARA) or E-ADF10 (HOYA) | 517/524 | Exact |
+| PP | 1.51633 | 64.14 | 0.53531 | S-BSL7 (OHARA) | 516/641 | Exact |
+
+All glasses except L12 and possibly L35 are identifiable as OHARA types, consistent with Fujifilm's established supply chain preference for OHARA optical glass.
+
+### ED Element Identification
+
+Fujifilm states the lens contains **three ED elements**. Anomalous partial dispersion analysis (deviation ΔθgF from the Schott normal line) identifies the three ED glasses:
+
+| Element | vd | ΔθgF | Classification |
+|---|---|---|---|
+| **L12** | 81.61 | **+0.032** | **ED** — Fluorophosphate crown (FCD1), strong anomalous dispersion |
+| **L13** | 67.73 | **+0.014** | **ED** — Phosphate crown (S-FPM2), moderate anomalous dispersion |
+| **L31** | 67.73 | **+0.014** | **ED** — Same glass as L13 (S-FPM2) |
+
+L12 (FCD1/HOYA) is the strongest ED glass in the design, with vd = 81.61 and a large positive ΔθgF of +0.032. This is a calcium fluoride substitute widely used for secondary spectrum correction. L13 and L31 both use S-FPM2, which has a more moderate but still clearly anomalous partial dispersion.
+
+L11 (S-BSL7, vd = 64.14) has essentially zero anomalous dispersion (ΔθgF = −0.001) and is *not* an ED glass; it is a standard borosilicate crown.
+
+---
+
+## 6. Focusing Mechanism
+
+The lens employs **inner focusing** via G2 only. Key characteristics:
+
+- **Travel distance:** 8.096 mm (infinity to 0.6 m closest focus)
+- **Direction:** G2 moves from object side toward image side
+- **Fixed elements:** G1, aperture stop, and G3 are all stationary relative to the image plane
+- **Focus group mass:** Only 2 cemented elements (L21+L22), enabling the Quad Linear Motor system to achieve the advertised 0.14-second autofocus speed
+- **Diaphragm:** 7 rounded blades (from Fujifilm specifications), contributing to the smooth bokeh rendering the lens is known for
+
+The constant total gap (DD[8] + DD[11] = 23.353 mm) means the lens barrel length does not change during focusing — an important characteristic for weather sealing (seven internal seals). The fixed stop position also means the f-number variation during focusing is purely geometric (from β = 0 at infinity to β = 0.14 at closest focus), with no mechanical stop diameter change.
+
+---
+
+## 7. Design Summary
+
+| Parameter | Value |
+|---|---|
+| Patent embodiment | Example 1 (US 2016/0274335 A1) |
+| Design focal length | 87.495 mm (marketed as 90 mm) |
+| Design f-number | f/2.06 (marketed as f/2.0) |
+| Half-field angle | 9.2° (full angle 18.4°) |
+| Total track (TL) | 115.1 mm |
+| Back focus (air) | 24.66 mm |
+| Telephoto ratio (TL/f) | 1.315 |
+| Elements / Groups | 11 / 8 |
+| ED elements | 3 (L12: FCD1, L13: S-FPM2, L31: S-FPM2) |
+| Aspherical surfaces | None |
+| Focus type | Inner focus (G2 only) |
+| Focus travel | 8.1 mm |
+| Closest focus | 0.6 m (β = 0.14) |
+| Petzval sum | +0.00201 mm⁻¹ |
+| Diaphragm | 7 blades, rounded |
+
+The Fujifilm XF 90mm f/2 R LM WR is an all-spherical, 11-element inner-focus telephoto that relies on careful glass selection — particularly three ED elements and two ultra-high-dispersion flints — to achieve excellent chromatic correction without aspherical surfaces. The compact, lightweight G2 focus group (a single cemented doublet of exotic glass) enables fast, quiet autofocus while maintaining aberration stability across the focus range.

--- a/src/lens-data/FujifilmXF90mmf2.data.ts
+++ b/src/lens-data/FujifilmXF90mmf2.data.ts
@@ -1,0 +1,280 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — FUJIFILM FUJINON XF 90mm f/2 R LM WR        ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2016/0274335 A1 Example 1 (Kawamura / Fujifilm). ║
+ * ║  Three-group inner-focus telephoto for APS-C mirrorless.           ║
+ * ║  11 elements / 8 groups, 0 aspherical surfaces, 3 ED elements.    ║
+ * ║  Focus: Inner focus — G2 (cemented doublet) moves toward image.   ║
+ * ║                                                                    ║
+ * ║  NOTE ON R1 (OCR CORRECTION):                                      ║
+ * ║    Patent Table 1 surface 1 reads "134,542.19" in US-format OCR.  ║
+ * ║    The comma is a thousands separator, yielding R ≈ 135 m (flat). ║
+ * ║    However, paraxial EFL with R1 = 134542 gives ~107 mm, far from ║
+ * ║    the patent-stated f = 87.495. Using R1 = 134.54219 recovers    ║
+ * ║    EFL = 87.50 and all seven conditional formulae. The decimal     ║
+ * ║    point was corrupted to a comma during OCR. R1 = 134.54219.     ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list semi-diameters. Estimated by combined      ║
+ * ║    marginal + chief ray trace at the design f-number (f/2.06)     ║
+ * ║    and full field angle (ω = 9.2°), with ~8% mechanical clearance.║
+ * ║    Constrained by 62 mm filter thread, positive edge thickness,   ║
+ * ║    cemented-pair matching, and sd/|R| < 0.90.                     ║
+ * ║                                                                    ║
+ * ║  NOTE ON COVER GLASS:                                              ║
+ * ║    Patent Table 1 includes a parallel plate PP (S21–S22,           ║
+ * ║    nd = 1.51633, d = 2.850 mm). Excluded from surfaces array;     ║
+ * ║    its optical path length is folded into the BFD (last surface   ║
+ * ║    d = patent Bf = 24.663 mm, air-converted).                     ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "fujifilm-xf90f2",
+  maker: "Fujifilm",
+  name: "FUJIFILM FUJINON XF 90mm f/2 R LM WR",
+  subtitle: "US 2016/0274335 A1 EXAMPLE 1 — FUJIFILM / KAWAMURA",
+  specs: [
+    "11 ELEMENTS / 8 GROUPS",
+    "f ≈ 87.5 mm (marketed 90 mm)",
+    "F/2.06 (marketed F/2.0)",
+    "2ω ≈ 18.4°",
+    "3 ED ELEMENTS",
+    "ALL SPHERICAL",
+  ],
+
+  focalLengthMarketing: 90,
+  focalLengthDesign: 87.5,
+  apertureMarketing: 2.0,
+  apertureDesign: 2.06,
+  patentYear: 2016,
+  elementCount: 11,
+  groupCount: 8,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L11",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.51633,
+      vd: 64.14,
+      fl: 182.1,
+      glass: "S-BSL7 (OHARA)",
+      apd: false,
+      role: "Weak front positive — begins converging beam with low spherical contribution",
+    },
+    {
+      id: 2,
+      name: "L12",
+      label: "Element 2",
+      type: "Plano-Convex Positive",
+      nd: 1.497,
+      vd: 81.61,
+      fl: 114.9,
+      glass: "FCD1 (HOYA)",
+      apd: "inferred",
+      apdNote: "ΔθgF ≈ +0.032, fluorophosphate crown — strongest ED element in design",
+      role: "Primary ED element — corrects longitudinal chromatic aberration in G1",
+    },
+    {
+      id: 3,
+      name: "L13",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.59522,
+      vd: 67.73,
+      fl: 67.1,
+      glass: "S-FPM2 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔθgF ≈ +0.014, phosphate crown — moderate anomalous dispersion",
+      cemented: "D1",
+      role: "Strongest G1 positive — bulk of front group convergence; cemented to L14",
+    },
+    {
+      id: 4,
+      name: "L14",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.7495,
+      vd: 35.33,
+      fl: -58.8,
+      glass: "S-NBH53 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "High-dispersion corrector — achromatizes G1 at cemented junction with L13",
+    },
+    {
+      id: 5,
+      name: "L21",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.92286,
+      vd: 18.9,
+      fl: 123.9,
+      glass: "S-NPH2 (OHARA)",
+      apd: false,
+      cemented: "D2",
+      role: "Ultra-high-index focus group positive — achromatizes G2 with L22",
+    },
+    {
+      id: 6,
+      name: "L22",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.63854,
+      vd: 55.38,
+      fl: -34.9,
+      glass: "S-BAM4 (OHARA)",
+      apd: false,
+      cemented: "D2",
+      role: "Focus group negative — dominant diverging power of inner-focus G2",
+    },
+    {
+      id: 7,
+      name: "L31",
+      label: "Element 7",
+      type: "Positive Meniscus",
+      nd: 1.59522,
+      vd: 67.73,
+      fl: 140.2,
+      glass: "S-FPM2 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔθgF ≈ +0.014 — same ED glass as L13; third ED element",
+      role: "Third ED element — corrects lateral color and secondary spectrum in rear group",
+    },
+    {
+      id: 8,
+      name: "L32",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.83481,
+      vd: 42.72,
+      fl: 31.9,
+      glass: "S-LAH55VS (OHARA)",
+      apd: false,
+      cemented: "D3",
+      role: "Strongest positive in entire lens — main relay element; cemented to L33",
+    },
+    {
+      id: 9,
+      name: "L33",
+      label: "Element 9",
+      type: "Biconcave Negative",
+      nd: 1.6727,
+      vd: 32.1,
+      fl: -27.9,
+      glass: "S-TIM22 (OHARA)",
+      apd: false,
+      cemented: "D3",
+      role: "High-dispersion corrector — achromatizes G31 doublet with L32",
+    },
+    {
+      id: 10,
+      name: "L34",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.713,
+      vd: 53.87,
+      fl: 41.5,
+      glass: "S-LAM60 (OHARA)",
+      apd: false,
+      role: "G32 singlet — corrects field curvature and astigmatism at large off-axis offset",
+    },
+    {
+      id: 11,
+      name: "L35",
+      label: "Element 11",
+      type: "Biconcave Negative",
+      nd: 1.51742,
+      vd: 52.43,
+      fl: -72.4,
+      glass: "S-NSL3 (OHARA)",
+      apd: false,
+      role: "G33 field flattener — directs off-axis rays for telecentricity; shortens total track",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── G1: Front objective (positive, f ≈ +70.4 mm) ──
+    { label: "1", R: 134.54219, d: 4.55, nd: 1.51633, elemId: 1, sd: 27.0 }, // L11 front
+    { label: "2", R: -308.4824, d: 0.52, nd: 1.0, elemId: 0, sd: 27.0 }, // L11 rear → air
+    { label: "3", R: 57.11452, d: 6.05, nd: 1.497, elemId: 2, sd: 24.5 }, // L12 front (ED)
+    { label: "4", R: 1e15, d: 0.18, nd: 1.0, elemId: 0, sd: 23.5 }, // L12 rear (flat) → air
+    { label: "5", R: 54.95203, d: 7.01, nd: 1.59522, elemId: 3, sd: 22.5 }, // L13 front (cemented D1)
+    { label: "6", R: -138.92, d: 3.0, nd: 1.7495, elemId: 4, sd: 22.5 }, // L13→L14 junction
+    { label: "7", R: 65.12954, d: 8.05, nd: 1.0, elemId: 0, sd: 22.5 }, // L14 rear → air
+
+    // ── Aperture stop (fixed between G1 and G2) ──
+    { label: "STO", R: 1e15, d: 4.6, nd: 1.0, elemId: 0, sd: 14.2 },
+
+    // ── G2: Inner-focus group (negative, f ≈ −48.1 mm) ──
+    { label: "9", R: -99.96703, d: 2.61, nd: 1.92286, elemId: 5, sd: 14.5 }, // L21 front (cemented D2)
+    { label: "10", R: -53.995, d: 1.49, nd: 1.63854, elemId: 6, sd: 14.5 }, // L21→L22 junction
+    { label: "11", R: 38.38332, d: 18.753, nd: 1.0, elemId: 0, sd: 14.5 }, // L22 rear → air
+
+    // ── G3: Rear relay (positive, f ≈ +57.5 mm) ──
+    // Sub-group G31 (positive): L31 + [L32+L33 cemented]
+    { label: "12", R: -299.93361, d: 2.8, nd: 1.59522, elemId: 7, sd: 16.5 }, // L31 front (ED)
+    { label: "13", R: -65.51447, d: 0.25, nd: 1.0, elemId: 0, sd: 16.0 }, // L31 rear → air
+    { label: "14", R: 65.03027, d: 6.51, nd: 1.83481, elemId: 8, sd: 16.0 }, // L32 front (cemented D3)
+    { label: "15", R: -43.003, d: 1.35, nd: 1.6727, elemId: 9, sd: 16.0 }, // L32→L33 junction
+    { label: "16", R: 33.7544, d: 9.18, nd: 1.0, elemId: 0, sd: 16.0 }, // L33 rear → air
+
+    // Sub-group G32 (positive): L34
+    { label: "17", R: 39.82254, d: 6.4, nd: 1.713, elemId: 10, sd: 16.0 }, // L34 front
+    { label: "18", R: -107.03524, d: 5.75, nd: 1.0, elemId: 0, sd: 15.5 }, // L34 rear → air
+
+    // Sub-group G33 (negative): L35
+    { label: "19", R: -75.1706, d: 1.35, nd: 1.51742, elemId: 11, sd: 13.5 }, // L35 front
+    { label: "20", R: 75.1706, d: 24.663, nd: 1.0, elemId: 0, sd: 13.5 }, // L35 rear → image (BFD, air-equiv.)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (inner focus) ──
+   *  G2 moves 8.096 mm toward image from infinity to 0.6 m.
+   *  Total gap (DD[8] + DD[11]) is constant at 23.353 mm.
+   */
+  var: {
+    STO: [4.6, 12.696], // stop to G2 front
+    "11": [18.753, 10.657], // G2 rear to G3 front
+  },
+  varLabels: [
+    ["STO", "D(St)"],
+    ["11", "BF₂"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+)", fromSurface: "1", toSurface: "7" },
+    { text: "G2 (−) ← Focus", fromSurface: "9", toSurface: "11" },
+    { text: "G3 (+)", fromSurface: "12", toSurface: "20" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "5", toSurface: "7" },
+    { text: "D2", fromSurface: "9", toSurface: "11" },
+    { text: "D3", fromSurface: "14", toSurface: "16" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.6,
+  focusDescription: "Inner focus — G2 cemented doublet (L21+L22) moves 8.1 mm toward image. Quad Linear Motor drive.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.0,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.52,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/VivitarSeries13585mmf28.analysis.md
+++ b/src/lens-data/VivitarSeries13585mmf28.analysis.md
@@ -1,0 +1,19 @@
+# Vivitar Series 1 35–85mm f/2.8 VMC — Key Findings
+
+## Patent Overview
+US Patent 3,975,089, filed April 1974 and granted August 1976, describes Ellis I. Betensky's innovative zoom lens design for Vivitar's premium Series 1 line. The optical prescription comprises 12 spherical elements arranged in four functional groups with a distinctive three-moving-group architecture.
+
+## Core Innovation
+Rather than the conventional two-moving-group zoom design, Betensky's approach allows the front positive group to participate in zoom motion. This strategy provides "additional degrees of freedom for aberration correction" while reducing the physical travel demands on the variator and compensator groups, enabling a more compact design without sacrificing optical quality.
+
+## Optical Configuration
+The lens employs a positive-negative-negative-positive (PNNP) power distribution. Group I (positive front) and Groups II and III (negative variator and compensator) all move during zooming, while Group IV (positive relay) remains stationary. The patent identifies three critical conditional relationships governing the facing surface radii and combined curvature parameters—all three conditions are satisfied in the published prescription.
+
+## Glass Palette
+The design uses six distinct optical glass types, dominated by high-index materials. Notably, the L9–L10 cemented doublet pairs fluorite crown (FK5, νd = 70.4) with ultra-dense flint (SF6, νd = 25.5), creating a Δνd = 44.9 differential for aggressive chromatic correction—a technique that would become standard in modern ED lens designs.
+
+## Field Curvature Control
+The computed Petzval sum of +0.0017 mm⁻¹ demonstrates exceptional field-curvature correction for an era before aspherical surfaces became commonplace. This performance results from carefully balanced high-index negative elements working against the positive groups.
+
+## Manufacturing Reality
+Each lens required individual calibration during production by Kino Precision Industries. The push-pull varifocal mechanism—not a true parfocal zoom—was marketed as "Auto Variable Focusing," converting a design constraint into a commercial feature while granting optical advantages in resolution and aberration control.

--- a/src/lens-data/VivitarSeries13585mmf28.data.ts
+++ b/src/lens-data/VivitarSeries13585mmf28.data.ts
@@ -1,0 +1,326 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — VIVITAR SERIES 1 35–85 mm f/2.8 VMC                  ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 3,975,089 Example 1 (Ellis I. Betensky /         ║
+ * ║  Ponder & Best, Inc.).  Corrected per Certificate of Correction   ║
+ * ║  dated January 25, 1977.                                          ║
+ * ║  12 elements / 4 functional groups (9 sub-groups), all spherical. ║
+ * ║  Focus: unit focus (entire optical assembly translates).           ║
+ * ║  Zoom: 3 moving groups (I, II, III); Group IV stationary.         ║
+ * ║                                                                    ║
+ * ║  Zoom variable gaps: D6 (Group I–II), D9 (Group II–III),          ║
+ * ║    D12 (Group III–STO, split from patent gap (3)).                 ║
+ * ║  Focus variable gap: D21 (BFD — whole lens translates, so only    ║
+ * ║    the back focal distance changes with focus).                    ║
+ * ║  Reversing groups: Group I exhibits non-monotonic motion           ║
+ * ║    (forward then back) — only 2 zoom positions available from     ║
+ * ║    the patent, so piecewise-linear interpolation is limited.      ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list semi-diameters.  Estimated from marginal  ║
+ * ║    ray trace at both zoom positions (f/2.8 design aperture),      ║
+ * ║    taking the maximum height across positions with ~5–10%         ║
+ * ║    mechanical clearance.  Validated for edge thickness > 0,       ║
+ * ║    sd/|R| < 0.90, cross-gap sag overlap, and element SD ratios.   ║
+ * ║                                                                    ║
+ * ║  NOTE ON EFL DISCREPANCY:                                          ║
+ * ║    Computed EFLs (~38.5 / ~89.1 mm) differ from the patent's     ║
+ * ║    stated 36–83 mm by ~7%.  Group powers, zoom ratio (2.32×),    ║
+ * ║    and all conditional expressions match precisely.  The offset   ║
+ * ║    likely reflects the patent gap values not corresponding to     ║
+ * ║    the extreme zoom positions.  Prescription used as-is.          ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP POSITION:                                            ║
+ * ║    Stop position inferred from Fig. 1 — iris between Groups III  ║
+ * ║    and IV, fixed to Group IV housing.  Patent gap (3) split into  ║
+ * ║    R12-to-STO (variable, 8.83/0.69 mm) + STO-to-R13 (fixed,     ║
+ * ║    0.50 mm).                                                       ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "vivitar-s1-35-85-f28",
+  maker: "Vivitar",
+  name: "VIVITAR SERIES 1 35–85mm f/2.8 VMC",
+  subtitle: "US 3,975,089 Example 1 — Betensky / Ponder & Best",
+  specs: [
+    "12 ELEMENTS / 9 GROUPS",
+    "f ≈ 38.5–89.1 mm (patent: 36–83 mm)",
+    "F/2.8",
+    "2ω ≈ 58.7°–27.3°",
+    "ALL SPHERICAL",
+  ],
+
+  focalLengthMarketing: [35, 85] as [number, number],
+  focalLengthDesign: [36, 83] as [number, number],
+  apertureMarketing: 2.8,
+  patentYear: 1976,
+  elementCount: 12,
+  groupCount: 9,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.805,
+      vd: 25.5,
+      fl: -89.6,
+      glass: "SF6 (Schott)",
+      apd: false,
+      role: "High-index negative meniscus (concave toward image). Negative Petzval contribution to flatten field.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconvex Positive",
+      nd: 1.531,
+      vd: 62.1,
+      fl: 68.7,
+      glass: "BSM-type crown (531/621)",
+      apd: false,
+      role: "Primary positive power in Group I. Exceptionally thick (13.8 mm) for principal-plane control.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.694,
+      vd: 53.3,
+      fl: 87.7,
+      glass: "S-LAL13 (Ohara)",
+      apd: false,
+      role: "Lanthanum crown meniscus completing Group I positive triplet.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.847,
+      vd: 23.8,
+      fl: 50.2,
+      glass: "SF57 (Schott)",
+      apd: false,
+      cemented: "D1",
+      role: "Ultra-dense flint; individually positive element of Group II variator doublet.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconcave Negative",
+      nd: 1.834,
+      vd: 37.3,
+      fl: -16.5,
+      glass: "LaSF5 (Schott)",
+      apd: false,
+      cemented: "D1",
+      role: "Strongly negative element dominating Group II. R9 (+17.98 mm) is the steepest curvature in the system.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.498,
+      vd: 65.1,
+      fl: -19.2,
+      glass: "BK3 (Schott)",
+      apd: false,
+      cemented: "D2",
+      role: "Low-index crown element of Group III compensator doublet.",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.785,
+      vd: 25.7,
+      fl: 24.5,
+      glass: "SF11 (Schott)",
+      apd: false,
+      cemented: "D2",
+      role: "Dense flint in reversed crown-flint arrangement; opposes Group II chromatism.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.62,
+      vd: 60.3,
+      fl: 38.4,
+      glass: "SK16 (Schott)",
+      apd: false,
+      role: "Strongest positive singlet. First element of stationary relay Group IV.",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Positive Meniscus",
+      nd: 1.487,
+      vd: 70.4,
+      fl: 31.4,
+      glass: "FK5 (Schott)",
+      apd: false,
+      cemented: "D3",
+      role: "Fluorite crown with near-plano front (R15 ≈ −502 mm). Positive power with minimal chromatic contribution.",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Negative Meniscus",
+      nd: 1.805,
+      vd: 25.5,
+      fl: -27.8,
+      glass: "SF6 (Schott)",
+      apd: false,
+      cemented: "D3",
+      role: "Chromatic corrector for L9. FK5+SF6 pairing yields Δνd = 44.9 — the most aggressive achromat in the system.",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Biconvex Positive",
+      nd: 1.639,
+      vd: 45.1,
+      fl: 33.9,
+      glass: "BaSF52 (Schott)",
+      apd: false,
+      role: "Strongly asymmetric biconvex in the converging beam. Moderate-dispersion barium flint for higher-order chromatic tuning.",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Negative Meniscus",
+      nd: 1.805,
+      vd: 25.5,
+      fl: -54.9,
+      glass: "SF6 (Schott)",
+      apd: false,
+      role: "Field flattener. High-index SF6 maximizes negative Petzval contribution per unit power. Convex side faces image.",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Group I (L1, L2, L3) — moves during zoom ──
+    { label: "1", R: 135.72, d: 2.6, nd: 1.805, elemId: 1, sd: 18.0 }, // L1 front
+    { label: "2", R: 46.71, d: 2.84, nd: 1.0, elemId: 0, sd: 17.5 }, // L1 rear → air
+    { label: "3", R: 46.5, d: 13.8, nd: 1.531, elemId: 2, sd: 18.0 }, // L2 front
+    { label: "4", R: -152.15, d: 0.1, nd: 1.0, elemId: 0, sd: 18.0 }, // L2 rear → air
+    { label: "5", R: 41.84, d: 6.6, nd: 1.694, elemId: 3, sd: 18.0 }, // L3 front
+    { label: "6", R: 125.2, d: 0.47, nd: 1.0, elemId: 0, sd: 16.5 }, // L3 rear → air — var gap (1)
+
+    // ── Group II (L4–L5 cemented) — moves during zoom ──
+    { label: "7", R: 140.19, d: 3.1, nd: 1.847, elemId: 4, sd: 10.5 }, // L4 front
+    { label: "8", R: -60.45, d: 1.1, nd: 1.834, elemId: 5, sd: 10.5 }, // L4→L5 junction
+    { label: "9", R: 17.98, d: 15.94, nd: 1.0, elemId: 0, sd: 10.5 }, // L5 rear → air — var gap (2)
+
+    // ── Group III (L6–L7 cemented) — moves during zoom ──
+    { label: "10", R: -16.56, d: 1.0, nd: 1.498, elemId: 6, sd: 10.5 }, // L6 front
+    { label: "11", R: 22.97, d: 3.1, nd: 1.785, elemId: 7, sd: 9.0 }, // L6→L7 junction
+    { label: "12", R: -112.11, d: 8.83, nd: 1.0, elemId: 0, sd: 11.0 }, // L7 rear → air — var gap (3a: R12→STO)
+
+    // ── Aperture stop (inferred from Fig. 1, fixed to Group IV) ──
+    { label: "STO", R: 1e15, d: 0.5, nd: 1.0, elemId: 0, sd: 12.0 },
+
+    // ── Group IV (L8, L9–L10, L11, L12) — stationary during zoom ──
+    { label: "13", R: 53.32, d: 2.9, nd: 1.62, elemId: 8, sd: 11.0 }, // L8 front
+    { label: "14", R: -42.06, d: 2.0, nd: 1.0, elemId: 0, sd: 11.0 }, // L8 rear → air
+    { label: "15", R: -502.33, d: 5.0, nd: 1.487, elemId: 9, sd: 10.5 }, // L9 front
+    { label: "16", R: -14.89, d: 0.9, nd: 1.805, elemId: 10, sd: 10.5 }, // L9→L10 junction
+    { label: "17", R: -45.59, d: 11.53, nd: 1.0, elemId: 0, sd: 10.5 }, // L10 rear → air
+    { label: "18", R: 125.96, d: 3.5, nd: 1.639, elemId: 11, sd: 11.0 }, // L11 front
+    { label: "19", R: -25.9, d: 5.98, nd: 1.0, elemId: 0, sd: 11.0 }, // L11 rear → air
+    { label: "20", R: -19.4, d: 1.296, nd: 1.805, elemId: 12, sd: 9.0 }, // L12 front
+    { label: "21", R: -35.59, d: 45.82, nd: 1.0, elemId: 0, sd: 9.0 }, // L12 rear → image — var BFD
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Zoom positions ── */
+  zoomPositions: [36, 83],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  /* ── Variable air spacings ──
+   *  Unit focus: inter-group gaps change with zoom only (identical inf/close pairs).
+   *  BFD (surface 21) changes with both zoom and focus.
+   *
+   *  Patent gap (3) between R12 and R13 has been split:
+   *    Surface "12": R12-to-STO (variable with zoom)
+   *    Surface "STO": STO-to-R13 (fixed at 0.50 mm)
+   *
+   *  BFD at close focus computed for MFD = 0.30 m (production spec) via
+   *  finite-conjugate paraxial ray trace with unit-focus extension.
+   */
+  var: {
+    "6": [
+      [0.47, 0.47],
+      [19.48, 19.48],
+    ],
+    "9": [
+      [15.94, 15.94],
+      [5.01, 5.01],
+    ],
+    "12": [
+      [8.83, 8.83],
+      [0.69, 0.69],
+    ],
+    "21": [
+      [45.82, 50.41],
+      [46.37, 75.21],
+    ],
+  },
+
+  varLabels: [
+    ["6", "D6"],
+    ["9", "D9"],
+    ["12", "D12"],
+    ["21", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "I (+)", fromSurface: "1", toSurface: "6" },
+    { text: "II (−)", fromSurface: "7", toSurface: "9" },
+    { text: "III (−)", fromSurface: "10", toSurface: "12" },
+    { text: "IV (+)", fromSurface: "13", toSurface: "21" },
+  ],
+
+  doublets: [
+    { text: "D1", fromSurface: "7", toSurface: "9" },
+    { text: "D2", fromSurface: "10", toSurface: "12" },
+    { text: "D3", fromSurface: "15", toSurface: "17" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.3,
+  focusDescription: "Unit focus — entire optical assembly translates. Push-pull zoom/focus ring.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.8,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.48,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -19,6 +19,12 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-04-08 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-04-08",
+    type: "lens",
+    summary: "Added Vivitar Series 1 35–85mm f/2.8 VMC, Fujifilm XF 90mm f/2 R LM WR, and Fujinon XF 56mm F1.2 R",
+  },
   // ── 2026-04-07 ──────────────────────────────────────────────────────────
   {
     date: "2026-04-07",


### PR DESCRIPTION
## Summary
Added three new lens optical data files with comprehensive patent-based prescriptions and detailed analysis documentation:

1. **Vivitar Series 1 35–85mm f/2.8 VMC** — vintage zoom lens from US Patent 3,975,089 (1976)
2. **Fujifilm Fujinon XF 56mm F1.2 R** — modern fast prime from US Patent 2015/0212302 A1 (2015)
3. **Fujifilm Fujinon XF 90mm f/2 R LM WR** — telephoto with inner focus from US Patent 2016/0274335 A1 (2016)

## Key Changes

### New Lens Data Files
- **`VivitarSeries13585mmf28.data.ts`** (326 lines)
  - 12 spherical elements in 4 functional groups
  - Three moving groups during zoom (innovative design for 1976)
  - Unit focus mechanism (entire assembly translates)
  - Variable air gaps for zoom and focus control
  - Estimated semi-diameters with validation notes
  - Includes detailed notes on EFL discrepancy (~7% vs. patent stated values) and stop position inference

- **`FujifilmXF56mmf12.data.ts`** (290 lines)
  - 11 elements in 8 groups, modified Gaussian design
  - 2 aspherical surfaces (even-order coefficients only; odd-order terms omitted per renderer limitations)
  - Inner focus with L21 + cemented triplet moving toward object
  - 2 ED elements for chromatic correction
  - Comprehensive notes on aspherical coefficient limitations and semi-diameter estimation

- **`FujifilmXF90mmf2.data.ts`** (280 lines)
  - 11 elements in 8 groups, three-group telephoto design
  - All spherical surfaces (no aspherical elements)
  - Inner focus with G2 doublet moving 8.1 mm toward image
  - 3 ED elements for secondary spectrum correction
  - **OCR correction applied**: Surface 1 radius corrected from "134,542.19" (misplaced decimal) to 134.54219 mm, recovering patent-stated EFL and all conditional formulae

### Analysis Documentation
- **`VivitarSeries13585mmf28.analysis.md`** — Brief overview of patent innovation and design strategy
- **`FujifilmXF56mmf12.analysis.md`** — Comprehensive 127-line analysis covering embodiment identification, optical construction, glass identification, and aspherical surface details
- **`FujifilmXF90mmf2.analysis.md`** — Detailed 134-line analysis including OCR correction methodology, optical configuration, glass matching, and conditional formula verification

### Supporting Updates
- Updated `src/utils/changelogData.ts` with new entry for 2026-04-08
- Updated `README.md` to reflect new lens count (49 → 52 files)

## Notable Implementation Details

- **Semi-diameter estimation**: All three lenses lack published semi-diameters; values estimated from marginal + chief ray traces at design aperture with 5–10% mechanical clearance, validated for edge thickness, sd/|R| ratios, and cross-gap sag clearance
- **Aspherical handling**: XF 56mm includes even-order polynomial coefficients (A4–A14) only; odd-order terms (A3, A5–A19) and higher-order (A16–A20) omitted due to renderer limitations, with detailed notes on impact
- **OCR correction methodology**: XF 90mm R1 value corrected by interpreting comma as corrupted decimal point; correction verified against all seven patent conditional formulae
- **Focus mechanisms**: Vivitar uses unit focus (entire assembly); both Fujifilm lenses use inner focus with different moving groups
- **Variable gap documentation**: All three lenses include detailed notes on zoom/focus variable air spacings with patent gap references and computed values for close focus

https://claude.ai/code/session_01CDfuMMUy4WBgxwDsq5jKCC