### PR TITLE
Add five Leica lenses and Leica maker entry

### DIFF
--- a/scripts/generate-build-metadata.mjs
+++ b/scripts/generate-build-metadata.mjs
@@ -35,6 +35,7 @@ const MAKER_PREFIXES = [
   { prefix: "CARL ZEISS", slug: "carl-zeiss" },
   { prefix: "FUJIFILM", slug: "fujifilm" },
   { prefix: "FUJINON", slug: "fujifilm" },
+  { prefix: "LEICA", slug: "leica" },
   { prefix: "VOIGTLÄNDER", slug: "voigtlander" },
   { prefix: "NIKON", slug: "nikon" },
   { prefix: "RICOH", slug: "ricoh" },

--- a/src/lens-data/Leica28mmf17.analysis.md
+++ b/src/lens-data/Leica28mmf17.analysis.md
@@ -1,0 +1,183 @@
+# Leica Summilux 28 mm f/1.7 ASPH — Optical Design Analysis
+
+## Patent Identification
+
+**US 2016/0266350 A1**, "Lens System and Imaging Device"
+Filed by Panasonic Intellectual Property Management Co., Ltd., Osaka, Japan.
+Inventors: Tomoko Iiyama (Osaka), Masafumi Sueyoshi (Kanagawa).
+Japanese priority: JP 2014-195434, filed September 25, 2014.
+US continuation filed May 20, 2016; published September 15, 2016.
+
+**Production lens:** Leica Summilux 28 mm f/1.7 ASPH, the fixed lens of the Leica Q (Typ 116), Q2, and Q3 compact cameras. Designed by Peter Karbe (head of optics at Leica Camera AG), manufactured by Panasonic, which produces the Q-series hardware. This patent covers the optical prescription used in the production lens, with Example 1 (Numerical Example 1) being the implemented embodiment.
+
+**Confirmation of identity:** The Leica Q's published specification — 11 elements in 9 groups, 3 aspherical elements, 28 mm f/1.7 on a full-frame (36 × 24 mm) sensor — exactly matches Example 1's computed parameters: f = 27.08 mm (marketed as 28 mm), F/1.76 (marketed as f/1.7), image height 19.88 mm, and 11 glass elements in a 5-group focusing architecture with 5 aspherical surfaces across 3 elements. Peter Karbe has publicly confirmed that he designed the Q's lens, and that the same optical formula has been retained across all three Q generations.
+
+The "9 groups" in Leica's published specification refers to the traditional air-separated group count (5 singlets in the front group, 2 cemented doublets, and 2 rear singlets), while the patent's "5 groups" (G1–G5) designates the focusing-architecture groups that move or remain stationary as units during focus.
+
+---
+
+## Design Overview
+
+The Summilux 28 mm f/1.7 is a 5-group, 11-element wide-angle prime designed for a fixed-lens full-frame compact camera. Its architecture exploits the closed optical-mechanical system of the Q cameras: with no interchangeable mount or focal-plane shutter to clear, the rear elements can sit extremely close to the sensor — the back focal distance is only 1.0 mm beyond the cover glass. This freedom allows the designer to place a strong negative field-flattener (G5) just millimetres from the image plane, dramatically improving corner performance without the BFD constraints that would handicap an interchangeable lens.
+
+The optical layout features a negative-leading front group (G1) that accepts the full ±40° field angle, a centrally placed aperture stop, and a sequence of post-stop groups that provide inner-focus capability and field correction. Five aspherical surfaces on three elements — one in G2, two each in G4 and G5 — control higher-order aberrations across the full f/1.7 aperture. The negative first element (L1) is not a retrofocus arrangement for extending back focus (BFD/EFL = 0.037, far below unity), but rather provides the angular coverage needed for a 28 mm-equivalent wide-angle while keeping the front element diameter manageable.
+
+| Parameter | Patent (Example 1) | Marketed |
+|-----------|-------------------|----------|
+| Focal length | 27.08 mm | 28 mm |
+| Maximum aperture | F/1.76 | f/1.7 |
+| Half-field angle | 39.94° | ~38° (at infinity) |
+| Image height | 19.88 mm | Full-frame (21.6 mm diagonal half) |
+| Elements / Groups | 11 / 9 (5 focusing groups) | 11 / 9 |
+| Aspherical elements | 3 (5 surfaces) | 3 |
+| Overall length (infinity) | 63.98 mm | ~64 mm |
+| Back focal distance | 1.0 mm (after cover glass) | — |
+| Close focus (State M1) | 0.3 m (object to image plane) | 0.3 m |
+| Close focus (State M2, macro) | 0.163 m (object to image plane) | 0.17 m |
+
+---
+
+## Group Structure and Focusing Mechanism
+
+The five lens groups, their powers, and their roles during focusing are:
+
+| Group | Elements | Group f (mm) | Power | Behaviour in focus |
+|-------|----------|-------------|-------|-------------------|
+| G1 (+) | L1–L5 (5 singlets) | +36.08 | Positive | Fixed in M1; extends with G2–G4 in M2 |
+| G2 (+) | L6–L7 (cemented doublet) | +178.32 | Weakly positive | Moves toward object (1st focus group) |
+| G3 (+) | L8–L9 (cemented doublet) | +363.44 | Weakly positive | Fixed; shifts laterally for OIS |
+| G4 (+) | L10 (singlet) | +33.98 | Positive | Moves toward object (2nd focus group) |
+| G5 (−) | L11 (singlet) | −27.84 | Negative | Fixed (stationary throughout) |
+
+### Focusing in State M1 (infinity to 0.3 m)
+
+G2 and G4 both translate toward the object along the optical axis. G1, G3, and G5 remain stationary. The overall lens length does not change — the sum of the four variable air gaps (d11 + d14 + d17 + d19) stays constant at 19.41 mm. At 0.3 m focus, G2 moves 1.95 mm toward the object, while G4 moves 2.95 mm. The different travel distances provide floating-element field correction: G4's stronger excursion primarily corrects field curvature and coma that would otherwise degrade at close range, while G2's smaller movement trims spherical aberration.
+
+### Focusing in State M2 (macro mode, 0.3 m down to ~0.16 m)
+
+Upon switching to macro mode, groups G1 through G4 extend as a rigid unit approximately 2.35 mm toward the object, with G5 remaining stationary. Within this extended state, G2 and G4 continue to move independently for fine focus. The aperture diaphragm is automatically stopped down — the F-number jumps from approximately f/1.8 to f/2.9 — to maintain image quality at these extreme close-focus distances (patent [0086]).
+
+### Focus Breathing
+
+Inner focusing inherently changes the system's effective focal length as the focus groups shift. The Summilux 28 exhibits significant focus breathing:
+
+| Focus state | EFL (mm) | Δ from infinity | F-number |
+|-------------|----------|-----------------|----------|
+| Infinity (M1) | 27.08 | — | F/1.76 |
+| 0.3 m (M1) | 23.74 | −12.3% | F/1.79 |
+| ~0.3 m (M2) | 25.14 | −7.2% | F/2.90 |
+| Macro limit (M2) | 21.67 | −20.0% | F/2.81 |
+
+At the 0.3 m close-focus limit of State M1, the effective focal length has shortened to approximately 24 mm — a 12% reduction. In macro mode at the closest distance, the EFL drops to 21.7 mm, a 20% reduction. This breathing is a trade-off inherent to the inner-focus architecture; it enables the compact, lightweight focusing groups that deliver fast, silent autofocus at the expense of focal-length stability.
+
+### Optical Image Stabilization
+
+G3 (the L8–L9 cemented doublet) serves as the OIS compensation group. Per the patent ([0051], FIG. 1), G3 shifts perpendicular to the optical axis to compensate for camera shake. The patent's lateral aberration diagrams (FIG. 3) evaluate performance at 0.5 mm of decentering, demonstrating well-controlled asymmetric aberration in the stabilised state. Using the stationary (non-focusing) G3 for OIS avoids interference with the focusing mechanism — G2 and G4 handle focus, while G3 independently handles stabilisation.
+
+### Patent Conditional Expressions
+
+The patent's conditional expressions confirm the power balance:
+
+- |f2/f4| = 5.25 (condition 1: must lie between 2.5 and 6.5). G4 is roughly five times more powerful than G2, meaning G4 does the heavy lifting of focus compensation while G2 provides a fine-tuning correction.
+- |f/f4| = 0.80 (condition 2: must lie between 0.5 and 1.5). G4's focal length is close to the system's, keeping its travel short and its weight low for fast, silent autofocus.
+
+Both focusing groups together contain only three lens elements (a cemented doublet plus a singlet), making the moving mass very small — an important factor in the Leica Q's contrast-detect AF speed, which Leica marketed at the time as the fastest in its class.
+
+---
+
+## Element-by-Element Analysis
+
+### Group 1: Front Positive Group (L1–L5, f = +36.08 mm)
+
+G1 is the stationary front group, carrying the bulk of the lens's positive optical power. Its five air-spaced singlets form a sequence of negative–positive–negative–positive–positive elements that progressively bends the wide-angle ray bundle toward the axis while managing spherical aberration and coma. The alternating-power structure distributes the refractive work across multiple surfaces, reducing higher-order aberrations that would result from concentrating the power in fewer elements.
+
+**L1 — Biconcave Negative (f = −31.0 mm)**
+R1 = −111.98 mm, R2 = +20.94 mm; d = 1.4 mm; nd = 1.56732, vd = 42.8.
+Glass: **S-BAL42 (OHARA)** — barium light crown. Exact catalog match.
+
+L1 is a strongly negative element whose steeply curved rear surface (R2 = 20.94 mm) diverges the incoming ray bundle. As the first element in the system, it accepts light at the full field angle of ±40° and spreads the beam, allowing the downstream positive elements to collect it at manageable angles. The moderate-index barium crown glass provides adequate dispersion control at this position, where the on-axis ray height is still modest. The biconcave shape with a much stronger rear surface introduces substantial negative Petzval contribution — essential for counteracting the strong positive Petzval from the downstream high-index positive elements.
+
+**L2 — Biconvex Positive (f = +30.7 mm)**
+R1 = +33.30 mm, R2 = −131.60 mm; d = 6.17 mm; nd = 1.881, vd = 40.1.
+Glass: **S-LAH58 (OHARA)** — lanthanum dense flint. Exact catalog match.
+
+L2 is the primary power-carrying element of G1. Its high refractive index (nd = 1.881) provides strong positive power with relatively gentle surface curvatures, which keeps higher-order spherical aberration manageable at wide apertures. The biconvex shape with a dominant front surface (R1 ~ 33 mm vs. R2 ~ −132 mm) is a classical choice for minimising spherical aberration from a single positive element — a form close to the best-form singlet for a distant object conjugate. At 6.17 mm centre thickness, L2 is the thickest element in G1, indicating that substantial ray bending occurs here.
+
+**L3 — Symmetric Biconcave Negative (f = −39.5 mm)**
+R1 = −47.87 mm, R2 = +47.87 mm; d = 1.0 mm; nd = 1.60342, vd = 38.0.
+Glass: **S-TIM5 (OHARA)** — titanium flint. Exact catalog match.
+
+L3 is notable for its perfectly symmetric biconcave form (|R1| = |R2|), which eliminates odd-order coma contributions at the element level by symmetry. Positioned after the strong positive L2, it acts as an aberration corrector: the negative power partially compensates the Petzval contribution from L2, and the titanium flint glass (lower Abbe number, vd = 38) provides chromatic compensation.
+
+**L4 — Biconvex Positive (f = +31.2 mm)**
+R1 = +23.77 mm, R2 = −76.96 mm; d = 4.64 mm; nd = 1.59282, vd = 68.6.
+Glass: **L-LAM60 (OHARA)** — low-softening-temperature lanthanum crown (PGM glass). Exact catalog match.
+
+L4 is the second strong positive element in G1, and its glass choice is significant: L-LAM60 is a precision glass moulding (PGM) type with an unusually high Abbe number for its index class (vd = 68.6), meaning very low dispersion. This element restores positive power while introducing minimal chromatic aberration.
+
+**L5 — Positive Meniscus, Convex to Object (f = +80.2 mm)**
+R1 = +62.55 mm, R2 = +428.74 mm; d = 1.81 mm; nd = 1.91082, vd = 35.2.
+Glass: **S-LAH79 (OHARA)** — ultra-high-index lanthanum dense flint. Exact catalog match.
+
+L5 is the final element before the aperture stop. Its very high refractive index (nd = 1.911, the highest in the system) allows the gently curved meniscus to contribute positive power while keeping surface slopes moderate. The meniscus shape acts as a weak positive field lens, guiding the chief ray through the stop at a favourable angle.
+
+### Aperture Diaphragm
+
+The iris diaphragm sits between G1 and G2, in the air gap d11 (6.38 mm at infinity). Its position approximately 38% of the way from front to image allows the front elements to handle the full ±40° field angle at moderate ray heights.
+
+### Group 2: First Focusing Doublet (L6–L7, f = +178.3 mm)
+
+G2 is a cemented doublet comprising a positive meniscus and a negative meniscus, both convex toward the image. Together they form a very weakly positive group (f = +178.3 mm) that moves toward the object during focus. The weak net power ensures that even large translational movements produce only modest changes in system aberrations.
+
+**L6 — Positive Meniscus (f = +24.8 mm)** — aspherical front surface (Surface 12A).
+**L7 — Negative Meniscus (f = −28.9 mm)** — cemented to L6.
+
+### Group 3: Stationary Corrector Doublet and OIS Group (L8–L9, f = +363.4 mm)
+
+G3 is a fixed cemented doublet. Its very weak positive power means it contributes almost nothing to the system's focal length; its role is corrective and stabilising. G3 shifts perpendicular to the optical axis to provide optical image stabilisation (OIS).
+
+**L8 — Biconcave Negative (f = −21.7 mm)** — niobium heavy flint (S-NBH55).
+**L9 — Biconvex Positive (f = +22.5 mm)** — same glass as L2 (S-LAH58).
+
+### Group 4: Second Focusing Singlet (L10, f = +33.98 mm)
+
+**L10 — Positive Meniscus (f = +34.0 mm)** — both surfaces aspherical (Surfaces 18A and 19A).
+
+L10 carries substantially more power than the G2 doublet. It is a thick, strongly curved meniscus with both surfaces aspherical — the most heavily corrected single element in the design. L10 moves during focus, and its aspherical profiles must maintain correction quality across the full travel range.
+
+### Group 5: Field Flattener (L11, f = −27.84 mm)
+
+**L11 — Negative Meniscus (f = −27.8 mm)** — both surfaces aspherical (Surfaces 20A and 21A). Glass: H-ZF52A (CDGM) dense flint.
+
+L11 is the final optical element before the sensor cover glass. Its strong negative power shortens the back focal distance, allowing the overall lens to be more compact, while the strongly concave front surface bends the image field back toward flatness. Surface 20A has K = −1.070 (hyperboloid) — the only non-zero conic constant in the design — providing zone-dependent correction for astigmatism and field curvature at the extreme corners of the full-frame sensor.
+
+---
+
+## Aspherical Surface Summary
+
+| Surface | Element | Group | Conic K | Dominant A4 | Role |
+|---------|---------|-------|---------|-------------|------|
+| 12A | L6 front | G2 (focus) | 0 | −2.24e-05 | Spherical aberration control near the stop |
+| 18A | L10 front | G4 (focus) | 0 | −2.96e-05 | Corrector-plate-like wavefront trim |
+| 19A | L10 rear | G4 (focus) | 0 | −7.64e-06 | Field-dependent correction during focus travel |
+| 20A | L11 front | G5 (fixed) | −1.070 | +6.71e-05 | Astigmatism/field curvature (hyperboloid) |
+| 21A | L11 rear | G5 (fixed) | 0 | +5.71e-05 | Final wavefront trimming |
+
+The concentration of aspherical surfaces behind the stop — and particularly on the focusing and field-flattening groups — follows Peter Karbe's established design philosophy: aspherical surfaces are most effective for correcting oblique spherical aberration when placed where off-axis ray bundles are well separated from the on-axis bundle.
+
+---
+
+## Verification Summary
+
+All patent-stated parameters were independently verified by ABCD paraxial ray trace:
+
+| Parameter | Patent value | Computed | Residual |
+|-----------|-------------|----------|---------|
+| System EFL | 27.0831 mm | 27.0834 mm | +0.0003 mm |
+| G1 focal length | 36.07796 mm | 36.0783 mm | +0.0003 mm |
+| G2 focal length | 178.3235 mm | 178.3257 mm | +0.0022 mm |
+| G3 focal length | 363.4437 mm | 363.4437 mm | < 0.001 mm |
+| G4 focal length | 33.98372 mm | 33.9837 mm | < 0.001 mm |
+| G5 focal length | −27.8386 mm | −27.8386 mm | < 0.001 mm |
+
+All values agree within expected rounding tolerance, confirming the transcription integrity of the patent data.

--- a/src/lens-data/Leica28mmf17.data.ts
+++ b/src/lens-data/Leica28mmf17.data.ts
@@ -1,0 +1,317 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║       LENS DATA — LEICA SUMMILUX 28 mm f/1.7 ASPH.                ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2016/0266350 A1, Example 1 (Panasonic IPM /      ║
+ * ║  Iiyama & Sueyoshi). Production lens of Leica Q (Typ 116),       ║
+ * ║  Q2, and Q3 cameras. Designed by Peter Karbe (Leica).            ║
+ * ║  11 elements / 9 groups (5 focusing-architecture groups),         ║
+ * ║  3 aspherical elements (5 aspherical surfaces).                   ║
+ * ║  Focus: floating inner focus — G2 (cemented doublet) and G4      ║
+ * ║  (singlet) move toward object; G1, G3, G5 fixed.                 ║
+ * ║  G3 (L8–L9 doublet) shifts laterally for OIS.                    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Estimated from paraxial marginal + chief ray trace at           ║
+ * ║    f/1.76, ω = 39.9°, with ~8% mechanical clearance.             ║
+ * ║    Front element constrained by 49 mm filter thread.              ║
+ * ║                                                                    ║
+ * ║  NOTE ON COVER GLASS:                                              ║
+ * ║    Patent surfaces 22–23 (cover glass, nd = 1.5168, 1.4 mm)       ║
+ * ║    omitted from surfaces array; physical thickness folded into    ║
+ * ║    BFD of last surface.                                            ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "leica-summilux-28f17",
+  maker: "Leica",
+  name: "LEICA SUMMILUX 28 mm f/1.7 ASPH.",
+  subtitle: "US 2016/0266350 A1 Example 1 — PANASONIC IPM / IIYAMA & SUEYOSHI",
+  specs: ["11 ELEMENTS / 9 GROUPS", "f ≈ 27.08 mm", "F/1.76", "2ω ≈ 79.9°", "3 ASPHERICAL ELEMENTS (5 SURFACES)"],
+
+  focalLengthMarketing: 28,
+  focalLengthDesign: 27.08,
+  apertureMarketing: 1.7,
+  apertureDesign: 1.76,
+  patentYear: 2016,
+  elementCount: 11,
+  groupCount: 9,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconcave Negative",
+      nd: 1.56732,
+      vd: 42.8,
+      fl: -31.0,
+      glass: "S-BAL42 (OHARA)",
+      apd: false,
+      role: "Negative front element — diverges field bundle for angular coverage",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconvex Positive",
+      nd: 1.881,
+      vd: 40.1,
+      fl: 30.7,
+      glass: "S-LAH58 (OHARA)",
+      apd: false,
+      role: "Primary positive power carrier in G1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconcave Negative",
+      nd: 1.60342,
+      vd: 38.0,
+      fl: -39.5,
+      glass: "S-TIM5 (OHARA)",
+      apd: false,
+      role: "Symmetric aberration corrector; chromatic compensation",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.59282,
+      vd: 68.6,
+      fl: 31.2,
+      glass: "L-LAM60 (OHARA)",
+      apd: false,
+      role: "Low-dispersion positive power; PGM glass for high-volume production",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Positive Meniscus",
+      nd: 1.91082,
+      vd: 35.2,
+      fl: 80.2,
+      glass: "S-LAH79 (OHARA)",
+      apd: false,
+      role: "Ultra-high-index field lens guiding chief ray into stop",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Pos. Meniscus (1× Asph)",
+      nd: 1.87722,
+      vd: 37.0,
+      fl: 24.8,
+      glass: "S-LAH63 (OHARA)",
+      apd: false,
+      role: "Aspherical focusing doublet — spherical aberration control near stop",
+      cemented: "D1",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.76182,
+      vd: 26.6,
+      fl: -28.9,
+      glass: "S-TIH14 (OHARA)",
+      apd: false,
+      role: "High-dispersion corrector in G2 focusing doublet",
+      cemented: "D1",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconcave Negative",
+      nd: 1.74077,
+      vd: 27.8,
+      fl: -21.7,
+      glass: "S-NBH55 (OHARA)",
+      apd: false,
+      role: "Chromatic corrector in OIS doublet",
+      cemented: "D2",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Biconvex Positive",
+      nd: 1.881,
+      vd: 40.1,
+      fl: 22.5,
+      glass: "S-LAH58 (OHARA)",
+      apd: false,
+      role: "OIS doublet positive — same glass as L2",
+      cemented: "D2",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Pos. Meniscus (2× Asph)",
+      nd: 1.77271,
+      vd: 49.7,
+      fl: 34.0,
+      glass: "S-LAM66 (OHARA)",
+      apd: false,
+      role: "Double-asphere 2nd focusing singlet — primary focus corrector",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Neg. Meniscus (2× Asph)",
+      nd: 1.6825,
+      vd: 33.0,
+      fl: -27.8,
+      glass: "H-ZF52A (CDGM)",
+      apd: false,
+      role: "Aspherical field-flattener; shortens BFD for compact body",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── G1: Front positive group (L1–L5), fixed ──
+    { label: "1", R: -111.983, d: 1.4, nd: 1.56732, elemId: 1, sd: 19.0 }, // L1 front
+    { label: "2", R: 20.9441, d: 3.1601, nd: 1.0, elemId: 0, sd: 17.0 }, // L1 rear → air
+    { label: "3", R: 33.3039, d: 6.1681, nd: 1.881, elemId: 2, sd: 17.0 }, // L2 front
+    { label: "4", R: -131.595, d: 1.6754, nd: 1.0, elemId: 0, sd: 15.5 }, // L2 rear → air
+    { label: "5", R: -47.8716, d: 1.0, nd: 1.60342, elemId: 3, sd: 14.5 }, // L3 front
+    { label: "6", R: 47.8716, d: 1.3489, nd: 1.0, elemId: 0, sd: 14.0 }, // L3 rear → air
+    { label: "7", R: 23.7727, d: 4.6431, nd: 1.59282, elemId: 4, sd: 12.0 }, // L4 front
+    { label: "8", R: -76.9617, d: 1.0, nd: 1.0, elemId: 0, sd: 11.5 }, // L4 rear → air
+    { label: "9", R: 62.5536, d: 1.8121, nd: 1.91082, elemId: 5, sd: 10.5 }, // L5 front
+    { label: "10", R: 428.7396, d: 2.0, nd: 1.0, elemId: 0, sd: 10.0 }, // L5 rear → air
+
+    // ── Aperture stop (between G1 and G2) ──
+    { label: "STO", R: 1e15, d: 6.3788, nd: 1.0, elemId: 0, sd: 7.95 },
+
+    // ── G2: 1st focusing doublet (L6–L7), moves toward object ──
+    { label: "12A", R: -305.338, d: 2.3735, nd: 1.87722, elemId: 6, sd: 8.5 }, // L6 front (asph)
+    { label: "13", R: -20.3412, d: 0.7, nd: 1.76182, elemId: 7, sd: 9.0 }, // L6→L7 junction
+    { label: "14", R: -274.05, d: 3.0255, nd: 1.0, elemId: 0, sd: 9.2 }, // L7 rear → air
+
+    // ── G3: Stationary OIS doublet (L8–L9), shifts laterally for stabilisation ──
+    { label: "15", R: -22.7936, d: 0.9, nd: 1.74077, elemId: 8, sd: 10.0 }, // L8 front
+    { label: "16", R: 55.5503, d: 5.0027, nd: 1.881, elemId: 9, sd: 10.5 }, // L8→L9 junction
+    { label: "17", R: -29.5541, d: 4.3357, nd: 1.0, elemId: 0, sd: 12.0 }, // L9 rear → air
+
+    // ── G4: 2nd focusing singlet (L10), moves toward object ──
+    { label: "18A", R: -1000, d: 5.69, nd: 1.77271, elemId: 10, sd: 13.0 }, // L10 front (asph)
+    { label: "19A", R: -25.6511, d: 5.6658, nd: 1.0, elemId: 0, sd: 14.0 }, // L10 rear (asph) → air
+
+    // ── G5: Field-flattener (L11), fixed ──
+    { label: "20A", R: -17.7688, d: 2.0, nd: 1.6825, elemId: 11, sd: 15.0 }, // L11 front (asph)
+    { label: "21A", R: -286.769, d: 4.7011, nd: 1.0, elemId: 0, sd: 15.5 }, // L11 rear (asph) → image (BFD incl. cover glass)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "12A": {
+      K: 0,
+      A4: -2.2402e-5,
+      A6: -1.9303e-7,
+      A8: 1.9069e-9,
+      A10: 3.45582e-11,
+      A12: -1.62696e-12,
+      A14: 1.42308e-14,
+    },
+    "18A": {
+      K: 0,
+      A4: -2.9558e-5,
+      A6: 1.54985e-7,
+      A8: -1.28788e-9,
+      A10: 5.79353e-12,
+      A12: -7.18388e-15,
+      A14: 0,
+    },
+    "19A": {
+      K: 0,
+      A4: -7.63516e-6,
+      A6: 1.21226e-7,
+      A8: -8.41754e-10,
+      A10: 3.04999e-12,
+      A12: -1.88131e-15,
+      A14: 0,
+    },
+    "20A": {
+      K: -1.07027,
+      A4: 6.7124e-5,
+      A6: -7.99132e-7,
+      A8: 4.89936e-9,
+      A10: -1.35501e-11,
+      A12: 1.21204e-14,
+      A14: 0,
+    },
+    "21A": {
+      K: 0,
+      A4: 5.71492e-5,
+      A6: -7.71272e-7,
+      A8: 3.68213e-9,
+      A10: -8.24551e-12,
+      A12: 6.72998e-15,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (State M1: infinity to 0.3 m) ──
+   *  Floating inner focus: G2 and G4 move toward object.
+   *  Five variable gaps: stop–G2, G2–G3, G3–G4, G4–G5, and BFD.
+   *  Patent also defines State M2 (macro, 0.3–0.17 m) where G1–G4
+   *  extend as a unit; only M1 is modelled here.
+   */
+  var: {
+    STO: [6.3788, 4.4288],
+    "14": [3.0255, 4.9755],
+    "17": [4.3357, 1.3888],
+    "19A": [5.6658, 8.6128],
+    "21A": [4.7011, 4.7763],
+  },
+  varLabels: [
+    ["STO", "D11"],
+    ["14", "D14"],
+    ["17", "D17"],
+    ["19A", "D19"],
+    ["21A", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+)", fromSurface: "1", toSurface: "10" },
+    { text: "G2 (+)", fromSurface: "12A", toSurface: "14" },
+    { text: "G3 (+)", fromSurface: "15", toSurface: "17" },
+    { text: "G4 (+)", fromSurface: "18A", toSurface: "19A" },
+    { text: "G5 (−)", fromSurface: "20A", toSurface: "21A" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "12A", toSurface: "14" },
+    { text: "D2", fromSurface: "15", toSurface: "17" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.3,
+  focusDescription:
+    "Floating inner focus: G2 (doublet) and G4 (singlet) move toward object. Macro mode (M2) extends G1–G4 as a unit to 0.17 m.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 1.7,
+  fstopSeries: [1.7, 2, 2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/LeicaAPO35mmf2.analysis.md
+++ b/src/lens-data/LeicaAPO35mmf2.analysis.md
@@ -1,0 +1,288 @@
+# Leica APO-Summicron-M 35 f/2 ASPH. — Optical Analysis
+
+**Patent:** US 2022/0066176 A1 (published March 3, 2022)  
+**Priority:** DE 10 2018 132 472.3 (December 17, 2018)  
+**PCT Filing:** PCT/EP2019/085673 (December 17, 2019)  
+**Inventors:** Stefan Roth, Kathrin Keller (Lahnau, Germany)  
+**Applicant:** Leica Camera AG, Wetzlar  
+**Embodiment analyzed:** Example 1 (the sole worked example; FIGS. 1–3)
+
+---
+
+## 1. Design Overview
+
+The Leica APO-Summicron-M 35 f/2 ASPH. is a ten-element, five-group wide-angle prime designed for the Leica M rangefinder mount. It is classified in the patent as a "quasi-symmetrical" design — three lens groups (front, middle, rear) each contribute net positive refractive power, with the aperture stop positioned between the front and middle groups. This distinguishes it from conventional retrofocus wide-angle designs, which rely on a negative front group and positive rear group. The quasi-symmetrical configuration enables a compact overall length (SO'/f ≈ 1.85) while providing inherently better correction of coma, distortion, and lateral chromatic aberration than an asymmetrical retrofocus layout.
+
+### Production specifications (from Leica Camera AG)
+
+| Parameter | Value |
+|-----------|-------|
+| Focal length | 35 mm |
+| Maximum aperture | f/2.0 |
+| Angle of view (diagonal) | ~63° (full 24×36 frame) / 62.2° (patent design field) |
+| Optical construction | 10 elements in 5 groups |
+| Aspherical surfaces | 4 (on 3 elements; one element double-sided) |
+| APD elements | 6 |
+| Minimum focus distance | 0.3 m |
+| Filter thread | E39 |
+| Aperture blades | 11 |
+| Weight | ~305 g |
+| Length (without hood) | 40.9 mm |
+
+### Computed specifications (from patent data, scaled to f = 35 mm)
+
+| Parameter | Computed (n_e) | Computed (n_d) | Patent (normalized) |
+|-----------|----------------|----------------|---------------------|
+| EFL | 35.0 mm | 34.8 mm | f = 1.00 mm |
+| BFD (paraxial, from last surface) | 14.6 mm | 14.4 mm | — |
+| BFD (patent-stated S'O') | 15.1 mm | — | 0.43 × f |
+| Total track (SO') | 64.8 mm | 64.1 mm | 1.85 × f |
+| SO'/f | 1.85 | 1.84 | 1.85 |
+| S'O'/f | 0.43 | — | 0.43 |
+| Half-image diagonal | ~21.1 mm | — | — |
+| Petzval radius | ~387 mm | — | 11.05 (norm.) |
+| Entrance pupil diameter | 17.5 mm | 17.4 mm | 0.50 (norm.) |
+
+The computed EFL from the ABCD matrix paraxial ray trace is 0.9996 mm at f = 1 normalization (using the patent's n_e values), confirming the patent prescription is internally consistent. When the same prescription is evaluated using n_d (d-line, 587.56 nm) catalog values — as required by the data file convention — the computed EFL is 34.75 mm and BFD is 14.39 mm. The ~0.7% shift is normal for the e-line → d-line wavelength conversion.
+
+The sum of the tabulated d values is 1.78 mm (normalized), which is less than the patent's stated SO' = 1.85. The difference arises because the tabulated d₁₆ = 0.36 mm is not the full back focal distance; the ABCD-derived paraxial BFD from the last surface is 0.418 mm (at n_e). Using this corrected BFD yields SO' = 1.78 − 0.36 + 0.418 = 1.84 ≈ 1.85, consistent with the patent's stated value. The patent's S'O'/f = 0.43 similarly represents the true paraxial image distance rather than the tabulated d₁₆. The 2.0 mm discrepancy between the tabulated d₁₆ (12.6 mm scaled) and the paraxial BFD (14.6 mm scaled) is consistent with the presence of a sensor cover glass/IR filter stack omitted from the prescription, as is standard practice.
+
+---
+
+## 2. Group Structure and Focal Lengths
+
+The design organizes ten elements into three principal groups (VG, MG, HG) containing five subgroups (G1–G5). Each subgroup is either a cemented compound lens or a single lens.
+
+| Group | Subgroup | Elements | Form | f'/f (computed) | f'/f (patent) |
+|-------|----------|----------|------|-----------------|---------------|
+| VG (Front) | G1 | L1 + L2 | Cemented doublet | 44.2 | 48.07 |
+| | G2 | L3 + L4 | Cemented doublet | 2.47 | 2.47 |
+| MG (Middle) | G3 | L5 + L6 + L7 | Cemented triplet | 3.36 | 3.34 |
+| HG (Rear) | G4 | L8 + L9 | Cemented doublet | 2.04 | 2.04 |
+| | G5 | L10 | Single lens | −3.29 | −3.29 |
+
+**Principal group focal lengths:**
+
+| Group | f'/f (computed) | f'/f (patent) | Role |
+|-------|-----------------|---------------|------|
+| VG | 2.51 | 2.52 | Front positive group |
+| MG | 3.36 | 3.34 | Middle positive group |
+| HG | 3.86 | 3.87 | Rear positive group |
+
+The G2, G4, and MG/HG values match the patent to within rounding. The G1 discrepancy (44.2 computed vs. 48.07 patent) is a natural consequence of G1's near-afocal configuration: when net power is close to zero, the EFL is extremely sensitive to the least-significant digits of the radii. Sensitivity analysis shows that shifting R₁ by just 0.005 mm (from 1.546 to 1.551) changes the computed G1 EFL from 44 to 49. Since the patent's prescription is rounded to three decimal places (0.001 mm at normalized scale, corresponding to 0.035 mm at production scale), a G1 EFL anywhere in the range 40–55 is consistent with the tabulated data. The essential point — G1 is nearly afocal — is confirmed by both values. The G3 discrepancy (3.36 vs. 3.34) is within the rounding tolerance of the prescription data.
+
+---
+
+## 3. Element-by-Element Analysis
+
+### 3.1 Front Group (VG): L1–L4
+
+#### L1 — Biconvex Positive (1× Aspherical)
+
+- **Glass:** S-LAH89 (OHARA) — n_e = 1.855, v_e = 40; n_d = 1.85150, v_d = 40.78
+- **Focal length:** +19.0 mm (at f = 35)
+- **Shape:** Biconvex, R1 = +1.546, R2 = −0.628 (normalized); strongly asymmetric with steeper rear surface
+- **Aspherical surface:** Surface 1 (object-side), K = 0, polynomial corrections through A8
+
+The patent explicitly identifies S-LAH89 as the front element glass ([0071]), chosen for its Knoop hardness (HK ≥ 600 N/mm²) and acid resistance (ISO 8424 class ≤ 4). As the exposed front element of a compact M-mount lens with only a screw-in hood, mechanical and chemical durability is paramount.
+
+The aspherical object-side surface controls distortion contribution from the strongly curved front element. The patent notes ([0037]) that this asphere, combined with the near-afocal G1 doublet configuration, minimizes distortion and makes G1 suitable as an assembly adjustment member for centering the on-axis image.
+
+#### L2 — Biconcave Negative
+
+- **Glass:** KZFS-type short flint — n_e = 1.658, v_e = 39, ΔP_gF = −0.004; n_d ≈ 1.65412, v_d ≈ 39.70
+- **Focal length:** −18.0 mm (at f = 35)
+- **Shape:** Biconcave, R1 = −0.628, R2 = +0.742 (normalized)
+- **Cemented to:** L1 (junction = surface 2)
+
+L2 is cemented to L1 to form subgroup G1. The doublet is designed to be nearly afocal (f'/f ≈ 48) — that is, the positive power of L1 and the negative power of L2 nearly cancel. The purpose of this near-zero power is two-fold: it allows L1's aspherical surface to control distortion without injecting significant chromatic aberration, and it provides the first stage of lateral color correction. The negative ΔP_gF of the KZFS glass begins the secondary spectrum correction.
+
+#### L3 — Biconcave Negative
+
+- **Glass:** KZFS-type short flint — n_e = 1.658, v_e = 39, ΔP_gF = −0.004
+- **Focal length:** −18.7 mm (at f = 35)
+- **Shape:** Biconcave, R1 = −0.790, R2 = +0.648 (normalized)
+- **Cemented to:** L4 (junction = surface 5)
+
+L3 is the front element of the G2 cemented doublet. It provides negative power to counterbalance L4's strong positive power and contributes to Petzval sum reduction. The patent notes ([0065]) that L3 is the one negative element exempted from the D/d_M ≥ 18 thinness constraint — its greater center thickness relative to diameter is needed for a better balance between coma and astigmatism correction.
+
+#### L4 — Biconvex Positive
+
+- **Glass:** S-LAH79 (OHARA) — n_e = 1.888, v_e = 41; n_d = 1.88300, v_d = 40.76
+- **Focal length:** +16.6 mm (at f = 35)
+- **Shape:** Biconvex, R1 = +0.648, R2 = −1.081 (normalized)
+- **Cemented to:** L3 (junction = surface 5)
+
+L4 carries the highest refractive index in the entire design (n_d ≈ 1.883). The patent requires n_d ≥ 1.86 for this element ([0026]). The high index serves two purposes: it provides strong positive refractive power from moderate curvatures (reducing higher-order aberrations), and it minimizes the Petzval contribution (since Petzval sum contributions scale as φ/n, a higher n for positive elements reduces the positive Petzval contribution). The G2 doublet (L3 + L4) is the primary power-bearing subgroup of VG, with f'/f = 2.47.
+
+### 3.2 Aperture Stop (BL)
+
+The aperture diaphragm is located between the front group VG and the middle group MG, at surface 7 in the prescription. Its axial position — just behind the front group — is characteristic of quasi-symmetrical designs. The stop position enables approximate symmetry of the aberration contributions from the front and rear halves of the design, which is the foundation for the low distortion and lateral chromatic aberration. In the production lens, the aperture has 11 blades.
+
+### 3.3 Middle Group (MG): L5–L7
+
+#### G3 — Cemented Apochromatic Triplet
+
+- **L5:** S-FPL51 (biconvex positive) — n_e = 1.498, v_e = 81, ΔP_gF = +0.031; f' = +53.4 mm
+- **L6:** KZFS-type (biconcave negative) — n_e = 1.658, v_e = 39, ΔP_gF = −0.004; f' = −19.7 mm
+- **L7:** S-FPL51 (biconvex positive) — n_e = 1.498, v_e = 81, ΔP_gF = +0.031; f' = +26.1 mm
+- **Group focal length:** f'/f = 3.36 (computed) ≈ 3.34 (patent)
+
+This triplet is the optical heart of the APO correction. The two S-FPL51 elements (L5, L7) have very high Abbe numbers (v_d ≈ 81.6) and strongly positive anomalous partial dispersion (+0.031), while the sandwiched KZFS element (L6) has low Abbe number (v_d ≈ 39) and negative anomalous partial dispersion (−0.004). This combination — positive APD crowns flanking a negative APD flint — is the classic configuration for bringing three wavelengths to a common focus (apochromatic correction). The patent states ([0047]) that the positive elements require v_d ≥ 65 and ΔP_gF ≥ +0.013.
+
+The triplet also addresses the sagittal astigmatism and serves as an assembly adjustment member for minimizing field centering errors ([0046]).
+
+Note that L5 has a very weak front radius (R = +5.209 normalized, compared to the rear at R = −0.876), making it nearly plano-convex with power concentrated at the rear surface. This distributes the refraction across the cemented interfaces, reducing surface-by-surface aberration contributions.
+
+### 3.4 Rear Group (HG): L8–L10
+
+#### L8 — Biconvex Positive (1× Aspherical)
+
+- **Glass:** S-LAH89 (OHARA) — n_e = 1.855, v_e = 40
+- **Focal length:** +15.4 mm (at f = 35)
+- **Shape:** Biconvex, R1 = +0.802, R2 = −0.616 (normalized)
+- **Aspherical surface:** Surface 12 (object-side), K = 0, polynomial corrections through A8
+- **Cemented to:** L9 (junction = surface 13)
+
+L8 is the strongest positive element in the design (shortest focal length at +15.4 mm). Its aspherical front surface contributes to balancing spherical aberration. The patent ([0054]) states that this asphere helps minimize unwanted spherical aberration contributions. L8 uses the same glass as L1 (S-LAH89), exploiting the quasi-symmetrical layout where corresponding elements on either side of the stop share optical properties.
+
+#### L9 — Biconcave Negative
+
+- **Glass:** KZFS-type short flint — n_e = 1.658, v_e = 39, ΔP_gF = −0.004
+- **Focal length:** −16.8 mm (at f = 35)
+- **Shape:** Biconcave, R1 = −0.616, R2 = +0.653 (normalized)
+- **Cemented to:** L8 (junction = surface 13)
+
+L9 completes the G4 cemented doublet with L8. This is the fourth KZFS-type element in the design, continuing the secondary spectrum correction in the rear group. The patent ([0063]) notes that the G4 doublet design makes the individual elements insensitive to decentration errors during assembly, but in opposite senses — so the combined subgroup is insensitive as a whole.
+
+#### L10 — Negative Meniscus (2× Aspherical)
+
+- **Glass:** L-BAL42 (OHARA PGM) — n_e = 1.583, v_e = 59; n_d = 1.58313, v_d = 59.37
+- **Focal length:** −115.0 mm (at f = 35)
+- **Shape:** Negative meniscus, concave toward object; R1 = −1.490, R2 = −6.742 (normalized)
+- **Aspherical surfaces:** Both surfaces 15 and 16, K = 0, with polynomials through A12 (surface 15) and A8 (surface 16)
+
+L10 is the single-element subgroup G5 and the only lens in the design manufactured by precision glass molding (PGM). The patent explicitly exempts the last element from the KZFS glass requirement ([0022]) "in favor of an aspherical design by precision glass molding." The L-BAL42 glass (OHARA's "L-" prefix denotes low-softening-temperature PGM-compatible grades) enables both surfaces to be aspherically molded in a single pressing operation.
+
+Despite its weak net power (f' ≈ −115 mm, only about −0.3 diopters at production scale), L10 plays a critical role in field correction. The patent states ([0054]) that both aspherical surfaces contribute to "balancing the astigmatic difference and coma over the image field, as well as minimizing unwanted contributions to the spherical aberration." Surface 15 carries the most complex aspherical polynomial in the design, with coefficients specified through A12 (h¹² term), indicating significant higher-order departure from the spherical base curve.
+
+The condition r16 < r15 (both radii negative, |r16| > |r15|) specified in [0062] ensures the meniscus has the correct orientation — concave toward the object — which is essential for its field-flattening function.
+
+---
+
+## 4. Aspherical Surfaces
+
+Four of the sixteen optical surfaces are aspherical. All use K = 0 (spherical base conic) with polynomial departures only. The sag equation from the patent is:
+
+$$z(h) = \frac{h^2 / r_0}{1 + \sqrt{1 - (1+k)(h/r_0)^2}} + a_2 h^4 + a_3 h^6 + \cdots + a_6 h^{12}$$
+
+where the patent coefficients a2–a6 correspond to the standard notation A4–A12.
+
+### Aspherical coefficient table (patent normalization, f = 1 mm)
+
+| Coeff. | Surface 1 (L1 front) | Surface 12 (L8 front) | Surface 15 (L10 front) | Surface 16 (L10 rear) |
+|--------|----------------------|-----------------------|------------------------|-----------------------|
+| K | 0 | 0 | 0 | 0 |
+| A4 | +1.569 × 10⁻⁵ | +1.111 × 10⁻⁶ | +9.390 × 10⁻⁵ | +6.674 × 10⁻⁵ |
+| A6 | −1.820 × 10⁰ | −5.241 × 10⁻¹ | +3.573 × 10¹ | +3.666 × 10¹ |
+| A8 | +2.404 × 10⁻¹¹ | +4.762 × 10⁻¹¹ | +9.081 × 10⁻¹⁰ | +1.080 × 10⁻⁹ |
+| A10 | — | — | +1.699 × 10¹ | — |
+| A12 | — | — | +7.799 × 10⁻¹⁶ | — |
+
+### Scaling behavior and aspherical departures
+
+The A6 coefficients appear strikingly large in magnitude — particularly for surfaces 15 and 16 (~35), and non-trivially for surfaces 1 and 12 (~1.8 and ~0.5). This is a consequence of the f = 1 mm normalization: under uniform scaling by factor s, the A₂ₙ coefficient scales as s^(2n−1), so going from f = 35 mm production scale to f = 1 mm normalization multiplies A6 by 35⁵ ≈ 5.3 × 10⁷ while multiplying A4 by only 35³ ≈ 4.3 × 10⁴. The design uses intentionally small A4 departures (4th-order correction largely absorbed by the spherical base curvature during optimization), concentrating the aspherical correction in the 6th-order and higher terms.
+
+At production scale, the aspherical departures are not negligible — particularly for L10. Using the estimated semi-diameters from the 2-ray trace (~10.5 mm for surfaces 15–16), the A6 polynomial term alone contributes approximately 0.5–0.8 mm of sag departure, which is comparable to the base spherical sag (~1.1 mm for surface 15 at R = −52.15 mm). This makes L10 a relatively strong asphere by production standards — consistent with it being a PGM element rather than conventionally polished. By contrast, surfaces 1 and 12 show much milder aspherical departures: at their estimated semi-diameters (~12–15 mm), the total polynomial sag departure is on the order of 10⁻³ mm, confirming that L1 and L8 are mild aspherics suitable for CNC or MRF polishing on the high-index S-LAH89 substrate.
+
+**Manufacturing implications:** Surfaces 1 and 12 are on S-LAH89 glass, which cannot be precision-molded (its glass transition temperature is too high). These aspherics are therefore ground and polished using conventional CNC or MRF (magnetorheological finishing) techniques — consistent with Leica's well-known capabilities in aspherical lens production at the Wetzlar facility. Surfaces 15 and 16 are on L-BAL42 PGM glass and are molded.
+
+---
+
+## 5. Glass Selection and the APO Designation
+
+The design uses only five distinct glass types across ten elements:
+
+| Glass | n_d | v_d | ΔP_gF | Elements | Count |
+|-------|-----|-----|-------|----------|-------|
+| S-LAH89 (OHARA) | 1.85150 | 40.78 | ~0 | L1, L8 | 2 |
+| N-KZFS5 (Schott) / S-NBH5 (OHARA) | 1.65412 | 39.70 | −0.004 | L2, L3, L6, L9 | 4 |
+| S-FPL51 (OHARA) | 1.49700 | 81.61 | +0.031 | L5, L7 | 2 |
+| L-BAL42 (OHARA PGM) | 1.58313 | 59.37 | ~0 | L10 | 1 |
+| S-LAH79 (OHARA) | 1.88300 | 40.76 | ~0 | L4 | 1 |
+
+*Note: The patent specifies refractive indices at the e-line (n_e, 546.07 nm) and Abbe numbers v_e. The n_d and v_d values above are from catalog cross-references. The KZFS-type glass (n_e = 1.658, v_e = 39) matches Schott N-KZFS5 (n_d = 1.65412, n_e = 1.65844, v_d = 39.70, ΔP_gF = −0.0044) or its OHARA equivalent S-NBH5 (n_d = 1.65446, v_d = 39.60). The data file uses the Schott N-KZFS5 catalog value (n_d = 1.65412).*
+
+Six elements carry anomalous partial dispersion — four with negative ΔP_gF (the KZFS-type short flints) and two with positive ΔP_gF (S-FPL51 fluorophosphate crowns). This matches Leica's stated specification. The strategy is systematic: every negative-power element except L10 uses the same KZFS-type glass with ΔP_gF = −0.004, and these are distributed across all three groups (two in VG, one in MG, one in HG). This distributed correction architecture ensures that secondary spectrum is corrected not just at the image center (where the MG triplet dominates) but also across the field (where the VG and HG elements dominate the off-axis chromatic contributions).
+
+The "APO" designation requires correction of chromatic aberration at three wavelengths (apochromatic correction), which demands glass types whose partial dispersion deviates from the "normal line" relating P_gF to v_d. The combination of positive-ΔP_gF crowns (S-FPL51) with negative-ΔP_gF flints (KZFS) enables three-color focus convergence that is not achievable with glasses lying on the normal line.
+
+---
+
+## 6. Focus Mechanism
+
+The patent describes a floating-element focus system ([0023], [0091]). During focusing from infinity to close range:
+
+1. The **residual objective** (VG + aperture diaphragm BL + MG, i.e., L1–L7) translates forward as a unit.
+2. The **rear group HG** (L8–L10) also translates forward, but with a shorter travel distance.
+
+This differential motion changes two air gaps: the spacing between MG and HG (surface 11, d = 0.35 mm at production scale for infinity) and the back focal distance (surface 16). Because HG moves less than the front assembly, the gap between MG and HG increases during close focusing. Both groups move forward (away from the image plane) to accommodate the longer conjugate distance required by closer objects.
+
+The floating element strategy is motivated by aberration correction at close range. As the patent states ([0023]), the differential motion of HG compensates for changes in coma and astigmatic difference that would otherwise degrade close-range image quality. This is why the lens achieves what Leica describes as "exceptional rendition quality across the entire image at all distance settings" down to its unusually close 0.3 m minimum focus distance — the shortest of any M-mount lens.
+
+The production lens implements this with a 300° focus ring throw, with a tactile detent at 0.7 m marking the boundary of rangefinder-coupled focusing. Below 0.7 m, the user must use Live View or an EVF.
+
+**Note on variable gap estimation:** The patent does not provide explicit close-focus spacing tables. The data file's close-focus gap values are estimated from paraxial conjugate equations assuming a floating ratio (δ_rear ≈ 0.70 × δ_front), yielding d₁₁ ≈ 2.51 mm and BFD ≈ 19.44 mm at 0.3 m. These are approximate and flagged as inferred.
+
+---
+
+## 7. Petzval Sum and Field Curvature
+
+The computed Petzval sum (at n_e wavelength) is +0.0905 in normalized units, corresponding to a Petzval radius of approximately 387 mm at f = 35 mm production scale. This is a relatively large Petzval radius (flat field) for a 35 mm lens, indicating effective field curvature correction.
+
+The field flattening strategy relies on three mechanisms working in concert. First, every positive element uses a high-refractive-index glass (n_d ≥ 1.49 for S-FPL51, 1.85 for S-LAH89, 1.88 for S-LAH79), which reduces the Petzval contribution (φ/n) of each positive surface. Second, four negative elements with comparatively lower index (n_d ≈ 1.654) provide counterbalancing negative Petzval contributions. Third, L10's negative meniscus form provides a field-flattening correction in the final image space, fine-tuned by its double-asphere surfaces.
+
+---
+
+## 8. Symmetry and Aberration Correction Philosophy
+
+The patent repeatedly emphasizes the quasi-symmetrical architecture as the foundation of the design. Examining the element pattern across the stop reveals a clear structural mirror:
+
+| Front of stop | ← Stop → | Rear of stop |
+|---------------|-----------|--------------|
+| G1: (+) doublet [LAH89 / KZFS] | BL | G3: (+) triplet [FPL51 / KZFS / FPL51] |
+| G2: (+) doublet [KZFS / LAH79] | | G4: (+) doublet [LAH89 / KZFS] |
+| | | G5: (−) single [PGM asph.] |
+
+The VG-side and HG-side share structural DNA: both contain cemented doublets pairing a high-index positive crown with a KZFS-type negative flint. G1 (LAH89/KZFS) mirrors G4 (LAH89/KZFS); G2 (KZFS/LAH79) has no exact rear mirror but the power balance is maintained by G3 and G5 together. The MG triplet sits at the center, acting as the chromatic correction hub.
+
+This quasi-symmetry means that odd-order aberrations (coma, distortion, lateral color) generated by the front half are approximately cancelled by the rear half — which is why the patent can claim "imperceptible distortion" ([0075]) and MTF contrast above ~75% at the image margin at 20 lp/mm.
+
+---
+
+## 9. Summary of Aspherical Surface Roles
+
+| Surface | Element | Location | Primary correction role |
+|---------|---------|----------|------------------------|
+| 1 | L1 front | Object-facing | Distortion minimization; centering adjustment |
+| 12 | L8 front | Rear group entry | Spherical aberration reduction |
+| 15 | L10 front | Field corrector | Astigmatic difference and coma over field |
+| 16 | L10 rear | Last surface before image | Field curvature and residual coma balancing |
+
+The distribution of aspherics is deliberate: one at the front of the lens where off-axis beams are farthest from the axis (distortion), one just after the stop where on-axis beams are widest (spherical aberration), and two at the rear of the lens where they can fine-tune field-dependent aberrations without affecting the axial correction. The double-asphere on L10, with its higher-order A10 and A12 terms on surface 15, provides the degrees of freedom needed to simultaneously correct astigmatism, field curvature, and coma across the full 62° field.
+
+---
+
+## 10. Relationship to Leica's APO-Summicron Family
+
+The APO-Summicron-M 35 f/2 ASPH. is the latest addition to the APO-designated M-mount lens family, following the 90 mm f/2 (1998, the first APO-Summicron-M), the 75 mm f/2 (2005), and the 50 mm f/2 (2012). It is the first 35 mm M-lens to achieve apochromatic correction — a fact Leica emphasizes in its marketing materials. The design shares the distributed-APD-glass philosophy of its predecessors — using KZFS-type flints in every negative element across all groups — but introduces the double-asphere PGM element (L10) as a new tool for compact field correction. The floating focus mechanism, previously employed in the 75 mm APO-Summicron-M and the 50 mm f/1.4 Summilux-M ASPH., is extended here to achieve a 0.3 m close focus distance — the shortest in the M-mount system.
+
+---
+
+## 11. Data File Notes
+
+The companion data file (`LeicaAPO35mmf2.data.ts`) uses d-line (587.56 nm) refractive indices from glass catalogs rather than the patent's e-line values. This produces a computed EFL of ~34.75 mm (vs. 35.0 mm at the e-line). The discrepancy is expected and represents the wavelength-dependent focal shift, not a transcription error.
+
+The patent's aspherical coefficient notation uses a non-standard labeling (a2, a3, ..., a6 for A4, A6, ..., A12). The "D ± N" exponential format in the patent (e.g., "0.1569D − 4" = 1.569 × 10⁻⁵) is a Fortran-style double-precision notation common in German optical patents.
+
+Semi-diameters are estimated (not patent-specified) and should be treated as approximate. The front element SD of 15.0 mm is constrained by the E39 filter thread geometry. Variable gap values for close focus are inferred from paraxial conjugate analysis and should likewise be treated as estimates rather than authoritative design data.

--- a/src/lens-data/LeicaAPO35mmf2.data.ts
+++ b/src/lens-data/LeicaAPO35mmf2.data.ts
@@ -1,0 +1,334 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — LEICA APO-SUMMICRON-M 35 f/2 ASPH.          ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2022/0066176 A1, Example 1 (Roth & Keller,       ║
+ * ║    Leica Camera AG). Priority: DE 10 2018 132 472.3 (2018-12-17). ║
+ * ║  Quasi-symmetrical wide-angle prime for Leica M mount.            ║
+ * ║  10 elements / 5 groups, 4 aspherical surfaces (on 3 elements).   ║
+ * ║  Focus: floating rear group (HG) — VG+BL+MG move together,       ║
+ * ║    HG moves in the same direction but with shorter travel.        ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent normalized to f = 1 mm. All R, d, sd values scaled      ║
+ * ║    ×35 to production focal length f ≈ 35 mm.                      ║
+ * ║    Aspherical coefficients scaled accordingly:                     ║
+ * ║      A_{2n,prod} = A_{2n,norm} / 35^(2n−1).                      ║
+ * ║                                                                    ║
+ * ║  NOTE ON REFRACTIVE INDICES:                                       ║
+ * ║    Patent specifies n_e (546.07 nm) and v_e. Data file uses       ║
+ * ║    n_d (587.56 nm) and v_d from catalog cross-references.         ║
+ * ║    Computed EFL at d-line: ~34.75 mm (vs. 35.0 at e-line).       ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list semi-diameters. Estimated from paraxial   ║
+ * ║    2-ray trace (marginal + 60% chief ray) with ~10% mechanical    ║
+ * ║    clearance, constrained by E39 filter thread (front) and        ║
+ * ║    M-mount bayonet (rear). Edge thickness validated ≥ 0 for all   ║
+ * ║    elements at the assigned SDs.                                   ║
+ * ║                                                                    ║
+ * ║  NOTE ON VARIABLE GAPS:                                            ║
+ * ║    Patent does not provide explicit close-focus spacing tables.    ║
+ * ║    Close-focus gaps estimated from paraxial conjugate equations    ║
+ * ║    with an assumed floating ratio (δ_rear/δ_front ≈ 0.70).       ║
+ * ║    These are approximate and flagged as inferred.                  ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "leica-apo-summicron-m-35f2",
+  maker: "Leica",
+  name: "LEICA APO-SUMMICRON-M 35 f/2 ASPH.",
+  subtitle: "US 2022/0066176 A1 Ex. 1 — Leica Camera AG / Roth & Keller",
+  specs: [
+    "10 ELEMENTS / 5 GROUPS",
+    "f ≈ 34.8 mm (d-line)",
+    "F/2.0",
+    "2ω ≈ 62.2°",
+    "4 ASPHERICAL SURFACES (3 ELEMENTS)",
+  ],
+
+  /* ── Explicit metadata fields ── */
+  focalLengthMarketing: 35,
+  focalLengthDesign: 34.8,
+  apertureMarketing: 2.0,
+  apertureDesign: 2.0,
+  patentYear: 2022,
+  elementCount: 10,
+  groupCount: 5,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconvex Positive (1× Asph)",
+      nd: 1.8515,
+      vd: 40.78,
+      fl: 19.0,
+      glass: "S-LAH89 (OHARA)",
+      apd: false,
+      role: "Front positive; aspherical object surface controls distortion. Patent-specified for Knoop hardness ≥ 600 and acid resistance.",
+      cemented: "G1",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconcave Negative",
+      nd: 1.65412,
+      vd: 39.7,
+      fl: -18.0,
+      glass: "N-KZFS5 (Schott) / S-NBH5 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔPgF ≈ −0.004 (patent-stated for KZFS-type elements)",
+      role: "Nearly afocal doublet with L1 (G1, f'/f ≈ 48). Begins lateral color and secondary spectrum correction.",
+      cemented: "G1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconcave Negative",
+      nd: 1.65412,
+      vd: 39.7,
+      fl: -18.7,
+      glass: "N-KZFS5 (Schott) / S-NBH5 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔPgF ≈ −0.004",
+      role: "Negative element in G2 doublet; Petzval sum reduction. Exempted from D/d_M ≥ 18 thinness constraint per patent.",
+      cemented: "G2",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.76,
+      fl: 16.6,
+      glass: "S-LAH79 (OHARA)",
+      apd: false,
+      role: "Highest-index element (nd ≈ 1.883). Primary power element of VG (G2, f'/f = 2.47). High n minimizes Petzval contribution.",
+      cemented: "G2",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.61,
+      fl: 53.4,
+      glass: "S-FPL51 (OHARA)",
+      apd: "patent",
+      apdNote: "ΔPgF = +0.031 (patent-stated)",
+      role: "Front crown of apochromatic triplet (G3). Nearly plano-convex; power concentrated at cemented rear surface.",
+      cemented: "G3",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.65412,
+      vd: 39.7,
+      fl: -19.7,
+      glass: "N-KZFS5 (Schott) / S-NBH5 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔPgF ≈ −0.004",
+      role: "Central flint of apochromatic triplet (G3). APD flint sandwiched between FPL51 crowns for three-wavelength correction.",
+      cemented: "G3",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.61,
+      fl: 26.1,
+      glass: "S-FPL51 (OHARA)",
+      apd: "patent",
+      apdNote: "ΔPgF = +0.031 (patent-stated)",
+      role: "Rear crown of apochromatic triplet (G3). Stronger curvature than L5; carries more refractive power.",
+      cemented: "G3",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconvex Positive (1× Asph)",
+      nd: 1.8515,
+      vd: 40.78,
+      fl: 15.4,
+      glass: "S-LAH89 (OHARA)",
+      apd: false,
+      role: "Strongest positive element (f' = 15.4 mm). Aspherical front surface minimizes spherical aberration. Mirrors L1 across stop (quasi-symmetry).",
+      cemented: "G4",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Biconcave Negative",
+      nd: 1.65412,
+      vd: 39.7,
+      fl: -16.8,
+      glass: "N-KZFS5 (Schott) / S-NBH5 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔPgF ≈ −0.004",
+      role: "Fourth KZFS element; completes G4 doublet. Insensitive to decentration in combined assembly.",
+      cemented: "G4",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Neg. Meniscus (2× Asph)",
+      nd: 1.58313,
+      vd: 59.37,
+      fl: -115.0,
+      glass: "L-BAL42 (OHARA PGM)",
+      apd: false,
+      role: "Field corrector; both surfaces aspherical (precision glass molded). Weak net power but critical for astigmatism/coma/field curvature over full 62° field.",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Patent normalized to f = 1 mm; all R, d values here ×35.
+   *  nd values: d-line (587.56 nm) from catalog cross-references.
+   *  Patent aspherical surfaces: 1, 12, 15, 16 → labels 1A, 12A, 15A, 16A.
+   */
+  surfaces: [
+    // ── Front Group (VG) ──
+    // G1: L1 + L2 cemented doublet
+    { label: "1A", R: 54.11, d: 5.95, nd: 1.8515, elemId: 1, sd: 15.0 }, // L1 front (asph)
+    { label: "2", R: -21.98, d: 1.05, nd: 1.65412, elemId: 2, sd: 12.0 }, // L1→L2 junction
+    { label: "3", R: 25.97, d: 3.5, nd: 1.0, elemId: 0, sd: 11.5 }, // L2 rear → air
+    // G2: L3 + L4 cemented doublet
+    { label: "4", R: -27.65, d: 2.1, nd: 1.65412, elemId: 3, sd: 10.5 }, // L3 front
+    { label: "5", R: 22.68, d: 4.55, nd: 1.883, elemId: 4, sd: 10.5 }, // L3→L4 junction
+    { label: "6", R: -37.835, d: 1.4, nd: 1.0, elemId: 0, sd: 9.8 }, // L4 rear → air
+
+    // ── Aperture Stop ──
+    { label: "STO", R: 1e15, d: 1.4, nd: 1.0, elemId: 0, sd: 8.75 },
+
+    // ── Middle Group (MG) ──
+    // G3: L5 + L6 + L7 cemented triplet
+    { label: "8", R: 182.315, d: 6.65, nd: 1.497, elemId: 5, sd: 9.5 }, // L5 front
+    { label: "9", R: -30.66, d: 1.05, nd: 1.65412, elemId: 6, sd: 10.5 }, // L5→L6 junction
+    { label: "10", R: 22.435, d: 5.25, nd: 1.497, elemId: 7, sd: 10.5 }, // L6→L7 junction
+    { label: "11", R: -28.315, d: 0.35, nd: 1.0, elemId: 0, sd: 10.8 }, // L7 rear → air
+
+    // ── Rear Group (HG) ──
+    // G4: L8 + L9 cemented doublet
+    { label: "12A", R: 28.07, d: 7.7, nd: 1.8515, elemId: 8, sd: 11.0 }, // L8 front (asph)
+    { label: "13", R: -21.56, d: 1.05, nd: 1.65412, elemId: 9, sd: 11.0 }, // L8→L9 junction
+    { label: "14", R: 22.855, d: 6.65, nd: 1.0, elemId: 0, sd: 11.0 }, // L9 rear → air
+    // G5: L10 single lens
+    { label: "15A", R: -52.15, d: 1.05, nd: 1.58313, elemId: 10, sd: 10.5 }, // L10 front (asph)
+    { label: "16A", R: -235.97, d: 14.39, nd: 1.0, elemId: 0, sd: 10.5 }, // L10 rear (asph) → image; d = BFD
+  ],
+
+  /* ── Aspherical coefficients ──
+   *  Patent convention: z(h) = h²/r₀ / [1+√(1−(1+k)(h/r₀)²)] + a2·h⁴ + a3·h⁶ + ...
+   *  Patent coefficients are at f = 1 normalization.
+   *  Below: scaled to production (f ≈ 35 mm) via A_{2n,prod} = A_{2n,norm} / 35^(2n−1).
+   *  All K = 0 (spherical base conic, polynomial-only departure).
+   *
+   *  The patent specifies only through A8 for surfaces 1 and 12, and through
+   *  A12 for surface 15 and A8 for surface 16. Higher-order terms are zero.
+   *  Note: A8 contributions for surfaces 1A and 12A are negligible at production scale
+   *  (~10⁻²² × h⁸) but included for completeness.
+   */
+  asph: {
+    "1A": {
+      K: 0,
+      A4: 3.6595e-10,
+      A6: -3.4659e-8,
+      A8: 3.7364e-22,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+    "12A": {
+      K: 0,
+      A4: 2.5913e-11,
+      A6: -9.9778e-9,
+      A8: 7.4014e-22,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+    "15A": {
+      K: 0,
+      A4: 2.1901e-9,
+      A6: 6.8035e-7,
+      A8: 1.4114e-20,
+      A10: 2.1561e-13,
+      A12: 8.0778e-33,
+      A14: 0,
+    },
+    "16A": {
+      K: 0,
+      A4: 1.5566e-9,
+      A6: 6.9795e-7,
+      A8: 1.6786e-20,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (floating-element focus) ──
+   *  VG + BL + MG (surfaces 1–11) translate forward as a unit.
+   *  HG (surfaces 12–16) translates forward with shorter travel.
+   *  Two gaps change: surface 11 (MG→HG) and surface 16 (BFD).
+   *
+   *  Close-focus values are INFERRED (patent does not provide explicit
+   *  close-focus spacing data). Estimated assuming floating ratio ≈ 0.70
+   *  (δ_rear = 0.70 × δ_front) at 0.3 m close focus (from film plane).
+   */
+  var: {
+    "11": [0.35, 2.51],
+    "16A": [14.39, 19.44],
+  },
+  varLabels: [
+    ["11", "D11"],
+    ["16A", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "VG (FRONT)", fromSurface: "1A", toSurface: "6" },
+    { text: "MG (MIDDLE)", fromSurface: "8", toSurface: "11" },
+    { text: "HG (REAR)", fromSurface: "12A", toSurface: "16A" },
+  ],
+  doublets: [
+    { text: "G1", fromSurface: "1A", toSurface: "3" },
+    { text: "G2", fromSurface: "4", toSurface: "6" },
+    { text: "G3", fromSurface: "8", toSurface: "11" },
+    { text: "G4", fromSurface: "12A", toSurface: "14" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.3,
+  focusDescription:
+    "Floating rear group: VG+BL+MG translate forward together; HG translates forward with shorter travel (~70% of front assembly). Differential motion compensates coma and astigmatic difference at close range.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.0,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16],
+  apertureBlades: 11,
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/LeicaAPO35mmf2.data.ts
+++ b/src/lens-data/LeicaAPO35mmf2.data.ts
@@ -209,11 +209,11 @@ const LENS_DATA = {
     // G1: L1 + L2 cemented doublet
     { label: "1A", R: 54.11, d: 5.95, nd: 1.8515, elemId: 1, sd: 15.0 }, // L1 front (asph)
     { label: "2", R: -21.98, d: 1.05, nd: 1.65412, elemId: 2, sd: 12.0 }, // L1→L2 junction
-    { label: "3", R: 25.97, d: 3.5, nd: 1.0, elemId: 0, sd: 11.5 }, // L2 rear → air
+    { label: "3", R: 25.97, d: 3.5, nd: 1.0, elemId: 0, sd: 10.0 }, // L2 rear → air
     // G2: L3 + L4 cemented doublet
-    { label: "4", R: -27.65, d: 2.1, nd: 1.65412, elemId: 3, sd: 10.5 }, // L3 front
-    { label: "5", R: 22.68, d: 4.55, nd: 1.883, elemId: 4, sd: 10.5 }, // L3→L4 junction
-    { label: "6", R: -37.835, d: 1.4, nd: 1.0, elemId: 0, sd: 9.8 }, // L4 rear → air
+    { label: "4", R: -27.65, d: 2.1, nd: 1.65412, elemId: 3, sd: 9.0 }, // L3 front
+    { label: "5", R: 22.68, d: 4.55, nd: 1.883, elemId: 4, sd: 9.0 }, // L3→L4 junction
+    { label: "6", R: -37.835, d: 1.4, nd: 1.0, elemId: 0, sd: 9.0 }, // L4 rear → air
 
     // ── Aperture Stop ──
     { label: "STO", R: 1e15, d: 1.4, nd: 1.0, elemId: 0, sd: 8.75 },

--- a/src/lens-data/LeicaAPO43mmf2.analysis.md
+++ b/src/lens-data/LeicaAPO43mmf2.analysis.md
@@ -1,0 +1,228 @@
+# Leica APO-Summicron 43mm f/2 ASPH — Optical Analysis
+
+**Patent:** US 2024/0241349 A1, Example 1 (First Embodiment)
+**Applicant:** Panasonic Intellectual Property Management Co., Ltd.
+**Inventors:** Takehiro Nishioka, Yoshiaki Kurioka
+**Priority:** JP 2022-142614 (Sep. 8, 2022) · Published Jul. 18, 2024
+**Production lens:** Leica APO-Summicron 43mm f/2 ASPH. (fixed to the Leica Q3 43)
+
+---
+
+## 1. Overview and Identification
+
+This patent describes the imaging optical system fitted to the Leica Q3 43, a full-frame fixed-lens camera announced in September 2024. The connection between Example 1 and the production lens is established by convergent evidence: Example 1 has 11 elements in 5 power-grouped units (G1 through G5), which correspond to 8 air-separated physical groups — matching Leica's published specification of 11 elements in 8 groups. Seven aspherical surfaces span four elements, again matching the Leica specification of "four aspherical elements" bearing seven aspherical surfaces. The overall design f-number of 2.06 at f ≈ 41.7 mm is consistent with the marketed 43 mm f/2 designation. DPReview's review explicitly notes the lens was designed "per a design patented by Panasonic," confirming the link through the Panasonic–Leica L-Mount Alliance partnership.
+
+Peter Karbe, Leica's chief lens designer, has stated that the APO correction allows the nominally f/2 lens to have a comparable depth-of-focus appearance to a conventional f/1.4 lens. The mechanism is that apochromatic correction sharpens the in-focus plane so dramatically that the transition from sharp to out-of-focus becomes steeper, creating a perceptual impression of shallower depth of field despite the geometrically identical f/2 cone angle.
+
+### Key Specifications (Patent vs. Manufacturer)
+
+| Parameter | Patent (Example 1, ∞) | Leica Published |
+|---|---|---|
+| Focal length | 41.71 mm (design EFL) | 43 mm (marketing) |
+| Maximum aperture | f/2.06 (design) | f/2.0 (marketing) |
+| Half-field angle | 27.50° | — |
+| Full field (2ω) | 54.99° | — |
+| Image height Y | 20.0 mm | 21.6 mm (sensor half-diagonal) |
+| Total track length | 68.37 mm | — |
+| Elements / groups | 11 / 5 (power groups) | 11 / 8 (air-separated) |
+| Aspherical surfaces | 7 (on 4 elements) | 7 aspherical surfaces |
+| Close focus (standard) | — | 0.6 m |
+| Close focus (macro) | — | 0.27 m |
+| Filter thread | — | E49 |
+| OIS | L5 decentered ⊥ axis | Integrated OIS |
+
+The marketing focal length of 43 mm corresponds to the diagonal of a 24×36 mm full-frame sensor (√(24² + 36²) = 43.27 mm), making this a geometrically "true normal" lens. The design EFL of 41.71 mm is the paraxial value; the difference from the marketed 43 mm reflects the standard industry practice of rounding to a nominal value.
+
+---
+
+## 2. Optical Configuration
+
+The system follows a G1(+) – A – G2(+) – G3(−) – G4(+) – G5(−) architecture, where A denotes the aperture stop located between G1 and G2. The positive front group followed by alternating positive and negative rear groups is characteristic of modern inner-focus designs for mirrorless cameras, where the rear section must balance chromatic correction, field flattening, and independent focus motion within a compact package.
+
+### Power-group to physical-group mapping
+
+| Power Group | Sign | Elements | Air-Separated Subgroups | Physical Group # |
+|---|---|---|---|---|
+| G1 (+) | Positive | L1, L2, L3–L4 cemented, L5 | 4 subgroups | 1–4 |
+| G2 (+) | Positive | L6–L7 cemented | 1 subgroup | 5 |
+| G3 (−) | Negative | L8–L9 cemented | 1 subgroup | 6 |
+| G4 (+) | Positive | L10 | 1 subgroup | 7 |
+| G5 (−) | Negative | L11 | 1 subgroup | 8 |
+
+This gives 4 + 1 + 1 + 1 + 1 = **8 air-separated groups**, matching the Leica specification.
+
+### Element Summary
+
+| Element | Shape | nd | νd | Glass (best match) | f (mm) | Asph | Cemented | Role |
+|---|---|---|---|---|---|---|---|---|
+| L1 | Biconcave | 1.64769 | 33.8 | S-TIM22 (OHARA) | −35.6 | — | — | Front negative; field flattening, retrofocus contribution |
+| L2 | Biconvex | 2.00069 | 25.5 | S-NPH4 (OHARA) | +29.9 | — | — | Ultra-high-index positive; strong refraction at minimum curvature |
+| L3 | Biconvex | 1.59282 | 68.6 | 593/686 (PK crown, uncertain ID) | +28.7 | — | D1 (with L4) | Positive crown; primary positive power in G1; APD glass |
+| L4 | Biconcave | 1.76182 | 26.6 | S-TIH6 (OHARA) | −24.4 | — | D1 (with L3) | Negative flint; chromatic correction partner for L3 |
+| L5 | Biconvex (2× Asph) | 1.58660 | 59.0 | 587/590 (HOYA FDS family) | +66.0 | 8A, 9A | — | OIS element; weak positive with aspherics for SA/coma |
+| L6 | Biconcave (1× Asph) | 1.68948 | 31.0 | S-TIM28 / L-TIM28 (OHARA) | −22.3 | 10A | D2 (with L7) | Negative flint; aberration control at stop |
+| L7 | Biconvex | 1.95375 | 32.3 | S-LAH99 / TAFD33 (OHARA) | +19.0 | — | D2 (with L6) | Ultra-high-index positive; primary power in G2 |
+| L8 | Pos. Meniscus (convex to image) | 1.90366 | 31.3 | S-NPH53 / TAFD30 (OHARA) | +37.8 | — | D3 (with L9) | Positive meniscus; high-index short flint for Petzval correction |
+| L9 | Biconcave | 1.69895 | 30.1 | S-TIM35 (OHARA) | −31.0 | — | D3 (with L8) | Negative flint; G3 diverging power for field correction |
+| L10 | Biconvex (2× Asph) | 1.55332 | 71.7 | S-FPM3 / L-FPM3 (OHARA) | +40.0 | 16A, 17A | — | Fluorophosphate positive; main APD contributor; focus group |
+| L11 | Neg. Meniscus (convex to image, 2× Asph) | 1.58660 | 59.0 | 587/590 (HOYA FDS family) | −31.2 | 18A, 19A | — | Rear field-flattener; G5 negative for Petzval balance |
+
+---
+
+## 3. Glass Selection and Chromatic Correction
+
+The APO designation on this lens is not merely marketing. The glass selection reveals a deliberate apochromatic correction strategy built around several key material choices.
+
+### 3.1 Ultra-High-Index Glasses
+
+Three elements use glasses with refractive indices approaching or exceeding 1.9:
+
+**L2 — S-NPH4 (nd = 2.00069, νd = 25.5).** This OHARA super-high-index heavy flint is one of the highest-index optical glasses in current production. Its extreme refractive index means that the same optical power can be achieved with much shallower curvatures than lower-index alternatives. For L2, this is critical: as a biconvex element contributing strong positive power to G1 (f = +29.9 mm), using S-NPH4 allows the surface radii (R3 = +37.97, R4 = −131.51) to remain moderate, reducing both spherical aberration and higher-order monochromatic residuals. The low Abbe number (25.5) means L2 also serves as the primary chromatic dispersion source in the front group, which is then corrected by L3.
+
+**L7 — S-LAH99 (nd = 1.95375, νd = 32.3).** This ultra-high-index lanthanum glass carries the primary positive power of G2 (f = +19.0 mm), the strongest positive element in the rear half of the system. Its placement immediately behind the aperture stop, cemented to the negative L6, forms a powerful doublet that handles both axial color and spherical aberration in the post-stop region.
+
+**L8 — S-NPH53 (nd = 1.90366, νd = 31.3).** Another ultra-high-index short flint, used as a positive meniscus in G3. The high index reduces curvature demands on the meniscus surfaces, limiting the introduction of higher-order astigmatism.
+
+### 3.2 Anomalous Partial Dispersion Glasses
+
+The APO correction depends on anomalous partial dispersion (APD) to bring a third wavelength (typically g-line at 435.8 nm) to a common focus alongside the standard d-line and C-line correction of an ordinary achromat.
+
+**L3 — Six-digit code 593/686 (nd = 1.59282, νd = 68.6).** This glass sits in the phosphate crown (PK) region of the glass map, characteristic of low-dispersion positive crown glasses. The closest standard catalog match is OHARA S-FPM2 (nd = 1.59522, νd = 67.73), but with non-trivial residuals (Δnd = +0.0024, Δνd = −0.87), suggesting the patent may use a specialty melt, a glass from a secondary supplier (CDGM, Sumita), or intentionally rounded values. Regardless of the specific designation, a glass at this position on the nd/νd diagram will have positive anomalous partial dispersion (ΔPgF > 0). Paired with the normal-dispersion flint L4 (S-TIH6, νd = 26.6) in a cemented doublet, L3's APD helps pull the short-wavelength (blue/violet) focus closer to the long-wavelength focus, reducing secondary spectrum in the front group.
+
+**L10 — S-FPM3 (nd = 1.55332, νd = 71.7).** This fluorophosphate glass is the cornerstone of the APO correction. With a high Abbe number (71.7) and positive APD, it provides the same kind of secondary-spectrum reduction as ED (extra-low dispersion) glass does in telephoto designs, but here applied to a fast normal lens. L10 is a powerful biconvex element (f = +40.0 mm) with two aspherical surfaces — the most optically complex single element in the design. The patent's Inequality (7) requires νd4G > 62, and the actual value of 71.7 provides substantial margin, indicating that chromatic correction was a primary design driver for this element.
+
+**L5 and L11 — Six-digit code 587/590 (nd = 1.58660, νd = 59.0).** Both the OIS element and the rear field-flattener use the same glass, a crown in the BAL/BAM region of the glass map. The closest catalog match is in the HOYA FDS family (nd = 1.58660, νd = 59.01, exact to five decimal places), available in PGM-compatible grades. While not as strongly anomalous as fluorophosphate glass, the νd = 59.0 of these elements contributes to keeping the overall secondary spectrum low. The patent's Inequality (8) requires νd5G > 50 for L11; the value of 59.0 satisfies this comfortably.
+
+### 3.3 Optical Cement
+
+All three cemented doublets (D1 = L3+L4, D2 = L6+L7, D3 = L8+L9) use the same cement with nd = 1.56732 and νd = 42.8, matching OHARA S-BAM4. The patent explicitly lists the cement as a 0.01 mm thick optical surface at each junction — an unusually detailed treatment that acknowledges the cement's non-negligible refractive contribution.
+
+### 3.4 Cover Glass
+
+The parallel plate P (nd = 1.51680, νd = 64.2) matches OHARA L-BSL7, the low-softening-temperature variant of BK7-equivalent glass. In the Q3 43, this represents the combined IR-cut / low-pass filter stack in front of the sensor.
+
+### 3.5 Petzval Sum
+
+The computed Petzval sum is +0.00098 mm⁻¹, yielding a Petzval radius of approximately −1019 mm. This is exceptionally well-corrected — nearly flat Petzval field. The deliberate use of high-index glasses throughout the design (five elements with nd > 1.68) is the primary mechanism: high-index positive elements contribute less to the Petzval sum per unit of optical power than low-index ones, while the strong negative elements (L1, L4, L6, L9, L11) provide the necessary Petzval counter-bending. The result is a lens that can deliver sharp corners on the Q3 43's demanding 60-megapixel sensor even at full aperture.
+
+---
+
+## 4. Aspherical Surfaces
+
+Seven surfaces across four elements carry aspherical profiles, making this one of the most aggressively aspherized normal-focal-length designs in current production. All aspherical departures below are computed at the estimated clear-aperture semi-diameter (SD) for each surface, derived from paraxial marginal and chief ray traces at f/2.06 with 8% mechanical clearance.
+
+### 4.1 L5 — Surfaces 8A and 9A (OIS Element)
+
+Both surfaces of the image-stabilization element are aspherical. The departures from the base sphere are approximately −197 μm on surface 8A (SD ≈ 9.4 mm) and −146 μm on surface 9A (SD ≈ 9.1 mm). Both surfaces have K = 0 (spherical base), with the aspheric profile defined entirely by even-order polynomial coefficients through A14.
+
+The aspherical departures on L5 serve a dual purpose. First, they correct residual spherical aberration from the front group at the marginal ray height near the stop. Second, because L5 moves perpendicularly to the optical axis during image stabilization, the aspherical profiles must be designed to maintain correction quality over the full decentering range — a considerably tighter design constraint than for a stationary aspheric. The patent states that the image blur compensation displacement at infinity is 0.401 mm.
+
+### 4.2 L6 — Surface 10A (Front of Post-Stop Doublet)
+
+The object-side surface of L6 carries a significant conic constant (K = −0.420) along with polynomial terms through A10 (higher orders are zero). The prolate-ellipsoid base shape (K < 0) reduces the surface slope at the rim compared to a sphere of the same vertex radius, which helps control coma and oblique spherical aberration for off-axis ray bundles passing through the stop.
+
+The combined aspheric departure at the clear aperture (SD ≈ 7.1 mm) is approximately −60 μm, with the polynomial terms (−64 μm) dominating over the mild conic contribution (+3 μm). The conic sets the bulk wavefront shape while the polynomial provides fine high-order correction.
+
+### 4.3 L10 — Surfaces 16A and 17A (Focus Group)
+
+L10 is a biconvex fluorophosphate element with aspherics on both surfaces. The front surface (16A) at SD ≈ 11.9 mm has moderate departure (−114 μm) while the rear surface (17A) at SD ≈ 14.2 mm shows a much larger +610 μm departure — the rear surface flattens significantly relative to its base sphere (R = −24.52 mm), creating a pronounced "bent" profile that redirects the converging beam.
+
+Both surfaces have K = 0 with polynomial coefficients through A14. The asymmetric departure pattern (negative on front, positive on rear) indicates that the aspherics are primarily working to control the field-dependent behavior of G4 as a focusing group: since L10 moves during focus (see §5), the aspherical profiles must maintain correction quality across the entire internal-focus range from infinity to the standard minimum focus distance of 0.6 m.
+
+### 4.4 L11 — Surfaces 18A and 19A (Rear Field-Flattener)
+
+The rear-most glass element carries the largest aspherical departures in the entire system. Surface 18A has K = −0.276 (a prolate ellipsoid) plus polynomial terms yielding a total departure of approximately +3,785 μm — nearly 3.8 mm of aspheric departure from the base sphere at SD ≈ 15.3 mm. The conic contributes approximately +1,126 μm, with the polynomial terms adding a further +2,659 μm. Surface 19A adds −106 μm of departure at SD ≈ 16.2 mm.
+
+The extreme aspherization of surface 18A reflects L11's role as a field-flattener operating close to the image plane. Its base radius is only −17.17 mm, producing a steeply curved spherical surface, and the large SD-to-radius ratio (sd/|R| ≈ 0.89) places the clear aperture near the geometric limit of the sphere. The prolate conic and polynomial terms together reshape this steep surface to redirect the strongly diverging off-axis beam, correcting astigmatism, field curvature, and distortion without introducing excessive higher-order residuals. At this position, ray heights vary strongly with field angle, so the aspherical departures primarily affect off-axis performance rather than on-axis spherical aberration.
+
+### 4.5 Manufacturing Implications
+
+The four aspherical elements span two glass types:
+
+- **L5 and L11** use the 587/590 glass (best match: HOYA FDS family, nd = 1.58660). HOYA offers this glass in PGM-compatible ("M-" prefix) grades, making it a standard choice for high-volume aspherical element production via precision glass molding.
+- **L10** uses OHARA S-FPM3 (nd = 1.55332), a fluorophosphate glass. OHARA offers L-FPM3 as the low-Tg PGM variant with identical optical constants. Given the production volumes of the Q3 43, PGM is the likely manufacturing method.
+- **L6** uses S-TIM28 (nd = 1.68948). OHARA offers L-TIM28 as the PGM variant, suggesting this element is also glass-molded.
+
+---
+
+## 5. Focus Mechanism
+
+The lens uses a **floating-element inner focus** system with two independently moving groups. During focus from infinity to close range, both G2 (L6–L7 cemented doublet) and G4 (L10 singlet) translate toward the object along the optical axis. The remaining three groups (G1, G3, G5) and the aperture stop remain stationary.
+
+### Variable Air Gaps
+
+| Gap | Location | Infinity | Middle | Close | Δ(close−∞) | Meaning |
+|---|---|---|---|---|---|---|
+| d11 | Stop → G2 front | 8.500 | 7.638 | 6.498 | −2.002 | G2 advances toward object |
+| d15 | G2 rear → G3 front | 2.398 | 3.260 | 4.400 | +2.002 | Space opens behind G2 |
+| d19 | G3 rear → G4 front | 4.563 | 3.377 | 1.811 | −2.753 | G4 advances toward object |
+| d21 | G4 rear → G5 front | 5.271 | 6.457 | 8.024 | +2.753 | Space opens behind G4 |
+
+Two critical observations emerge:
+
+1. **Complementary gap conservation:** d11 + d15 = 10.898 mm at all focus positions (constant within 0.001 mm), and d19 + d21 = 9.834 mm at all focus positions. This means the total track length from the stop to G3, and from G3 to G5, remains constant during focus. The overall lens length does not change. This is the hallmark of a well-designed inner-focus system: the barrel does not extend during focusing.
+
+2. **Differential motion:** G4 moves 37% farther than G2 (2.753 mm vs. 2.002 mm). This differential creates the "floating" element behavior that maintains correction quality across the focus range. If both groups moved the same amount, as in a simpler unit-focus or single-group IF design, the balance of spherical aberration and field curvature would shift substantially at close focus. The independent motion allows each group to track its optimal position.
+
+The patent (§0049–0050) explicitly states that G2 and G4 move toward the object during close focusing, while G1, G3, and G5 remain fixed at constant distances from the image plane.
+
+### Macro Mode
+
+The Leica Q3 43 extends its close-focus capability to 0.27 m through a separate macro mechanism. According to reviewer observations, engaging the macro ring physically advances the entire optical assembly forward by approximately 3 mm, changing the lens-to-sensor distance. This mechanical extension is distinct from the internal electronic focusing and explains why the macro mode forces the maximum aperture to f/2.8 (the increased extension shifts the effective f-number). This macro extension mechanism is not described in the patent, which covers only the internal focus system.
+
+---
+
+## 6. Image Stabilization
+
+The patent (§0051) identifies L5 as the image blur compensation lens. This element — the rearmost element of G1, positioned immediately before the aperture stop — translates perpendicularly to the optical axis to counteract camera shake.
+
+L5 is a weak positive singlet (f = +66.0 mm) with both surfaces aspherical. Its position near the stop is optimal for OIS because the marginal ray height is relatively small there (minimizing the induced aberration from decentering), while the chief ray height is near zero (minimizing the shift of the image field). The patent's lateral aberration diagrams (Fig. 1C) show that the compensated state (Dec = 0.401 mm) maintains excellent correction out to 70% of the field, with lateral chromatic aberration staying well within ±0.04 mm across the pupil — confirming that the aspherical profiles on L5 were explicitly optimized for decentered performance.
+
+---
+
+## 7. Conditional Expression Verification
+
+The patent defines ten inequalities that characterize the design space. All values were independently verified using the prescription data:
+
+| Ineq. | Expression | Range | Computed | Patent Value | Status |
+|---|---|---|---|---|---|
+| (1) | f1/f | 1.0 – 1.5 | 1.246 | 1.25 | ✓ |
+| (2) | \|f5/f\| | 0.5 – 1.0 | 0.747 | 0.75 | ✓ |
+| (3) | f2/f4 | 1.8 – 3.4 | 2.374 | 2.37 | ✓ |
+| (4) | BF/Y | 0.1 – 0.5 | 0.300 | 0.30 | ✓ |
+| (5) | TL/Y | 3.0 – 3.8 | 3.419 | 3.42 | ✓ |
+| (6) | nd2Gp | > 1.8 | 1.954 | 1.95375 | ✓ |
+| (7) | vd4G | > 62 | 71.7 | 71.68 | ✓ |
+| (8) | vd5G | > 50 | 59.0 | 59.01 | ✓ |
+| (9) | (1−β4×β4)×β4r×β4r | 0.4 – 1.0 | 0.72 | 0.72 | ✓ |
+| (10) | \|(1−β)×βr\| | 0.2 – 10 | 0.54 | 0.54 | ✓ |
+
+Inequality (9) defines the position sensitivity of the fourth lens group G4 during focus. Here β4 is the lateral magnification of G4 at infinity, and β4r is the composite lateral magnification of all elements image-side of G4. The value of 0.72 falls in the "more preferably satisfied" range of 0.6–0.8 (Inequalities 9c/9d), indicating that G4's motion is well-optimized for a balance between focus sensitivity and aberration stability across the focus range.
+
+Inequality (10) governs the OIS compensation ratio. Here β is the lateral magnification of the image blur compensation lens (L5) at infinity, and βr is the composite lateral magnification of all elements between L5 and the image plane. The product |(1−β)×βr| = 0.54 defines the ratio of image shift to lens decentering, indicating that each millimeter of L5 lateral displacement produces approximately 0.54 mm of image shift — a moderate ratio allowing effective stabilization without demanding excessive mechanical travel.
+
+---
+
+## 8. Design Philosophy
+
+This lens represents a sophisticated modern approach to the classical "fast normal" design problem, distinguished by several notable features:
+
+**Starting-point negative.** L1's biconcave negative element at the very front of the system is an unusual choice for a ~43 mm normal lens. Its primary role is aberration management rather than power contribution: by pre-diverging the incoming beam before it encounters the strong positive elements L2 and L3, L1 controls the ray heights and incidence angles on downstream surfaces, reducing the higher-order monochromatic residuals that would otherwise be introduced by the steep curvatures of the high-index positives. L1 also contributes to Petzval correction — as a negative element with moderate index (nd = 1.648), it bends the Petzval surface backward, counteracting the positive elements' inward-curving contribution. The overall system BFD of ~6 mm against an EFL of ~42 mm yields BFD/EFL ≈ 0.14, confirming this remains a compact, slightly telephoto-ratio configuration appropriate for a mirrorless fixed-lens camera with a short flange distance.
+
+**Three cemented doublets in rapid succession.** The rear half of the lens contains three cemented doublets (D2, D3) plus the powerful L10 singlet, all operating at high ray incidence angles immediately after the stop. This dense packing of high-index doublets is characteristic of modern computational optimization — each doublet provides a paired correction "knob" for simultaneous chromatic and monochromatic aberration control that would be impossible to achieve with singlets alone.
+
+**Extreme index range.** The design spans an extraordinary range of refractive indices, from 1.553 (L10, S-FPM3) to 2.001 (L2, S-NPH4). This 0.45-unit range is among the widest in any production camera lens. The high-index elements minimize surface curvatures and thus higher-order aberrations, while the low-index fluorophosphate elements provide the anomalous dispersion needed for APO correction.
+
+**Aspherics placed for maximum leverage.** Rather than distributing aspherics uniformly, the design concentrates them at four strategic positions: at the OIS element (L5, near the stop for SA correction), at the first post-stop surface (L6, for coma and oblique SA), and at the two rear elements (L10 and L11, for field curvature, astigmatism, and distortion). No aspherics appear on the front three elements (L1, L2, L3/L4), where the ultra-high-index glasses already provide sufficient curvature latitude.
+
+---
+
+## 9. Patent Comparison Across Embodiments
+
+The patent presents five embodiments, all sharing the G1(+)–A–G2(+)–G3(−)–G4(+)–G5(−) architecture. Examples 1–4 have 11 elements; Example 5 has 12 (an additional element L6 in G1, bringing it to six elements before the stop).
+
+Example 1 was selected as the production design based on its match with the Leica Q3 43's published specifications (11 elements / 8 groups / 7 aspherical surfaces), its aberration performance (the tightest SA correction at f/2.06 across all embodiments per the longitudinal aberration plots), and its image stabilization compensation distance of 0.401 mm.
+
+---
+
+*Analysis based on US 2024/0241349 A1, Example 1. All element focal lengths, inequality values, and glass identifications independently verified via thick-lens computation and catalog matching. Aspherical departures computed from patent polynomial coefficients at paraxially ray-traced semi-diameters. Petzval sum verified via surface-by-surface computation. Manufacturer specifications sourced from Leica Camera AG product pages and DPReview.*

--- a/src/lens-data/LeicaAPO43mmf2.data.ts
+++ b/src/lens-data/LeicaAPO43mmf2.data.ts
@@ -1,0 +1,345 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — LEICA APO-SUMMICRON 43mm f/2 ASPH.                   ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2024/0241349 A1, Example 1 (Nishioka / Kurioka). ║
+ * ║  Panasonic IP Management Co., Ltd.  Priority: JP 2022-142614.     ║
+ * ║  Production lens: Leica APO-Summicron 43mm f/2 ASPH. (Q3 43).    ║
+ * ║  11 elements / 5 power groups (8 air-separated) / 7 asph surfs.  ║
+ * ║  Focus: floating inner focus — G2 (L6–L7) and G4 (L10) move.     ║
+ * ║                                                                    ║
+ * ║  NOTE ON CEMENT LAYERS:                                            ║
+ * ║    Patent models 0.01 mm cement layers (nd = 1.56732) at each     ║
+ * ║    cemented junction (D1, D2, D3). Since junction surfaces share  ║
+ * ║    the same R, the cement thickness is folded into the preceding  ║
+ * ║    element's center thickness (e.g., L3 d = 5.00 + 0.01 = 5.01). ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list semi-diameters. Estimated via paraxial    ║
+ * ║    marginal ray (at f/2.06) + chief ray (70% field for post-stop  ║
+ * ║    surfaces), with 8% mechanical clearance. Front SD constrained  ║
+ * ║    by E49 filter thread (max OD ~47 mm; not binding here).        ║
+ * ║                                                                    ║
+ * ║  NOTE ON COVER GLASS:                                              ║
+ * ║    Patent parallel plate P (nd = 1.51680, d = 1.40) plus 1.00 mm ║
+ * ║    air gap omitted from surfaces; total 6.00 mm folded into BFD. ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "leica-apo-summicron-43f2",
+  maker: "Leica",
+  name: "LEICA APO-SUMMICRON 43mm f/2 ASPH.",
+  subtitle: "US 2024/0241349 A1 EXAMPLE 1 — PANASONIC / NISHIOKA",
+  specs: ["11 ELEMENTS / 8 GROUPS", "f ≈ 41.7 mm", "F/2.06", "2ω ≈ 55.0°", "7 ASPHERICAL SURFACES (4 ELEMENTS)"],
+
+  focalLengthMarketing: 43,
+  focalLengthDesign: 41.71,
+  apertureMarketing: 2.0,
+  apertureDesign: 2.06,
+  patentYear: 2024,
+  elementCount: 11,
+  groupCount: 8,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconcave Negative",
+      nd: 1.64769,
+      vd: 33.8,
+      fl: -35.6,
+      glass: "S-TIM22 (OHARA)",
+      apd: false,
+      role: "Front negative; pre-diverges beam to reduce higher-order aberrations on downstream high-index positives; Petzval counter-bending",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconvex Positive",
+      nd: 2.00069,
+      vd: 25.5,
+      fl: 29.9,
+      glass: "S-NPH4 (OHARA)",
+      apd: false,
+      role: "Ultra-high-index positive; strong refraction at minimal curvature, primary chromatic dispersion source in G1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.59282,
+      vd: 68.6,
+      fl: 28.7,
+      glass: "593/686 (PK crown, uncertain ID)",
+      apd: "inferred",
+      apdNote: "Phosphate crown region; νd = 68.6 implies positive ΔPgF for secondary spectrum correction",
+      role: "Positive crown in D1 doublet; primary positive power in G1; APD glass for secondary spectrum correction",
+      cemented: "D1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.76182,
+      vd: 26.6,
+      fl: -24.4,
+      glass: "S-TIH6 (OHARA)",
+      apd: false,
+      role: "Negative flint in D1 doublet; chromatic correction partner for L3",
+      cemented: "D1",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive (2× Asph)",
+      nd: 1.5866,
+      vd: 59.0,
+      fl: 66.0,
+      glass: "587/590 (HOYA FDS family / PGM)",
+      apd: false,
+      role: "OIS element — shifts ⊥ to optical axis for image stabilization; weak positive with aspherics for SA/coma correction near stop",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative (1× Asph)",
+      nd: 1.68948,
+      vd: 31.0,
+      fl: -22.3,
+      glass: "S-TIM28 / L-TIM28 (OHARA)",
+      apd: false,
+      role: "Negative flint in D2 doublet; aspherical front surface for coma and oblique SA control at stop",
+      cemented: "D2",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.95375,
+      vd: 32.3,
+      fl: 19.0,
+      glass: "S-LAH99 / TAFD33 (OHARA)",
+      apd: false,
+      role: "Ultra-high-index positive in D2 doublet; primary power in G2; focus group component",
+      cemented: "D2",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Positive Meniscus",
+      nd: 1.90366,
+      vd: 31.3,
+      fl: 37.8,
+      glass: "S-NPH53 / TAFD30 (OHARA)",
+      apd: false,
+      role: "High-index positive meniscus (convex to image) in D3 doublet; Petzval correction",
+      cemented: "D3",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Biconcave Negative",
+      nd: 1.69895,
+      vd: 30.1,
+      fl: -31.0,
+      glass: "S-TIM35 (OHARA)",
+      apd: false,
+      role: "Negative flint in D3 doublet; G3 diverging power for field curvature correction",
+      cemented: "D3",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Positive (2× Asph)",
+      nd: 1.55332,
+      vd: 71.7,
+      fl: 40.0,
+      glass: "S-FPM3 / L-FPM3 (OHARA)",
+      apd: "inferred",
+      apdNote: "Fluorophosphate; νd = 71.7 — primary APO contributor; patent requires νd4G > 62",
+      role: "Fluorophosphate APD positive; cornerstone of APO correction; focus group (G4 moves during IF)",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Neg. Meniscus (2× Asph)",
+      nd: 1.5866,
+      vd: 59.0,
+      fl: -31.1,
+      glass: "587/590 (HOYA FDS family / PGM)",
+      apd: false,
+      role: "Rear field-flattener; G5 negative for Petzval balance; aggressive aspherization for astigmatism and distortion",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── G1 (+) — L1 through L5 ──
+    { label: "1", R: -48.2488, d: 1.5, nd: 1.64769, elemId: 1, sd: 10.9 }, // L1 front
+    { label: "2", R: 44.7343, d: 0.7288, nd: 1.0, elemId: 0, sd: 11.1 }, // L1 rear → air
+    { label: "3", R: 37.972, d: 5.0, nd: 2.00069, elemId: 2, sd: 11.3 }, // L2 front
+    { label: "4", R: -131.5072, d: 0.9, nd: 1.0, elemId: 0, sd: 11.3 }, // L2 rear → air
+    { label: "5", R: 25.1796, d: 6.61, nd: 1.59282, elemId: 3, sd: 11.2 }, // L3 front (D1); d includes 0.01 cement
+    { label: "6", R: -47.5179, d: 1.1, nd: 1.76182, elemId: 4, sd: 9.8 }, // D1 junction → L4
+    { label: "7", R: 30.7715, d: 2.9914, nd: 1.0, elemId: 0, sd: 9.6 }, // L4 rear → air
+    { label: "8A", R: 54.8186, d: 2.8, nd: 1.5866, elemId: 5, sd: 9.4 }, // L5 front (OIS element)
+    { label: "9A", R: -129.0571, d: 1.3423, nd: 1.0, elemId: 0, sd: 9.1 }, // L5 rear → air
+
+    // ── Aperture stop ──
+    { label: "STO", R: 1e15, d: 8.5, nd: 1.0, elemId: 0, sd: 8.2 }, // d11 variable
+
+    // ── G2 (+) — L6–L7 cemented (focus group) ──
+    { label: "10A", R: -34.7967, d: 1.41, nd: 1.68948, elemId: 6, sd: 7.1 }, // L6 front; d includes 0.01 cement
+    { label: "11", R: 27.9597, d: 4.0, nd: 1.95375, elemId: 7, sd: 7.0 }, // D2 junction → L7
+    { label: "12", R: -47.7042, d: 2.3984, nd: 1.0, elemId: 0, sd: 6.9 }, // L7 rear → air; d15 variable
+
+    // ── G3 (−) — L8–L9 cemented ──
+    { label: "13", R: -69.0757, d: 3.11, nd: 1.90366, elemId: 8, sd: 8.1 }, // L8 front; d includes 0.01 cement
+    { label: "14", R: -23.3606, d: 1.0, nd: 1.69895, elemId: 9, sd: 9.1 }, // D3 junction → L9
+    { label: "15", R: 306.9478, d: 4.5634, nd: 1.0, elemId: 0, sd: 9.4 }, // L9 rear → air; d19 variable
+
+    // ── G4 (+) — L10 singlet (focus group) ──
+    { label: "16A", R: 202.6421, d: 7.1497, nd: 1.55332, elemId: 10, sd: 11.9 }, // L10 front
+    { label: "17A", R: -24.5159, d: 5.2709, nd: 1.0, elemId: 0, sd: 14.2 }, // L10 rear → air; d21 variable
+
+    // ── G5 (−) — L11 singlet ──
+    { label: "18A", R: -17.1668, d: 2.0, nd: 1.5866, elemId: 11, sd: 15.3 }, // L11 front
+    { label: "19A", R: -295.0, d: 6.0, nd: 1.0, elemId: 0, sd: 16.2 }, // L11 rear → image (BFD incl. cover glass)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "8A": {
+      // Patent surface 9 — L5 front
+      K: 0,
+      A4: -1.30306e-5,
+      A6: -5.62107e-8,
+      A8: -3.60682e-10,
+      A10: 8.61029e-14,
+      A12: -7.87986e-14,
+      A14: 5.22901e-17,
+    },
+    "9A": {
+      // Patent surface 10 — L5 rear
+      K: 0,
+      A4: -9.82247e-6,
+      A6: -9.90962e-9,
+      A8: -2.51292e-9,
+      A10: 3.89661e-11,
+      A12: -4.70452e-13,
+      A14: 1.70621e-15,
+    },
+    "10A": {
+      // Patent surface 12 — L6 front (prolate ellipsoid base)
+      K: -4.20325e-1,
+      A4: -2.20963e-5,
+      A6: -1.90668e-8,
+      A8: -1.28958e-9,
+      A10: 1.02111e-11,
+      A12: 0,
+      A14: 0,
+    },
+    "16A": {
+      // Patent surface 20 — L10 front
+      K: 0,
+      A4: -1.18748e-5,
+      A6: 6.25689e-8,
+      A8: -1.36411e-10,
+      A10: 7.15711e-14,
+      A12: -3.29562e-17,
+      A14: -1.87905e-18,
+    },
+    "17A": {
+      // Patent surface 21 — L10 rear
+      K: 0,
+      A4: 3.3582e-6,
+      A6: 1.04068e-7,
+      A8: -6.34208e-10,
+      A10: 4.09992e-12,
+      A12: -1.28044e-14,
+      A14: 1.19979e-17,
+    },
+    "18A": {
+      // Patent surface 22 — L11 front (prolate ellipsoid base)
+      K: -2.75865e-1,
+      A4: 7.31746e-5,
+      A6: -2.58094e-7,
+      A8: 7.84314e-10,
+      A10: 2.62197e-13,
+      A12: -3.52305e-15,
+      A14: 0,
+    },
+    "19A": {
+      // Patent surface 23 — L11 rear
+      K: 0,
+      A4: 3.22163e-5,
+      A6: -2.53939e-7,
+      A8: 7.10332e-10,
+      A10: -8.86821e-13,
+      A12: 0,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (floating inner focus) ──
+   *  G2 (L6–L7) and G4 (L10) advance toward object during close focusing.
+   *  G1, G3, G5 remain stationary. Constant overall length.
+   *  d(STO) + d(12) = 10.898 mm (constant); d(15) + d(17A) = 9.834 mm (constant).
+   */
+  var: {
+    STO: [8.5, 6.4983],
+    "12": [2.3984, 4.4001],
+    "15": [4.5634, 1.8105],
+    "17A": [5.2709, 8.0238],
+  },
+  varLabels: [
+    ["STO", "D11"],
+    ["12", "D15"],
+    ["15", "D19"],
+    ["17A", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+)", fromSurface: "1", toSurface: "9A" },
+    { text: "G2 (+)", fromSurface: "10A", toSurface: "12" },
+    { text: "G3 (−)", fromSurface: "13", toSurface: "15" },
+    { text: "G4 (+)", fromSurface: "16A", toSurface: "17A" },
+    { text: "G5 (−)", fromSurface: "18A", toSurface: "19A" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "5", toSurface: "7" },
+    { text: "D2", fromSurface: "10A", toSurface: "12" },
+    { text: "D3", fromSurface: "13", toSurface: "15" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.6,
+  focusDescription: "Floating inner focus: G2 (L6–L7) and G4 (L10) translate toward object. Constant overall length.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.0,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.32,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/LeicaElcan50mmf2.analysis.md
+++ b/src/lens-data/LeicaElcan50mmf2.analysis.md
@@ -1,0 +1,166 @@
+# Leica ELCAN 50mm f/2 — Optical Analysis
+
+**Patent:** US 3,649,104 — *Four Component Objective*
+**Filed:** July 30, 1970 (German priority: August 1, 1969 — P 19 39 099.9)
+**Granted:** March 14, 1972
+**Inventors:** Garry Edwards, Walter Mandler, Erich Wagner
+**Assignee:** Ernst Leitz GmbH, Wetzlar, Germany
+**Design center:** Ernst Leitz Canada (ELCAN), Midland, Ontario
+
+## 1. Context and Production History
+
+US 3,649,104 discloses a family of four-element, four-group photographic objectives across nineteen worked examples. The patent's central thesis is that four surfaces of unusually high refractive power — previously considered uncorrectable — can be combined to yield imaging quality rivaling the more complex double-Gauss ("Gauss-type") designs. The patent expresses this through normalized refractive power conditions on four critical surfaces:
+
+- φ₁₁ (front of L1): 1.5 ≤ φ ≤ 2.0
+- φ₂₁ (front of L2): 1.4 ≤ φ ≤ 2.4
+- φ₂₂ (rear of L2): −2.0 ≤ φ ≤ −1.0
+- φ₃₂ (rear of L3): −3.7 ≤ φ ≤ −2.5
+
+**Example 3** is an f/2, 45° field design — the fastest wide-angle variant in the patent — and is the embodiment most consistent with the production 50mm f/2 ELCAN lens supplied with the Leica KE-7A military camera system. The patent's 19 examples span from f/2 to f/4.3 and field angles from 6° to 45°, demonstrating the versatility of the design form across focal lengths and speed classes. Only Examples 1, 2, and 3 share the f/2, 45° field specification matching the ELCAN production lens; the remaining examples address slower, narrower-field telephoto and long-focus applications. Among the three f/2 variants, Example 3 uses the lowest-index glasses — consistent with the patent's stated goal of employing "the most inexpensive glasses" — making it the most cost-effective candidate for military mass production. Approximately 460 KE-7A kits were produced in 1972 for the U.S. military, plus roughly 55 civilian surplus units. The lens features four air-spaced (non-cemented) elements, a construction chosen specifically for thermal shock resistance and tolerance of explosive concussion in combat environments.
+
+## 2. Prescription — Example 3
+
+The patent prescription is normalized to f = 100 mm. All radii, thicknesses, and spacings are scaled by ×0.5 for the 50 mm production lens. The following table gives the patent-scale values.
+
+| Surface | Radius (mm) | Spacing (mm) | nd | νd | Element |
+|:-------:|------------:|-------------:|------:|------:|:-------:|
+| r₁ | +37.8820 | 10.3776 | 1.6940 | 54.5 | L1 |
+| r₂ | +190.3362 | 0.1922 | 1.0 | — | air |
+| r₃ | +32.1397 | 5.9575 | 1.6734 | 46.8 | L2 |
+| r₄ | +49.9450 | 3.2670 | 1.0 | — | air |
+| r₅ | +200.4813 | 1.5374 | 1.7471 | 27.4 | L3 |
+| r₆ | +23.4264 | 21.9082 | 1.0 | — | air |
+| r₇ | +95.2488 | 11.5306 | 1.7546 | 34.7 | L4 |
+| r₈ | −424.3870 | (BFD) | 1.0 | — | air |
+
+**Back focal distance (s′):** 50.5074 mm (patent scale)
+
+### 2.1 Sign Convention Note
+
+During transcription, the signs of r₅ and r₆ required particular care. The patent's OCR-scanned text is ambiguous on these surfaces, but the correct signs are determined uniquely by requiring: (a) the computed BFD matches the patent's stated s′ = 50.5074 mm, (b) the computed normalized powers match the patent's stated φ values, and (c) the computed EFL confirms the f = 100 normalization. A systematic search over all sign and digit-drop permutations confirms that r₅ = +200.4813 and r₆ = +23.4264 (both positive) is the only combination satisfying all three conditions simultaneously, yielding EFL = 100.002 mm and BFD = 50.510 mm.
+
+This sign pattern is independently confirmed by cross-validation against **Example 1**, which uses the same surface sign structure (r₁ through r₇ all positive, only r₈ negative) and yields EFL = 100.005 mm with BFD = 49.484 mm against the patent's stated s′ = 49.4781 — a match within 0.006 mm.
+
+A minor transcription discrepancy exists for a₃ (L2 thickness): the patent description section gives 5.9575, while the claims section appears to show 5.9375 — likely an OCR or typographical error. Computational verification confirms a₃ = 5.9575 as correct.
+
+### 2.2 Paraxial Verification
+
+Computed via ABCD matrix transfer:
+
+| Parameter | Patent Scale | Production (×0.5) |
+|:----------|------------:|------------------:|
+| EFL | 100.002 mm | 50.00 mm |
+| BFD | 50.510 mm | 25.25 mm |
+| FFL | 96.23 mm | 48.12 mm |
+| Total track | 105.28 mm | 52.64 mm |
+| Track / EFL | 1.053 | 1.053 |
+
+The total track ratio of 1.053 is remarkably compact — barely longer than its own focal length — consistent with the patent's claim that these designs are "shorter by about 15 percent" compared to equivalent triplet objectives.
+
+Normalized surface powers, verified computationally against patent-stated values:
+
+| Surface | Patent φ | Computed φ | Δ |
+|:-------:|:--------:|:----------:|:---:|
+| φ₁₁ | +1.832 | +1.832 | 0.000 |
+| φ₂₁ | +2.095 | +2.095 | 0.000 |
+| φ₂₂ | −1.348 | −1.348 | 0.000 |
+| φ₃₂ | −3.189 | −3.189 | 0.000 |
+
+All four match to within rounding of the fourth decimal place.
+
+## 3. Element-by-Element Analysis
+
+### 3.1 Element L1 — Front Positive Meniscus
+
+**Shape:** Positive meniscus, convex toward object
+**Radii:** R₁ = +37.882, R₂ = +190.336 (production: +18.94, +95.17)
+**Thickness:** 10.378 mm (production: 5.19 mm)
+**Glass:** nd = 1.6940, νd = 54.5
+**Focal length:** +66.3 mm (production: +33.1 mm)
+
+L1 is the strongest positive element, with the shortest positive focal length in the system. Its strongly convex front surface carries the highest positive surface power (φ₁₁ = +1.832). At production scale, L1 is 5.19 mm thick — a substantial piece of glass relative to its 18.94 mm front radius. The large glass path inside L1 introduces higher-order aberration contributions that participate in the balancing of the residual zone corrections that the patent identifies as its key innovation.
+
+**Glass identification:** The nd/νd pairing of 1.6940/54.5 closely matches Schott **LaK9** (nd = 1.6910, νd = 54.71). LaK9 is a lanthanum crown glass. Production records confirm that the first element used LaK9 in the manufactured lens. LaK9 is radioactive due to its lanthanum oxide content, and the slight yellowing observed in surviving ELCAN lenses over decades of storage is characteristic of this glass family.
+
+### 3.2 Element L2 — Second Positive Meniscus
+
+**Shape:** Positive meniscus, convex toward object
+**Radii:** R₃ = +32.140, R₄ = +49.945 (production: +16.07, +24.97)
+**Thickness:** 5.958 mm (production: 2.98 mm)
+**Glass:** nd = 1.6734, νd = 46.8
+**Focal length:** +118.0 mm (production: +59.0 mm)
+
+L2 sits only 0.19 mm (patent scale) behind L1 — essentially in contact — forming a closely spaced front doublet. L2's front surface carries the system's second-highest power (φ₂₁ = +2.095), while its rear surface provides a significant negative counter-power (φ₂₂ = −1.348). The air space between L1 and L2 (a₂ = 0.192 mm, production: 0.10 mm) is extraordinarily thin — essentially a polished gap.
+
+**Glass identification:** The nd/νd pairing of 1.6734/46.8 is close to Schott **BaF10** (nd = 1.6700, νd = 47.11). Production records describe this element as using "Leitz glass," suggesting a proprietary formulation.
+
+### 3.3 Element L3 — Diverging Negative Meniscus
+
+**Shape:** Negative meniscus, both surfaces convex toward object
+**Radii:** R₅ = +200.481, R₆ = +23.426 (production: +100.24, +11.71)
+**Thickness:** 1.537 mm (production: 0.77 mm)
+**Glass:** nd = 1.7471, νd = 27.4
+**Focal length:** −35.6 mm (production: −17.8 mm)
+
+L3 is the sole diverging element and the thinnest element in the system. The front surface is nearly flat (R₅ = +200.5), while the rear surface is steeply curved (R₆ = +23.4), producing the most extreme power in the entire design: φ₃₂ = −3.189. The patent's central innovation claim rests heavily on this surface. The strongly powered rear surface of L3 generates large negative contributions to spherical aberration, astigmatism, and coma that cancel the correspondingly large positive contributions from the front surfaces of L1 and L2.
+
+**Glass identification:** The nd/νd of 1.7471/27.4 places this glass in the dense flint (SF) region. The closest standard match is Schott **SF4** (nd = 1.7552, νd = 27.58).
+
+### 3.4 Element L4 — Rear Biconvex Positive
+
+**Shape:** Biconvex positive
+**Radii:** R₇ = +95.249, R₈ = −424.387 (production: +47.62, −212.19)
+**Thickness:** 11.531 mm (production: 5.77 mm)
+**Glass:** nd = 1.7546, νd = 34.7
+**Focal length:** +104.1 mm (production: +52.0 mm)
+
+L4 is the field-correcting rear element. Both surfaces contribute positive power: the front surface (φ = +0.792) provides the bulk of L4's converging power, while the nearly flat rear surface (φ = +0.178) adds fine-tuning. L4's primary roles are: completing the converging power to achieve f/2, contributing to lateral color correction, and using its substantial thickness to fine-tune field curvature and astigmatism balance.
+
+**Glass identification:** The nd/νd of 1.7546/34.7 falls in the lanthanum flint region. The closest standard match is Schott **LAFN7** (nd = 1.7495, νd = 34.95). Production records confirm L4 used "lanthanum Flint glass."
+
+## 4. Aspherical Surfaces
+
+The patent specifies **no aspherical surfaces.** All eight refractive surfaces are spherical. This is consistent with the patent's design philosophy: correction is achieved entirely through power distribution across four high-power spherical surfaces, combined with judicious glass selection and spacing. The all-spherical construction was also advantageous for the military application, as spherical surfaces are easier to manufacture, more robust to re-polishing in the field, and simpler to test interferometrically.
+
+## 5. Petzval Sum and Field Curvature
+
+| Element | Petzval contribution (×f) |
+|:-------:|:-------------------------:|
+| L1 | +0.866 |
+| L2 | +0.446 |
+| L3 | −1.612 |
+| L4 | +0.553 |
+| **Total** | **+0.253** |
+
+The system Petzval sum is positive and small (Petzval radius ≈ +197 mm at production scale), indicating a slightly undercorrected Petzval field. The dominant negative contribution comes from L3 (−1.612), whose high-index, strongly powered rear surface provides the bulk of the Petzval flattening. The characteristic corner softness at wide apertures — consistently reported by users — is more attributable to residual higher-order astigmatism and coma than to Petzval curvature. Stopping down to f/4 substantially improves corner performance.
+
+## 6. Chromatic Correction Strategy
+
+The four glasses span a wide Abbe number range: 54.5, 46.8, 27.4, 34.7. The **front pair** (L1 + L2) introduces positive longitudinal chromatic aberration. The **negative element** L3, with its very low Abbe number (νd = 27.4, dense flint), provides a strong overcorrecting chromatic contribution. The air-spaced construction means there are no cemented achromatic doublets — achromatization is achieved entirely through power-dispersion balance across separated elements.
+
+## 7. Focusing Mechanism
+
+- **Type:** Unit focusing (entire optical assembly translates as a rigid unit)
+- **Close focus:** 0.762 m (30 inches / 2.5 feet)
+- **Only BFD changes** during focus — no internal floating groups
+
+Unit focusing is the simplest and most mechanically robust focus implementation, aligning with the lens's military design requirements. The production BFD of 25.25 mm is approximately 2.55 mm shorter than the Leica M flange-to-film distance of 27.80 mm, meaning the rear element (L4) protrudes roughly 2.5 mm into the camera body cavity.
+
+## 8. Aperture Stop
+
+The aperture stop is located in the air gap between L2 and L3 (spacing a₄ = 3.267 mm at patent scale, 1.63 mm at production). The patent does not list the stop as a separate surface in the prescription table. The stop position is inferred from the drawing, where the iris diaphragm is shown just ahead of L3. The production lens has a **10-blade aperture diaphragm** with stops from f/2 to f/16.
+
+## 9. Design Lineage and Significance
+
+The ELCAN 50mm f/2 belongs to the "four-component objective" or "Ernostar derivative" family — characterized by four separated positive-positive-negative-positive singlets. Walter Mandler is reported to have considered the 50mm focal length "overstretched" for this four-element form, which was originally more comfortable in the 90mm range. Nevertheless, the combination of f/2 speed, extremely compact size (total track barely exceeding the focal length), and four-element simplicity was precisely what the military specification required: a lens cheaper to produce than the Summicron, robust enough for combat, and optically adequate for military documentation photography.
+
+## 10. Summary of Glass Types
+
+| Element | Patent nd/νd | Production Glass | Family | Role |
+|:-------:|:------------:|:----------------:|:------:|:----:|
+| L1 | 1.6940 / 54.5 | LaK9 (lanthanum crown) | Crown | Primary positive power |
+| L2 | 1.6734 / 46.8 | Leitz proprietary (≈BaF10) | Barium flint | Secondary positive |
+| L3 | 1.7471 / 27.4 | Dense flint (≈SF4) | Dense flint | Sole diverging element |
+| L4 | 1.7546 / 34.7 | LAFN7 (lanthanum flint) | LaF | Rear positive |
+
+All four glasses are conventional polished types with no anomalous partial dispersion (APD). The patent explicitly notes that the "most inexpensive glasses" were used, keeping manufacturing costs comparable to those of triplet objectives despite the superior four-element performance.

--- a/src/lens-data/LeicaElcan50mmf2.data.ts
+++ b/src/lens-data/LeicaElcan50mmf2.data.ts
@@ -1,0 +1,143 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — LEICA ELCAN 50mm f/2                         ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 3,649,104 Example 3 (Edwards, Mandler, Wagner).   ║
+ * ║  Ernst Leitz GmbH / ELCAN (Leitz Canada), filed 1970.             ║
+ * ║  Four-element, four-group all-spherical objective.                 ║
+ * ║  4 elements / 4 groups, 0 aspherical surfaces.                    ║
+ * ║  Focus: unit focusing (entire lens translates).                    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent at f = 100 mm; all R, d, sd values scaled ×0.5 to       ║
+ * ║    f ≈ 50 mm production focal length.                             ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                          ║
+ * ║    Estimated via combined marginal (f/2) + chief (60% field)      ║
+ * ║    ray trace with 8% mechanical clearance. Front element           ║
+ * ║    constrained by ~39 mm filter thread (Series V).                ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP POSITION:                                           ║
+ * ║    Patent does not list stop as a surface. Position inferred from  ║
+ * ║    Fig. 1 iris placement — approximately mid-gap between L2 and   ║
+ * ║    L3 (a₄ split evenly).                                          ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "leica-elcan-50f2",
+  maker: "Leica",
+  name: "LEICA ELCAN 50mm f/2",
+  subtitle: "US 3,649,104 EXAMPLE 3 — ERNST LEITZ / EDWARDS, MANDLER, WAGNER",
+  specs: ["4 ELEMENTS / 4 GROUPS", "f ≈ 50.0 mm", "F/2.0", "2ω = 45°", "ALL SPHERICAL"],
+
+  /* ── Explicit metadata fields ── */
+  focalLengthMarketing: 50,
+  focalLengthDesign: 50.0,
+  apertureMarketing: 2,
+  apertureDesign: 2.0,
+  patentYear: 1972,
+  elementCount: 4,
+  groupCount: 4,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.694,
+      vd: 54.5,
+      fl: 33.1,
+      glass: "LaK9 (Schott / Leitz)",
+      apd: false,
+      role: "Primary positive power; front surface carries highest positive surface power (φ₁₁ = +1.832)",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.6734,
+      vd: 46.8,
+      fl: 59.0,
+      glass: "≈BaF10 (Leitz proprietary)",
+      apd: false,
+      role: "Secondary positive power; nearly in contact with L1, forming a closely spaced front pair",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.7471,
+      vd: 27.4,
+      fl: -17.8,
+      glass: "≈SF4 (dense flint)",
+      apd: false,
+      role: "Sole diverging element; rear surface carries strongest power in the system (φ₃₂ = −3.189)",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.7546,
+      vd: 34.7,
+      fl: 52.0,
+      glass: "≈LAFN7 (lanthanum flint)",
+      apd: false,
+      role: "Rear field-correcting element; high-index lanthanum flint for chromatic fine-tuning",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Patent Example 3 (f = 100) scaled ×0.5 to production f ≈ 50 mm.
+   *  Stop position inferred from Fig. 1 — mid-gap in a₄.
+   */
+  surfaces: [
+    { label: "1", R: 18.941, d: 5.1888, nd: 1.694, elemId: 1, sd: 15.5 },
+    { label: "2", R: 95.1681, d: 0.0961, nd: 1.0, elemId: 0, sd: 13.0 },
+    { label: "3", R: 16.06985, d: 2.97875, nd: 1.6734, elemId: 2, sd: 13.0 },
+    { label: "4", R: 24.9725, d: 0.8168, nd: 1.0, elemId: 0, sd: 10.0 },
+    { label: "STO", R: 1e15, d: 0.8168, nd: 1.0, elemId: 0, sd: 9.1 },
+    { label: "5", R: 100.24065, d: 0.7687, nd: 1.7471, elemId: 3, sd: 9.5 },
+    { label: "6", R: 11.7132, d: 10.9541, nd: 1.0, elemId: 0, sd: 9.5 },
+    { label: "7", R: 47.6244, d: 5.7653, nd: 1.7546, elemId: 4, sd: 12.5 },
+    { label: "8", R: -212.1935, d: 25.255, nd: 1.0, elemId: 0, sd: 12.5 },
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (unit focus — only BFD changes) ── */
+  var: {
+    "8": [25.255, 28.77],
+  },
+  varLabels: [["8", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT PAIR", fromSurface: "1", toSurface: "4" },
+    { text: "REAR", fromSurface: "7", toSurface: "8" },
+  ],
+  doublets: [],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.762,
+  focusDescription: "Unit focusing — entire optical assembly translates as a rigid unit.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.55,
+  yScFill: 0.4,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/LeicaElcan50mmf2.data.ts
+++ b/src/lens-data/LeicaElcan50mmf2.data.ts
@@ -102,7 +102,7 @@ const LENS_DATA = {
   surfaces: [
     { label: "1", R: 18.941, d: 5.1888, nd: 1.694, elemId: 1, sd: 15.5 },
     { label: "2", R: 95.1681, d: 0.0961, nd: 1.0, elemId: 0, sd: 13.0 },
-    { label: "3", R: 16.06985, d: 2.97875, nd: 1.6734, elemId: 2, sd: 13.0 },
+    { label: "3", R: 16.06985, d: 2.97875, nd: 1.6734, elemId: 2, sd: 12.0 },
     { label: "4", R: 24.9725, d: 0.8168, nd: 1.0, elemId: 0, sd: 10.0 },
     { label: "STO", R: 1e15, d: 0.8168, nd: 1.0, elemId: 0, sd: 9.1 },
     { label: "5", R: 100.24065, d: 0.7687, nd: 1.7471, elemId: 3, sd: 9.5 },

--- a/src/lens-data/LeicaSummicronV550mmf2.analysis.md
+++ b/src/lens-data/LeicaSummicronV550mmf2.analysis.md
@@ -1,0 +1,292 @@
+# Leica Summicron-M 50mm f/2 (Version IV/V) — Patent Analysis
+
+**Patent:** US 4,123,144 — "Four-Member Gauss Objective"
+**Inventors:** Walter Mandler, Garry Edwards, Erich Wagner (Ernst Leitz Canada Ltd., Midland, Ontario)
+**Filed:** May 16, 1977 (DE priority May 18, 1976, DE 2621981)
+**Granted:** October 31, 1978
+**Leica computation number:** C368 (design circa 1974)
+**Production embodiment:** Example 9 (FIG. 2 configuration)
+**Production era:** Summicron-R 50mm f/2 II (R-mount, 1976–2009); Summicron-M 50mm f/2 (M-mount, 1979–present)
+
+---
+
+## 1. Overview
+
+The Summicron-M 50mm f/2, designed at Leitz Canada under the direction of Walter Mandler, is one of the most celebrated and longest-lived lens designs in photographic history. Its optical formula — six elements in four groups, all spherical — has been in continuous production since 1976 and remains current in the Leica M-mount lineup. The lens is internally designated C368 and was first realized as the Summicron-R 50mm f/2 II for Leica's R-mount SLR system in 1976, then adapted for the M-mount rangefinder in 1979. The M-mount Version IV (1979–1994, order no. 11819) and Version V (1994–present, order no. 11826) differ only in barrel design and coatings; the optical cell is identical.
+
+The patent presents nine worked examples, all sharing the same basic Gauss-type topology but differing in glass selection. Example 9, the final and most refined embodiment, corresponds to the production lens. It follows the FIG. 2 configuration, distinguished by a plano-convex sixth element (flat surface facing the object). This gives the design three flat optical surfaces in total (the two cemented bonds and the L6 object-facing surface), in addition to the flat surfaces implicit in the plano-convex and plano-concave element forms — a remarkable feature that was central to Mandler's manufacturing-cost strategy.
+
+The design achieves an aperture ratio of 1:2, a field angle of ±22.5° (45° total, covering the 24×36mm format), and a back focal distance of approximately 29.4 mm at f = 50 mm — well-suited to the M-mount's 27.8 mm flange distance. The patent prescription is given at f = 100 mm; all production dimensions are scaled by a factor of ≈0.50.
+
+---
+
+## 2. Aspherical Surfaces
+
+**There are no aspherical surfaces in this design.** Every optical surface is either spherical or flat (infinite radius). The patent makes no mention of aspherical coefficients, conic constants, or polynomial departures anywhere in the text or prescription tables.
+
+This is a defining characteristic of the Summicron-M 50/2: Mandler achieved its exceptional correction status through glass selection and the exploitation of symmetry, rather than through aspherical surfaces or floating-element focusing mechanisms. The absence of aspherics was also central to the patent's stated goal of minimizing production costs — aspherical surface fabrication in the late 1970s was prohibitively expensive for volume production.
+
+---
+
+## 3. Optical Prescription (Example 9, f = 100 mm)
+
+| Surface | Radius (r) | Spacing (a) | Lens | n_d | v_d | Element Shape |
+|---------|-----------|-------------|------|-------|-------|---------------|
+| 1 | 59.94 | 9.57 | L1 | 1.79227 | 47.15 | Positive meniscus, front |
+| 2 | 167.31 | 0.38 | — | 1.0 | — | L1 rear → air |
+| 3 | 40.30 | 14.35 | L2 | 1.67133 | 41.64 | Plano-convex, front |
+| 4 | ∞ | 2.87 | L3 | 1.73430 | 28.19 | Cemented bond (flat) |
+| 5 | 25.67 | 10.81 | — | 1.0 | — | L3 rear → air |
+| 6 | (diaphragm) | 13.39 | — | 1.0 | — | Aperture stop |
+| 7 | −27.69 | 1.91 | L4 | 1.63003 | 35.45 | Plano-concave, front |
+| 8 | ∞ | 7.65 | L5 | 1.72055 | 47.69 | Cemented bond (flat) |
+| 9 | −40.30 | 0.38 | — | 1.0 | — | L5 rear → air |
+| 10 | ∞ | 8.61 | L6 | 1.72055 | 47.69 | Plano-convex, front (flat) |
+| 11 | −59.94 | s' | — | 1.0 | — | L6 rear → air |
+
+**Back focal length:** s' = 58.88 mm (at f = 100)
+
+### Computed verification (paraxial ray trace)
+
+- **EFL (computed):** 100.03 mm — consistent with patent's stated f = 100 ✓
+- **BFD (computed):** 58.91 mm — consistent with patent's stated s' = 58.88 ✓
+- **Total track (vertex-to-vertex):** 69.92 mm; overall length (to image): 128.83 mm
+
+The vertex-to-vertex total track is only 70% of the focal length, resulting in a physically compact optical cell. However, the overall optical length — from first vertex to the image plane — is 128.83 mm, or approximately 1.29× the effective focal length. By the standard definition (overall length / EFL), this is not a telephoto design; rather, the rear principal plane H' lies approximately 20.5 mm ahead of the last vertex (at production scale), which shortens the back focal distance to roughly 59% of the EFL. This large H'-to-vertex offset is what permits the relatively compact BFD of ≈29.4 mm at f = 50 mm — sufficient for the M-mount's 27.8 mm flange distance — despite the design not being formally telephoto.
+
+---
+
+## 4. Group and Element Analysis
+
+### 4.1 Group I — Front Positive Meniscus (L1)
+
+**Element:** L1 (surfaces r₁, r₂)
+**Shape:** Positive meniscus, concave toward the diaphragm
+**Glass:** n_d = 1.79227, v_d = 47.15 (lanthanum-containing dense crown)
+**Thick-lens focal length:** +113.4 mm (at f = 100); +56.7 mm at production scale
+
+L1 is the front collector element. Its meniscus form — convex toward the object, concave toward the diaphragm — is characteristic of the outer elements in a Gauss-type design. The high refractive index (nearly 1.80) provides strong refracting power while keeping the surface curvatures moderate, which reduces both spherical aberration and higher-order monochromatic aberrations. The moderate Abbe number (47.15) places this glass in the lanthanum crown family, providing adequate chromatic correction without requiring extreme dispersion compensation elsewhere.
+
+In the patent's symmetry scheme, r₁ = +59.94 is paired with r₁₁ = −59.94 on L6, forming one of the two matched-radius pairs that reduce tooling costs.
+
+**Glass identification:** The n_d/v_d pair (1.792/47.2) does not precisely match any standard Schott catalog glass. The nearest candidates are Schott TaF4 (1.788/47.4) and LaFN21 (1.788/47.5), both showing residuals of approximately Δn_d ≈ −0.004. This suggests either a proprietary Leitz melt, a special-order variant from a glass manufacturer, or a production glass whose catalog designation has since been discontinued. This was common practice at Leitz Canada, where Mandler had access to custom melt compositions optimized for specific designs.
+
+### 4.2 Group II — Front Cemented Doublet (L2 + L3)
+
+**Elements:** L2 (surfaces r₃, r₄) cemented to L3 (surfaces r₄, r₅)
+**Bond surface:** r₄ = ∞ (flat, planar cement joint)
+**Component shape:** Meniscus, concave toward the diaphragm
+**Doublet focal length:** −141.5 mm (weakly negative); −70.8 mm at production scale
+
+#### L2 — Plano-Convex Positive
+
+**Shape:** Convex front (r₃ = +40.30), flat rear (r₄ = ∞)
+**Glass:** n_d = 1.67133, v_d = 41.64
+**Element focal length:** +60.0 mm (at f = 100); +30.0 mm at production scale
+
+L2 is the positive element of the front doublet. Its strong convex front surface (r₃ = 40.30) provides the primary converging power in this group. The flat rear surface simultaneously serves as the cemented bond face and eliminates one curved surface from fabrication. The glass has moderate index and dispersion, placing it in the barium flint or dense barium crown range. The nearest Schott catalog match is BaSF6 (1.668/41.9), with a modest residual (Δn_d ≈ −0.003, Δv_d ≈ +0.3).
+
+In the symmetry scheme, r₃ = +40.30 is paired with r₉ = −40.30 on L5.
+
+#### L3 — Plano-Concave Negative
+
+**Shape:** Flat front (r₄ = ∞, the bond surface), concave rear (r₅ = +25.67; center of curvature to the right, so the surface is concave toward the diaphragm)
+**Glass:** n_d = 1.73430, v_d = 28.19 (dense flint)
+**Element focal length:** −35.0 mm (at f = 100); −17.5 mm at production scale
+
+L3 is the negative flint element of the front doublet. Its high dispersion (v_d = 28.19) provides the chromatic correction needed to achromatize the front group. The refractive index step at the cemented bond — Δn = n₃ − n₂ = 1.73430 − 1.67133 = +0.063 — satisfies the patent's condition 0.05 ≤ n₃ − n₂ ≤ 0.20.
+
+The flat bond surface itself has zero optical power (since φ = Δn/R = 0 when R = ∞), so the doublet's net refracting power comes entirely from the two curved surfaces, r₃ and r₅. However, the index step at the bond is not optically inert: converging rays passing from L2 glass (n = 1.671) into L3 glass (n = 1.734) are refracted toward the normal at the flat interface, changing their convergence angle. This alters the wavefront curvature and affects the aberration contributions of the downstream surface r₅. The deliberate choice of index contrast is thus a subtle but real correction lever, distinct from surface power.
+
+The nearest Schott catalog matches for L3 are SF3 (1.740/28.3) and SF10 (1.728/28.4), with residuals of Δn_d ≈ ±0.006.
+
+The overall doublet power is weakly negative (f ≈ −141.5 mm), consistent with the patent's description that "each of the doublet components has either a low positive power of refraction or a negative power of refraction."
+
+### 4.3 Aperture Stop
+
+The diaphragm is located in the air space between Groups II and III — surface r₆ in the patent's notation, with 10.81 mm of clearance behind the front doublet and 13.39 mm before the rear doublet. The total distance from the first surface to the stop is 37.98 mm; from the stop to the last surface, 31.94 mm. This slight asymmetry in stop placement (closer to the front) helps balance the residual odd-order aberrations that the lens's near-symmetry leaves uncorrected.
+
+The production lens uses an 8-blade diaphragm in most examples, though both 8- and 10-blade variants have appeared across the production run. The Summicron-R II uses a 6-blade diaphragm. All versions are adjustable from f/2 to f/16.
+
+### 4.4 Group III — Rear Cemented Doublet (L4 + L5)
+
+**Elements:** L4 (surfaces r₇, r₈) cemented to L5 (surfaces r₈, r₉)
+**Bond surface:** r₈ = ∞ (flat, planar cement joint)
+**Component shape:** Meniscus, concave toward the diaphragm
+**Doublet focal length:** −386.4 mm (very weakly negative); −193.2 mm at production scale
+
+#### L4 — Plano-Concave Negative
+
+**Shape:** Concave front (r₇ = −27.69; center of curvature to the left, so the surface is concave toward the diaphragm), flat rear (r₈ = ∞)
+**Glass:** n_d = 1.63003, v_d = 35.45
+**Element focal length:** −44.0 mm (at f = 100); −22.0 mm at production scale
+
+L4 is the negative element of the rear doublet, positioned immediately behind the diaphragm. Its concave front surface faces the stop, creating the classic Gauss "air lens" between the inner concave surfaces of the two doublets (r₅ and r₇). This strongly diverging air space is the primary corrector for spherical aberration and coma in the Gauss design. The close spacing of r₅ and r₇ — with only the 10.81 + 13.39 = 24.20 mm diaphragm gap between them — and their similar but deliberately non-identical radii (25.67 vs. 27.69) is where the core Gauss correction mechanism operates.
+
+The glass has moderate index and intermediate dispersion. The nearest Schott catalog match is F2 (1.620/36.4), but the residual in refractive index is relatively large (Δn_d ≈ 0.010), suggesting a non-standard melt.
+
+#### L5 — Plano-Convex Positive
+
+**Shape:** Flat front (r₈ = ∞, the bond surface), convex rear (r₉ = −40.30; center of curvature to the left, so the surface is convex toward the image)
+**Glass:** n_d = 1.72055, v_d = 47.69 (lanthanum crown)
+**Element focal length:** +55.9 mm (at f = 100); +27.9 mm at production scale
+
+L5 is the positive element of the rear doublet. The refractive index step at the cemented bond — Δn = n₅ − n₄ = 1.72055 − 1.63003 = +0.091 — satisfies the patent's condition 0.05 ≤ n₅ − n₄ ≤ 0.15. As with the front doublet bond, the flat surface has zero power, but the index step refracts converging rays passing from L4 glass into L5 glass, modifying wavefront curvature and the downstream aberration balance.
+
+The glass is identical to that used in L6 (n_d = 1.72055, v_d = 47.69). The nearest Schott catalog match is LaF10 (1.720/46.4) for refractive index, or LaF3 (1.717/48.0) for overall proximity. The exact match is uncertain.
+
+### 4.5 Group IV — Rear Positive Element (L6)
+
+**Element:** L6 (surfaces r₁₀, r₁₁)
+**Shape:** Plano-convex, flat surface facing the object
+**Glass:** n_d = 1.72055, v_d = 47.69 (same glass as L5)
+**Thick-lens focal length:** +83.2 mm (at f = 100); +41.6 mm at production scale
+
+L6 is the final collecting element. Its plano-convex form — flat front (r₁₀ = ∞), convex rear (r₁₁ = −59.94) — is the distinguishing feature of the FIG. 2 configuration. The flat object-facing surface satisfies the patent's preferred condition that r₁₀ "is greater than six times the focal length" (infinity being obviously greater than 600 mm). This third flat optical surface maximizes the cost advantages described in the patent: fewer diamond-tool setups, simpler alignment in Leitz's precision mounting system (referenced as German Offenlegungsschrift 2,364,621), and reduced fabrication time.
+
+The use of the same glass type for L5 and L6 is another cost-reduction measure — it reduces the number of distinct glass types from six to five. Matching the rear pair's dispersion also improves lateral color correction through approximate material symmetry about the stop.
+
+In the symmetry scheme, r₁₁ = −59.94 is paired with r₁ = +59.94 on L1.
+
+---
+
+## 5. Symmetry and Manufacturing Philosophy
+
+The patent's central thesis is that a high-performance Gauss objective can be designed with enough symmetry and flat surfaces to drastically reduce manufacturing costs without sacrificing optical correction. Example 9 achieves this through:
+
+**Matched-radius pairs (symmetric about the diaphragm):**
+
+1. |r₁| = |r₁₁| = 59.94 mm — outer surfaces of L1 and L6
+2. |r₃| = |r₉| = 40.30 mm — L2 front and L5 rear
+3. r₄ = r₈ = ∞ — cemented bond surfaces (trivially matched)
+
+**Flat optical surfaces (three):**
+
+1. r₄ = ∞ — front doublet bond
+2. r₈ = ∞ — rear doublet bond
+3. r₁₀ = ∞ — L6 object-facing surface
+
+The only radii that lack a symmetric partner are r₂ = +167.31 (L1 rear), r₅ = +25.67 (L3 rear), and r₇ = −27.69 (L4 front). Note that r₅ and r₇ are close but deliberately not identical (25.67 vs. 27.69), providing the asymmetry needed to correct odd-order aberrations (coma, distortion, lateral color) that pure symmetry cannot address.
+
+This arrangement means the entire lens can be fabricated with only **five distinct curved radii** — r₁ (= |r₁₁|), r₂, r₃ (= |r₉|), r₅, and r₇ — plus flat surfaces that share common tooling. For a six-element lens, this is an exceptionally low number of unique tool setups.
+
+---
+
+## 6. Patent Conditional Expressions — Verification
+
+The patent specifies several relationships between glass properties that must be satisfied. All are verified computationally for Example 9:
+
+| Condition | Required Range | Computed Value | Status |
+|-----------|---------------|---------------|--------|
+| v₁ : v₆ | 0.58 – 1.0 | 0.989 | ✓ |
+| v₂ : v₅ | 0.8 – 0.9 | 0.873 | ✓ |
+| v₃ : v₄ | 0.74 – 0.8 | 0.795 | ✓ |
+| n₃ − n₂ | 0.05 – 0.20 | 0.063 | ✓ |
+| n₅ − n₄ | 0.05 – 0.15 | 0.091 | ✓ |
+| r₁₀ / f | > 6 | ∞ | ✓ |
+
+The near-unity ratio v₁ : v₆ = 0.989 in Example 9 reflects the choice to use nearly identical dispersion values for the outer elements (47.15 vs. 47.69), which enhances lateral color symmetry. The v₂ : v₅ ratio of 0.873 and v₃ : v₄ ratio of 0.795 are both near the center of their allowed ranges, suggesting Example 9 represents a well-balanced compromise within the design space.
+
+---
+
+## 7. Petzval Sum and Field Curvature
+
+The Petzval sum is computed surface-by-surface using Σ (n' − n) / (R · n' · n). Flat surfaces (R = ∞) contribute zero to the sum.
+
+| Surface | R | Contribution |
+|---------|------|-------------|
+| 1 | +59.94 | +0.00737 |
+| 2 | +167.31 | −0.00264 |
+| 3 | +40.30 | +0.00997 |
+| 5 | +25.67 | −0.01649 |
+| 7 | −27.69 | −0.01396 |
+| 9 | −40.30 | +0.01039 |
+| 11 | −59.94 | +0.00699 |
+
+**Petzval sum:** 0.00163 mm⁻¹
+**Petzval radius:** 615 mm ≈ 6.15 × EFL
+
+The Petzval sum is positive and small, indicating mild inward (undercorrected) field curvature that is partially compensated by astigmatism. A Petzval radius of roughly six times the focal length is typical for well-corrected standard lenses and produces the characteristic gentle field curvature that many photographers describe as the "Leica look" — center sharpness with a smooth roll-off toward the corners at wide apertures, resolving to near-uniform sharpness by f/4.
+
+---
+
+## 8. Chromatic Correction
+
+The design uses a classical achromatic strategy: high-dispersion flint elements (L3 and L4, v_d ≈ 28–35) are paired with lower-dispersion positive elements within each cemented doublet. The approximate symmetry about the stop provides the primary lateral color correction.
+
+However, the achromatic correction is conventional — not apochromatic. Erwin Puts, the pre-eminent independent analyst of Leica optics, noted that Mandler's designs exhibited under-correction in the blue portion of the spectrum. During the film era, this was an acceptable compromise because silver-halide emulsions had relatively low sensitivity to blue and violet wavelengths. On modern digital sensors, which have more uniform spectral response, this under-correction manifests as purple fringing on high-contrast edges — a known characteristic of the Summicron-M 50/2 that reviewers consistently observe.
+
+This limitation was ultimately one of the motivations for Peter Karbe's APO-Summicron-M 50/2 ASPH (2012), which uses anomalous partial dispersion glasses and an aspherical surface to bring the blue wavelengths into much tighter correction.
+
+---
+
+## 9. Focusing Mechanism
+
+The Summicron-M 50/2 uses **unit focusing** — the entire optical cell translates forward as a rigid unit to focus from infinity to the minimum focus distance. There are no internal focusing groups or floating elements. The only variable gap is the back focal distance between the last surface (r₁₁) and the image plane (film or sensor).
+
+**Production specifications (M-mount):**
+- Minimum focus distance: 0.7 m (2.3 ft)
+- Maximum reproduction ratio: 1:11.5 (Leica published)
+- Focus extension at 0.7 m (thick-lens computation): ≈3.85 mm
+- BFD at infinity (scaled to f = 50 mm): ≈29.46 mm
+- BFD at 0.7 m: ≈33.31 mm
+
+Note: the paraxial thick-lens computation yields a reproduction ratio of approximately 1:13 at 0.7 m, while Leica publishes 1:11.5. This discrepancy likely arises from a combination of factors: the production lens may be slightly re-optimized from Example 9, the published MFD may be measured to the film plane rather than the front principal plane, and the actual conjugate geometry differs from the paraxial model at finite conjugates. The Summicron-R II version uses a shorter minimum focus distance of 0.5 m, made possible by the SLR's longer flange distance accommodating greater lens extension.
+
+The absence of floating elements means that aberration correction is optimized for a single object distance (infinity). At closer focus distances, performance degrades gently — particularly field curvature and spherical aberration increase — but the overall correction remains excellent within the lens's intended use range.
+
+---
+
+## 10. Glass Selection Philosophy
+
+The six glass types in Example 9 can be organized into three functional pairs that mirror each other across the stop:
+
+| Position | Element | n_d | v_d | Role |
+|----------|---------|------|------|------|
+| Front outer | L1 | 1.79227 | 47.15 | High-index collector (lanthanum crown) |
+| Rear outer | L6 | 1.72055 | 47.69 | High-index collector (lanthanum crown) |
+| Front positive | L2 | 1.67133 | 41.64 | Moderate-index barium flint/crown |
+| Rear positive | L5 | 1.72055 | 47.69 | Lanthanum crown (shared with L6) |
+| Front negative | L3 | 1.73430 | 28.19 | Dense flint (chromatic corrector) |
+| Rear negative | L4 | 1.63003 | 35.45 | Light/medium flint (chromatic corrector) |
+
+Several patterns emerge from this arrangement:
+
+**Dispersion pairing:** The outer elements (L1, L6) have nearly matched Abbe numbers (47.15, 47.69), providing excellent lateral color symmetry. The inner doublet negatives (L3, L4) have low Abbe numbers (28.19, 35.45) that provide the chromatic correcting power.
+
+**Index contrasts at the cemented bonds:** The patent explicitly requires that the negative element in each doublet has a higher refractive index than its positive partner (n₃ > n₂ and n₅ > n₄). Although the flat bond surfaces have zero optical power, the index step refracts converging or diverging wavefronts at the interface, altering the aberration contributions of downstream surfaces. This is the mechanism by which the patent's index-difference conditions (n₃ − n₂ and n₅ − n₄) influence the correction balance — not through surface power, but through wavefront reshaping.
+
+**High-index outer elements:** The use of lanthanum-containing glasses with n_d > 1.72 for all elements outside the negative flints keeps surface curvatures gentle throughout, which is essential for controlling higher-order aberrations at f/2.
+
+**Economy of types:** By sharing the same glass (n_d = 1.72055, v_d = 47.69) for both L5 and L6, the design reduces the number of distinct glass procurements from six to five — another manufacturing cost optimization.
+
+**Glass identification uncertainty:** None of the six glass types precisely match standard Schott catalog entries from the 1970s era. Residuals range from Δn_d ≈ 0.003 (for L2 vs. BaSF6) to Δn_d ≈ 0.010 (for L4 vs. F2). This pattern is consistent across all six positions and strongly suggests that Leitz Canada used proprietary melts or special compositions from the Leitz Glass Research Laboratory in Wetzlar. Without access to internal Leitz computation records, definitive catalog identifications are not possible from the patent data alone.
+
+---
+
+## 11. Production Scaling
+
+The patent prescription is stated at f = 100 mm. The production Summicron-M 50mm f/2 has a nominal focal length of approximately 50 mm, requiring a uniform scale factor of ≈0.50 applied to all linear dimensions (radii, thicknesses, spacings, and semi-diameters). Angular quantities (field angle, f-number) are scale-invariant and remain unchanged.
+
+| Parameter | Patent (f = 100) | Production (f ≈ 50) |
+|-----------|-----------------|-------------------|
+| EFL | 100.0 mm | ≈50.0 mm |
+| BFD | 58.88 mm | ≈29.4 mm |
+| Total track | 69.92 mm | ≈35.0 mm |
+| Overall length | 128.8 mm | ≈64.4 mm |
+| Field angle | ±22.5° | ±22.5° (≈45° diagonal) |
+| F-number | f/2 | f/2 |
+
+The production M-mount lens weighs 240 g, accepts 39mm (E39) filters, and measures approximately 43.5 × 53 mm (diameter × length). The close focus distance is 0.7 m with a maximum reproduction ratio of 1:11.5. The Summicron-R II version is slightly larger (E55 filters, 250–300 g) with a closer MFD of 0.5 m.
+
+---
+
+## 12. Historical and Optical Significance
+
+The Summicron-M 50/2 represents a masterclass in balancing optical performance against manufacturing pragmatism. Mandler's genius lay not in pushing the boundaries of optical complexity — as Zeiss's Erhard Glatzel was doing contemporaneously with computer-optimized designs of far greater element counts — but in extracting maximum performance from a minimum of optical surfaces, with deliberate attention to producibility.
+
+The patent explicitly frames the design problem in economic terms: material costs, fabricating costs, and tooling costs. The strategy of maximizing flat surfaces and matched radii addresses all three — flat surfaces need no specialized diamond tools, matched radii share tooling, and the use of only five distinct glass types reduces procurement complexity. The patent even references a specific mounting arrangement (German Offenlegungsschrift 2,364,621) that takes particular advantage of planar surfaces for simplified assembly.
+
+The design's longevity speaks for itself. Over four decades later, the same optical formula remains in production, and many reviewers consider it to outperform more complex modern designs in subjective image quality — particularly in the organic rendering of micro-contrast and the smooth transition from in-focus to out-of-focus regions. Peter Karbe, Leica's current head of optical design, acknowledged Mandler's enduring contribution after his death in 2005.
+
+The lens was eventually complemented (not replaced) in 2012 by the APO-Summicron-M 50/2 ASPH — an eight-element, five-group design with aspherical and anomalous-dispersion elements, designed by Karbe. That the two lenses continue to be sold side by side, at vastly different price points, testifies to the enduring appeal of Mandler's 1974 design: a lens whose carefully chosen compromises have, for many photographers, aged into virtues.

--- a/src/lens-data/LeicaSummicronV550mmf2.data.ts
+++ b/src/lens-data/LeicaSummicronV550mmf2.data.ts
@@ -1,0 +1,183 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — Leica Summicron-M 50mm f/2 (Version IV/V)            ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,123,144 Example 9 (Mandler / Ernst Leitz).     ║
+ * ║  Four-component six-element Gauss objective, all spherical.        ║
+ * ║  6 elements / 4 groups, 0 aspherical surfaces.                    ║
+ * ║  Focus: unit focusing (entire optical cell translates).            ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent at f = 100; all R, d, sd values scaled ×0.50 to         ║
+ * ║    f ≈ 50.0 mm production. BFD at close focus computed via        ║
+ * ║    thick-lens conjugate equations (paraxial).                      ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                          ║
+ * ║    Patent does not list semi-diameters. SDs estimated from        ║
+ * ║    combined marginal + chief ray trace at f/2 and ±22.5°          ║
+ * ║    half-field with ~8–10% mechanical clearance. Front elements    ║
+ * ║    constrained by E39 filter thread (max clear aperture ~18 mm). ║
+ * ║    Cemented surfaces matched within each doublet.                 ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "leica-summicron-m-50f2-v5",
+  maker: "Leica",
+  name: "LEICA SUMMICRON-M 50mm f/2",
+  subtitle: "US 4,123,144 EXAMPLE 9 — MANDLER / ERNST LEITZ CANADA",
+  specs: ["6 ELEMENTS / 4 GROUPS", "f ≈ 50.0 mm", "F/2.0", "2ω ≈ 45°", "ALL SPHERICAL"],
+
+  focalLengthMarketing: 50,
+  focalLengthDesign: 50.0,
+  apertureMarketing: 2,
+  apertureDesign: 2.0,
+  patentYear: 1978,
+  elementCount: 6,
+  groupCount: 4,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.79227,
+      vd: 47.15,
+      fl: 56.7,
+      glass: "Lanthanum crown (proprietary Leitz melt; nearest: Schott TaF4 / LaFN21)",
+      apd: false,
+      role: "Front collector. High-index meniscus concave toward diaphragm; |r₁| = |r₁₁| symmetry pair.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Plano-Convex Positive",
+      nd: 1.67133,
+      vd: 41.64,
+      fl: 30.0,
+      glass: "Barium flint / dense barium crown (proprietary; nearest: Schott BaSF6)",
+      apd: false,
+      role: "Positive element of front cemented doublet. Flat rear is cemented bond surface.",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Plano-Concave Negative",
+      nd: 1.7343,
+      vd: 28.19,
+      fl: -17.5,
+      glass: "Dense flint (proprietary; nearest: Schott SF3 / SF10)",
+      apd: false,
+      role: "Negative flint of front doublet. High dispersion for chromatic correction. Concave surface faces diaphragm.",
+      cemented: "D1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Plano-Concave Negative",
+      nd: 1.63003,
+      vd: 35.45,
+      fl: -22.0,
+      glass: "Light/medium flint (proprietary; nearest: Schott F2)",
+      apd: false,
+      role: "Negative element of rear doublet. Concave surface faces diaphragm; inner concave air lens with L3.",
+      cemented: "D2",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Plano-Convex Positive",
+      nd: 1.72055,
+      vd: 47.69,
+      fl: 27.9,
+      glass: "Lanthanum crown (proprietary; nearest: Schott LaF10). Same glass as L6.",
+      apd: false,
+      role: "Positive element of rear cemented doublet. Flat front is cemented bond surface. |r₉| = |r₃| symmetry pair.",
+      cemented: "D2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Plano-Convex Positive",
+      nd: 1.72055,
+      vd: 47.69,
+      fl: 41.6,
+      glass: "Lanthanum crown (same glass as L5)",
+      apd: false,
+      role: "Rear collector. Flat surface faces object (FIG. 2 configuration); |r₁₁| = |r₁| symmetry pair.",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Scaled from patent f = 100 by ×0.50.
+   *  All surfaces spherical or flat.
+   *
+   *  The 0.19 mm air gap between S2 and S3 (L1 rear to L2 front) is
+   *  physically tight but the gap widens at the rim: S3's stronger
+   *  curvature (R = 20.15) curves away from the gap faster than S2's
+   *  weak curvature (R = 83.655) intrudes into it.
+   */
+  surfaces: [
+    { label: "1", R: 29.97, d: 4.785, nd: 1.79227, elemId: 1, sd: 15.0 },
+    { label: "2", R: 83.655, d: 0.19, nd: 1.0, elemId: 0, sd: 14.0 },
+    { label: "3", R: 20.15, d: 7.175, nd: 1.67133, elemId: 2, sd: 13.0 },
+    { label: "4", R: 1e15, d: 1.435, nd: 1.7343, elemId: 3, sd: 12.5 },
+    { label: "5", R: 12.835, d: 5.405, nd: 1.0, elemId: 0, sd: 11.0 },
+    { label: "STO", R: 1e15, d: 6.695, nd: 1.0, elemId: 0, sd: 7.8 },
+    { label: "7", R: -13.845, d: 0.955, nd: 1.63003, elemId: 4, sd: 8.5 },
+    { label: "8", R: 1e15, d: 3.825, nd: 1.72055, elemId: 5, sd: 9.0 },
+    { label: "9", R: -20.15, d: 0.19, nd: 1.0, elemId: 0, sd: 10.5 },
+    { label: "10", R: 1e15, d: 4.305, nd: 1.72055, elemId: 6, sd: 10.5 },
+    { label: "11", R: -29.97, d: 29.457, nd: 1.0, elemId: 0, sd: 12.0 },
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (unit focus) ──
+   *  Only BFD changes; entire lens translates as a rigid unit.
+   *  Close focus BFD computed via thick-lens conjugate at MFD = 0.7 m.
+   */
+  var: {
+    "11": [29.457, 33.306],
+  },
+  varLabels: [["11", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "I", fromSurface: "1", toSurface: "2" },
+    { text: "II", fromSurface: "3", toSurface: "5" },
+    { text: "III", fromSurface: "7", toSurface: "9" },
+    { text: "IV", fromSurface: "10", toSurface: "11" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "3", toSurface: "5" },
+    { text: "D2", fromSurface: "7", toSurface: "9" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.7,
+  focusDescription: "Unit focusing — entire optical cell translates forward.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16],
+  apertureBlades: 8,
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -19,6 +19,13 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-04-09 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-04-09",
+    type: "lens",
+    summary:
+      "Added five Leica lenses: Summilux 28mm f/1.7 ASPH (Q-series), APO-Summicron 43mm f/2 ASPH (Q3 43), ELCAN 50mm f/2, APO-Summicron-M 35mm f/2 ASPH, and Summicron-M 50mm f/2 V5",
+  },
   // ── 2026-04-08 ──────────────────────────────────────────────────────────
   {
     date: "2026-04-08",

--- a/src/utils/lensMetadata.ts
+++ b/src/utils/lensMetadata.ts
@@ -23,6 +23,7 @@ const MAKER_PREFIXES: { prefix: string; display: string; slug: string }[] = [
   { prefix: "CARL ZEISS", display: "Carl Zeiss", slug: "carl-zeiss" },
   { prefix: "FUJIFILM", display: "Fujifilm", slug: "fujifilm" },
   { prefix: "FUJINON", display: "Fujifilm", slug: "fujifilm" },
+  { prefix: "LEICA", display: "Leica", slug: "leica" },
   { prefix: "VOIGTLÄNDER", display: "Voigtländer", slug: "voigtlander" },
   { prefix: "NIKON", display: "Nikon", slug: "nikon" },
   { prefix: "RICOH", display: "Ricoh", slug: "ricoh" },

--- a/src/utils/makerDetails.ts
+++ b/src/utils/makerDetails.ts
@@ -11,6 +11,7 @@
  *   2026-03-26  Added Canon maker entry.
  *   2026-03-27  Added Fujifilm maker entry.
  *   2026-04-07  Added Vivitar maker entry.
+ *   2026-04-09  Added Leica maker entry.
  */
 
 export interface MakerDetails {
@@ -22,6 +23,16 @@ export interface MakerDetails {
 }
 
 export const MAKER_DETAILS: Record<string, MakerDetails> = {
+  leica: {
+    founded: 1914,
+    headquarters: "Wetzlar, Germany",
+    summary:
+      "German precision optical manufacturer renowned for the M-series rangefinder cameras and Summicron, Summilux, and APO-Summicron lens families, blending meticulous handcraft with advanced optical science at small production volumes.",
+    history:
+      "Leica's optical origins reach back to 1849, when Carl Kellner founded an optical institute in Wetzlar that eventually became Ernst Leitz GmbH. The company built microscopes and binoculars before engineer Oskar Barnack, working at Leitz, developed a compact 35mm camera prototype (the Ur-Leica) between 1913 and 1914. The production Leica I, introduced at the Leipzig Spring Fair in 1925, established 35mm photography as a serious medium and defined a new class of small, fast cameras for photojournalism, street photography, and scientific documentation.\n\nLeica's optical design heritage is inseparable from a succession of landmark lens designers. Max Berek created the original Leitz Elmar (1925), a derivative of the Tessar formula, followed by the Summar and Hektor designs of the 1930s. Walter Mandler, working at Ernst Leitz Canada (ELCAN) in Midland, Ontario from the 1950s through the 1980s, developed much of the Summicron and Summilux lineage — including the Summicron-M 50mm f/2 (1953), the Noctilux 50mm f/1.2 and f/1.0, and the legendary Summilux-M 35mm f/1.4 ASPH. Mandler's designs often pursued maximum correction through all-spherical constructions, relying on sophisticated glass selection rather than aspherical surfaces.\n\nThe introduction of the M-mount in 1954 with the Leica M3 established the bayonet standard still used today. The compact, short-flange-distance mount enables a class of wide-angle and standard lenses with minimal retrofocus complexity — an advantage that influenced every Leica lens designed for rangefinder cameras. The M-system continued evolving through the M6, M7, M-A, and the digital M8, M9, M10, and M11 bodies.\n\nPeter Karbe, head of optics at Leica Camera AG from the early 2000s, extended the design tradition with aspherical constructions optimized for digital sensors. His APO-Summicron-M 50mm f/2 ASPH (2012) is widely considered one of the finest photographic lenses ever made, with essentially perfect aberration correction across the full field. Karbe also designed the Leica Q series fixed lenses — including the Summilux 28mm f/1.7 ASPH (jointly developed with Panasonic) — which brought interchangeable-lens-quality optics to a fixed-lens compact system. The APO-Summicron-M 35mm f/2 ASPH (2015) continued the APO lineage with fluorophosphate glass and KZFS-type flints for three-wavelength chromatic correction.\n\nLeica produces lenses in relatively small volumes at its Wetzlar facility, where assembly, cementing, and final adjustment are performed by hand. This manufacturing philosophy — prioritizing perfection over scale — results in lenses that command substantial premiums but are widely regarded as benchmarks for the craft.",
+    notableDesigns:
+      "Elmar 50mm f/3.5, Summicron-M 50mm f/2, Summilux-M 35mm f/1.4 ASPH, Noctilux-M 50mm f/0.95 ASPH, APO-Summicron-M 50mm f/2 ASPH, APO-Summicron-M 35mm f/2 ASPH, Summilux 28mm f/1.7 ASPH",
+  },
   fujifilm: {
     founded: 1934,
     headquarters: "Tokyo, Japan",


### PR DESCRIPTION
Adds five Leica lens prescriptions from issue #384:
- Leica Summilux 28mm f/1.7 ASPH (US 2016/0266350 A1) — fixed lens of Q/Q2/Q3
- Leica APO-Summicron 43mm f/2 ASPH (US 2024/0241349 A1) — fixed lens of Q3 43
- Leica ELCAN 50mm f/2 (US 3,649,104 Ex. 3) — military KE-7A lens
- Leica APO-Summicron-M 35mm f/2 ASPH (US 2022/0066176 A1)
- Leica Summicron-M 50mm f/2 V5 (US 4,123,144)

Each lens ships with a paired .analysis.md optical design document.

Also adds:
- Leica maker entry to MAKER_PREFIXES (lensMetadata.ts + generate-build-metadata.mjs)
- Leica history and notable designs to makerDetails.ts
- Changelog entry for 2026-04-09

https://claude.ai/code/session_012W9oNrbzdk2JfdnP7Fu6n7