### PR TITLE
Render LaTeX math in articles and lens analysis via KaTeX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Interactive web-based optical lens cross-section visualizer and ray-tracing tool
 - **SVG rendering** — all visuals are inline SVG, no canvas
 - **Inline styles** — no CSS files or UI libraries
 - **react-helmet-async** — SEO meta tags per page
-- **react-markdown + remark-gfm** — rendering markdown content
+- **react-markdown + remark-gfm + remark-math + rehype-katex** — markdown rendering with GFM tables/footnotes and KaTeX math (`$inline$`, `$$display$$`); KaTeX CSS imported once in `src/main.tsx`, available to all articles and lens analysis panels
 
 ## Project Structure
 

--- a/agent_docs/adding_an_article.md
+++ b/agent_docs/adding_an_article.md
@@ -59,6 +59,25 @@ The landing page is just another markdown file — no special component, no rout
 
 ---
 
+## Math / LaTeX
+
+Math is rendered via KaTeX (through `remark-math` + `rehype-katex`). Both article pages and lens analysis (`DescriptionPanel`) support it — no per-article opt-in.
+
+- **Inline math:** wrap in single dollar signs — `$S_I = -A^2 h\,\Delta(u/n)$`
+- **Display math:** wrap in double dollar signs on their own line —
+
+  ```
+  $$\Delta S_I \approx 4\delta S_{II}$$
+  ```
+
+- **Supported syntax:** the [KaTeX function list](https://katex.org/docs/supported.html). Common macros (`\frac`, `\tfrac`, `\bar`, `\mathcal`, `\sum`, `\cdots`, `\approx`, `\propto`, Greek letters) all work.
+- **Unsupported:** `\begin{align}`/`\end{align}` environments, `\label`/`\ref`, `\cite`. Use display-math blocks and prose references instead.
+- **Escaping a literal dollar sign** in prose (e.g., USD amounts): write `\$` so `remark-math` doesn't interpret it as math.
+
+Global KaTeX CSS is imported once in `src/main.tsx`; the fonts are emitted as hashed assets during build.
+
+---
+
 ## Hovering Table of Contents
 
 Opt in via `toc: true`. Behavior:

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -14,7 +14,7 @@
 | `MakerPage.tsx` | `src/pages/` | Maker page at `/makers/:maker`, lists maker's lenses |
 | `MakersIndexPage.tsx` | `src/pages/` | Maker index at `/makers`, lists all makers with lens counts |
 | `ComparePage.tsx` | `src/pages/` | Comparison page at `/compare/:slugA/:slugB` with SEO metadata |
-| `ArticlePage.tsx` | `src/pages/` | Individual article page at `/articles/:slug`; resets scroll to the top when the article slug changes during SPA navigation |
+| `ArticlePage.tsx` | `src/pages/` | Individual article page at `/articles/:slug`; renders markdown with `remark-gfm`, `remark-math`, `rehype-slug`, `rehype-katex`; resets scroll to the top when the article slug changes during SPA navigation |
 | `ArticlesPage.tsx` | `src/pages/` | Articles index at `/articles`; resets scroll to the top on mount so archive visits start at the page heading |
 | `NotFoundPage.tsx` | `src/pages/` | 404 catch-all with navigation links |
 
@@ -28,7 +28,7 @@
 | `ViewToggleBar.tsx` | `src/components/layout/` | Generic view-mode toggle (mobile + desktop) |
 | `OverlayModal.tsx` | `src/components/layout/` | Generic backdrop + modal + close button |
 | `LensDiagramPanel.tsx` | `src/components/layout/` | Diagram composition: wires hooks + sub-components |
-| `DescriptionPanel.tsx` | `src/components/layout/` | Markdown panel with themed styling |
+| `DescriptionPanel.tsx` | `src/components/layout/` | Markdown panel with themed styling; supports GFM + KaTeX math (`$inline$`, `$$display$$`) |
 | `BreadcrumbBar.tsx` | `src/components/layout/` | Breadcrumb navigation (Home / Makers / {Maker} / {Lens Name}) for lens pages |
 | `PageNavBar.tsx` | `src/components/layout/` | Shared navigation bar for static pages with theme toggle |
 | `PanelOverlay.tsx` | `src/components/layout/` | Panel-scoped overlay (position:absolute) for diagram-level LCA/Petzval overlays |

--- a/agents.md
+++ b/agents.md
@@ -13,7 +13,7 @@ Interactive web-based optical lens cross-section visualizer and ray-tracing tool
 - **SVG rendering** — all visuals are inline SVG, no canvas
 - **Inline styles** — no CSS files or UI libraries
 - **react-helmet-async** — SEO meta tags per page
-- **react-markdown + remark-gfm** — rendering markdown content
+- **react-markdown + remark-gfm + remark-math + rehype-katex** — markdown rendering with GFM tables/footnotes and KaTeX math (`$inline$`, `$$display$$`); KaTeX CSS imported once in `src/main.tsx`, available to all articles and lens analysis panels
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,16 @@
       "version": "1.0.0",
       "dependencies": {
         "github-slugger": "^2.0.0",
+        "katex": "^0.16.45",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
         "react-markdown": "^10.1.0",
         "react-router": "^7.13.2",
+        "rehype-katex": "^7.0.1",
         "rehype-slug": "^6.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1796,6 +1799,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2853,6 +2862,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3132,7 +3150,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -4045,10 +4062,117 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
       "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -4098,6 +4222,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -4105,6 +4245,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4874,6 +5031,22 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5182,6 +5355,25 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5504,6 +5696,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -6540,6 +6751,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-slug": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
@@ -6568,6 +6798,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -7490,6 +7736,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -7510,6 +7770,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7607,6 +7881,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7795,6 +8083,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,16 @@
   },
   "dependencies": {
     "github-slugger": "^2.0.0",
+    "katex": "^0.16.45",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
     "react-markdown": "^10.1.0",
     "react-router": "^7.13.2",
+    "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/components/layout/DescriptionPanel.tsx
+++ b/src/components/layout/DescriptionPanel.tsx
@@ -13,6 +13,8 @@ import { useMemo } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import type { Theme } from "../../types/theme.js";
 
 interface DescriptionPanelProps {
@@ -159,7 +161,7 @@ export default function DescriptionPanel({ markdown, theme: t }: DescriptionPane
   }
   return (
     <div style={WRAPPER_STYLE}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={components}>
         {markdown}
       </ReactMarkdown>
     </div>

--- a/src/content/FocusingDualSide.md
+++ b/src/content/FocusingDualSide.md
@@ -35,9 +35,9 @@ This is a direct application of the Wynne framework (Wynne, 1952): the designer 
 
 ### Case Example: Nikon AF-S Micro-Nikkor 105mm f/2.8G VR
 
-**Patent:** US 7,218,457, Example 3
-**Production lens:** 14 elements in 12 groups; one ED element; VR II image stabilization
-**MFD:** 0.314 m (1:1 reproduction)
+- **Patent:** US 7,218,457, Example 3
+- **Production lens:** 14 elements in 12 groups; one ED element; VR II image stabilization
+- **MFD:** 0.314 m (1:1 reproduction)
 
 The [Micro-Nikkor 105mm f/2.8G VR](/lens/nikon-afs-105f28-vr-micro) confronts the most demanding conjugate range of any common photographic lens: performance from infinity to 1:1 reproduction — a magnification change from 0 to −1. The enormous conjugate-shift parameter $\delta$ at 1:1 makes single-group IF fundamentally inadequate, as the Wynne impossibility theorem guarantees severe degradation of multiple aberrations simultaneously (Wynne, 1952).
 

--- a/src/content/FocusingFrontOfStop.md
+++ b/src/content/FocusingFrontOfStop.md
@@ -25,8 +25,8 @@ A particularly effective variant places a **negative-power** focusing group ahea
 
 ### Case Example: Nikon AF-S Nikkor 105mm f/1.4E ED
 
-**Patent:** WO 2019/116563, Example 3
-**Production lens:** 14 elements in 9 groups; three ED elements; Nano Crystal Coat; no aspherical surfaces
+- **Patent:** WO 2019/116563, Example 3
+- **Production lens:** 14 elements in 9 groups; three ED elements; Nano Crystal Coat; no aspherical surfaces
 
 The [Nikon 105mm f/1.4E](/lens/nikkor-105-f14e-ed) places its negative-power focusing group ahead of the stop. The ED glass elements are positioned in the fixed front group G1, where their chromatic correction contribution remains constant regardless of focus position. The focusing group itself — a lightweight cemented doublet — has minimal chromatic contribution and presents low inertial mass to the Silent Wave Motor.
 

--- a/src/content/FocusingMonolithic.md
+++ b/src/content/FocusingMonolithic.md
@@ -29,9 +29,9 @@ Moving the stop with the focusing group preserves this quasi-symmetry. The aberr
 
 ### Case Example: Nikon AF-S Nikkor 85mm f/1.4G
 
-**Patent:** US 8,767,319, Example 1 (jointly assigned to Nikon Corporation and Konica Minolta Advanced Layers, Inc.)
-**Production lens:** 10 elements in 9 groups; no aspherical elements; no ED elements
-**MFD:** 0.85 m
+- **Patent:** US 8,767,319, Example 1 (jointly assigned to Nikon Corporation and Konica Minolta Advanced Layers, Inc.)
+- **Production lens:** 10 elements in 9 groups; no aspherical elements; no ED elements
+- **MFD:** 0.85 m
 
 The [Nikon 85mm f/1.4G](/lens/nikkor-85f14g) moves a central group containing elements on both sides of the stop as a monolithic unit. The patent's prior-art discussion explains the rationale explicitly: placing the aperture stop within the focusing group "reduces variation in off-axial aberrations during focusing."
 

--- a/src/content/FocusingRearGroupRetrofocus.md
+++ b/src/content/FocusingRearGroupRetrofocus.md
@@ -23,9 +23,9 @@ During focusing from infinity to close range, the rear group moves toward the ob
 
 ### Case Example: Nikon AF-S Nikkor 28mm f/1.4E ED
 
-**Patent:** JP 2017-227799, Example 1 (jointly assigned to Nikon Corporation and Konica Minolta Inc.)
-**Production lens:** 14 elements in 11 groups; two ED elements; three aspherical elements; Nano Crystal Coat; fluorine front-element coating
-**MFD:** 0.28 m
+- **Patent:** JP 2017-227799, Example 1 (jointly assigned to Nikon Corporation and Konica Minolta Inc.)
+- **Production lens:** 14 elements in 11 groups; two ED elements; three aspherical elements; Nano Crystal Coat; fluorine front-element coating
+- **MFD:** 0.28 m
 
 The [Nikon 28mm f/1.4E](/lens/nikon-afs-28f14e) uses a two-group rear-focusing strategy, with the rear positive group moving toward the object side during focusing from infinity to close range.
 

--- a/src/content/FocusingRearOfStop.md
+++ b/src/content/FocusingRearOfStop.md
@@ -27,8 +27,8 @@ Behind the stop, the chief ray height $\bar{h}$ starts at zero (at the stop) and
 
 ### Case Example: Canon RF 135mm f/1.8 L IS USM
 
-**Patent:** US 2023/0213745 A1, Example 4
-**Production lens:** 17 elements in 12 groups; three UD elements; Air Sphere Coating; Nano USM AF motor
+- **Patent:** US 2023/0213745 A1, Example 4
+- **Production lens:** 17 elements in 12 groups; three UD elements; Air Sphere Coating; Nano USM AF motor
 
 The [Canon RF 135mm f/1.8 L](/lens/canon-rf-135f18) places a negative-power focusing unit behind the aperture stop. A positive rear unit behind the focusing group contains the image-stabilization subunit. During focusing, the focusing unit moves toward the image side. (Note: the patent-to-production correspondence for this lens is approximate; the focusing group's negative power and post-stop placement are stated in the patent text but have not been independently confirmed against production teardown data.)
 

--- a/src/content/InternalFocusingMonograph.md
+++ b/src/content/InternalFocusingMonograph.md
@@ -147,9 +147,9 @@ See the dedicated primers for a deeper treatment:
 
 ## Case Study I: Front-of-Stop Focusing — Nikon AF-S Nikkor 105mm f/1.4E ED
 
-**Patent:** WO 2019/116563, Example 3
-**Production lens:** 14 elements in 9 groups; three ED elements; Nano Crystal Coat; no aspherical surfaces
-**Weight:** 985 g | **MFD:** 1.0 m | **Lens page:** [/lens/nikkor-105-f14e-ed](/lens/nikkor-105-f14e-ed)
+- **Patent:** WO 2019/116563, Example 3
+- **Production lens:** 14 elements in 9 groups; three ED elements; Nano Crystal Coat; no aspherical surfaces
+- **Weight:** 985 g | **MFD:** 1.0 m | **Lens page:** [/lens/nikkor-105-f14e-ed](/lens/nikkor-105-f14e-ed)
 
 The Nikon 105mm f/1.4E employs a focusing group of **negative refractive power** positioned ahead of the aperture stop. The optical system follows a three-group architecture: a front positive group G1, a negative focusing group G2, and a rear group G3 containing the aperture stop. During focusing from infinity to close range, G2 translates toward the image side.
 
@@ -171,9 +171,9 @@ For a focused treatment, see the **[Front-of-Stop Focusing primer](/articles/foc
 
 ## Case Study II: Rear-of-Stop Focusing — Canon RF 135mm f/1.8 L IS USM
 
-**Patent:** US 2023/0213745 A1, Example 4
-**Production lens:** 17 elements in 12 groups; three UD elements; Air Sphere Coating; Nano USM AF motor
-**MFD:** 0.70 m | **Lens page:** [/lens/canon-rf-135f18](/lens/canon-rf-135f18)
+- **Patent:** US 2023/0213745 A1, Example 4
+- **Production lens:** 17 elements in 12 groups; three UD elements; Air Sphere Coating; Nano USM AF motor
+- **MFD:** 0.70 m | **Lens page:** [/lens/canon-rf-135f18](/lens/canon-rf-135f18)
 
 The Canon RF 135mm f/1.8 L IS USM places its focusing group behind the aperture stop — the most common IF architecture in modern telephoto primes. The cited patent describes a three-unit architecture: a positive first lens unit L1, the aperture stop, a **negative second lens unit L2** that serves as the focusing unit, and a positive third lens unit L3 containing an image-stabilization subunit.
 
@@ -195,9 +195,9 @@ For a focused treatment, see the **[Rear-of-Stop Focusing primer](/articles/focu
 
 ## Case Study III: Dual-Side Focusing — Nikon AF-S Micro-Nikkor 105mm f/2.8G VR
 
-**Patent:** US 7,218,457, Example 3
-**Production lens:** 14 elements in 12 groups; one ED element; VR II image stabilization
-**MFD:** 0.314 m (1:1 reproduction) | **Lens page:** [/lens/nikon-afs-105f28-vr-micro](/lens/nikon-afs-105f28-vr-micro)
+- **Patent:** US 7,218,457, Example 3
+- **Production lens:** 14 elements in 12 groups; one ED element; VR II image stabilization
+- **MFD:** 0.314 m (1:1 reproduction) | **Lens page:** [/lens/nikon-afs-105f28-vr-micro](/lens/nikon-afs-105f28-vr-micro)
 
 The Micro-Nikkor 105mm f/2.8G VR confronts the most demanding conjugate range of any of the five case studies: performance from infinity to **1:1 reproduction** — a magnification change from 0 to −1.
 
@@ -219,9 +219,9 @@ For a focused treatment, see the **[Dual-Side Focusing primer](/articles/focusin
 
 ## Case Study IV: Monolithic Group Focusing — Nikon AF-S Nikkor 85mm f/1.4G
 
-**Patent:** US 8,767,319, Example 1
-**Production lens:** 10 elements in 9 groups; no aspherical elements; no ED elements
-**Weight:** 595 g | **MFD:** 0.85 m | **Lens page:** [/lens/nikkor-85f14g](/lens/nikkor-85f14g)
+- **Patent:** US 8,767,319, Example 1
+- **Production lens:** 10 elements in 9 groups; no aspherical elements; no ED elements
+- **Weight:** 595 g | **MFD:** 0.85 m | **Lens page:** [/lens/nikkor-85f14g](/lens/nikkor-85f14g)
 
 The Nikon 85mm f/1.4G takes a philosophically different approach: **a single central group that includes elements on both sides of the aperture stop, plus the stop itself, moves as a monolithic unit** during focusing.
 
@@ -245,9 +245,9 @@ For a focused treatment, see the **[Monolithic Group Focusing primer](/articles/
 
 ## Case Study V: Rear-Group Focusing in a Fast Retrofocus Wide-Angle — Nikon AF-S Nikkor 28mm f/1.4E ED
 
-**Patent:** JP 2017-227799, Example 1
-**Production lens:** 14 elements in 11 groups; two ED elements; three aspherical elements; Nano Crystal Coat; fluorine front-element coating
-**MFD:** 0.28 m | **Lens page:** [/lens/nikon-afs-28f14e](/lens/nikon-afs-28f14e)
+- **Patent:** JP 2017-227799, Example 1
+- **Production lens:** 14 elements in 11 groups; two ED elements; three aspherical elements; Nano Crystal Coat; fluorine front-element coating
+- **MFD:** 0.28 m | **Lens page:** [/lens/nikon-afs-28f14e](/lens/nikon-afs-28f14e)
 
 The Nikon 28mm f/1.4E employs a two-group rear-focusing strategy: the patent divides the system into a fixed first group and a **second group that moves toward the object side** during focusing from infinity to close range.
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from "react-router";
 import { HelmetProvider } from "react-helmet-async";
 import ErrorBoundary from "./components/errors/ErrorBoundary.js";
 import router from "./router.js";
+import "katex/dist/katex.min.css";
 
 // Track SPA navigations in GoatCounter. The script tag in index.html handles the
 // initial page view automatically; this subscription fires only on subsequent

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -10,7 +10,9 @@ import type { CSSProperties, ReactNode } from "react";
 import { useParams, Navigate, Link } from "react-router";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 import rehypeSlug from "rehype-slug";
+import rehypeKatex from "rehype-katex";
 import SEOHead from "../components/SEOHead.js";
 import PageNavBar from "../components/layout/PageNavBar.js";
 import ArticleTOC from "../components/display/ArticleTOC.js";
@@ -295,7 +297,11 @@ export default function ArticlePage() {
         </nav>
 
         <article style={{ maxWidth: 700, lineHeight: 1.7 }}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSlug]} components={components}>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkMath]}
+            rehypePlugins={[rehypeSlug, rehypeKatex]}
+            components={components}
+          >
             {entry.markdown}
           </ReactMarkdown>
         </article>


### PR DESCRIPTION
## Summary
- Adds `remark-math` + `rehype-katex` to the markdown pipeline in `ArticlePage` and `DescriptionPanel`, with KaTeX CSS imported globally from `src/main.tsx` so all articles (current and future) plus lens `.analysis.md` files render inline (`$...$`) and display (`$$...$$`) math correctly. The Focusing Architectures monograph and primers previously showed raw LaTeX source; equations now render at build time (prerendered HTML contains KaTeX markup).
- Converts adjacent bold metadata lines (`**Patent:** ...` / `**Production lens:** ...` / `**MFD:** ...`) in the focusing primers and monograph case studies to bullet lists so they no longer collapse into a single run-on paragraph.
- Documents math support in `CLAUDE.md`, `agents.md` / `AGENTS.md`, `agent_docs/adding_an_article.md` (new "Math / LaTeX" section with supported/unsupported constructs and the `\$` escape rule), and `agent_docs/architecture.md`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` (1195 passed)
- [x] `npm run build` — 99 routes prerendered; KaTeX CSS + fonts emitted as hashed assets; `dist/articles/internal-focusing-monograph/index.html` contains rendered KaTeX markup
- [ ] Visual spot-check of the monograph, primers, and a lens analysis panel that uses math

🤖 Generated with [Claude Code](https://claude.com/claude-code)