### PR TITLE
[codex] Fix Canon RF 28-70 f/2 L SD geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `71` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
+- `72` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Nikon, Zeiss, Voigtlander, Canon, Ricoh, and Vivitar
 - Lens pages pair interactive diagrams with long-form optical analysis markdown
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `72` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
+- `75` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Nikon, Zeiss, Voigtlander, Canon, Ricoh, and Vivitar
 - Lens pages pair interactive diagrams with long-form optical analysis markdown
 

--- a/__tests__/lensIndexPage.test.tsx
+++ b/__tests__/lensIndexPage.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { HelmetProvider } from "react-helmet-async";
 import LensIndexPage from "../src/pages/LensIndexPage.js";
+import { CATALOG_ENTRIES, FILTER_BOUNDS, defaultCustomFilter, matchesCustomFilter } from "../src/pages/lensIndex/catalog.js";
 import { clearBrowserState, installMatchMediaMock, renderWithRouter } from "./testUtils.js";
 
 vi.mock("../src/components/SEOHead.js", () => ({
@@ -107,9 +108,32 @@ describe("LensIndexPage", () => {
     fireEvent.change(patentYearMinInput, { target: { value: "2024" } });
     fireEvent.keyDown(patentYearMinInput, { key: "Enter" });
 
-    expect(screen.getByText("No lenses match the current custom filter.")).toBeTruthy();
+    const expectedCanonEntries = CATALOG_ENTRIES.filter((entry) =>
+      matchesCustomFilter(
+        entry,
+        {
+          ...defaultCustomFilter(FILTER_BOUNDS),
+          makerSlugs: ["canon"],
+          patentYearMin: 2024,
+        },
+        FILTER_BOUNDS,
+      ),
+    );
 
-    fireEvent.click(screen.getByRole("button", { name: "Reset Custom Filter" }));
+    expect(
+      screen.getByText(
+        new RegExp(`Showing ${expectedCanonEntries.length} of \\d+ interactive optical cross-section diagrams`, "i"),
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /NIKON NIKKOR Z 26mm f\/2.8/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /CANON SERENAR 35mm f\/3.2/i })).toBeNull();
+
+    for (const entry of expectedCanonEntries) {
+      const escapedName = entry.data.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      expect(screen.getByRole("link", { name: new RegExp(escapedName) })).toBeTruthy();
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear Filters" }));
 
     expect(screen.getByRole("link", { name: /CANON SERENAR 35mm f\/3.2/i })).toBeTruthy();
     expect(screen.getByRole("link", { name: /NIKON NIKKOR Z 26mm f\/2.8/i })).toBeTruthy();

--- a/__tests__/solveZ24120CloseFocus.test.ts
+++ b/__tests__/solveZ24120CloseFocus.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Close-focus solver for NIKKOR Z 24-120mm f/4 S.
+ *
+ * The patent (WO 2022/259649 A1) tabulates only infinity-focus spacings.
+ * This script solves for close-focus group displacements (Δ5, Δ6) at each
+ * zoom position, given the published spec (MFD = 0.35 m at all zooms).
+ *
+ * Unknowns:
+ *   Δ5 — G5 displacement toward object (mm, positive = toward object)
+ *   Δ6 — G6 displacement toward object (mm, positive = toward object)
+ *
+ * Gap changes:
+ *   d21_close = d21_inf − Δ5       (G4 ↔ G5 gap)
+ *   d25_close = d25_inf + Δ5 − Δ6  (G5 ↔ G6 gap)
+ *   d27_close = d27_inf + Δ6       (G6 ↔ G7 gap)
+ *
+ * Single constraint + regularization (physical minimum-displacement):
+ *   F1: paraxial axial ray from object @ 0.35 m focuses at image plane
+ *   Reg: among all (Δ5, Δ6) satisfying F1 = 0, pick the minimum-norm solution
+ *        (i.e. smallest combined group motion). This avoids unphysical
+ *        cancellation (large Δ5 fighting large Δ6) when the two groups have
+ *        similar focus sensitivity.
+ *
+ * Published spec: MFD = 0.35 m at all zoom positions; max MRR = 0.39× at
+ * 120 mm. Zoom-ring marks: 24, 28, 35, 50, 70, 85, 120 mm.
+ *
+ * Run: npx vitest run __tests__/solveZ24120CloseFocus.test.ts --reporter=verbose
+ */
+
+import { describe, it, expect } from "vitest";
+import buildLens from "../src/optics/buildLens.js";
+import { traceSurfacesReal } from "../src/optics/internal/traceSurfaces.js";
+import { buildStateSurfaces } from "../src/optics/internal/lensState.js";
+import LENS_DEFAULTS from "../src/lens-data/defaults.js";
+import NikkorZ24120Raw from "../src/lens-data/NikonNikkorZ24120mmf4S.data.js";
+import type { LensData, SurfaceData, AsphericCoefficients } from "../src/types/optics.js";
+
+/* ── Configuration ── */
+const IDX_D21 = 20; // gap "21" — between G4 and G5
+const IDX_D25 = 24; // gap "25" — between G5 and G6
+const IDX_D27 = 26; // gap "27A" — between G6 and G7
+const IDX_LAST = 29; // gap "30" — back focal (image side of G7)
+
+const MFD_MM = 350.0; // minimum focus distance (image plane to object)
+const Y_PAR = 0.05; // mm — near-axis probe ray height (paraxial proxy)
+
+/* Zoom positions to solve: focal lengths in mm (design values).
+ * Chosen to span the zoom-ring marks (24, 28, 35, 50, 70, 85, 120 mm)
+ * while using 24.7 and 116.5 as the endpoints matching the patent. */
+const ZOOM_TARGETS = [24.7, 35.0, 50.0, 70.0, 85.0, 116.5];
+const F_WIDE = 24.7;
+const F_TELE = 116.5;
+
+interface Residuals {
+  f1: number;
+}
+
+interface SolveResult {
+  fDesign: number;
+  zoomT: number;
+  delta5: number;
+  delta6: number;
+  d21_inf: number;
+  d25_inf: number;
+  d27_inf: number;
+  d21_close: number;
+  d25_close: number;
+  d27_close: number;
+  residuals: Residuals;
+  magnification: number;
+}
+
+/**
+ * Build a modified surface array with (Δ5, Δ6) applied.
+ */
+function modifiedSurfaces(
+  S_inf: SurfaceData[],
+  d21_inf: number,
+  d25_inf: number,
+  d27_inf: number,
+  delta5: number,
+  delta6: number,
+): SurfaceData[] {
+  const S = S_inf.map((s) => ({ ...s }));
+  S[IDX_D21] = { ...S[IDX_D21], d: d21_inf - delta5 };
+  S[IDX_D25] = { ...S[IDX_D25], d: d25_inf + delta5 - delta6 };
+  S[IDX_D27] = { ...S[IDX_D27], d: d27_inf + delta6 };
+  return S;
+}
+
+/**
+ * Trace a ray from on-axis object point at (z = -objDistFromS1, y = 0),
+ * passing through the first surface at height y0. Returns intercept at
+ * the image plane (i.e., y at z = sum of all gaps).
+ */
+function rayInterceptAtImage(
+  S: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  y0: number,
+  objDistFromS1: number,
+): number {
+  const u0 = y0 / objDistFromS1; // slope from (-D, 0) to (0, y0)
+  const tr = traceSurfacesReal(S, asphByIdx, y0, u0);
+  if (!isFinite(tr.y) || !isFinite(tr.u)) return NaN;
+  const dLast = S[IDX_LAST].d;
+  return tr.y + dLast * tr.u;
+}
+
+/**
+ * Single-scalar focus residual: on-axis paraxial ray should hit image plane at y=0.
+ */
+function focusResidual(
+  S_inf: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  d21_inf: number,
+  d25_inf: number,
+  d27_inf: number,
+  totalLensLength_inf: number,
+  delta5: number,
+  delta6: number,
+): Residuals {
+  const S = modifiedSurfaces(S_inf, d21_inf, d25_inf, d27_inf, delta5, delta6);
+  const objDistFromS1 = MFD_MM - totalLensLength_inf;
+  const f1 = rayInterceptAtImage(S, asphByIdx, Y_PAR, objDistFromS1);
+  return { f1 };
+}
+
+const MIN_GAP = 0.5; // mm — mechanical clearance floor on any variable gap
+
+/**
+ * Constrained Newton solve with an additional equality constraint on the
+ * G5↔G6 gap: d25_inf + Δ5 − Δ6 = dFixed  ⇒  Δ6 = Δ5 + (d25_inf − dFixed).
+ * Reduces to a 1D Newton on Δ5 for focus.
+ */
+function solveDeltasWithD25Fixed(
+  S_inf: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  d21_inf: number,
+  d25_inf: number,
+  d27_inf: number,
+  d25Fixed: number,
+): { delta5: number; delta6: number; residuals: Residuals } {
+  const totalLensLength_inf = S_inf.reduce((acc, s) => acc + s.d, 0);
+  const offset = d25_inf - d25Fixed; // Δ6 − Δ5 = offset
+  const h = 1e-4;
+  let delta5 = 0;
+  const residAt = (d5: number) => {
+    const d6 = d5 + offset;
+    return focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, d5, d6);
+  };
+  for (let iter = 0; iter < 80; iter++) {
+    const F = residAt(delta5);
+    if (!isFinite(F.f1)) throw new Error(`non-finite at iter=${iter}, d25Fixed`);
+    if (Math.abs(F.f1) < 1e-9) break;
+    const Fp = residAt(delta5 + h);
+    const deriv = (Fp.f1 - F.f1) / h;
+    if (Math.abs(deriv) < 1e-15) break;
+    let alpha = 1.0;
+    const step = F.f1 / deriv;
+    for (let t = 0; t < 15; t++) {
+      const d5try = delta5 - alpha * step;
+      const Ftry = residAt(d5try);
+      if (isFinite(Ftry.f1) && Math.abs(Ftry.f1) < Math.abs(F.f1)) {
+        delta5 = d5try;
+        break;
+      }
+      alpha *= 0.5;
+    }
+  }
+  return { delta5, delta6: delta5 + offset, residuals: residAt(delta5) };
+}
+
+/**
+ * Minimum-norm solver for (Δ5, Δ6) satisfying focus residual = 0.
+ *
+ * Method: steepest-descent/ascent along the gradient of f1, then project
+ * back onto the f1=0 level curve each iteration. This traces the path of
+ * minimum cumulative displacement, producing a physically plausible motion
+ * (neither group moves more than necessary for focus).
+ *
+ * Mathematical justification: among all (Δ5, Δ6) with f1(Δ)=0, the solution
+ * closest to origin is reached by moving purely along ∇f1 (the normal to the
+ * f1=0 curve passes through origin only at that nearest point).
+ */
+function solveDeltas(
+  S_inf: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  d21_inf: number,
+  d25_inf: number,
+  d27_inf: number,
+): { delta5: number; delta6: number; residuals: Residuals } {
+  const totalLensLength_inf = S_inf.reduce((acc, s) => acc + s.d, 0);
+  const h = 1e-4;
+  const maxIter = 200;
+  const tol = 1e-9;
+  let delta5 = 0;
+  let delta6 = 0;
+
+  // Compute gradient at origin (fixes the direction of minimum-norm solution)
+  const F0 = focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, 0, 0);
+  const F0p5 = focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, h, 0);
+  const F0p6 = focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, 0, h);
+  const g5_init = (F0p5.f1 - F0.f1) / h;
+  const g6_init = (F0p6.f1 - F0.f1) / h;
+  const gNorm_init = Math.hypot(g5_init, g6_init);
+  if (gNorm_init < 1e-12) throw new Error("zero gradient at origin — solver cannot proceed");
+
+  // Initial step along −∇f1 / ||∇f1||²  (Newton step in 1D along gradient)
+  const stepScale_init = -F0.f1 / (gNorm_init * gNorm_init);
+  delta5 = stepScale_init * g5_init;
+  delta6 = stepScale_init * g6_init;
+
+  // Iterate: Newton corrections along current gradient direction, re-projecting
+  // each step to stay on the minimum-norm manifold. For a smooth nonlinear f1,
+  // this converges to the nearest point on f1=0.
+  for (let iter = 0; iter < maxIter; iter++) {
+    const F = focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, delta5, delta6);
+    if (!isFinite(F.f1)) throw new Error(`non-finite residual at iter=${iter}, Δ5=${delta5}, Δ6=${delta6}`);
+    if (Math.abs(F.f1) < tol) break;
+
+    const Fp5 = focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, delta5 + h, delta6);
+    const Fp6 = focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, delta5, delta6 + h);
+    const g5 = (Fp5.f1 - F.f1) / h;
+    const g6 = (Fp6.f1 - F.f1) / h;
+    const gNorm = Math.hypot(g5, g6);
+    if (gNorm < 1e-12) break;
+
+    // Pure gradient-direction Newton step (normal to f1=0)
+    const t = -F.f1 / (gNorm * gNorm);
+    const step5 = t * g5;
+    const step6 = t * g6;
+
+    // Damping
+    let alpha = 1.0;
+    const oldNorm = Math.abs(F.f1);
+    for (let trial = 0; trial < 15; trial++) {
+      const d5try = delta5 + alpha * step5;
+      const d6try = delta6 + alpha * step6;
+      const Ftry = focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, d5try, d6try);
+      if (isFinite(Ftry.f1) && Math.abs(Ftry.f1) < oldNorm) {
+        delta5 = d5try;
+        delta6 = d6try;
+        break;
+      }
+      alpha *= 0.5;
+    }
+  }
+  return {
+    delta5,
+    delta6,
+    residuals: focusResidual(S_inf, asphByIdx, d21_inf, d25_inf, d27_inf, totalLensLength_inf, delta5, delta6),
+  };
+}
+
+/**
+ * Estimate lateral magnification using two real rays from off-axis object.
+ * Not a constraint — diagnostic only.
+ */
+function estimateMagnification(
+  S: SurfaceData[],
+  asphByIdx: Record<number, AsphericCoefficients>,
+  objDistFromS1: number,
+): number {
+  const h_obj = 5.0; // object height in mm
+  // Launch two rays from (y=h_obj, z=-D) that pass through S1 at different y
+  // Chief-ray-like: passes through S1 at y=0 (near pupil center approximation)
+  // Marginal-ish: passes through S1 at small height
+  // From object point at (h_obj, -D), a ray going to (y_s1, 0) has slope:
+  //   u = (y_s1 - h_obj) / D
+  // At S1: y = y_s1, u as above
+  const trace = (y_s1: number) => {
+    const u0 = (y_s1 - h_obj) / objDistFromS1;
+    const tr = traceSurfacesReal(S, asphByIdx, y_s1, u0);
+    return tr.y + S[IDX_LAST].d * tr.u;
+  };
+  const y_image_lo = trace(0.3);
+  const y_image_hi = trace(-0.3);
+  const y_image_avg = (y_image_lo + y_image_hi) / 2;
+  return y_image_avg / h_obj; // negative for real image (inverted)
+}
+
+describe("Nikkor Z 24-120 close-focus solver", () => {
+  const lensData = { ...LENS_DEFAULTS, ...NikkorZ24120Raw } as LensData;
+  const L = buildLens(lensData);
+
+  it("solves (Δ5, Δ6) at each target zoom position", () => {
+    const results: SolveResult[] = [];
+
+    for (const fDesign of ZOOM_TARGETS) {
+      // Map focal length → zoomT via linear interpolation between wide/tele
+      const zoomT = (fDesign - F_WIDE) / (F_TELE - F_WIDE);
+
+      // Base surfaces with infinity gaps at this zoomT (engine interpolates)
+      const S_inf = buildStateSurfaces(L.S as unknown as SurfaceData[], L.varByIdx, true, 0, zoomT);
+      const d21_inf = S_inf[IDX_D21].d;
+      const d25_inf = S_inf[IDX_D25].d;
+      const d27_inf = S_inf[IDX_D27].d;
+
+      let { delta5, delta6, residuals: R } = solveDeltas(S_inf, L.asphByIdx, d21_inf, d25_inf, d27_inf);
+
+      let d21_close = d21_inf - delta5;
+      let d25_close = d25_inf + delta5 - delta6;
+      let d27_close = d27_inf + delta6;
+
+      // If any gap falls below the mechanical clearance, constrain and resolve.
+      // The G5↔G6 gap (d25) is the binding constraint in this design at tele.
+      if (d25_close < MIN_GAP) {
+        ({
+          delta5,
+          delta6,
+          residuals: R,
+        } = solveDeltasWithD25Fixed(S_inf, L.asphByIdx, d21_inf, d25_inf, d27_inf, MIN_GAP));
+        d21_close = d21_inf - delta5;
+        d25_close = d25_inf + delta5 - delta6;
+        d27_close = d27_inf + delta6;
+      }
+
+      // Diagnostic: magnification at close focus
+      const S_close = modifiedSurfaces(S_inf, d21_inf, d25_inf, d27_inf, delta5, delta6);
+      const totalLen = S_inf.reduce((a, s) => a + s.d, 0);
+      const mag = estimateMagnification(S_close, L.asphByIdx, MFD_MM - totalLen);
+
+      results.push({
+        fDesign,
+        zoomT,
+        delta5,
+        delta6,
+        d21_inf,
+        d25_inf,
+        d27_inf,
+        d21_close,
+        d25_close,
+        d27_close,
+        residuals: R,
+        magnification: mag,
+      });
+    }
+
+    /* ── Pretty-print results table ── */
+    console.log("\n=== NIKKOR Z 24-120 CLOSE-FOCUS SOLVE ===");
+    console.log("(MFD = 0.35 m from image plane, all zoom positions)\n");
+    console.log("f(mm)  zoomT  Δ5(mm)   Δ6(mm)   d21_inf  d21_cl   d25_inf  d25_cl   d27_inf  d27_cl   |F|        mag");
+    for (const r of results) {
+      const norm = Math.abs(r.residuals.f1);
+      console.log(
+        `${r.fDesign.toFixed(1).padStart(5)}  ` +
+          `${r.zoomT.toFixed(3)}  ` +
+          `${r.delta5.toFixed(3).padStart(7)}  ${r.delta6.toFixed(3).padStart(7)}  ` +
+          `${r.d21_inf.toFixed(3).padStart(7)}  ${r.d21_close.toFixed(3).padStart(7)}  ` +
+          `${r.d25_inf.toFixed(3).padStart(7)}  ${r.d25_close.toFixed(3).padStart(7)}  ` +
+          `${r.d27_inf.toFixed(3).padStart(7)}  ${r.d27_close.toFixed(3).padStart(7)}  ` +
+          `${norm.toExponential(2)}  ${r.magnification.toFixed(4)}`,
+      );
+    }
+
+    /* ── Emit var-table snippets for pasting into the data file ── */
+    console.log("\n=== VAR-TABLE VALUES (for lens data file) ===");
+    const names = ["21", "25", "27A"];
+    const arrs = [
+      results.map((r) => [r.d21_inf, r.d21_close]),
+      results.map((r) => [r.d25_inf, r.d25_close]),
+      results.map((r) => [r.d27_inf, r.d27_close]),
+    ];
+    for (let i = 0; i < names.length; i++) {
+      const rows = arrs[i].map(([inf, cl]) => `  [${inf.toFixed(3)}, ${cl.toFixed(3)}],`).join("\n");
+      console.log(`"${names[i]}": [\n${rows}\n],`);
+    }
+
+    /* ── Assertions (sanity) ── */
+    for (const r of results) {
+      expect(Math.abs(r.residuals.f1), `f=${r.fDesign}mm`).toBeLessThan(1e-4);
+      // All close-focus gaps must stay positive (mechanical clearance)
+      expect(r.d21_close, `d21 at f=${r.fDesign}`).toBeGreaterThan(0.2);
+      expect(r.d25_close, `d25 at f=${r.fDesign}`).toBeGreaterThan(0.2);
+      expect(r.d27_close, `d27 at f=${r.fDesign}`).toBeGreaterThan(0.2);
+    }
+  });
+});

--- a/agent_docs/records/canon-rf-28-70-f2-sd-tuning-260415.md
+++ b/agent_docs/records/canon-rf-28-70-f2-sd-tuning-260415.md
@@ -1,0 +1,18 @@
+# Canon RF 28-70mm f/2 L SD Tuning
+
+## Summary
+- Refined the Canon RF 28-70mm f/2 L USM semi-diameters to clean up the front-group silhouette and remove rear-group crowding/collision risk.
+
+## Changes
+- Reduced the L3 front and rear SDs to give the first singlet a cleaner taper.
+- Rebalanced the rear block SDs from L12 through L18 so thin edges gained margin and the L16→L17 / L17→L18 region no longer crowds visually.
+- Added a homepage changelog entry for the user-visible rendering fix.
+
+## Verification
+- `npm run typecheck` — passed
+- `npm run format:check` — passed
+- `npm run lint` — passed
+- `npm run test` — passed
+
+## Follow-ups
+- Check the rendered SVG against the patent cross-section again if further by-eye SD tuning is needed on adjacent Canon RF zooms.

--- a/src/lens-data/CanonRF24240mmf463.analysis.md
+++ b/src/lens-data/CanonRF24240mmf463.analysis.md
@@ -1,0 +1,380 @@
+# Canon RF 24-240mm F4-6.3 IS USM — Optical Design Analysis
+
+**Patent:** US 2020/0142167 A1 (Pub. May 7, 2020)
+**Inventor:** Shohei Kikuchi (Canon Kabushiki Kaisha)
+**Priority:** JP 2018-207200, filed November 2, 2018
+**Numerical Example:** 1 (of 5 examples in the patent)
+**Production Lens:** Canon RF24-240mm F4-6.3 IS USM (Canon RF mount, released 2019)
+
+---
+
+## 1. Overview
+
+The Canon RF 24-240mm F4-6.3 IS USM is a 10× superzoom for Canon's full-frame RF mirrorless system. Canon's published specifications describe the optical formula as **21 elements in 15 groups**, incorporating **1 aspherical lens** and **2 UD (Ultra-low Dispersion) lenses**, with a 7-blade circular aperture diaphragm. The patent's Example 1 matches the production lens in element count, group count, and general architecture, and is the basis for this analysis.
+
+### Key Specifications (Manufacturer vs. Patent Example 1)
+
+| Parameter | Canon Published | Patent Example 1 |
+|-----------|----------------|-------------------|
+| Focal Length | 24–240 mm | 24.72–232.80 mm |
+| Maximum Aperture | f/4–6.3 | f/4.12–6.41 |
+| Zoom Ratio | 10× | 9.42× |
+| Elements / Groups | 21 / 15 | 21 / 15 |
+| Close Focus (wide) | 0.50 m | — |
+| Close Focus (tele) | 0.78 m | — |
+| Aspherical Elements | 1 | 1 (2 asph. surfaces) |
+| UD Elements | 2 | 2 |
+| Aperture Blades | 7 (circular) | — |
+| Image Circle | 43.2 mm (36×24) | 2 × 21.64 = 43.28 mm |
+
+The slight focal-length and f-number discrepancies are normal between patent design examples and production-tuned lenses. The marketing "24–240mm" and "f/4–6.3" values are rounded from the computed design values per standard industry practice.
+
+---
+
+## 2. Zoom Architecture: Six Moving Groups
+
+The lens consists of six lens units (zoom groups) arranged front-to-rear, with sign convention indicating their refractive power:
+
+| Unit | Patent Label | Power | Focal Length | Elements | Surfaces | Role |
+|------|-------------|-------|-------------|----------|----------|------|
+| 1 | L1 | Positive | +103.63 mm | L1, L2, L3 | 1–4 | Front positive group (collecting) |
+| 2 | L2 | Negative | −16.74 mm | L4, L5, L6, L7 | 6–12 | Variator (main zoom power) |
+| 3 | L3 / XYZ | Positive | +60.67 mm | L8–L13 | 14–23 | Correction group with OIS unit |
+| 4 | L4 | Positive | +22.87 mm | L14–L17 | 25–30 | Relay / compensator |
+| 5 | L5 | Negative | −53.51 mm | L18, L19 | 32–33 | Focus group |
+| 6 | L6 | Negative | −138.27 mm | L20, L21 | 35–36 | Rear field corrector |
+
+This is a **positive-lead** zoom of the form **+ − + + − −**, which the patent describes as a first lens unit with positive power, second with negative, third with positive, and a rear group (LR) comprising the fourth (positive), fifth (negative), and sixth (negative) units. The intervals between all six units vary during zooming.
+
+### Zoom Motion
+
+During zooming from wide (24.72 mm) to tele (232.80 mm), the six variable air gaps change as follows:
+
+| Gap | Location | Wide (mm) | Mid (mm) | Tele (mm) | Change |
+|-----|----------|-----------|----------|-----------|--------|
+| d5 | L1 → L2 | 1.34 | 32.74 | 59.28 | +57.94 |
+| d13 | L2 → L3 | 22.25 | 8.64 | 2.35 | −19.90 |
+| d24 | L3 → L4 | 8.46 | 3.21 | 1.00 | −7.46 |
+| d31 | L4 → L5 | 3.73 | 4.64 | 1.50 | −2.23 |
+| d34 | L5 → L6 | 15.54 | 14.63 | 17.77 | +2.23 |
+| d37 | BFD | 15.78 | 45.06 | 57.20 | +41.42 |
+
+The dominant zoom action is the separation of L1 from L2 (d5 expanding by nearly 58 mm) while L2 closes toward L3 (d13 contracting by 20 mm). This is the classic variator mechanism: the negative second unit moves image-ward relative to the positive first unit, increasing the system's effective focal length. The total track grows from 142 mm at wide to 214 mm at tele—the lens is a rotary-extending zoom, not an internal zoom, consistent with the production lens's two-stage barrel extension.
+
+The gap d34 between L5 and L6 shows **non-monotonic** behavior: it decreases from 15.54 at wide to 14.63 at mid, then increases to 17.77 at tele. This reversing motion is handled by piecewise-linear interpolation in a renderer.
+
+---
+
+## 3. The 15 Air-Separated Groups
+
+Canon's published "15 groups" count refers to the air-separated optical groups (not the zoom units). Tracing through the prescription, the 21 elements form exactly 15 air-separated groups:
+
+| Group | Elements | Configuration | Lens Unit |
+|-------|----------|---------------|-----------|
+| 1 | L1 + L2 | Cemented doublet | L1 |
+| 2 | L3 | Singlet | L1 |
+| 3 | L4 | Singlet | L2 |
+| 4 | L5 | Singlet | L2 |
+| 5 | L6 | Singlet | L2 |
+| 6 | L7 | Singlet | L2 |
+| 7 | L8 | Singlet | L3 (subunit X) |
+| 8 | L9 + L10 | Cemented doublet | L3 (subunit X) |
+| 9 | L11 + L12 | Cemented doublet | L3 (subunit Y / OIS) |
+| 10 | L13 | Singlet | L3 (subunit Z) |
+| 11 | L14 | Singlet (aspherical) | L4 |
+| 12 | L15 + L16 | Cemented doublet | L4 |
+| 13 | L17 | Singlet | L4 |
+| 14 | L18 + L19 | Cemented doublet | L5 |
+| 15 | L20 + L21 | Cemented doublet | L6 |
+
+This gives 6 cemented doublets and 9 singlets, totaling 15 groups — matching Canon's specification.
+
+---
+
+## 4. Element-by-Element Optical Analysis
+
+### 4.1 Lens Unit 1 — Front Positive Collector (f = +103.63 mm)
+
+**L1** (surfaces 1–2): nd = 1.90366, νd = 31.3
+A **negative meniscus** (f = −160.9 mm) convex toward the object, made of ultra-high-index lanthanum dense flint glass (glass code 90366/313, matching OHARA S-LAH79 or equivalent). Both radii are positive (R₁ = +131.4 mm, R₂ = +68.6 mm), giving a crescent-shaped cross-section with the convex face toward the object and the concave face toward the image. The rear surface is more strongly curved than the front, which is characteristic of a thick negative meniscus in a front collector group. Despite being a negative element, its role is primarily to control spherical aberration and field curvature contributed by the strong positive elements behind it. The very high refractive index (nd ≈ 1.90) allows the surface curvatures to remain moderate despite the element's corrective power.
+
+**L2** (surfaces 2–3): nd = 1.49700, νd = 81.5 — **★ UD Element**
+A **positive biconvex** element (f = +126.6 mm) cemented to L1. This is one of the two UD (Ultra-low Dispersion) elements Canon specifies for the production lens. The glass code 49700/815 corresponds to a fluorophosphate crown such as OHARA S-FPL51 or Canon's proprietary equivalent. With νd = 81.5, this glass has exceptionally low chromatic dispersion. The L1/L2 cemented doublet forms a powerful achromatic pair: the high-dispersion negative flint (L1) and low-dispersion positive crown (L2) work together to control axial chromatic aberration across the wide zoom range. This achromat is critical because the front group sees the full entrance pupil diameter and must manage chromatic errors at maximum aperture.
+
+**L3** (surfaces 4–5): nd = 1.61800, νd = 63.4
+A **positive meniscus** (f = +123.7 mm) in phosphate crown glass (matching OHARA S-PHM52). This singlet adds positive power to the front group while its meniscus form (convex toward the object) helps correct spherical aberration. The overall front group power of +103.63 mm is typical for a positive-lead zoom—strong enough to converge light toward the variator, but not so strong that it demands extreme curvatures.
+
+The front group's effective diameter spans 52–57 mm, the largest apertures in the system, consistent with the 72 mm filter thread of the production lens.
+
+### 4.2 Lens Unit 2 — Variator (f = −16.74 mm)
+
+This is the most powerful unit in the system. Its strong negative focal length (−16.74 mm) makes it the primary zoom variator: as it moves away from the front group during zooming to tele, the divergence it introduces shifts the effective focal length of the combined system dramatically.
+
+**L4** (surfaces 6–7): nd = 1.85150, νd = 40.8
+A **negative meniscus** (f = −26.5 mm) in lanthanum dense flint (OHARA S-LAH66 equivalent). Both radii are positive (R₁ = +243.5 mm, R₂ = +20.6 mm), making this a meniscus convex toward the object with a very weakly curved front face and a strongly curved rear face. The extreme curvature mismatch gives this element its strong negative power and contributes the bulk of the variator's diverging capability.
+
+**L5** (surfaces 8–9): nd = 1.85150, νd = 40.8
+A **biconcave negative** element (f = −29.5 mm) in the same glass as L4. Together with L4, they form a strong negative doublet pair that efficiently diverges the beam.
+
+**L6** (surfaces 10–11): nd = 1.92286, νd = 20.9
+A **positive biconvex** element (f = +25.1 mm) in ultra-high-index dense flint glass (glass code 923/209, HOYA E-FD15 or equivalent). This positive element within the negative variator serves as a chromatic corrector—its very high dispersion (νd = 20.9) paired with its positive power provides the opposite chromatic contribution to the two negative elements, keeping longitudinal chromatic aberration controlled across the zoom range.
+
+**L7** (surfaces 12–13): nd = 1.77250, νd = 49.6
+A **biconcave negative** element (f = −40.3 mm) in lanthanum light flint (OHARA S-LAL54), with R₁ = −32.4 mm and R₂ = +821.5 mm. The front surface is strongly concave; the rear is very weakly concave (nearly flat). This trailing negative element shapes the exit beam of the variator and helps correct higher-order aberrations. The variator's four-element, all-singlet configuration gives the designer maximum freedom to balance coma, astigmatism, and chromatic aberration across the zoom range.
+
+### 4.3 Lens Unit 3 — Correction Group with Image Stabilization (f = +60.67 mm)
+
+This is the most complex unit in the design, containing six elements organized into three subunits designated X, Y, and Z in the patent. The aperture stop (surface 14) is the first surface of this unit, positioned at the front of subunit X.
+
+#### Subunit X — Front positive subgroup (fx = +55.81 mm)
+
+**L8** (surfaces 15–16): nd = 1.76182, νd = 26.5
+A **positive biconvex** element (f = +34.5 mm) in heavy flint glass (OHARA S-TIH6). Located immediately after the aperture stop, it begins converging the beam toward the image. Its high dispersion enables chromatic correction when paired with the subsequent cemented doublet.
+
+**L9** (surfaces 17–18): nd = 1.58144, νd = 40.8
+A **positive plano-convex** element (f = +34.1 mm) in barium crown glass (OHARA S-BAM4). The rear surface is flat (R = ∞). This element is cemented to L10.
+
+**L10** (surfaces 18–19): nd = 2.00100, νd = 29.1
+A negative element (f = −20.5 mm) in ultra-high-index dense flint glass (OHARA S-NPH2), with a **plano-convex geometric form** — the front surface is flat (the cemented junction with L9) and the rear surface is convex (R₂ = +20.5 mm). Despite its convex exit surface, the element has strong negative optical power because light transitions from the very high refractive index glass (nd = 2.001) into air at that surface, producing divergence. The L9/L10 cemented doublet provides achromatic correction within subunit X and controls the beam diameter entering the OIS subunit.
+
+#### Subunit Y — Image Stabilization Unit (fy = +41.45 mm)
+
+This is the subunit that physically shifts perpendicular to the optical axis during image stabilization (OIS). At the telephoto end, the patent specifies a correction shift of 0.509 mm. The subunit consists of a single cemented doublet:
+
+**L11** (surfaces 20–21): nd = 2.00069, νd = 25.5
+A **negative meniscus** (f = −40.9 mm) in ultra-high-index dense flint glass (OHARA S-NPH1). This is the first element of the cemented IS doublet.
+
+**L12** (surfaces 21–22): nd = 1.72000, νd = 43.7
+A **positive biconvex** element (f = +20.6 mm) in lanthanum flint glass (OHARA S-LAM3), cemented to L11.
+
+The L11/L12 cemented doublet has a combined focal length of approximately +41.5 mm (verified: thin-lens computation gives +41.61 mm, close to the patent's stated fy = +41.45 mm). The patent notes that all lenses in the second subunit are preferably spherical to simplify manufacturing by polishing—no aspherical surfaces are used in the IS group. This is important for manufacturing cost and for maintaining tight tolerances when the element is mounted on a moving gimbal mechanism.
+
+The cemented doublet configuration also provides chromatic correction during IS operation. When the subunit shifts off-axis, it introduces decentering aberrations; by using a positive and negative element cemented together, lateral color is partially self-corrected during the shift.
+
+#### Subunit Z — Rear negative subgroup (fz = −30.98 mm)
+
+**L13** (surfaces 23–24): nd = 2.00100, νd = 29.1
+A **negative meniscus** (f = −31.0 mm) in the same ultra-high-index dense flint glass as L10 (OHARA S-NPH2). This singlet provides the negative power needed to increase the effective positive power of the IS subunit Y, thereby reducing the physical shift distance required for a given amount of image correction. The patent explains this explicitly: "the third subunit Z with a negative refractive power is arranged on the image side of the image blurring correction unit to increase the positive refractive power of the second subunit Y, so that the movement amount in the image blurring correction is suppressed."
+
+The boundary between subunit Y and subunit Z is confirmed by the patent's conditional expression (6) parameters: Ryz1 = −63.451 mm (the image-side surface of L12, surface 22) and Ryz2 = −26.036 mm (the object-side surface of L13, surface 23).
+
+### 4.4 Lens Unit 4 — Relay / Compensator (f = +22.87 mm)
+
+This is the strongest positive unit in the rear half of the lens. It relays the image formed by the front groups toward the sensor and contains the only aspherical element in the design.
+
+**L14** (surfaces 25–26): nd = 1.53110, νd = 55.9 — **★ Aspherical Element**
+A weak **positive meniscus** singlet (f = +105.0 mm) in barium light crown glass (OHARA S-BAL42 or equivalent), convex toward the object (R₁ = +45.6 mm, R₂ = +246.6 mm — both radii positive). Both surfaces carry aspherical profiles (detailed in Section 5). The relatively low refractive index (1.531) and moderate Abbe number suggest this is a glass-molded aspherical element (as opposed to polished), which is consistent with Canon's manufacturing approach for non-L consumer zoom lenses.
+
+**L15 + L16** (surfaces 27–29): Cemented doublet
+- **L15**: nd = 1.85478, νd = 24.8 — **biconcave negative** (f = −99.6 mm) in short flint glass (OHARA S-TIH53W)
+- **L16**: nd = 1.59282, νd = 68.6 — **biconvex positive** (f = +39.3 mm) in borosilicate crown glass (OHARA S-BSM81)
+
+This cemented doublet is a classic achromat with a strong positive element and a weaker negative corrector. Located behind the aspherical element, it handles the primary chromatic correction duties for unit 4.
+
+**L17** (surfaces 30–31): nd = 1.49700, νd = 81.5 — **★ UD Element**
+A **positive biconvex** element (f = +47.0 mm) — the second UD element in the design. Same fluorophosphate crown glass as L2 (49700/815, OHARA S-FPL51 equivalent). Positioned at the rear of unit 4 where off-axis ray heights are increasing, this UD element provides additional longitudinal and lateral chromatic aberration correction, particularly important for maintaining color performance at the telephoto end where chromatic aberration tends to increase.
+
+### 4.5 Lens Unit 5 — Focus Group (f = −53.51 mm)
+
+**L18 + L19** (surfaces 32–34): Cemented doublet
+- **L18**: nd = 1.80518, νd = 25.4 — **positive meniscus** (f = +166.3 mm) in heavy flint, convex toward object
+- **L19**: nd = 1.63854, νd = 55.4 — **negative meniscus** (f = −40.0 mm) in barium crown, convex toward object
+
+This cemented doublet is the **focusing group**. The patent states that during focusing from infinity to the closest distance, "the fifth lens unit L5 is moved toward the image side." The movement arrows in Figure 1 (arrow 5c) confirm this rear-focusing mechanism. The doublet format provides chromatic correction during focus, preventing color shift as focus distance changes—an important quality-of-life feature for video shooters.
+
+The focus group's negative power (−53.51 mm) means it acts as a diverging element. Moving it toward the image plane shortens the effective back focal distance, shifting the focus plane closer. This rear-focus approach has the advantage that the front group remains stationary, the filter thread doesn't rotate, and the focusing mass is relatively small (two elements), enabling the fast, quiet Nano USM autofocus the production lens is known for.
+
+### 4.6 Lens Unit 6 — Rear Field Corrector (f = −138.27 mm)
+
+**L20 + L21** (surfaces 35–37): Cemented doublet
+- **L20**: nd = 1.83481, νd = 42.7 — **biconcave negative** (f = −32.0 mm) in lanthanum dense flint
+- **L21**: nd = 1.84666, νd = 23.8 — **biconvex positive** (f = +43.2 mm) in heavy flint
+
+This trailing cemented doublet has a combined weak negative focal length of −138.27 mm. Positioned closest to the image plane, it serves as a field-flattening and telecentricity-correcting group. In a mirrorless system like Canon's RF mount (20 mm flange distance), maintaining reasonable exit pupil distances across the field is important for sensor performance. The high-index glasses (nd > 1.83 in both elements) allow strongly curved surfaces while keeping the element thin, and the cemented configuration prevents ghost reflections between the two surfaces.
+
+---
+
+## 5. Aspherical Surfaces
+
+The single aspherical element is **L14** (surfaces 25 and 26), the leading element of lens unit 4. The aspherical sag equation used in the patent is:
+
+```
+Z(h) = (h²/R) / [1 + √(1 − (1+K)·(h/R)²)] + A4·h⁴ + A6·h⁶ + A8·h⁸ + A10·h¹⁰ + A12·h¹²
+```
+
+### Surface 25 (front of L14)
+
+| Parameter | Value |
+|-----------|-------|
+| R | 45.628 mm |
+| K (conic) | 0 (spherical base) |
+| A4 | −3.69428 × 10⁻⁶ |
+| A6 | −1.81514 × 10⁻⁷ |
+| A8 | +1.12707 × 10⁻⁹ |
+| A10 | −1.37724 × 10⁻¹¹ |
+| A12 | +4.19334 × 10⁻¹⁴ |
+
+### Surface 26 (rear of L14)
+
+| Parameter | Value |
+|-----------|-------|
+| R | 246.555 mm |
+| K (conic) | 0 (spherical base) |
+| A4 | +2.68822 × 10⁻⁵ |
+| A6 | −1.85641 × 10⁻⁷ |
+| A8 | +9.59349 × 10⁻¹⁰ |
+| A10 | −1.18429 × 10⁻¹¹ |
+| A12 | +3.67346 × 10⁻¹⁴ |
+
+Both surfaces have K = 0, meaning the base curve is spherical and all aspherical correction comes from the even-order polynomial terms. At the working clear aperture (approximately h = 10 mm where the beam passes through this element across zoom positions), the aspherical departures from a sphere are:
+
+- **Surface 25**: approximately −200 µm at h = 10 mm (flattening relative to the sphere)
+- **Surface 26**: approximately +97 µm at h = 10 mm (steepening relative to the sphere)
+
+The dominant effect of surface 25's aspherical profile is to flatten the surface progressively toward the rim compared to a sphere, which primarily corrects **spherical aberration** and **coma** in the converging beam. Surface 26's profile adds a compensating steepening that helps control **astigmatism** and **field curvature**. Because both surfaces are on the same element, the designer can independently tune on-axis and off-axis correction while keeping the manufacturing to a single precision-molded part.
+
+The glass choice for L14 (nd = 1.531, νd = 55.9) is notable: moderate-index barium light crown is a standard glass-molding candidate. Canon's PMo (Precision-Molded Optics) technology is well-suited to this glass type, allowing cost-effective production of the doubly-aspherical element.
+
+### Why only one aspherical element?
+
+In a consumer-grade 10× superzoom, cost constraints limit the use of aspherical elements. Canon placed the single aspherical element strategically in unit 4, where it sits in a converging beam between the IS correction group and the focus group. This position allows it to correct residual aberrations from the entire front optical train (units 1–3) while also pre-correcting for the diverging rear groups (units 5–6). The patent's aberration diagrams show well-controlled spherical aberration and astigmatism at all zoom positions, suggesting this single aspherical element placement is highly effective.
+
+---
+
+## 6. Glass Selection and Special Elements
+
+### The Two UD Elements
+
+Canon identifies two UD (Ultra-low Dispersion) elements in the production lens. Based on the patent prescription, these are:
+
+1. **L2** (nd = 1.49700, νd = 81.5) — in the front group cemented doublet
+2. **L17** (nd = 1.49700, νd = 81.5) — in the rear relay group
+
+Both elements use the same fluorophosphate crown glass. UD glass has anomalous partial dispersion: it bends blue and red light more equally than conventional glass, reducing secondary chromatic aberration (the residual color error that persists even after primary achromatization). The placement of one UD element near the front (where the marginal ray is high) and one near the rear (where off-axis rays diverge) provides chromatic correction across both the aperture and the field.
+
+### Ultra-High-Index Glasses (nd ≥ 2.0)
+
+The design makes extensive use of ultra-high-index glasses:
+
+- **nd = 2.00100** (νd = 29.1): Used in L10 and L13 — both negative elements in the correction group. This glass (OHARA S-NPH2 or equivalent) allows extremely strong curvatures in compact form. In the IS unit, the high index keeps the elements thin and lightweight, directly benefiting the stabilization mechanism's speed and power consumption.
+
+- **nd = 2.00069** (νd = 25.5): Used in L11 — the negative element of the IS cemented doublet. Similar to S-NPH1.
+
+These nd ≈ 2.0 glasses are expensive specialty materials, but their use is justified in the IS subunit where minimizing weight and diameter directly improves stabilization performance.
+
+### Glass Summary Table
+
+| Element | nd | νd | Glass Type | Category |
+|---------|-------|-------|------------|----------|
+| L1 | 1.90366 | 31.3 | S-LAH79 type | Lanthanum dense flint |
+| L2 | 1.49700 | 81.5 | S-FPL51 type | Fluorophosphate crown **(UD)** |
+| L3 | 1.61800 | 63.4 | S-PHM52 type | Phosphate crown |
+| L4 | 1.85150 | 40.8 | S-LAH66 type | Lanthanum dense flint |
+| L5 | 1.85150 | 40.8 | S-LAH66 type | Lanthanum dense flint |
+| L6 | 1.92286 | 20.9 | E-FD15 type | Ultra-high index dense flint |
+| L7 | 1.77250 | 49.6 | S-LAL54 type | Lanthanum light flint |
+| L8 | 1.76182 | 26.5 | S-TIH6 type | Heavy flint |
+| L9 | 1.58144 | 40.8 | S-BAM4 type | Barium crown |
+| L10 | 2.00100 | 29.1 | S-NPH2 type | Ultra-high index dense flint |
+| L11 | 2.00069 | 25.5 | S-NPH1 type | Ultra-high index dense flint |
+| L12 | 1.72000 | 43.7 | S-LAM3 type | Lanthanum flint |
+| L13 | 2.00100 | 29.1 | S-NPH2 type | Ultra-high index dense flint |
+| L14 | 1.53110 | 55.9 | S-BAL42 type | Barium light crown **(ASPH)** |
+| L15 | 1.85478 | 24.8 | S-TIH53W type | Short flint |
+| L16 | 1.59282 | 68.6 | S-BSM81 type | Borosilicate crown |
+| L17 | 1.49700 | 81.5 | S-FPL51 type | Fluorophosphate crown **(UD)** |
+| L18 | 1.80518 | 25.4 | S-TIH10 type | Heavy flint |
+| L19 | 1.63854 | 55.4 | S-BSM14 type | Barium crown |
+| L20 | 1.83481 | 42.7 | S-LAH60 type | Lanthanum dense flint |
+| L21 | 1.84666 | 23.8 | S-TIH14 type | Heavy flint |
+
+*Note: Glass identifications are based on 6-digit nd/νd code matching against major catalogs. Canon may use proprietary melt equivalents; the catalog names here indicate the glass type and optical properties.*
+
+---
+
+## 7. Focus Mechanism
+
+The patent explicitly identifies the **fifth lens unit (L5)**, consisting of L18 and L19 as a cemented doublet, as the focusing group. Focus is achieved by moving this doublet toward the image side when focusing from infinity to closer distances.
+
+This is a **rear inner-focus** design. The variable gaps d31 (between L4 and L5) and d34 (between L5 and L6) change during focusing, while the front groups remain stationary. The benefits of this arrangement include:
+
+1. **No front element rotation** — important for polarizer and graduated filter users.
+2. **Small focusing mass** — only two cemented elements need to move, enabling the fast, quiet Nano USM autofocus system Canon employs.
+3. **Constant overall length during focus** — the outer barrel doesn't change length when focusing (though it does extend when zooming).
+4. **Chromatic stability** — the cemented doublet format minimizes focus-dependent color shift (focus breathing in the chromatic domain).
+
+The production lens specifies close focus distances of 0.50 m (wide) and 0.78 m (tele), with a maximum magnification of 0.26× at 240 mm.
+
+---
+
+## 8. Image Stabilization System
+
+The optical image stabilization (IS) system resides entirely within lens unit 3 (the correction lens unit, labeled XYZ in the patent). It operates by physically shifting subunit Y perpendicular to the optical axis.
+
+### Subunit Architecture
+
+| Subunit | Elements | Power | Focal Length | Purpose |
+|---------|----------|-------|-------------|---------|
+| X | L8, L9+L10 | Positive | +55.81 mm | Converges beam, reduces IS unit diameter |
+| Y | L11+L12 | Positive | +41.45 mm | IS shift element (moves ⊥ to axis) |
+| Z | L13 | Negative | −30.98 mm | Amplifies Y's correction, reduces shift distance |
+
+The subunit X converges the beam before it enters the IS element, reducing the physical diameter of the shifted doublet. This directly benefits the actuator mechanism: a smaller, lighter IS element requires less motor force and responds faster, supporting Canon's claimed 5-stop stabilization performance.
+
+Subunit Z's negative power amplifies the angular deviation produced by subunit Y's physical shift, meaning a smaller physical movement achieves the same image-plane correction. At the telephoto end, the patent's aberration diagram (Fig. 3) uses an IS shift of 0.509 mm to demonstrate correction performance—a notably small displacement for a 233 mm focal length lens.
+
+### Conditional Expressions (all satisfied)
+
+The patent defines six inequalities governing the IS system's design balance:
+
+| Expression | Value | Range | Status |
+|------------|-------|-------|--------|
+| fxyz/fw | 2.45 | 0.01–4.55 | ✓ |
+| fxyz/fy | 1.46 | 0.82–10.0 | ✓ |
+| fxyz/fz | −1.96 | −10.0 to −1.3 | ✓ |
+| lis/fy | 1.28 | 0.60–50.0 | ✓ |
+| fxyz/fx | 1.09 | 0.30–10.0 | ✓ |
+| (Ryz1+Ryz2)/(Ryz1−Ryz2) | 2.39 | 0.5–75.0 | ✓ |
+
+---
+
+## 9. Petzval Sum and Field Curvature
+
+The Petzval sum computed via the exact surface-by-surface formula — Σ (n′ − n) / (n · n′ · R) across all 37 surfaces — gives **+0.00152 mm⁻¹**, corresponding to a Petzval radius of approximately **656 mm**. (A simpler thin-lens element-based approximation yields a misleadingly low value of 0.00008 mm⁻¹ because it does not properly account for thick-lens effects and cemented junction contributions; the surface-based result is authoritative.)
+
+A Petzval radius of 656 mm produces a field sag of approximately 0.36 mm at the image corner (half-diagonal ≈ 21.6 mm for a 36 × 24 mm sensor). This is a good result for a 10× superzoom — the six cemented doublets, each pairing positive and negative elements at different refractive indices, are largely responsible for keeping the Petzval sum this low. The residual Petzval curvature is compensated by deliberate introduction of opposite-sign astigmatism, which is the standard technique for flattening the tangential and sagittal image surfaces simultaneously. The aberration diagrams in the patent (Figs. 2A–2C) show the characteristic separated S and M astigmatic curves that indicate this balancing strategy is in effect.
+
+---
+
+## 10. Paraxial Verification
+
+Independent paraxial ray tracing through all 37 surfaces confirms the patent's stated focal lengths:
+
+| Position | Patent EFL | Computed EFL | Error |
+|----------|-----------|-------------|-------|
+| Wide angle | 24.72 mm | 24.72 mm | −0.01% |
+| Telephoto | 232.80 mm | 232.72 mm | −0.04% |
+
+The sub-0.1% agreement validates the transcribed surface data against the patent's stated specifications.
+
+---
+
+## 11. Summary of Design Philosophy
+
+The Canon RF 24-240mm F4-6.3 IS USM, as represented by patent Example 1, exemplifies a modern consumer superzoom optimized for several competing constraints:
+
+1. **10× zoom range** achieved through a six-unit positive-lead architecture with a powerful variator (f = −16.74 mm) and extensive group separation changes.
+
+2. **Compact size** maintained by using ultra-high-index glasses (nd ≥ 2.0) in the IS unit and correction group, minimizing element diameters where mass and inertia matter most.
+
+3. **Effective image stabilization** through a three-subunit correction architecture (X-Y-Z) where the positive front subunit X converges the beam to reduce the IS doublet's diameter, and the negative rear subunit Z amplifies the angular correction to minimize the physical shift distance, enabling Canon's 5-stop IS performance with fast response.
+
+4. **Cost-effective chromatic correction** using only two UD elements — strategically placed in the front group and rear relay group — supplemented by six cemented doublets distributed throughout the system.
+
+5. **Single aspherical element** in the relay group, using a moldable glass to control spherical aberration and field curvature across all zoom positions, balancing optical performance against production cost.
+
+6. **Fast, quiet rear focus** via a two-element cemented doublet (L18+L19) that moves toward the image during close focusing, enabling the Nano USM autofocus system.
+
+---
+
+*Analysis prepared from patent US 2020/0142167 A1, Numerical Data 1, cross-referenced with Canon's published product specifications for the RF24-240mm F4-6.3 IS USM. Glass identifications are inferred from nd/νd pairs and should be considered approximate catalog equivalents. All focal lengths and optical parameters verified by independent paraxial ray trace computation.*

--- a/src/lens-data/CanonRF24240mmf463.data.ts
+++ b/src/lens-data/CanonRF24240mmf463.data.ts
@@ -1,0 +1,482 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — CANON RF 24-240mm F4-6.3 IS USM             ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2020/0142167 A1, Example 1 (Canon / Kikuchi).    ║
+ * ║  Positive-lead 6-unit zoom: + − + + − − (LR = L4+L5+L6).         ║
+ * ║  21 elements / 15 groups, 2 aspherical surfaces (1 element).      ║
+ * ║  Focus: Rear inner focus via L5 (unit 5, L18+L19 cemented         ║
+ * ║         doublet) moving image-ward. Patent does not provide       ║
+ * ║         close-focus spacings; var entries are zoom-only.           ║
+ * ║                                                                    ║
+ * ║  Zoom variable gaps (all 6 change during zoom):                   ║
+ * ║    D5 (L1→L2), D13 (L2→L3), D24 (L3→L4),                        ║
+ * ║    D31 (L4→L5), D34 (L5→L6), D37 (BFD).                         ║
+ * ║  Reversing group: D34 is non-monotonic                            ║
+ * ║    (15.54 → 14.63 → 17.77 mm, wide→mid→tele).                    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                          ║
+ * ║    Patent lists "effective diameter" for every surface.            ║
+ * ║    sd = effective_diameter / 2.                                    ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "canon-rf24-240-f4-63",
+  maker: "Canon",
+  name: "CANON RF 24-240mm F4-6.3 IS USM",
+  subtitle: "US 2020/0142167 A1 EXAMPLE 1 — CANON / KIKUCHI",
+  specs: [
+    "21 ELEMENTS / 15 GROUPS",
+    "f ≈ 24.7–232.8 mm",
+    "F/4.12–6.41",
+    "2ω ≈ 75.1–10.6°",
+    "2 ASPHERICAL SURFACES (1 ELEMENT)",
+    "2 UD (ULTRA-LOW DISPERSION) ELEMENTS",
+  ],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: [24, 240],
+  focalLengthDesign: [24.72, 232.8],
+  apertureMarketing: 4,
+  apertureDesign: 4.12,
+  patentYear: 2020,
+  elementCount: 21,
+  groupCount: 15,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.90366,
+      vd: 31.3,
+      fl: -160.9,
+      glass: "S-LAH79 type (903/313)",
+      apd: false,
+      role: "Front collector — high-index negative meniscus for SA / field curvature control",
+      cemented: "D1",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.5,
+      fl: 126.6,
+      glass: "S-FPL51 type (497/815)",
+      apd: "inferred",
+      apdNote: "UD (Ultra-low Dispersion) — fluorophosphate crown, νd = 81.5",
+      role: "Achromatic partner to L1 — UD element for primary chromatic correction",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.618,
+      vd: 63.4,
+      fl: 123.7,
+      glass: "S-PHM52 type (618/634)",
+      apd: false,
+      role: "Front group positive power contributor; meniscus form for SA correction",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.8515,
+      vd: 40.8,
+      fl: -26.5,
+      glass: "S-LAH66 type (852/408)",
+      apd: false,
+      role: "Variator — primary negative power element with strong rear curvature",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconcave Negative",
+      nd: 1.8515,
+      vd: 40.8,
+      fl: -29.5,
+      glass: "S-LAH66 type (852/408)",
+      apd: false,
+      role: "Variator — second negative element for beam divergence",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.92286,
+      vd: 20.9,
+      fl: 25.1,
+      glass: "E-FD15 type (923/209)",
+      apd: false,
+      role: "Variator chromatic corrector — high-dispersion positive for LCA control",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconcave Negative",
+      nd: 1.7725,
+      vd: 49.6,
+      fl: -40.3,
+      glass: "S-LAL54 type (773/496)",
+      apd: false,
+      role: "Variator trailing negative — shapes exit beam and corrects higher-order aberrations",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.76182,
+      vd: 26.5,
+      fl: 34.5,
+      glass: "S-TIH6 type (762/265)",
+      apd: false,
+      role: "Subunit X front — converges beam entering the IS unit",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Plano-Convex Positive",
+      nd: 1.58144,
+      vd: 40.8,
+      fl: 34.1,
+      glass: "S-BAM4 type (581/408)",
+      apd: false,
+      role: "Subunit X achromat positive — cemented to L10",
+      cemented: "D4",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Plano-Convex Negative",
+      nd: 2.001,
+      vd: 29.1,
+      fl: -20.5,
+      glass: "S-NPH2 type (001/291)",
+      apd: false,
+      role: "Subunit X achromat negative — ultra-high index for compact power",
+      cemented: "D4",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Negative Meniscus",
+      nd: 2.00069,
+      vd: 25.5,
+      fl: -40.9,
+      glass: "S-NPH1 type (001/255)",
+      apd: false,
+      role: "IS doublet negative — shifts ⊥ to axis for image stabilization",
+      cemented: "D5",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Biconvex Positive",
+      nd: 1.72,
+      vd: 43.7,
+      fl: 20.6,
+      glass: "S-LAM3 type (720/437)",
+      apd: false,
+      role: "IS doublet positive — provides net positive power to IS subunit Y",
+      cemented: "D5",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Negative Meniscus",
+      nd: 2.001,
+      vd: 29.1,
+      fl: -31.0,
+      glass: "S-NPH2 type (001/291)",
+      apd: false,
+      role: "Subunit Z — amplifies IS angular correction, reduces required shift distance",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Pos. Meniscus (2× Asph)",
+      nd: 1.5311,
+      vd: 55.9,
+      fl: 105.0,
+      glass: "S-BAL42 type (531/559)",
+      apd: false,
+      role: "Aspherical relay element — corrects SA, coma, and field curvature across zoom",
+    },
+    {
+      id: 15,
+      name: "L15",
+      label: "Element 15",
+      type: "Biconcave Negative",
+      nd: 1.85478,
+      vd: 24.8,
+      fl: -99.6,
+      glass: "S-TIH53W type (855/248)",
+      apd: false,
+      role: "Relay achromat negative — cemented to L16",
+      cemented: "D6",
+    },
+    {
+      id: 16,
+      name: "L16",
+      label: "Element 16",
+      type: "Biconvex Positive",
+      nd: 1.59282,
+      vd: 68.6,
+      fl: 39.3,
+      glass: "S-BSM81 type (593/686)",
+      apd: false,
+      role: "Relay achromat positive — primary chromatic correction for unit 4",
+      cemented: "D6",
+    },
+    {
+      id: 17,
+      name: "L17",
+      label: "Element 17",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.5,
+      fl: 47.0,
+      glass: "S-FPL51 type (497/815)",
+      apd: "inferred",
+      apdNote: "UD (Ultra-low Dispersion) — fluorophosphate crown, νd = 81.5",
+      role: "Second UD element — chromatic correction where off-axis rays diverge",
+    },
+    {
+      id: 18,
+      name: "L18",
+      label: "Element 18",
+      type: "Positive Meniscus",
+      nd: 1.80518,
+      vd: 25.4,
+      fl: 166.3,
+      glass: "S-TIH10 type (805/254)",
+      apd: false,
+      role: "Focus doublet front — cemented to L19, moves image-ward for close focus",
+      cemented: "D7",
+    },
+    {
+      id: 19,
+      name: "L19",
+      label: "Element 19",
+      type: "Negative Meniscus",
+      nd: 1.63854,
+      vd: 55.4,
+      fl: -40.0,
+      glass: "S-BSM14 type (639/554)",
+      apd: false,
+      role: "Focus doublet rear — provides negative power for rear focus mechanism",
+      cemented: "D7",
+    },
+    {
+      id: 20,
+      name: "L20",
+      label: "Element 20",
+      type: "Biconcave Negative",
+      nd: 1.83481,
+      vd: 42.7,
+      fl: -32.0,
+      glass: "S-LAH60 type (835/427)",
+      apd: false,
+      role: "Field corrector negative — field flattening and telecentricity",
+      cemented: "D8",
+    },
+    {
+      id: 21,
+      name: "L21",
+      label: "Element 21",
+      type: "Biconvex Positive",
+      nd: 1.84666,
+      vd: 23.8,
+      fl: 43.2,
+      glass: "S-TIH14 type (847/238)",
+      apd: false,
+      role: "Field corrector positive — residual chromatic and field curvature correction",
+      cemented: "D8",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Unit 1: Front Positive Collector (f = +103.63 mm) ──
+    { label: "1", R: 131.399, d: 1.85, nd: 1.90366, elemId: 1, sd: 28.415 }, // L1 front
+    { label: "2", R: 68.561, d: 8.49, nd: 1.497, elemId: 2, sd: 27.72 }, // L1→L2 junction
+    { label: "3", R: -730.653, d: 0.15, nd: 1.0, elemId: 0, sd: 27.56 }, // L2 rear → air
+    { label: "4", R: 68.792, d: 6.48, nd: 1.618, elemId: 3, sd: 26.76 }, // L3 front
+    { label: "5", R: 664.437, d: 1.34, nd: 1.0, elemId: 0, sd: 26.38 }, // L3 rear → air (zoom var)
+
+    // ── Unit 2: Variator (f = −16.74 mm) ──
+    { label: "6", R: 243.528, d: 1.28, nd: 1.8515, elemId: 4, sd: 13.795 }, // L4 front
+    { label: "7", R: 20.583, d: 4.73, nd: 1.0, elemId: 0, sd: 11.19 }, // L4 rear → air
+    { label: "8", R: -56.381, d: 1.09, nd: 1.8515, elemId: 5, sd: 10.985 }, // L5 front
+    { label: "9", R: 45.818, d: 0.46, nd: 1.0, elemId: 0, sd: 10.39 }, // L5 rear → air
+    { label: "10", R: 35.871, d: 4.51, nd: 1.92286, elemId: 6, sd: 10.29 }, // L6 front
+    { label: "11", R: -61.247, d: 0.84, nd: 1.0, elemId: 0, sd: 9.82 }, // L6 rear → air
+    { label: "12", R: -32.368, d: 1.03, nd: 1.7725, elemId: 7, sd: 9.725 }, // L7 front
+    { label: "13", R: 821.472, d: 22.25, nd: 1.0, elemId: 0, sd: 9.32 }, // L7 rear → air (zoom var)
+
+    // ── Unit 3: Correction Group with IS — XYZ (f = +60.67 mm) ──
+    { label: "STO", R: 1e15, d: 0.35, nd: 1.0, elemId: 0, sd: 8.16 }, // Aperture stop
+    // Subunit X (positive, f = +55.81 mm)
+    { label: "15", R: 27.034, d: 3.05, nd: 1.76182, elemId: 8, sd: 8.515 }, // L8 front
+    { label: "16", R: -852.68, d: 0.15, nd: 1.0, elemId: 0, sd: 8.46 }, // L8 rear → air
+    { label: "17", R: 19.84, d: 3.53, nd: 1.58144, elemId: 9, sd: 8.325 }, // L9 front
+    { label: "18", R: 1e15, d: 0.82, nd: 2.001, elemId: 10, sd: 7.975 }, // L9→L10 junction (flat)
+    { label: "19", R: 20.522, d: 2.7, nd: 1.0, elemId: 0, sd: 7.605 }, // L10 rear → air
+    // Subunit Y (positive, IS shift element, f = +41.45 mm)
+    { label: "20", R: 35.803, d: 0.8, nd: 2.00069, elemId: 11, sd: 7.75 }, // L11 front
+    { label: "21", R: 18.888, d: 3.99, nd: 1.72, elemId: 12, sd: 7.63 }, // L11→L12 junction
+    { label: "22", R: -63.451, d: 2.27, nd: 1.0, elemId: 0, sd: 7.595 }, // L12 rear → air
+    // Subunit Z (negative, f = −30.98 mm)
+    { label: "23", R: -26.036, d: 0.8, nd: 2.001, elemId: 13, sd: 7.4 }, // L13 front
+    { label: "24", R: -164.761, d: 8.46, nd: 1.0, elemId: 0, sd: 7.55 }, // L13 rear → air (zoom var)
+
+    // ── Unit 4: Relay / Compensator (f = +22.87 mm) ──
+    { label: "25A", R: 45.628, d: 2.42, nd: 1.5311, elemId: 14, sd: 10.79 }, // L14 front (asph)
+    { label: "26A", R: 246.555, d: 0.9, nd: 1.0, elemId: 0, sd: 11.285 }, // L14 rear (asph) → air
+    { label: "27", R: -170.519, d: 1.25, nd: 1.85478, elemId: 15, sd: 11.375 }, // L15 front
+    { label: "28", R: 170.589, d: 5.53, nd: 1.59282, elemId: 16, sd: 11.91 }, // L15→L16 junction
+    { label: "29", R: -26.647, d: 0.15, nd: 1.0, elemId: 0, sd: 12.54 }, // L16 rear → air
+    { label: "30", R: 45.538, d: 6.19, nd: 1.497, elemId: 17, sd: 13.64 }, // L17 front
+    { label: "31", R: -45.788, d: 3.73, nd: 1.0, elemId: 0, sd: 13.69 }, // L17 rear → air (zoom var)
+
+    // ── Unit 5: Focus Group (f = −53.51 mm) ──
+    { label: "32", R: 93.245, d: 1.81, nd: 1.80518, elemId: 18, sd: 12.785 }, // L18 front
+    { label: "33", R: 304.63, d: 1.1, nd: 1.63854, elemId: 19, sd: 12.635 }, // L18→L19 junction
+    { label: "34", R: 23.508, d: 15.54, nd: 1.0, elemId: 0, sd: 12.06 }, // L19 rear → air (zoom var)
+
+    // ── Unit 6: Rear Field Corrector (f = −138.27 mm) ──
+    { label: "35", R: -53.59, d: 1.28, nd: 1.83481, elemId: 20, sd: 13.595 }, // L20 front
+    { label: "36", R: 53.854, d: 4.88, nd: 1.84666, elemId: 21, sd: 14.63 }, // L20→L21 junction
+    { label: "37", R: -109.597, d: 15.78, nd: 1.0, elemId: 0, sd: 15.0 }, // L21 rear → BFD (zoom var)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "25A": {
+      K: 0,
+      A4: -3.69428e-6,
+      A6: -1.81514e-7,
+      A8: 1.12707e-9,
+      A10: -1.37724e-11,
+      A12: 4.19334e-14,
+      A14: 0,
+    },
+    "26A": {
+      K: 0,
+      A4: 2.68822e-5,
+      A6: -1.85641e-7,
+      A8: 9.59349e-10,
+      A10: -1.18429e-11,
+      A12: 3.67346e-14,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (zoom only — no close-focus data in patent) ──
+   *  All 6 inter-unit gaps change during zooming. Patent does not provide
+   *  close-focus spacings, so all entries use identical inf/close pairs.
+   *  Focus is via L5 (unit 5): d31 expands, d34 contracts when focusing close.
+   */
+  zoomPositions: [24.72, 85.0, 232.8],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  var: {
+    "5": [
+      [1.34, 1.34],
+      [32.74, 32.74],
+      [59.28, 59.28],
+    ],
+    "13": [
+      [22.25, 22.25],
+      [8.64, 8.64],
+      [2.35, 2.35],
+    ],
+    "24": [
+      [8.46, 8.46],
+      [3.21, 3.21],
+      [1.0, 1.0],
+    ],
+    "31": [
+      [3.73, 3.73],
+      [4.64, 4.64],
+      [1.5, 1.5],
+    ],
+    "34": [
+      [15.54, 15.54],
+      [14.63, 14.63],
+      [17.77, 17.77],
+    ],
+    "37": [
+      [15.78, 15.78],
+      [45.06, 45.06],
+      [57.2, 57.2],
+    ],
+  },
+
+  varLabels: [
+    ["5", "D5"],
+    ["13", "D13"],
+    ["24", "D24"],
+    ["31", "D31"],
+    ["34", "D34"],
+    ["37", "BF"],
+  ],
+
+  /* ── Group annotations ── */
+  groups: [
+    { text: "L1 (+)", fromSurface: "1", toSurface: "5" },
+    { text: "L2 (−)", fromSurface: "6", toSurface: "13" },
+    { text: "L3 / XYZ (+)", fromSurface: "STO", toSurface: "24" },
+    { text: "L4 (+)", fromSurface: "25A", toSurface: "31" },
+    { text: "L5 (−) FOCUS", fromSurface: "32", toSurface: "34" },
+    { text: "L6 (−)", fromSurface: "35", toSurface: "37" },
+  ],
+
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "D4", fromSurface: "17", toSurface: "19" },
+    { text: "D5 (IS)", fromSurface: "20", toSurface: "22" },
+    { text: "D6", fromSurface: "27", toSurface: "29" },
+    { text: "D7 (Focus)", fromSurface: "32", toSurface: "34" },
+    { text: "D8", fromSurface: "35", toSurface: "37" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.5,
+  focusDescription:
+    "Rear inner focus via unit 5 (L18+L19 cemented doublet). L5 moves toward image for close focus. Canon Nano USM actuator.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: [4.12, 5.66, 6.41],
+  fstopSeries: [4, 4.5, 5, 5.6, 6.3, 7.1, 8, 11, 16, 22],
+  apertureBlades: 7,
+
+  /* ── Layout tuning ── */
+  scFill: 0.55,
+  yScFill: 0.4,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/CanonRF2870mmf28.analysis.md
+++ b/src/lens-data/CanonRF2870mmf28.analysis.md
@@ -1,0 +1,333 @@
+# Canon RF 28-70mm F2.8 IS STM — Optical Design Analysis
+
+**Patent:** US 2024/0329367 A1 (Pub. Oct 3, 2024)
+**Inventor:** Yasuaki Hagiwara (Canon Kabushiki Kaisha)
+**Priority:** JP 2023-051695 (Mar 28, 2023)
+**Embodiment analyzed:** First Numerical Example (§0083)
+
+---
+
+## 1. Design Overview
+
+The Canon RF 28-70mm F2.8 IS STM is a compact, constant-aperture standard zoom designed for Canon's RF-mount mirrorless system. According to Canon's first-party specifications, the production lens comprises **15 elements in 12 groups**, including **2 UD (Ultra-low Dispersion) elements** and **2 GMo (Glass-Molded) aspherical elements**, with a 9-blade circular aperture diaphragm. The lens is a retractable design, collapsing to 92.2 mm for transport.
+
+The first numerical example in the patent describes a zoom system with a **2.36× zoom ratio** spanning 28.80–67.90 mm at f/2.88–2.92. The zoom structure consists of seven independently movable lens units organized into four functional groups:
+
+- **B1** (positive, f = +135.53 mm) — 1 element, the front collecting group
+- **B2** (negative, f = −27.10 mm) — 4 elements, the variator
+- **Bm** (intermediate group containing the aperture stop):
+  - **B3** (positive, f = +51.68 mm) — 3 elements (includes stop)
+  - **B4** (negative, f = −321.04 mm) — 2 elements (cemented doublet)
+  - **B5** (positive, f = +26.75 mm) — 2 elements
+- **Br** (rear group):
+  - **B6** (negative, f = −57.18 mm) — 1 element (**focusing element**)
+  - **B7** (negative, f = −120.17 mm) — 2 elements (cemented doublet)
+
+A flat cover glass (GB, nd = 1.54400, 2.00 mm) follows B7 before the image plane.
+
+### Note on Surface 4 Radius
+
+Independent paraxial ray trace verification revealed that the **correct radius for surface 4 is R = 22.455 mm**. At low rendering resolution, the tens digit can appear ambiguous (resembling either "2" or "3"), but at 300 DPI the patent reads "22.455" directly. With this value, computed EFLs at all three zoom positions match the patent's stated values to within ±0.01 mm, and all seven group focal lengths reproduce exactly (see §7). With R = 32.455, the wide-angle EFL computes to 32.58 mm instead of 28.80 mm, and the B2 group focal length becomes −43.4 mm instead of the patent's −27.10 mm — conclusively ruling out the larger value.
+
+---
+
+## 2. Zoom Mechanism and Variable Gaps
+
+The lens uses **seven variable air gaps** (d2, d9, d16, d19, d23, d25, d28) that change with zoom. An eighth gap (d30, from the cover glass rear to the image plane) remains constant at 1.09 mm across all zoom positions. The patent provides spacings at three zoom positions:
+
+| Gap | Location | Wide (28.8 mm) | Intermediate (49.0 mm) | Telephoto (67.9 mm) | Role |
+|-----|----------|:-:|:-:|:-:|------|
+| d2 | B1 → B2 | 0.85 | 15.70 | 26.56 | Zoom (increases monotonically) |
+| d9 | B2 → STO | 21.64 | 7.73 | 2.90 | Zoom (decreases monotonically) |
+| d16 | B3 → B4 | 4.86 | 2.83 | 2.01 | Zoom (decreases monotonically) |
+| d19 | B4 → B5 | 2.00 | 4.04 | 4.86 | Zoom (increases monotonically) |
+| d23 | B5 → B6 | 3.22 | 3.12 | 2.00 | Zoom + Focus |
+| d25 | B6 → B7 | 12.68 | 12.78 | 13.90 | Zoom + Focus |
+| d28 | B7 → GB | 13.00 | 23.93 | 32.48 | Zoom (increases monotonically) |
+
+During zooming from wide to telephoto, the dominant motion is:
+
+1. **B1 moves toward the object side** relative to B2 (d2 increases by 25.7 mm), extending the front of the lens at the telephoto end.
+2. **B2 closes toward the stop** (d9 decreases by 18.7 mm), providing the primary variator motion.
+3. **The rear groups (Bm and Br) separate from the image plane** at different rates, with B7's spacing to the cover glass (d28) increasing by 19.5 mm.
+
+All variable gaps change **monotonically** across the zoom range — there are no reversing groups in this design. This simplifies the cam mechanism and allows smooth, linear interpolation between zoom positions.
+
+The patent states the Total Lens Length (front vertex to image plane) as 132.38, 144.25, and 158.83 mm at wide, intermediate, and telephoto respectively. The computed sum of all axial thicknesses from the prescription gives values ~0.9 mm shorter at all three positions (131.48, 143.36, 157.94 mm). This constant offset likely reflects the patent's inclusion of a mechanical reference (such as front barrel protrusion or vertex offset) not captured in the optical prescription alone.
+
+The air-equivalent back focal distance (bf = d28 + d29/n29 + d30) is 15.39 mm at wide, 26.32 mm at intermediate, and 34.87 mm at telephoto — matching the patent's stated values exactly.
+
+### Focus Mechanism
+
+The patent (§0042, §0065) describes B6 as the lens unit closest to the object side within the rear group Br that moves during focusing. B6 consists of a single element (L13), and it translates toward the image side when focusing from infinity to close distance. Both flanking gaps d23 (B5 → B6) and d25 (B6 → B7) change during zoom and focus, though the patent's Example 1 provides only infinity-focus spacings. Close-focus data is not available for this embodiment, so the data file encodes all gaps as zoom-only with identical infinity/close values.
+
+The close-focus distance of 0.27 m at 28 mm (AF) / 0.24 m (MF) and maximum magnification of 0.24× at 70 mm are from Canon's production specifications.
+
+The single-element focusing group enables fast, quiet autofocus with the leadscrew-type STM motor — minimal moving mass means rapid position changes with low power consumption.
+
+---
+
+## 3. Aspherical Surfaces
+
+Canon specifies **2 GMo (Glass-Molded) aspherical elements**, which in the patent correspond to **4 aspherical surfaces** on two double-asphere elements. Both elements use nd = 1.58313, νd = 59.4, matching the **BAL42 glass family** from OHARA (glass code 583594). This family exists in two forms: **S-BAL42** (conventional polishing grade) and **L-BAL42** (low-Tg molding grade). The optical constants are identical — the distinction rests entirely on thermal properties suitable for precision glass molding. Since Canon explicitly specifies "GMo" aspherical elements, the glass is identified as **L-BAL42**. The "L-" prefix in OHARA's nomenclature denotes their family of low-Tg moldable glass types.
+
+### Surface 13A — Front of L7 (B3, Intermediate Group)
+
+| Parameter | Value |
+|-----------|-------|
+| R (base) | +106.432 mm |
+| K (conic) | 0.0 (spherical base) |
+| A4 | −5.91734 × 10⁻⁶ |
+| A6 | −1.25922 × 10⁻⁸ |
+| A8 | −6.96192 × 10⁻¹¹ |
+| A10 | −1.24634 × 10⁻¹³ |
+| A12 | +3.32938 × 10⁻¹⁶ |
+
+At an estimated semi-diameter of ~13.5 mm, the aspherical departure from the base sphere is dominated by the negative A4 term, producing a progressive flattening toward the rim that corrects spherical aberration generated by the fast f/2.88 aperture. All coefficients through A10 are negative, with only the A12 term providing a small positive correction at the extreme rim.
+
+### Surface 14A — Rear of L7 (B3, Intermediate Group)
+
+| Parameter | Value |
+|-----------|-------|
+| R (base) | −70.798 mm |
+| K (conic) | 0.0 |
+| A4 | −2.81431 × 10⁻⁶ |
+| A6 | −1.15888 × 10⁻⁸ |
+| A8 | −1.20810 × 10⁻¹⁰ |
+| A10 | +3.67743 × 10⁻¹³ |
+| A12 | −6.62375 × 10⁻¹⁶ |
+
+The departure profile is similar to surface 13A (negative A4 dominance), but with a sign reversal at A10 that creates a subtle inflection at large aperture heights. Working together, surfaces 13A and 14A form a **doubly-aspherized corrector** immediately after the stop — the optimal position for correcting spherical aberration and coma simultaneously.
+
+### Surface 20A — Front of L11 (B5, Intermediate Group)
+
+| Parameter | Value |
+|-----------|-------|
+| R (base) | +55.622 mm |
+| K (conic) | 0.0 |
+| A4 | −2.16306 × 10⁻⁶ |
+| A6 | −3.51669 × 10⁻⁸ |
+| A8 | +3.80997 × 10⁻¹² |
+| A10 | −8.02806 × 10⁻¹³ |
+| A12 | +7.68937 × 10⁻¹⁶ |
+
+The A6 term here is notably larger (in magnitude) relative to A4 than on L7, indicating that higher-order aberration correction is more important at this position in the optical train. The A8 coefficient is unusually small (10⁻¹² vs the typical 10⁻¹⁰ progression), suggesting the 8th-order contribution is intentionally minimized at this surface — the correction burden shifts to A10 instead.
+
+### Surface 21A — Rear of L11 (B5, Intermediate Group)
+
+| Parameter | Value |
+|-----------|-------|
+| R (base) | −248.880 mm |
+| K (conic) | 0.0 |
+| A4 | +1.35282 × 10⁻⁵ |
+| A6 | −2.86368 × 10⁻⁸ |
+| A8 | +3.89958 × 10⁻¹¹ |
+| A10 | −1.08816 × 10⁻¹² |
+| A12 | +1.83610 × 10⁻¹⁵ |
+
+This surface stands out with a **positive A4 coefficient** — the only one among the four aspherical surfaces. With a very weak base sphere (R = −248.880), the aspherical terms effectively define the surface's power profile across the aperture. The positive A4 creates a progressive increase in local power toward the rim, providing correction for residual field curvature and astigmatism variation across the zoom range.
+
+### Summary of Aspherical Strategy
+
+Both aspherical elements are placed in the **intermediate group (Bm)**, specifically in B3 and B5 — the two positive-power units that bracket the weakly-powered B4 doublet. This placement is deliberate:
+
+1. **L7 (B3)** sits immediately after the aperture stop, where the marginal ray height is maximum and the chief ray height is near zero. Aspherical correction here is most effective against **spherical aberration** and **zonal spherical aberration**.
+
+2. **L11 (B5)** sits further from the stop, where both marginal and chief ray heights are significant. Aspherical correction here addresses **coma, astigmatism, and field curvature** — the off-axis aberrations that limit edge-to-edge sharpness across the zoom range.
+
+Together, the four aspherical surfaces provide six degrees of freedom for aberration correction beyond what the base sphere radii provide, enabling high imaging performance while keeping the element count to 15.
+
+---
+
+## 4. Glass Types and Identification
+
+| Element | nd | νd | 6-Digit Code | Probable Glass | Special |
+|---------|---------|------|------|------|------|
+| L1 | 1.49700 | 81.7 | 497817 | S-FPL51 (OHARA) | **UD** |
+| L2 | 1.89190 | 37.1 | 892371 | S-LAH66 family | — |
+| L3 | 1.60311 | 60.6 | 603606 | S-BSL7 family | — |
+| L4 | 1.90366 | 31.3 | 904313 | S-LAH58 family | — |
+| L5 | 1.85150 | 40.8 | 851408 | S-LAH65V | — |
+| L6 | 2.00100 | 29.1 | 001291 | S-NPH4 family | — |
+| L7 | 1.58313 | 59.4 | 583594 | L-BAL42 (OHARA) | **GMo Asph** |
+| L8 | 1.77047 | 29.7 | 770297 | S-TIH18 family | — |
+| L9 | 1.85478 | 24.8 | 855248 | S-TIH53W family | — |
+| L10 | 1.49700 | 81.7 | 497817 | S-FPL51 (OHARA) | **UD** |
+| L11 | 1.58313 | 59.4 | 583594 | L-BAL42 (OHARA) | **GMo Asph** |
+| L12 | 1.59522 | 67.7 | 595677 | S-BSM14 family | — |
+| L13 | 1.61340 | 44.3 | 613443 | S-BAH11 family | — |
+| L14 | 1.74400 | 44.8 | 744448 | S-LAL14 family | — |
+| L15 | 1.92286 | 20.9 | 923209 | S-NPH2 (OHARA) | — |
+
+Glass identifications marked "family" are nearest-catalog matches based on six-digit glass codes. Exact catalog designations cannot be confirmed without full melt-sheet data from Canon's supplier.
+
+### UD Elements (L1 and L10)
+
+Both UD elements use nd = 1.49700, νd = 81.7, closely matching **OHARA S-FPL51** — a fluorophosphate crown with anomalous partial dispersion (ΔPgF ≈ +0.028). The catalog value for S-FPL51 is nd = 1.49700, νd = 81.54 (glass code 497816); the patent's νd = 81.7 is within normal melt-to-melt variation for this glass family.
+
+Canon's marketing notes that the **large-diameter UD lens at the front** (L1) is a configuration previously found only in their L-series lenses. L1 serves as the primary collecting element of B1, and its UD glass ensures that the strong positive power it contributes does not introduce excessive chromatic aberration at the wide-angle end, where the marginal ray height on L1 is greatest.
+
+L10 is the rear element of the **cemented doublet D2** (L9 + L10), forming a classic anomalous-dispersion achromat. Paired with the ultra-dense flint L9 (νd = 24.8), this doublet corrects secondary chromatic aberration. The extreme Abbe number difference (81.7 − 24.8 = 56.9) enables strong secondary spectrum correction. B4's weak total power (f = −321 mm) means it contributes minimally to the zoom action; its primary role is **chromatic correction** across the full zoom range.
+
+### GMo Aspherical Elements (L7 and L11)
+
+Both aspherical elements use nd = 1.58313, νd = 59.4 (glass code 583594), matching **OHARA L-BAL42** — identified as the low-Tg molding grade rather than the optically identical S-BAL42 polishing grade based on Canon's "GMo" specification. Glass molding directly presses the aspherical profile into the glass, avoiding the need for grinding and polishing — a critical cost reduction for non-L-series lenses.
+
+### Notable High-Index Glasses
+
+**L6** (nd = 2.00100, νd = 29.1) is an **ultra-high index dense flint** — one of the highest-index optical glasses commercially available. This extreme refractive index allows L6 to achieve strong positive power (f ≈ +41.5 mm) with relatively gentle surface curvatures, minimizing higher-order aberrations. Its position immediately after the stop makes it the primary positive element controlling spherical aberration correction at the design aperture.
+
+**L15** (nd = 1.92286, νd = 20.9) is an ultra-dense short flint, matching OHARA **S-NPH2**. Paired with L14 in the B7 cemented doublet, it provides achromatic correction for the rear group while contributing strong positive power (f ≈ +44 mm) to partially offset L14's negative contribution (f ≈ −32 mm).
+
+---
+
+## 5. Element-by-Element Optical Role
+
+### B1 — Front Collecting Group (Positive, f = +135.53 mm)
+
+**L1** (Biconvex, f = +135.5 mm): A large-diameter positive element in S-FPL51 UD glass. As the only element in B1, L1 collects the incoming light bundle and provides the initial positive power. Its UD glass suppresses primary chromatic aberration at the wide-angle end, where the marginal ray height on L1 is greatest. The large front element diameter also determines the 67 mm filter size. The low density of fluorophosphate glass (~3.6 g/cm³) reduces the front-heavy weight distribution, improving handling balance.
+
+### B2 — Variator (Negative, f = −27.10 mm)
+
+B2 is the most strongly powered group in the system and provides the primary zoom action. Its four elements form a **classic negative variator** configuration:
+
+**L2** (Negative meniscus, f = −33.2 mm): A high-index lanthanum flint meniscus with the convex surface facing the object. Its strong negative power, combined with the steep rear curvature (R = 22.455 mm), is the primary source of the variator's diverging action.
+
+**L3 + L4** (Cemented doublet D1, f_pair = +101.3 mm): L3 is a biconcave negative element in borosilicate crown (νd = 60.6), with a nearly flat front surface (R = −369.959) giving it plano-concave character; it is cemented to L4, a strongly positive meniscus in dense lanthanum flint (νd = 31.3). The large νd difference (60.6 vs 31.3) provides achromatic correction within B2, preventing the strong negative power from introducing excessive chromatic aberration during zoom.
+
+**L5** (Negative meniscus, f = −73.0 mm): A moderately powered negative meniscus in lanthanum heavy flint (both radii negative: R = −36.457 / −89.252, concave to the object). Its placement at the rear of B2, closest to the aperture stop, helps control field curvature contribution.
+
+### B3 — First Intermediate Positive Unit (f = +51.68 mm)
+
+B3 contains the aperture stop and three elements forming a **modified Gauss-type corrector**:
+
+**L6** (Plano-convex, f = +41.5 mm): The strongest single element in the entire system, using ultra-high-index glass (nd = 2.001). Positioned immediately after the stop, it introduces strong positive power where the marginal ray height is maximum. The extreme refractive index allows gentle curvatures (R_front = 43.928, R_rear = −750.0), keeping higher-order aberrations low despite the high power.
+
+**L7** (Biconvex, double-asph, f = +73.5 mm): The first GMo aspherical element. Both surfaces carry aspherical profiles that systematically flatten toward the rim (negative A4 on both), correcting **zonal spherical aberration** — the residual ring-like aberration that limits wide-open performance in fast zoom lenses.
+
+**L8** (Biconcave, f = −45.2 mm): A dense flint element (νd = 29.7) providing chromatic correction for B3 while contributing negative power for Petzval sum control.
+
+### B4 — Weak Negative Compensator (f = −321.04 mm)
+
+**L9 + L10** (Cemented doublet D2, f = −321.0 mm): The **anomalous-dispersion achromatic doublet** at the heart of the zoom system. L9 is a plano-concave element in ultra-dense flint (νd = 24.8), cemented to L10, a biconvex UD element (νd = 81.7). B4's weak total power means it contributes minimally to the zoom action; its primary role is **secondary chromatic correction** across the full zoom range.
+
+### B5 — Second Intermediate Positive Unit (f = +26.75 mm)
+
+B5 is the **most strongly positive group** in the system and provides the primary image-forming convergence:
+
+**L11** (Biconvex, double-asph, f = +78.3 mm): The second GMo aspherical element. Its placement away from the stop means the aspherical profiles address **field-dependent aberrations**. The unique positive A4 on the rear surface creates a bulging departure that progressively increases local power toward the rim, counteracting natural field curvature.
+
+**L12** (Biconvex, f = +37.7 mm): A relatively low-dispersion barium crown (νd = 67.7) that provides the bulk of B5's positive power. Its strong biconvex shape (R_front = 69.909, R_rear = −31.690) concentrates power on the rear surface.
+
+### B6 — Focusing Element (Negative, f = −57.18 mm)
+
+**L13** (Negative meniscus, f = −57.2 mm): This single element constitutes the **entire focusing group**. It is a meniscus with the convex surface facing the object (R_front = 71.379, R_rear = 23.380), yielding negative power despite both radii being positive. The patent (§0065) explicitly states that B6 moves toward the image side when focusing from infinity to close distance.
+
+Using a single lightweight element for focusing is critical for the **STM (Stepping Motor) autofocus** system — the low mass allows the leadscrew-type STM to achieve fast, quiet, and accurate focus acquisition. The choice of a medium-index glass (nd = 1.61340, νd = 44.3) balances adequate negative power against manageable chromatic aberration contribution.
+
+### B7 — Rear Negative Doublet (f = −120.17 mm)
+
+**L14 + L15** (Cemented doublet D3): L14 is a biconcave element in lanthanum crown (nd = 1.74400), providing strong negative power (f ≈ −32 mm). L15 is a biconvex element in ultra-dense short flint S-NPH2 (nd = 1.92286, νd = 20.9), providing strong positive power (f ≈ +44 mm). The net effect is moderate negative power (f = −120 mm) with achromatic correction.
+
+B7's position at the rear of the optical train, close to the image plane, means it has the most influence on **field curvature and distortion**. The Canon marketing material acknowledges that this lens relies on **electronic distortion correction** — the raw images show significant barrel distortion at the wide end (on the order of 10% or more at full field per the patent's aberration plots), which is corrected in-camera for JPEGs and via lens profiles for RAW converters.
+
+### Cover Glass (GB)
+
+**Surfaces 29–30** (Flat, nd = 1.54400, νd = 66.3, thickness = 2.00 mm): A filter/cover glass assembly representing the sensor stack. The flat surfaces contribute no optical power. In the data file, the cover glass is excluded from the surface prescription, and its physical thickness (2.00 mm) plus the trailing air gap (1.09 mm) are folded into the back focal distance of the last optical surface (S28).
+
+---
+
+## 6. Verified Paraxial Properties
+
+All values verified via independent ABCD-matrix paraxial ray trace with R4 = 22.455:
+
+| Property | Wide | Intermediate | Telephoto | Source |
+|----------|:----:|:----:|:----:|:----:|
+| EFL (mm) | 28.804 | 49.007 | 67.900 | Computed (match to ±0.01 mm) |
+| F-number | 2.88 | 2.88 | 2.92 | Patent-stated |
+| Half-field ω (°) | 34.93 | 23.82 | 17.67 | Patent-stated |
+| Image height (mm) | 21.64 | 21.64 | 21.64 | Patent-stated |
+| Patent TLL (mm) | 132.38 | 144.25 | 158.83 | Patent-stated |
+| BFL air-equiv (mm) | 15.39 | 26.32 | 34.87 | Computed (exact match) |
+| Zoom ratio | — | — | 2.36 | Patent-stated |
+
+**Group focal lengths** (all match patent exactly):
+
+| Unit | Starting Surface | Focal Length (mm) | Computed (mm) |
+|------|:---:|:---:|:---:|
+| B1 | 1 | +135.53 | +135.53 |
+| B2 | 3 | −27.10 | −27.10 |
+| B3 | 10 | +51.68 | +51.68 |
+| B4 | 17 | −321.04 | −321.04 |
+| B5 | 20 | +26.75 | +26.75 |
+| B6 | 24 | −57.18 | −57.18 |
+| B7 | 26 | −120.17 | −120.17 |
+
+**Individual element focal lengths** (thick-lens ABCD):
+
+| Element | f (mm) | Element | f (mm) |
+|:---:|:---:|:---:|:---:|
+| L1 | +135.5 | L9+L10 (D2) | −321.0 |
+| L2 | −33.2 | L11 | +78.3 |
+| L3+L4 (D1) | +101.3 | L12 | +37.7 |
+| L5 | −73.0 | L13 | −57.2 |
+| L6 | +41.5 | L14+L15 (D3) | −120.2 |
+| L7 | +73.5 | | |
+| L8 | −45.2 | | |
+
+**Petzval sum:** +0.001622 mm⁻¹ (Petzval radius ≈ +617 mm). This is well-corrected for a zoom lens — the negative elements (especially B2 and the rear doublets) effectively flatten the Petzval field against the strong positive elements (B3, B5).
+
+---
+
+## 7. Design Philosophy and Tradeoffs
+
+Several aspects of this design reflect Canon's specific goals for a **compact, affordable, high-performance standard zoom**:
+
+**Electronic distortion correction as a design constraint.** The lens is designed from the outset to rely on in-camera distortion correction. This allows the optical designer to accept significant barrel distortion at the wide end (reducing the element count needed for geometric correction) and instead allocate the limited element budget toward sharpness, chromatic correction, and aberration control. The patent's aberration plots (FIG. 2A) show barrel distortion exceeding 10% at the full field angle of ω = 34.8° at the wide end.
+
+**Glass-molded aspherics instead of polished.** Using L-BAL42 (a moldable glass) for both aspherical elements enables high-volume production at lower cost than polished aspherics, consistent with the lens's non-L-series positioning. The tradeoff is visible in reviews as faint "onion ring" artifacts in out-of-focus highlights — a characteristic signature of molding marks on aspherical surfaces.
+
+**Single-element focusing unit.** The use of a single element (L13) for focusing minimizes the moving mass, enabling the compact leadscrew-type STM motor to achieve fast, quiet autofocus. The tradeoff is that a single negative element provides less aberration correction freedom during focus than a multi-element focus group — contributing to the slight performance falloff at close distances noted in some reviews.
+
+**UD glass at the front.** Placing an S-FPL51 element at the very front of the system is unusual for non-L lenses (as Canon's own marketing notes). The low density of fluorophosphate glass (~3.6 g/cm³) reduces the front-heavy weight distribution. The UD properties simultaneously address chromatic aberration at the position where it matters most — where the marginal ray is tallest.
+
+**Monotonic zoom cam.** All seven variable gaps change monotonically across the zoom range, with no reversing groups. This simplifies the mechanical cam design and contributes to the smooth zoom feel expected in a video-capable lens.
+
+---
+
+## 8. Comparison with Production Lens
+
+| Parameter | Patent Example 1 | Production RF 28-70mm F2.8 IS STM |
+|-----------|:-:|:-:|
+| Elements / Groups | 15 / 12 | 15 / 12 |
+| Focal range | 28.80–67.90 mm | 28–70 mm |
+| Maximum aperture | f/2.88–2.92 | f/2.8 (constant) |
+| Aspherical elements | 2 (4 surfaces) | 2 (GMo) |
+| UD elements | 2 | 2 |
+| Aperture blades | Not specified | 9 (circular) |
+| Close focus | Not specified in Ex.1 | 0.27 m (AF at 28 mm) |
+| IS | Not covered (optical only) | 5.5 stops (OIS) |
+| Filter diameter | Not specified | 67 mm |
+| Weight | Not specified | 495 g |
+
+The production lens matches the patent's first embodiment closely in element count, group structure, and special glass usage. The slight focal length rounding (28.80 → 28, 67.90 → 70) is standard marketing practice. The image stabilization unit is not part of the optical prescription — it operates by shifting an element group perpendicular to the optical axis, which does not appear in the patent's on-axis surface data.
+
+---
+
+## 9. Data File Notes
+
+The accompanying `CanonRF2870mmf28.data.ts` file encodes the first numerical example with the following conventions:
+
+- **Cover glass excluded:** The 2.00 mm cover glass (nd = 1.54400) and 1.09 mm trailing air gap are folded into the back focal distance of surface "28". At each zoom position, BFD = d28 + 2.00 + 1.09.
+- **Zoom-only variable gaps:** Since Example 1 provides only infinity-focus spacings, all seven variable gaps are encoded with identical [d_inf, d_close] pairs. If close-focus data becomes available (from another embodiment or measurement), gaps d23 and d25 should be updated to reflect the B6 focus travel.
+- **Semi-diameters estimated:** Combined marginal + chief ray trace at all three zoom positions, refined against the patent cross-section figure (FIG. 1) proportions. The initial unvignetted beam heights were reduced to satisfy multiple physical constraints: edge thickness ≥ 0.5 mm (six elements are binding — L1, L4, L10, L11, L12, L15), cross-gap sag overlap (the S4→S5 air gap limits the B2/D1 junction region to ~15.5 mm due to the very steep R = 22.455 mm rear surface of L2), sd/|R| ≤ 0.90 slope limit, and the 67 mm production filter thread (L1 max SD ≈ 29.5 mm). The resulting SDs imply moderate vignetting at the field corners, consistent with the production lens's known reliance on electronic vignetting correction.
+- **nominalFno as array:** The design f-number varies from 2.88 at wide/intermediate to 2.92 at telephoto. The array form [2.88, 2.88, 2.92] ensures the renderer computes the correct entrance pupil size at each zoom position.
+
+---
+
+## References
+
+1. US Patent Application Publication US 2024/0329367 A1, "Zoom Lens and Imaging Apparatus Including the Same," Yasuaki Hagiwara, Canon Kabushiki Kaisha, published October 3, 2024.
+2. Canon U.S.A., "RF28-70mm F2.8 IS STM" product page.
+3. Canon Europe, "RF 28-70mm F2.8 IS STM Specifications."
+4. OHARA Inc., Optical Glass Catalog (for S-FPL51, L-BAL42, S-NPH2 glass data).

--- a/src/lens-data/CanonRF2870mmf28.data.ts
+++ b/src/lens-data/CanonRF2870mmf28.data.ts
@@ -1,0 +1,419 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — Canon RF 28-70mm F2.8 IS STM                        ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2024/0329367 A1, Example 1 (§0083) — Canon.      ║
+ * ║  Compact constant-aperture standard zoom for RF mount.             ║
+ * ║  15 elements / 12 groups (7 movable units), 4 aspherical surfaces. ║
+ * ║  Zoom: 28.80–67.90 mm (marketed 28–70 mm), f/2.88–2.92.          ║
+ * ║  Internal zoom (total track 132–159 mm).                           ║
+ * ║  Zoom variable gaps: D2, D9, D16, D19, D23, D25, D28.             ║
+ * ║  Focus: rear inner focus via B6 (single element L13).              ║
+ * ║  Patent provides infinity-focus spacings only; close-focus data    ║
+ * ║  not available — all gaps encoded as zoom-only.                    ║
+ * ║                                                                    ║
+ * ║  NOTE ON R4: The patent's rendering of surface 4 radius is         ║
+ * ║  ambiguous at low resolution (22 vs 32). Independent paraxial ray  ║
+ * ║  trace confirms R4 = 22.455 mm — this produces exact EFL and       ║
+ * ║  group focal length matches at all three zoom positions.           ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║  Estimated via combined marginal + chief ray trace at all three    ║
+ * ║  zoom positions, refined against the patent cross-section figure   ║
+ * ║  (FIG. 1). Constrained by: edge thickness ≥ 0.5 mm (L1, L4, L10, ║
+ * ║  L11, L12, L15 are binding), cross-gap sag overlap (S4→S5 gap     ║
+ * ║  limits SD to ~15.5 mm at that junction), sd/|R| ≤ 0.90 slope     ║
+ * ║  limit, and 67 mm production filter thread (~29.5 mm max SD).     ║
+ * ║  Cover glass (nd=1.544, 2.00 mm) excluded; BFD includes its       ║
+ * ║  physical thickness + 1.09 mm air gap to image plane.             ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "canon-rf-28-70-f28-is-stm",
+  maker: "Canon",
+  name: "CANON RF 28-70mm F2.8 IS STM",
+  subtitle: "US 2024/0329367 A1 EXAMPLE 1 — CANON / HAGIWARA",
+  specs: [
+    "15 ELEMENTS / 12 GROUPS",
+    "f = 28.80–67.90 mm (2.36×)",
+    "F/2.88–2.92",
+    "2ω = 69.9–35.3°",
+    "4 ASPHERICAL SURFACES (2 GMo ELEMENTS)",
+    "2 UD ELEMENTS",
+  ],
+
+  focalLengthMarketing: [28, 70],
+  focalLengthDesign: [28.8, 67.9],
+  apertureMarketing: 2.8,
+  apertureDesign: 2.88,
+  patentYear: 2024,
+  elementCount: 15,
+  groupCount: 12,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.7,
+      fl: 135.5,
+      glass: "S-FPL51 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔPgF ≈ +0.028 (S-FPL51 catalog)",
+      role: "Front collecting element; UD glass suppresses chromatic aberration at wide-angle where marginal ray height is greatest.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.8919,
+      vd: 37.1,
+      fl: -33.2,
+      glass: "892371 — S-LAH66 family (OHARA)",
+      apd: false,
+      role: "Primary variator element; strong negative power drives zoom action in B2.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconcave Negative",
+      nd: 1.60311,
+      vd: 60.6,
+      fl: -34.6,
+      glass: "603606 — S-BSL7 family (OHARA)",
+      apd: false,
+      role: "Front element of cemented doublet D1 in B2; provides achromatic correction for the variator.",
+      cemented: "D1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Positive Meniscus",
+      nd: 1.90366,
+      vd: 31.3,
+      fl: 25.7,
+      glass: "904313 — S-LAH58 family (OHARA)",
+      apd: false,
+      role: "Rear element of D1; high-index lanthanum flint provides positive power for achromatic balance in B2.",
+      cemented: "D1",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.8515,
+      vd: 40.8,
+      fl: -73.0,
+      glass: "851408 — S-LAH65V (OHARA)",
+      apd: false,
+      role: "Rear element of B2; concave-to-object meniscus controls field curvature near the stop.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Plano-Convex Positive",
+      nd: 2.001,
+      vd: 29.1,
+      fl: 41.5,
+      glass: "001291 — S-NPH4 family (OHARA)",
+      apd: false,
+      role: "Ultra-high-index element immediately after stop; primary spherical aberration corrector at f/2.88.",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive (2× Asph)",
+      nd: 1.58313,
+      vd: 59.4,
+      fl: 73.5,
+      glass: "L-BAL42 (OHARA)",
+      apd: false,
+      role: "First GMo aspherical element; doubly-aspherized corrector for zonal spherical aberration post-stop.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconcave Negative",
+      nd: 1.77047,
+      vd: 29.7,
+      fl: -45.2,
+      glass: "770297 — S-TIH18 family (OHARA)",
+      apd: false,
+      role: "Chromatic corrector and Petzval flattener for B3.",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Plano-Concave Negative",
+      nd: 1.85478,
+      vd: 24.8,
+      fl: -33.7,
+      glass: "855248 — S-TIH53W family (OHARA)",
+      apd: false,
+      role: "Front element of anomalous-dispersion doublet D2; ultra-dense flint for secondary spectrum correction.",
+      cemented: "D2",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.7,
+      fl: 39.3,
+      glass: "S-FPL51 (OHARA)",
+      apd: "inferred",
+      apdNote: "ΔPgF ≈ +0.028 (S-FPL51 catalog)",
+      role: "Rear element of D2; UD glass paired with L9 for secondary chromatic aberration correction across zoom range.",
+      cemented: "D2",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Biconvex Positive (2× Asph)",
+      nd: 1.58313,
+      vd: 59.4,
+      fl: 78.3,
+      glass: "L-BAL42 (OHARA)",
+      apd: false,
+      role: "Second GMo aspherical element; addresses field-dependent aberrations (coma, astigmatism, field curvature) away from stop.",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Biconvex Positive",
+      nd: 1.59522,
+      vd: 67.7,
+      fl: 37.7,
+      glass: "595677 — S-BSM14 family (OHARA)",
+      apd: false,
+      role: "Primary positive element of B5; low-dispersion barium crown provides strong convergence for image formation.",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Negative Meniscus",
+      nd: 1.6134,
+      vd: 44.3,
+      fl: -57.2,
+      glass: "613443 — S-BAH11 family (OHARA)",
+      apd: false,
+      role: "Sole focusing element (B6); lightweight meniscus for fast, quiet STM autofocus. Convex side faces object per §0065.",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Biconcave Negative",
+      nd: 1.744,
+      vd: 44.8,
+      fl: -32.0,
+      glass: "744448 — S-LAL14 family (OHARA)",
+      apd: false,
+      role: "Front element of rear doublet D3; provides strong negative power for field curvature and distortion control.",
+      cemented: "D3",
+    },
+    {
+      id: 15,
+      name: "L15",
+      label: "Element 15",
+      type: "Biconvex Positive",
+      nd: 1.92286,
+      vd: 20.9,
+      fl: 44.3,
+      glass: "S-NPH2 (OHARA)",
+      apd: false,
+      role: "Rear element of D3; ultra-dense short flint provides achromatic correction and positive power to offset L14.",
+      cemented: "D3",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── B1: Front collecting group (L1) ──
+    { label: "1", R: 71.698, d: 7.4, nd: 1.497, elemId: 1, sd: 29.5 },
+    { label: "2", R: -1074.771, d: 0.85, nd: 1.0, elemId: 0, sd: 29.0 }, // d2 variable (zoom)
+
+    // ── B2: Variator (L2, L3+L4, L5) ──
+    { label: "3", R: 95.769, d: 1.6, nd: 1.8919, elemId: 2, sd: 18.5 },
+    { label: "4", R: 22.455, d: 7.05, nd: 1.0, elemId: 0, sd: 15.5 }, // R4 confirmed; cross-gap limited
+    { label: "5", R: -369.959, d: 1.25, nd: 1.60311, elemId: 3, sd: 15.5 }, // D1 front
+    { label: "6", R: 22.126, d: 7.0, nd: 1.90366, elemId: 4, sd: 16.0 }, // D1 junction
+    { label: "7", R: 412.508, d: 4.86, nd: 1.0, elemId: 0, sd: 15.5 },
+    { label: "8", R: -36.457, d: 1.0, nd: 1.8515, elemId: 5, sd: 13.5 },
+    { label: "9", R: -89.252, d: 21.64, nd: 1.0, elemId: 0, sd: 13.0 }, // d9 variable (zoom)
+
+    // ── B3: First intermediate positive (Stop, L6, L7, L8) ──
+    { label: "STO", R: 1e15, d: 0.65, nd: 1.0, elemId: 0, sd: 11.7 },
+    { label: "11", R: 43.928, d: 3.45, nd: 2.001, elemId: 6, sd: 12.0 },
+    { label: "12", R: -750.0, d: 2.4, nd: 1.0, elemId: 0, sd: 12.5 },
+    { label: "13A", R: 106.432, d: 3.7, nd: 1.58313, elemId: 7, sd: 13.0 },
+    { label: "14A", R: -70.798, d: 2.33, nd: 1.0, elemId: 0, sd: 13.0 },
+    { label: "15", R: -41.445, d: 1.2, nd: 1.77047, elemId: 8, sd: 13.0 },
+    { label: "16", R: 220.269, d: 4.86, nd: 1.0, elemId: 0, sd: 13.0 }, // d16 variable (zoom)
+
+    // ── B4: Weak negative compensator (L9+L10 cemented doublet D2) ──
+    { label: "17", R: 1e15, d: 1.2, nd: 1.85478, elemId: 9, sd: 14.5 },
+    { label: "18", R: 28.842, d: 6.1, nd: 1.497, elemId: 10, sd: 14.0 }, // D2 junction; edge-limited
+    { label: "19", R: -56.203, d: 2.0, nd: 1.0, elemId: 0, sd: 14.0 }, // d19 variable (zoom)
+
+    // ── B5: Second intermediate positive (L11, L12) ──
+    { label: "20A", R: 55.622, d: 3.8, nd: 1.58313, elemId: 11, sd: 17.0 },
+    { label: "21A", R: -248.88, d: 0.2, nd: 1.0, elemId: 0, sd: 17.0 },
+    { label: "22", R: 69.909, d: 7.75, nd: 1.59522, elemId: 12, sd: 17.0 },
+    { label: "23", R: -31.69, d: 3.22, nd: 1.0, elemId: 0, sd: 17.0 }, // d23 variable (zoom)
+
+    // ── B6: Focusing element (L13) ──
+    { label: "24", R: 71.379, d: 1.1, nd: 1.6134, elemId: 13, sd: 16.5 },
+    { label: "25", R: 23.38, d: 12.68, nd: 1.0, elemId: 0, sd: 16.0 }, // d25 variable (zoom)
+
+    // ── B7: Rear negative doublet (L14+L15 cemented doublet D3) ──
+    { label: "26", R: -53.964, d: 1.3, nd: 1.744, elemId: 14, sd: 17.0 },
+    { label: "27", R: 43.097, d: 4.8, nd: 1.92286, elemId: 15, sd: 18.0 }, // D3 junction
+    { label: "28", R: -750.0, d: 16.09, nd: 1.0, elemId: 0, sd: 18.0 }, // BFD (d28+CG+d30)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "13A": {
+      K: 0,
+      A4: -5.91734e-6,
+      A6: -1.25922e-8,
+      A8: -6.96192e-11,
+      A10: -1.24634e-13,
+      A12: 3.32938e-16,
+      A14: 0,
+    },
+    "14A": {
+      K: 0,
+      A4: -2.81431e-6,
+      A6: -1.15888e-8,
+      A8: -1.2081e-10,
+      A10: 3.67743e-13,
+      A12: -6.62375e-16,
+      A14: 0,
+    },
+    "20A": {
+      K: 0,
+      A4: -2.16306e-6,
+      A6: -3.51669e-8,
+      A8: 3.80997e-12,
+      A10: -8.02806e-13,
+      A12: 7.68937e-16,
+      A14: 0,
+    },
+    "21A": {
+      K: 0,
+      A4: 1.35282e-5,
+      A6: -2.86368e-8,
+      A8: 3.89958e-11,
+      A10: -1.08816e-12,
+      A12: 1.8361e-15,
+      A14: 0,
+    },
+  },
+
+  /* ── Zoom configuration ── */
+  zoomPositions: [28.8, 49.0, 67.9],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  /* ── Variable air spacings (zoom only — close-focus data not available) ── */
+  var: {
+    "2": [
+      [0.85, 0.85],
+      [15.7, 15.7],
+      [26.56, 26.56],
+    ],
+    "9": [
+      [21.64, 21.64],
+      [7.73, 7.73],
+      [2.9, 2.9],
+    ],
+    "16": [
+      [4.86, 4.86],
+      [2.83, 2.83],
+      [2.01, 2.01],
+    ],
+    "19": [
+      [2.0, 2.0],
+      [4.04, 4.04],
+      [4.86, 4.86],
+    ],
+    "23": [
+      [3.22, 3.22],
+      [3.12, 3.12],
+      [2.0, 2.0],
+    ],
+    "25": [
+      [12.68, 12.68],
+      [12.78, 12.78],
+      [13.9, 13.9],
+    ],
+    "28": [
+      [16.09, 16.09],
+      [27.02, 27.02],
+      [35.57, 35.57],
+    ],
+  },
+  varLabels: [
+    ["2", "D2"],
+    ["9", "D9"],
+    ["16", "D16"],
+    ["19", "D19"],
+    ["23", "D23"],
+    ["25", "D25"],
+    ["28", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "B1 (+)", fromSurface: "1", toSurface: "2" },
+    { text: "B2 (−)", fromSurface: "3", toSurface: "9" },
+    { text: "B3 (+)", fromSurface: "STO", toSurface: "16" },
+    { text: "B4 (−)", fromSurface: "17", toSurface: "19" },
+    { text: "B5 (+)", fromSurface: "20A", toSurface: "23" },
+    { text: "B6 (−)", fromSurface: "24", toSurface: "25" },
+    { text: "B7 (−)", fromSurface: "26", toSurface: "28" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "5", toSurface: "7" },
+    { text: "D2", fromSurface: "17", toSurface: "19" },
+    { text: "D3", fromSurface: "26", toSurface: "28" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.27,
+  focusDescription:
+    "Rear inner focus via B6 (L13). Patent §0042/§0065: B6 moves toward image side from ∞ to close. " +
+    "Close-focus spacings not provided in Example 1; zoom-only gaps encoded.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: [2.88, 2.88, 2.92],
+  fstopSeries: [2.8, 3.2, 3.5, 4, 4.5, 5, 5.6, 6.3, 8, 11, 16, 22],
+  apertureBlades: 9,
+
+  /* ── Layout tuning ── */
+  scFill: 0.48,
+  yScFill: 0.38,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/CanonRF2870mmf2L.analysis.md
+++ b/src/lens-data/CanonRF2870mmf2L.analysis.md
@@ -1,0 +1,373 @@
+# Canon RF 28-70mm F2 L USM — Optical Design Analysis
+
+**Patent:** JP 2020-118807 A (Published 2020-08-06), Example A Main Optical System  
+**Inventor:** Kohei Kimura (木村 公平), Canon Inc.  
+**Filing date:** 2019-01-22  
+**Manufacturer specification:** 19 elements in 13 groups, f/2 constant aperture, 28–70 mm zoom  
+
+---
+
+## 1. Overview and Context
+
+The Canon RF 28-70mm F2 L USM, launched alongside the Canon EOS R system in September 2018, was the world's first autofocus full-frame zoom lens with a constant f/2 maximum aperture. This analysis examines the optical prescription disclosed as "Example A" in JP 2020-118807 A, a patent that nominally describes a converter device (コンバータ装置) but whose Example A main optical system corresponds closely to the production RF 28-70mm F2 L USM.
+
+The patent was filed by Canon on January 22, 2019 — approximately four months after the lens's commercial release — and covers the use of a relay (re-imaging) optical system that can be placed between the main lens and sensor to independently adjust field curvature. The main optical systems (Examples A, B, C) are provided as reference designs for mating with the converter; Example A is a four-group zoom lens with a 2.35× zoom ratio, F/2.06 maximum aperture, and focal length range of 28.9–67.9 mm, aligning precisely with the RF 28-70mm F2's marketed specifications.
+
+The RF mount's 54 mm throat diameter and 20 mm flange distance were critical enablers for this design. The short back focus permits large-diameter rear elements to be placed close to the sensor, which reduces peripheral aberrations at f/2 — a constraint that made an f/2 constant-aperture standard zoom impractical on the EF mount with its 44 mm flange distance.
+
+### 1.1 Patent Data Verification
+
+Independent paraxial ray trace of the full prescription yields the following:
+
+| Position | Patent EFL | Computed EFL | Patent F/# |
+|----------|-----------|-------------|-----------|
+| Wide     | 28.90 mm  | 28.90 mm    | 2.06      |
+| Mid      | 50.00 mm  | 50.01 mm    | 2.06      |
+| Tele     | 67.90 mm  | 67.92 mm    | 2.06      |
+
+The agreement is effectively exact, confirming correct transcription of the patent data. Group focal lengths also verify within ±0.01 mm of the patent-stated values (G1: +104.99, G2: −19.18, G3: +47.05, G4: +44.67).
+
+---
+
+## 2. Optical Architecture
+
+The design is a four-group positive-negative-positive-positive zoom with inner focusing. This is a classic zoom topology, but the f/2 constant aperture demands exceptionally well-corrected aberrations at every zoom position, driving the high element count (19 elements) and extensive use of special glass.
+
+### 2.1 Group Structure
+
+| Group | Elements | Focal Length | Power | Role |
+|-------|---------|-------------|-------|------|
+| G1 (L1–L3) | 3 elements, 2 sub-groups | +104.99 mm | Positive | Front collector — gathers light and sets the entrance pupil diameter |
+| G2 (L4–L8) | 5 elements, 3 sub-groups | −19.17 mm | Negative | Variator — moves rearward to zoom from wide to tele |
+| G3 (L9–L12) | 4 elements, 3 sub-groups | +47.05 mm | Positive | Compensator/focuser — contains the aperture stop (SP) |
+| G4 (L13–L19) | 7 elements, 5 sub-groups | +44.67 mm | Positive | Rear image-forming group — close to sensor via RF mount short flange |
+
+This yields 2 + 3 + 3 + 5 = 13 sub-groups, matching Canon's stated "13 groups."
+
+A flare-cut stop (AP) is positioned between Groups 3 and 4, near the primary image plane. The patent encodes this as a flat surface (r = ∞) with a negative thickness (d = −2.59 mm), which represents a backwards offset from the first surface of Group 4. For data-file encoding, this negative thickness is absorbed into the preceding air gap (d₂₁): the effective gap at each zoom position becomes d₂₁(patent) − 2.59 mm. The AP contributes no refractive power and is omitted as a separate surface.
+
+### 2.2 Zoom Movement
+
+The zoom is accomplished by moving Groups 2, 3, and 4 while Group 1 remains fixed. The variable air spacings at each zoom position are:
+
+| Gap | Wide (28.9 mm) | Mid (50.0 mm) | Tele (67.9 mm) | Δ (W→T) |
+|-----|---------------|--------------|---------------|---------|
+| d₅ (G1–G2) | 3.93 mm | 20.98 mm | 29.21 mm | +25.28 mm |
+| d₁₃ (G2–G3) | 15.61 mm | 6.51 mm | 2.27 mm | −13.34 mm |
+| d₂₁ (G3–G4)* | 6.08 mm | 2.00 mm | 1.02 mm | −5.06 mm |
+| d₃₄ (G4–image)† | 19.71 mm | 28.93 mm | 34.37 mm | +14.66 mm |
+
+*d₂₁ values include the absorbed flare-cut offset (patent d₂₁ − 2.59 mm).  
+†d₃₄ values include the cover glass path (patent d₃₄ + 1.96 mm CG glass + 2.75 mm air).
+
+The total track increases from approximately 157.5 mm (wide) to 179.1 mm (tele), consistent with the lens's external barrel extension during zooming. The RF 28-70mm F2 is not an internally-zooming design — the barrel extends approximately 21.5 mm when zooming from 28 mm to 70 mm.
+
+All moving groups shift rearward during zoom to telephoto, but at different rates. Group 2 (the variator) has the largest excursion (+25.3 mm), which is characteristic: the variator's movement relative to the fixed front group is what changes the system magnification and hence the focal length.
+
+### 2.3 Focusing Mechanism
+
+Canon specifies "inner focusing" with a ring-type USM (ultrasonic motor). The patent itself does not explicitly label the focusing group for Example A (it is not the patent's subject), but the architecture strongly implies that Group 3 (L9–L12) is the inner focus group:
+
+1. Group 3 contains the aperture stop (S14 is its first surface), and the powered elements L9–L12 follow immediately after it — a common arrangement for the focusing group in modern zoom designs.
+2. The four elements of Group 3 (L9–L12) are of moderate size — smaller than G1 or G4 — making them suitable for rapid USM-driven focusing.
+3. The patent text (paragraph 16) references "a lens that moves during focusing" in the main optical system, and the converter patent's variable-gap analysis for the re-imaging system requires the main lens's focus group to move in coordination with field curvature adjustment.
+
+The patent provides only infinity-focus spacings at each zoom position. No close-focus data is available for Example A. The minimum focus distance of 0.39 m (0.18× maximum magnification) is per Canon's published specification.
+
+---
+
+## 3. Aspherical Surfaces
+
+Canon specifies **four aspherical elements bearing five aspherical surfaces**: two ground-and-polished (G&P) aspherical elements and two glass-molded (GMo) aspherical elements. The Canon Hong Kong product page specifically notes that the glass-molded aspherics were produced on "a new type of glass molding machine with a significantly higher level of aspheric accuracy."
+
+All five aspherical surfaces in the patent use a conic constant K = 0 (spherical base curve) with even-order polynomial deformation terms through A12. The sag equation used in the patent is:
+
+$$
+X = \frac{(1/R) \cdot H^2}{1 + \sqrt{1 - (1+K)(H/R)^2}} + A_2 H^2 + A_4 H^4 + A_6 H^6 + A_8 H^8 + A_{10} H^{10} + A_{12} H^{12}
+$$
+
+The patent's formula explicitly includes an A2 (second-order) term. In all five numerical prescriptions, no A2 value is given, implying A2 = 0. The A2 term is not part of the project's data-file schema (which starts at A4), and since A2 = 0 throughout, the coefficients transfer directly.
+
+### 3.1 Surface S6 — L4 Front (Group 2 Variator)
+
+| Parameter | Value |
+|-----------|-------|
+| R | 167.209 mm |
+| K | 0 |
+| A4 | +4.38428 × 10⁻⁶ |
+| A6 | −2.70954 × 10⁻⁹ |
+| A8 | +4.53124 × 10⁻¹² |
+| A10 | −5.11345 × 10⁻¹⁶ |
+| A12 | +2.85627 × 10⁻¹⁸ |
+
+This is the front surface of L4, a strong negative meniscus (f = −30.6 mm) at the entrance to the variator. The aspheric departure is moderate: approximately +42 µm at h = 10 mm, increasing to +155 µm at h = 14 mm. The positive A4 term steepens the surface at the margins, adding negative power at the rim. This corrects higher-order spherical aberration introduced by the high-aperture beam passing through the variator.
+
+**Manufacturing classification:** Likely glass-molded (GMo). The element is thin (d = 1.55 mm), uses S-LAM54 (nd = 1.769) — a lanthanum medium crown available in moldable formulations — and is positioned in the variator where diameters are moderate.
+
+### 3.2 Surface S13 — L8 Rear (Group 2 Variator)
+
+| Parameter | Value |
+|-----------|-------|
+| R | −64.186 mm |
+| K | 0 |
+| A4 | −2.04866 × 10⁻⁶ |
+| A6 | −6.82741 × 10⁻¹⁰ |
+| A8 | −2.06847 × 10⁻¹¹ |
+| A10 | +9.28973 × 10⁻¹⁴ |
+| A12 | −1.47499 × 10⁻¹⁶ |
+
+This is the rear (exit) surface of cemented doublet D3, specifically the rear surface of L8 (S-LAH60, nd = 1.883). The departure is approximately −22 µm at h = 10 mm, growing to −96 µm at h = 14 mm. The negative A4 flattens the concave surface at the margins, reducing the divergence of oblique ray bundles exiting the variator.
+
+**Manufacturing classification:** Likely glass-molded (GMo). L8 is thin (d = 1.20 mm) and its glass (S-LAH60, nd = 1.883) may be available in moldable formulations. Being the last surface of Group 2, it serves as a "clean-up" asphere for the variator's residual aberrations across all zoom positions.
+
+### 3.3 Surface S18 — L10 Rear (Group 3 Compensator)
+
+| Parameter | Value |
+|-----------|-------|
+| R | −87.269 mm |
+| K | 0 |
+| A4 | +2.64029 × 10⁻⁶ |
+| A6 | −2.43625 × 10⁻⁹ |
+| A8 | −1.84031 × 10⁻¹² |
+| A10 | −2.30946 × 10⁻¹⁷ |
+| A12 | +4.15861 × 10⁻¹⁸ |
+
+The rear surface of L10, a thick biconvex element (d = 9.50 mm, f = +35.8 mm) that is the primary power contributor in Group 3. The departure is approximately +24 µm at h = 10 mm, growing to +81 µm at h = 14 mm. The positive A4 steepens the concave rear surface, adding negative power at the rim to flatten the tangential field.
+
+**Manufacturing classification:** Likely ground and polished (G&P). L10 is the thickest element in Group 3 (9.50 mm), uses a high-index lanthanum glass (S-LAH65V, nd = 1.804) that is typically not available in precision moldable grades at this size, and being part of the likely inner focus group, it carries the full-aperture beam at all zoom positions. The large clear aperture demands the higher-accuracy G&P process.
+
+### 3.4 Surfaces S30 and S31 — L17 Double Asphere (Group 4 Rear)
+
+#### S30 (L17 front):
+
+| Parameter | Value |
+|-----------|-------|
+| R | −1000.000 mm |
+| K | 0 |
+| A4 | −4.43289 × 10⁻⁵ |
+| A6 | −1.56326 × 10⁻⁸ |
+| A8 | +3.31996 × 10⁻¹⁰ |
+| A10 | −1.13489 × 10⁻¹² |
+| A12 | +2.02156 × 10⁻¹⁵ |
+
+#### S31 (L17 rear):
+
+| Parameter | Value |
+|-----------|-------|
+| R | 119.129 mm |
+| K | 0 |
+| A4 | −2.52968 × 10⁻⁵ |
+| A6 | +2.32789 × 10⁻⁸ |
+| A8 | +3.09529 × 10⁻¹⁰ |
+| A10 | −9.01793 × 10⁻¹³ |
+| A12 | +1.19241 × 10⁻¹⁵ |
+
+L17 is a double-asphere element — both surfaces are aspherical — positioned in the rear portion of Group 4, close to the sensor. The base radii are nearly flat on the front (R = −1000 mm, essentially a plano surface) and moderately convex on the rear (R = +119 mm), making this nominally a weak negative meniscus (f_thin = −124.6 mm) in its spherical base form.
+
+The aspherical departures are extremely large:
+
+| Height h | S30 departure | S31 departure |
+|----------|---------------|---------------|
+| 5 mm | −28 µm | −15 µm |
+| 8 mm | −181 µm | −93 µm |
+| 10 mm | −435 µm | −207 µm |
+| 12 mm | −875 µm | −367 µm |
+| 14 mm | −1544 µm | −533 µm |
+
+At h = 14 mm, S30's departure exceeds 1.5 mm — an enormous aspherical correction that radically reshapes the wavefront. The front surface goes from essentially flat (R = −1000 mm) to strongly concave at the rim due to the dominant negative A4 coefficient. The rear surface similarly flattens dramatically at the margins, converting what is nominally a weak meniscus into a powerful field-flattening and distortion-correcting element.
+
+**Manufacturing classification:** Almost certainly ground and polished (G&P). The enormous aspheric departures (>1 mm on S30) are far beyond what glass molding can achieve with optical precision. The glass is S-LAH66 (nd = 1.854), a conventional lanthanum crown not available in low-Tg moldable grades. Ground-and-polished aspherics at this departure level require magnetorheological finishing (MRF) or similar sub-aperture polishing technology.
+
+The double-asphere L17 is arguably the most critical single element in the entire design. Its position near the image plane — where chief ray heights are large but marginal ray heights are decreasing — makes it uniquely effective at controlling field-dependent aberrations (field curvature, astigmatism, and distortion) independently of axial aberrations (spherical, longitudinal chromatic). This is precisely the zone where the RF mount's short flange distance provides the mechanical clearance to place such a complex element.
+
+### 3.5 Aspherical Summary
+
+| Surface | Element | Group | Departure @ h=10mm | Manufacturing (inferred) |
+|---------|---------|-------|--------------------|-----------------------|
+| S6 | L4 front | G2 | +42 µm | Glass-molded (GMo) |
+| S13 | L8 rear | G2 | −22 µm | Glass-molded (GMo) |
+| S18 | L10 rear | G3 | +24 µm | Ground & polished (G&P) |
+| S30 | L17 front | G4 | −435 µm | Ground & polished (G&P) |
+| S31 | L17 rear | G4 | −207 µm | Ground & polished (G&P) |
+
+This yields 2 GMo elements (L4, L8) and 2 G&P elements (L10, L17), matching Canon's stated "two ground and polished aspheric lenses, two glass-molded aspheric lenses."
+
+---
+
+## 4. Glass Selection and Chromatic Correction
+
+### 4.1 Glass Catalog Identification
+
+All 19 glasses are exact catalog matches (Δnd = 0.00000, Δνd ≤ 0.04 in all cases).
+
+| Element | nd | νd | 6-digit Code | Glass | Catalog | Glass Type |
+|---------|----|----|-------------|-------|---------|-----------|
+| L1 | 1.80810 | 22.8 | 808/228 | S-NPH1 | OHARA | Short flint (APD) |
+| L2 | 1.72916 | 54.7 | 729/547 | S-LAL18 | OHARA | Lanthanum crown |
+| L3 | 1.77250 | 49.6 | 773/496 | S-LAH55V | OHARA | Lanthanum crown |
+| L4 | 1.76902 | 49.3 | 769/493 | S-LAM54 | OHARA | Lanthanum medium crown |
+| L5 | 1.76385 | 48.5 | 764/485 | **M-TAFD305** | **HOYA** | Lanthanum crown (PGM-designated) |
+| L6 | 1.85478 | 24.8 | 855/248 | S-NPH5 | OHARA | Heavy phosphate flint (APD) |
+| L7 | 1.48749 | 70.2 | 487/702 | S-FSL5 | OHARA | Fluorophosphate crown |
+| L8 | 1.88300 | 40.8 | 883/408 | S-LAH60 | OHARA | Lanthanum heavy crown |
+| L9 | 1.72916 | 54.7 | 729/547 | S-LAL18 | OHARA | Lanthanum crown |
+| L10 | 1.80400 | 46.6 | 804/466 | S-LAH65V | OHARA | Lanthanum crown |
+| L11 | 1.73800 | 32.3 | 738/323 | S-NBH8 | OHARA | Barium heavy flint |
+| L12 | 1.49700 | 81.5 | 497/815 | **S-FPL51** | OHARA | **UD glass** (APD) |
+| L13 | 1.43875 | 94.7 | 439/947 | **S-FPL53** | **OHARA** | **Super UD glass** (APD) |
+| L14 | 1.59522 | 67.7 | 595/677 | S-FPM2 | OHARA | Fluorophosphate crown |
+| L15 | 1.49700 | 81.5 | 497/815 | **S-FPL51** | OHARA | **UD glass** (APD) |
+| L16 | 1.80610 | 33.3 | 806/333 | S-NBH56 | OHARA | Barium heavy flint |
+| L17 | 1.85400 | 40.4 | 854/404 | S-LAH66 | OHARA | Lanthanum crown |
+| L18 | 1.48749 | 70.2 | 487/702 | S-FSL5 | OHARA | Fluorophosphate crown |
+| L19 | 2.00100 | 29.1 | 201/291 | S-NPH2 | OHARA | Heavy phosphate flint (APD) |
+
+**Correction note:** L5 was previously listed as uncertain. It is an exact match to HOYA M-TAFD305 (nd = 1.76385, νd = 48.49). The M-prefix indicates this glass is designated for precision glass molding, though the element itself (being part of cemented doublet D2) is likely conventionally fabricated. L13 was previously described as a possible Canon proprietary glass formulation; it is in fact OHARA S-FPL53 (nd = 1.43875, νd = 94.66), a standard catalog Super UD glass used by Canon as their "Super UD" element.
+
+### 4.2 Special Dispersion Glasses
+
+Canon's specification lists "two UD elements and one Super UD element." These map to:
+
+**L12 (S-FPL51, νd = 81.5):** Ultra-low Dispersion glass with anomalous partial dispersion. Positioned in cemented doublet D4 within Group 3, paired with the high-dispersion L11 (S-NBH8, νd = 32.3). This combination corrects secondary spectrum in the compensator/focus group.
+
+**L13 (S-FPL53, νd = 94.7):** The Super UD element. OHARA S-FPL53 is a fluorophosphate crown with the highest Abbe number in OHARA's catalog glass line and strong anomalous partial dispersion. Its placement at the front of Group 4, where marginal ray heights are large, maximizes its chromatic correction contribution. The nearly-plano rear surface (R₂ = −665 mm) minimizes surface reflections and sensitivity to centering errors.
+
+**L15 (S-FPL51, νd = 81.5):** The second UD element, in cemented doublet D5 within Group 4, paired with high-dispersion L16 (S-NBH56, νd = 33.3). This provides additional secondary-spectrum correction in the rear group.
+
+The placement strategy is deliberate: all three anomalous-dispersion elements are concentrated in Groups 3 and 4, which handle the final image formation. The variator (Group 2) uses heavy phosphate flint (S-NPH5 in D2) and lanthanum crown (S-LAH60 in D3) for its chromatic correction — the NPH glass contributes some anomalous dispersion benefit, but the primary secondary-spectrum correction is handled by the UD and Super UD elements in the rear groups where the converging beam is being brought to focus.
+
+### 4.3 Heavy Phosphate Flint (S-NPH) Family
+
+Three elements use OHARA's S-NPH heavy phosphate flint series — L1 (S-NPH1, nd = 1.808), L6 (S-NPH5, nd = 1.855), and L19 (S-NPH2, nd = 2.001). This family is characterized by positive anomalous partial dispersion (dPgF > 0), which means their blue-violet dispersion is higher than the normal glass line predicts. When paired with crown glasses in cemented doublets, the NPH glasses provide secondary-spectrum correction in addition to primary chromatic correction. The use of three NPH elements across the full extent of the optical system (front, variator, and rear) reflects a coordinated strategy for chromatic correction.
+
+### 4.4 Ultra-High-Index Glass: L19 (nd = 2.001)
+
+L19 is the rearmost positive element of the design, using S-NPH2 — a heavy phosphate flint with nd = 2.00100. This is among the highest refractive indices used in any production camera lens. With nd > 2, even moderate curvatures produce significant refractive power: L19's thin-lens focal length is +36.2 mm despite having radii of 50.0 mm and −131.6 mm. In a conventional glass (nd ≈ 1.5), equivalent curvatures would yield roughly f = +72 mm — requiring much steeper curves for the same power, which would dramatically worsen higher-order aberrations.
+
+The ultra-high index is especially valuable this close to the sensor, where any element curvature is amplified in its effect on off-axis ray paths. By minimizing curvature at full power, L19 keeps the peripheral illumination uniform across the full 43.3 mm image circle — a critical requirement at f/2.
+
+### 4.5 Petzval Sum
+
+The computed Petzval sum for the full system is +0.00108 mm⁻¹, corresponding to a Petzval radius of −926 mm. This is an extraordinarily flat Petzval surface for a zoom lens, indicating very well-controlled intrinsic field curvature. The positive sign (backward-curving Petzval surface) means the natural tendency is toward undercorrected field curvature, which the aspherical elements (particularly L17) compensate.
+
+---
+
+## 5. Element-by-Element Analysis
+
+### Group 1: Front Collector (L1–L3, f = +104.99 mm)
+
+**Cemented Doublet D1 (L1 + L2):**
+The front doublet consists of a thin negative meniscus L1 (S-NPH1, nd = 1.808, νd = 22.8, f = −160.5 mm) cemented to a thick positive meniscus L2 (S-LAL18, nd = 1.729, νd = 54.7, f = +136.3 mm). The doublet's combined thin-lens focal length is +901 mm — very weakly positive, essentially acting as a corrector plate rather than a power element. Its primary role is achromatic correction: the negative flint cancels the chromatic contribution of the positive crown, establishing a color-neutral entrance to the system.
+
+**L3 (Positive Meniscus):**
+S-LAH55V lanthanum crown (nd = 1.773, νd = 49.6), f = +121.5 mm. This meniscus contributes most of Group 1's positive power. Its meniscus shape (convex surface toward the object, R₁ = 59.0 mm, R₂ = 158.7 mm) helps control spherical aberration by bending the marginal rays gradually rather than abruptly.
+
+Group 1 is the largest-diameter element group. At f/2 and 28 mm wide angle, the entrance pupil diameter is approximately 14 mm, but accounting for the telephoto-end EP (33 mm diameter) and off-axis chief ray heights, the front elements must clear semi-diameters approaching 43–44 mm (consistent with the 95 mm filter thread).
+
+### Group 2: Variator (L4–L8, f = −19.17 mm)
+
+The variator is the heart of the zoom mechanism. Its strong negative power (f = −19 mm) diverges the beam from Group 1, and its axial position controls the system's overall focal length.
+
+**L4 (Strong Negative Meniscus, 1× Asph):**
+S-LAM54 (nd = 1.769, νd = 49.3), f = −30.6 mm. The dramatic radius difference (R₁ = 167 mm, R₂ = 20.6 mm) creates a deeply curved meniscus that bends marginal rays outward aggressively. The aspherical front surface (S6) fine-tunes this divergence to control zonal spherical aberration.
+
+**Cemented Doublet D2 (L5 + L6):**
+An achromatic pair consisting of biconcave L5 (M-TAFD305, nd = 1.764, νd = 48.5, f = −22.5 mm) cemented to biconvex L6 (S-NPH5, nd = 1.855, νd = 24.8, f = +20.5 mm). The doublet's combined focal length is +222 mm, providing gentle positive correction within the overwhelmingly negative variator. The identification of L5 as HOYA M-TAFD305 is noteworthy — it is the only non-OHARA glass in the design. Canon's use of a HOYA glass here may reflect either a performance advantage of this specific melt or supply chain considerations. The M-prefix indicates the glass is PGM-compatible, though L5 itself (within a cemented doublet) is conventionally fabricated.
+
+**Cemented Doublet D3 (L7 + L8):**
+L7 is a positive meniscus (f = +71.5 mm) of S-FSL5 (nd = 1.487, νd = 70.2) — a low-index, low-dispersion fluorophosphate. L8 is a negative meniscus (f = −30.8 mm) of S-LAH60 (nd = 1.883, νd = 40.8) with an aspherical rear surface (S13). The doublet's combined focal length is −54 mm, contributing additional negative power. Despite the individual elements having opposite signs, the pair works as a negative achromatic corrector. The asphere on S13 serves as a "clean-up" correction for oblique aberrations at the variator's exit, reducing coma and astigmatism that would otherwise degrade performance across the zoom range.
+
+### Group 3: Compensator / Focus Group (L9–L12, f = +47.05 mm)
+
+This group immediately follows the aperture stop (S14) and is the probable inner-focus group.
+
+**L9 (Plano-Convex):**
+S-LAL18 lanthanum crown (nd = 1.729, νd = 54.7), f = +76.5 mm. The flat rear surface (R₂ = ∞) makes this a simple positive converging element that begins refocusing the diverged beam from Group 2.
+
+**L10 (Thick Biconvex, 1× Asph):**
+S-LAH65V (nd = 1.804, νd = 46.6), f = +35.8 mm. This is the dominant power element in Group 3, with the thickest center (9.50 mm) of any element in the group. The aspherical rear surface (S18) provides approximately +24 µm of departure at h = 10 mm, correcting spherical aberration and flattening the tangential field. If Group 3 is indeed the focus group, L10 is the largest and heaviest element the USM must move during autofocus.
+
+**Cemented Doublet D4 (L11 + L12):**
+An achromatic pair optimized for secondary spectrum correction. L11 (S-NBH8, nd = 1.738, νd = 32.3) is a biconcave high-dispersion negative element (f = −22.5 mm); L12 (S-FPL51, nd = 1.497, νd = 81.5) is a positive meniscus UD glass (f = +58.3 mm). The doublet's combined thin-lens focal length is −36.5 mm — negative overall, which means it acts as a field-flattening achromatic corrector within the otherwise-positive Group 3. The UD glass's anomalous partial dispersion is essential here: a conventional crown would leave uncorrected secondary spectrum that would manifest as purple fringing at f/2.
+
+### Group 4: Rear Image-Forming Group (L13–L19, f = +44.67 mm)
+
+Group 4 is the largest group by element count (7 elements in 5 sub-groups) and benefits directly from the RF mount's short back focus. The last surface sits only about 15 mm (at wide) to 30 mm (at tele) from the sensor, which is mechanically possible only with the RF mount's 20 mm flange distance.
+
+**L13 (Super UD Biconvex):**
+OHARA S-FPL53 (nd = 1.439, νd = 94.7), f = +66.2 mm. The sole Super UD element, positioned at the front of Group 4 where marginal ray heights are largest. This glass's extreme anomalous partial dispersion provides powerful correction of secondary longitudinal chromatic aberration. The nearly-plano rear surface (R₂ = −665 mm) minimizes surface reflections and sensitivity to centering errors.
+
+**L14 (Biconvex):**
+S-FPM2 fluorophosphate crown (nd = 1.595, νd = 67.7), f = +55.2 mm. A straightforward positive element that shares the convergence load with L13, reducing the curvature required on any single surface.
+
+**Cemented Doublet D5 (L15 + L16):**
+L15 is the second UD element (S-FPL51, nd = 1.497, νd = 81.5), a biconvex positive with f = +84.9 mm. L16 is a biconcave negative of barium heavy flint (S-NBH56, nd = 1.806, νd = 33.3), f = −43.9 mm. The doublet's combined focal length is −90.9 mm — net negative, serving as a secondary-spectrum-correcting field flattener.
+
+**L17 (Double Asphere, Negative Meniscus):**
+S-LAH66 (nd = 1.854, νd = 40.4), f = −124.6 mm. This is the most optically sophisticated single element in the design (discussed in detail in Section 3.4). Both surfaces carry enormous aspherical departures (S30 up to 1.5 mm, S31 up to 0.5 mm). Its position near the image plane makes it the primary corrector for field curvature, astigmatism, distortion, and lateral chromatic aberration. The double-asphere configuration provides twice the degrees of freedom of a single asphere, enabling simultaneous correction of multiple field-dependent aberrations.
+
+**Cemented Doublet D6 (L18 + L19):**
+The final optical doublet before the sensor. L18 is S-FSL5 (nd = 1.487, νd = 70.2), a biconcave negative, f = −45.6 mm. L19 is S-NPH2 (nd = 2.001, νd = 29.1), a biconvex positive with f = +36.2 mm. The doublet has a combined focal length of +175.9 mm — gently positive.
+
+The pairing of the lowest-index glass in the system (L18, nd = 1.487) with the highest-index glass (L19, nd = 2.001) is deliberate: the extreme index differential at the cemented junction (Δnd = 0.514) creates a powerful chromatic corrector with minimal surface curvature. L19's nd = 2.001 means that even the weak curvatures of its surfaces refract strongly, keeping the element compact and reducing higher-order surface contributions to aberrations. This is the element that most directly exploits the RF mount's short flange distance — its rear surface sits only millimeters from the sensor plane.
+
+---
+
+## 6. Cemented Doublet Summary
+
+| Doublet | Elements | Combined f | Group | Primary Role |
+|---------|---------|-----------|-------|-------------|
+| D1 | L1 + L2 | +901 mm | G1 | Front achromatic corrector |
+| D2 | L5 + L6 | +222 mm | G2 | Variator achromatic pair |
+| D3 | L7 + L8 | −54 mm | G2 | Variator negative corrector (asph) |
+| D4 | L11 + L12 | −37 mm | G3 | Secondary spectrum corrector (UD) |
+| D5 | L15 + L16 | −91 mm | G4 | Secondary spectrum corrector (UD) |
+| D6 | L18 + L19 | +176 mm | G4 | Ultra-high-index rear achromat |
+
+---
+
+## 7. Design Philosophy and RF Mount Advantages
+
+The RF 28-70mm F2 represents a design philosophy where the optical prescription exploits the mechanical freedom of the RF mount to achieve performance that was physically impossible on the EF mount:
+
+1. **Large rear elements close to the sensor.** L19 (nd = 2.001) and the preceding elements of Group 4 can be placed within 15–30 mm of the sensor, well inside the EF mount's 44 mm flange distance. This reduces the angle of incidence of marginal rays on the sensor and improves peripheral illumination.
+
+2. **Double-asphere field corrector.** L17's position near the sensor plane would place it inside the mirror box of an SLR. On the RF mount, this element can sit in the space that was previously occupied by the reflex mirror, providing powerful field-dependent correction that conventional retro-focus zoom designs cannot match.
+
+3. **Constant f/2 without compromising size.** The four-group zoom architecture, with its strong negative variator (f = −19 mm) and equally strong positive compensator and rear groups, maintains the exit pupil position and size across the zoom range, keeping the f/2 cone angle consistent. On the EF mount, achieving this would require either a longer total track or larger front-group diameters.
+
+The combination of Super UD (S-FPL53), UD (S-FPL51), ultra-high-index glass (S-NPH2, nd > 2.0), and ground-and-polished aspherics represents the full arsenal of Canon's optical technology.
+
+---
+
+## 8. Data File Encoding Notes
+
+### 8.1 Flare-Cut Stop (Patent S22)
+
+Patent surface 22 is a flare-cut aperture (AP) encoded with d = −2.59 mm. This negative thickness represents a virtual offset — the AP sits 2.59 mm object-side of the first glass surface of Group 4. In the data file, this surface is omitted entirely and its negative thickness is absorbed into the preceding air gap: surface "21" carries d₂₁(effective) = d₂₁(patent) − 2.59 mm at each zoom position.
+
+### 8.2 Cover Glass
+
+Patent surfaces 35–36 describe a cover glass (nd = 1.51633, d = 1.96 mm) followed by an air gap (d = 2.75 mm, constant across zoom). These are excluded from the data file's surfaces array. The total physical path (1.96 + 2.75 = 4.71 mm) is added to d₃₄(patent) to produce the data file's BFD on surface "33."
+
+### 8.3 Semi-Diameter Estimation
+
+Semi-diameters are not provided in the patent. They were estimated by tracing marginal and chief rays at all three zoom positions (wide, mid, tele) through the clean prescription (no CG, flare-cut absorbed). The chief ray was traced at 80% of full field angle to model the ~20% corner vignetting typical of f/2 zoom lenses. The maximum beam footprint (marginal + chief) at each surface across all three zoom positions was taken, then 5% mechanical clearance applied and rounded to the nearest 0.5 mm.
+
+The front group (G1) semi-diameters were capped at 44.5 mm, consistent with the 95 mm filter thread's internal clear aperture (~89 mm diameter). The telephoto position drives the front group SDs (largest entrance pupil: EP ≈ 33 mm diameter), while the wide position drives the variator SDs (largest chief ray heights). The stop semi-diameter is set to 16.0 mm — the physical iris opening required at the tele end; the renderer derives the correct entrance pupil at each zoom position from `nominalFno` via paraxial ray trace.
+
+### 8.4 Focus Model Limitations
+
+The patent provides infinity-focus data only. No close-focus variable spacing tables are available for Example A. The data file encodes all variable gaps as zoom-only (identical infinity/close values). Canon's published minimum focus distance of 0.39 m is recorded as `closeFocusM` for reference, but the focus slider will not produce physically meaningful results — zooming will work correctly, but focus variation is not modeled.
+
+---
+
+## 9. Corrections from Initial Draft
+
+The following errors were identified during cross-verification and corrected in this revision:
+
+1. **L5 glass identification:** Previously listed as "uncertain." Verified as an exact match to HOYA M-TAFD305 (nd = 1.76385, νd = 48.49; Δnd = 0.00000, Δνd = 0.01). This is the only non-OHARA glass in the design.
+
+2. **L13 glass identification:** Previously described as "Canon proprietary Super UD formulation, intermediate between CaF₂ and S-FPL53." In fact, L13 is an exact match to OHARA S-FPL53 (nd = 1.43875, νd = 94.66; Δnd = 0.00000, Δνd = 0.04). It is a standard catalog glass, not a proprietary formulation.
+
+3. **L7 element type:** Previously described as "negative meniscus." L7 (R₁ = −42.283, R₂ = −19.110, nd = 1.487) has a thin-lens focal length of +71.5 mm — it is a **positive meniscus** (concave toward the object). The combined D3 doublet is still negative (f = −54 mm), as the stronger negative power of L8 dominates.

--- a/src/lens-data/CanonRF2870mmf2L.data.ts
+++ b/src/lens-data/CanonRF2870mmf2L.data.ts
@@ -319,8 +319,8 @@ const LENS_DATA = {
     { label: "2", R: 76.661, d: 8.55, nd: 1.72916, elemId: 2, sd: 44.5 },
     { label: "3", R: 335.605, d: 0.15, nd: 1.0, elemId: 0, sd: 39.25 },
     // L3 singlet
-    { label: "4", R: 58.97, d: 8.05, nd: 1.7725, elemId: 3, sd: 39.0 },
-    { label: "5", R: 158.73, d: 3.93, nd: 1.0, elemId: 0, sd: 35.5 }, // [var: G1–G2]
+    { label: "4", R: 58.97, d: 8.05, nd: 1.7725, elemId: 3, sd: 36.0 },
+    { label: "5", R: 158.73, d: 3.93, nd: 1.0, elemId: 0, sd: 35.0 }, // [var: G1–G2]
 
     // ── Group 2: Variator ──
     // L4 singlet (1× asph front)

--- a/src/lens-data/CanonRF2870mmf2L.data.ts
+++ b/src/lens-data/CanonRF2870mmf2L.data.ts
@@ -1,0 +1,493 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — CANON RF 28-70mm F2 L USM                            ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: JP 2020-118807 A Example A (Canon / Kimura).         ║
+ * ║  Four-group positive-negative-positive-positive zoom.              ║
+ * ║  19 elements / 13 groups, 5 aspherical surfaces (4 asph elements). ║
+ * ║  Focus: Inner focus (Group 3 probable focus group, USM-driven).    ║
+ * ║                                                                    ║
+ * ║  Zoom variable gaps: D5 (G1–G2), D13A (G2–G3), D21 (G3–G4),      ║
+ * ║                      D33 (BFD).                                    ║
+ * ║  All groups move rearward wide→tele except G1 (fixed).            ║
+ * ║  No close-focus data in patent; zoom-only variable gaps modeled.   ║
+ * ║                                                                    ║
+ * ║  NOTE ON FLARE CUT (patent S22):                                   ║
+ * ║    Patent surface 22 (AP, flare-cut stop) has d = −2.59 mm.       ║
+ * ║    This negative offset is combined into the preceding air gap     ║
+ * ║    d21: effective d21 = d21_patent − 2.59 at each zoom position.  ║
+ * ║                                                                    ║
+ * ║  NOTE ON COVER GLASS:                                              ║
+ * ║    Patent surfaces 35–36 (CG, nd = 1.51633, d = 1.96 mm) and      ║
+ * ║    the trailing air gap (d36 = 2.75 mm) are excluded from the      ║
+ * ║    surfaces array. Their physical path (1.96 + 2.75 = 4.71 mm)    ║
+ * ║    is folded into the BFD on surface "33".                         ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Not listed in patent. Estimated via combined marginal + chief   ║
+ * ║    ray trace at all three zoom positions (80% field vignetting     ║
+ * ║    model, 5% mechanical clearance), taking the maximum at each    ║
+ * ║    surface. Front group capped at ≈ 44.5 mm (95 mm filter        ║
+ * ║    thread). STO sd = 16.0 mm (tele-end physical iris maximum).    ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "canon-rf-28-70-f2",
+  maker: "Canon",
+  name: "CANON RF 28-70mm F2 L USM",
+  subtitle: "JP 2020-118807 A Example A — Canon / Kimura",
+  specs: [
+    "19 ELEMENTS / 13 GROUPS",
+    "f = 28.9 – 67.9 mm (patent)",
+    "F/2.06 (constant)",
+    "2ω = 73.6° – 35.3°",
+    "5 ASPHERICAL SURFACES (4 elements)",
+  ],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: [28, 70] as [number, number],
+  focalLengthDesign: [28.9, 67.9] as [number, number],
+  apertureMarketing: 2.0,
+  apertureDesign: 2.06,
+  patentYear: 2020,
+  elementCount: 19,
+  groupCount: 13,
+
+  /* ── Elements ── */
+  elements: [
+    // ── Group 1: Front Collector (f = +104.99 mm) ──
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.8081,
+      vd: 22.8,
+      fl: -160.5,
+      glass: "S-NPH1 (OHARA)",
+      apd: "inferred" as const,
+      apdNote: "Heavy phosphate short flint, dPgF > 0",
+      role: "Front negative corrector in D1; achromatic pair with L2",
+      cemented: "D1",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.72916,
+      vd: 54.7,
+      fl: 136.3,
+      glass: "S-LAL18 (OHARA)",
+      apd: false as const,
+      role: "Positive element in D1 doublet; primary front power contribution",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.7725,
+      vd: 49.6,
+      fl: 121.5,
+      glass: "S-LAH55V (OHARA)",
+      apd: false as const,
+      role: "Dominant positive power element in G1; controls entrance pupil",
+    },
+    // ── Group 2: Variator (f = −19.17 mm) ──
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.76902,
+      vd: 49.3,
+      fl: -30.6,
+      glass: "S-LAM54 (OHARA)",
+      apd: false as const,
+      role: "Strong negative meniscus at variator entrance; asph S6 corrects zonal SA",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconcave Negative",
+      nd: 1.76385,
+      vd: 48.5,
+      fl: -22.5,
+      glass: "M-TAFD305 (HOYA)",
+      apd: false as const,
+      role: "Negative element in D2; variator divergence",
+      cemented: "D2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.85478,
+      vd: 24.8,
+      fl: 20.5,
+      glass: "S-NPH5 (OHARA)",
+      apd: "inferred" as const,
+      apdNote: "Heavy phosphate flint, dPgF > 0; secondary spectrum correction in variator",
+      role: "Positive corrector in D2; achromatic pair with L5",
+      cemented: "D2",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Positive Meniscus",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 71.5,
+      glass: "S-FSL5 (OHARA)",
+      apd: false as const,
+      role: "Positive meniscus in D3; low-index fluorophosphate for chromatic balance",
+      cemented: "D3",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.883,
+      vd: 40.8,
+      fl: -30.8,
+      glass: "S-LAH60 (OHARA)",
+      apd: false as const,
+      role: "Negative corrector in D3; asph S13 cleans up variator exit aberrations",
+      cemented: "D3",
+    },
+    // ── Group 3: Compensator / Inner Focus (f = +47.05 mm) ──
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Plano-Convex Positive",
+      nd: 1.72916,
+      vd: 54.7,
+      fl: 76.5,
+      glass: "S-LAL18 (OHARA)",
+      apd: false as const,
+      role: "First converging element after stop; begins refocusing variator output",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Pos. (1× Asph)",
+      nd: 1.804,
+      vd: 46.6,
+      fl: 35.8,
+      glass: "S-LAH65V (OHARA)",
+      apd: false as const,
+      role: "Dominant power element in G3; asph S18 corrects SA and tangential field",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Biconcave Negative",
+      nd: 1.738,
+      vd: 32.3,
+      fl: -22.5,
+      glass: "S-NBH8 (OHARA)",
+      apd: false as const,
+      role: "High-dispersion negative in D4; secondary spectrum correction with UD partner",
+      cemented: "D4",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.5,
+      fl: 58.3,
+      glass: "S-FPL51 (OHARA)",
+      apd: "patent" as const,
+      apdNote: "UD glass; anomalous partial dispersion for secondary spectrum correction",
+      role: "UD positive meniscus in D4; corrects secondary spectrum in focus group",
+      cemented: "D4",
+    },
+    // ── Group 4: Rear Image-Forming (f = +44.67 mm) ──
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Biconvex Positive",
+      nd: 1.43875,
+      vd: 94.7,
+      fl: 66.2,
+      glass: "S-FPL53 (OHARA)",
+      apd: "patent" as const,
+      apdNote: "Super UD glass (νd = 94.7); strongest APD contributor in the system",
+      role: "Super UD biconvex at G4 front; maximum secondary spectrum correction at large marginal ray height",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Biconvex Positive",
+      nd: 1.59522,
+      vd: 67.7,
+      fl: 55.2,
+      glass: "S-FPM2 (OHARA)",
+      apd: false as const,
+      role: "Positive convergence element; shares load with L13 to reduce curvatures",
+    },
+    {
+      id: 15,
+      name: "L15",
+      label: "Element 15",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.5,
+      fl: 84.9,
+      glass: "S-FPL51 (OHARA)",
+      apd: "patent" as const,
+      apdNote: "UD glass; second UD element for rear group secondary spectrum correction",
+      role: "UD positive in D5; corrects secondary spectrum in rear image-forming group",
+      cemented: "D5",
+    },
+    {
+      id: 16,
+      name: "L16",
+      label: "Element 16",
+      type: "Biconcave Negative",
+      nd: 1.8061,
+      vd: 33.3,
+      fl: -43.9,
+      glass: "S-NBH56 (OHARA)",
+      apd: false as const,
+      role: "High-dispersion negative in D5; achromatic partner for UD L15",
+      cemented: "D5",
+    },
+    {
+      id: 17,
+      name: "L17",
+      label: "Element 17",
+      type: "Neg. Meniscus (2× Asph)",
+      nd: 1.854,
+      vd: 40.4,
+      fl: -124.6,
+      glass: "S-LAH66 (OHARA)",
+      apd: false as const,
+      role: "Double-asphere field corrector; >1.5 mm departure on S30 — primary corrector for FC, astigmatism, distortion near sensor",
+    },
+    {
+      id: 18,
+      name: "L18",
+      label: "Element 18",
+      type: "Biconcave Negative",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: -45.6,
+      glass: "S-FSL5 (OHARA)",
+      apd: false as const,
+      role: "Low-index negative in D6; extreme Δnd junction (0.514) with L19 for chromatic correction",
+      cemented: "D6",
+    },
+    {
+      id: 19,
+      name: "L19",
+      label: "Element 19",
+      type: "Biconvex Positive",
+      nd: 2.001,
+      vd: 29.1,
+      fl: 36.2,
+      glass: "S-NPH2 (OHARA)",
+      apd: "inferred" as const,
+      apdNote: "Ultra-high-index heavy phosphate flint (nd > 2.0); dPgF > 0",
+      role: "Final positive element; ultra-high nd minimizes curvatures close to sensor; exploits RF mount short flange",
+      cemented: "D6",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Group 1: Front Collector ──
+    // Cemented doublet D1 (L1 + L2)
+    { label: "1", R: 187.418, d: 2.2, nd: 1.8081, elemId: 1, sd: 44.5 },
+    { label: "2", R: 76.661, d: 8.55, nd: 1.72916, elemId: 2, sd: 44.5 },
+    { label: "3", R: 335.605, d: 0.15, nd: 1.0, elemId: 0, sd: 39.25 },
+    // L3 singlet
+    { label: "4", R: 58.97, d: 8.05, nd: 1.7725, elemId: 3, sd: 39.0 },
+    { label: "5", R: 158.73, d: 3.93, nd: 1.0, elemId: 0, sd: 35.5 }, // [var: G1–G2]
+
+    // ── Group 2: Variator ──
+    // L4 singlet (1× asph front)
+    { label: "6A", R: 167.209, d: 1.55, nd: 1.76902, elemId: 4, sd: 20.5 },
+    { label: "7", R: 20.639, d: 9.56, nd: 1.0, elemId: 0, sd: 18.5 },
+    // Cemented doublet D2 (L5 + L6)
+    { label: "8", R: -49.152, d: 1.0, nd: 1.76385, elemId: 5, sd: 17.0 },
+    { label: "9", R: 26.487, d: 8.15, nd: 1.85478, elemId: 6, sd: 16.1 },
+    { label: "10", R: -51.463, d: 1.45, nd: 1.0, elemId: 0, sd: 16.5 },
+    // Cemented doublet D3 (L7 + L8, rear asph)
+    { label: "11", R: -42.283, d: 5.85, nd: 1.48749, elemId: 7, sd: 16.5 },
+    { label: "12", R: -19.11, d: 1.2, nd: 1.883, elemId: 8, sd: 16.25 },
+    { label: "13A", R: -64.186, d: 15.61, nd: 1.0, elemId: 0, sd: 16.5 }, // [var: G2–G3]
+
+    // ── Aperture Stop ──
+    { label: "STO", R: 1e15, d: 0.3, nd: 1.0, elemId: 0, sd: 16.0 },
+
+    // ── Group 3: Compensator / Inner Focus ──
+    // L9 singlet (plano-convex)
+    { label: "15", R: 55.781, d: 5.05, nd: 1.72916, elemId: 9, sd: 17.0 },
+    { label: "16", R: 1e15, d: 0.15, nd: 1.0, elemId: 0, sd: 18.0 },
+    // L10 singlet (1× asph rear)
+    { label: "17", R: 42.901, d: 9.5, nd: 1.804, elemId: 10, sd: 18.5 },
+    { label: "18A", R: -87.269, d: 3.8, nd: 1.0, elemId: 0, sd: 18.5 },
+    // Cemented doublet D4 (L11 + L12, UD)
+    { label: "19", R: -50.369, d: 1.5, nd: 1.738, elemId: 11, sd: 18.5 },
+    { label: "20", R: 24.706, d: 7.7, nd: 1.497, elemId: 12, sd: 18.5 },
+    { label: "21", R: 166.989, d: 6.08, nd: 1.0, elemId: 0, sd: 19.5 }, // [var: G3–G4, includes AP offset]
+
+    // ── Group 4: Rear Image-Forming ──
+    // L13 singlet (Super UD)
+    { label: "22", R: 30.373, d: 7.3, nd: 1.43875, elemId: 13, sd: 19.2 },
+    { label: "23", R: -664.868, d: 0.15, nd: 1.0, elemId: 0, sd: 20.0 },
+    // L14 singlet
+    { label: "24", R: 48.839, d: 5.5, nd: 1.59522, elemId: 14, sd: 20.0 },
+    { label: "25", R: -100.131, d: 0.57, nd: 1.0, elemId: 0, sd: 18.45 },
+    // Cemented doublet D5 (L15 + L16, UD)
+    { label: "26", R: 66.531, d: 4.55, nd: 1.497, elemId: 15, sd: 19.8 },
+    { label: "27", R: -115.19, d: 1.2, nd: 1.8061, elemId: 16, sd: 19.1 },
+    { label: "28", R: 51.069, d: 3.84, nd: 1.0, elemId: 0, sd: 18.5 },
+    // L17 singlet (double-asphere)
+    { label: "29A", R: -1000.0, d: 3.0, nd: 1.854, elemId: 17, sd: 14.0 },
+    { label: "30A", R: 119.129, d: 3.42, nd: 1.0, elemId: 0, sd: 18.0 },
+    // Cemented doublet D6 (L18 + L19, ultra-high-index)
+    { label: "31", R: -39.992, d: 1.3, nd: 1.48749, elemId: 18, sd: 18.0 },
+    { label: "32", R: 50.003, d: 6.3, nd: 2.001, elemId: 19, sd: 18.5 },
+    { label: "33", R: -131.617, d: 19.71, nd: 1.0, elemId: 0, sd: 19.5 }, // [var: BFD, includes CG path]
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "6A": {
+      K: 0,
+      A4: 4.38428e-6,
+      A6: -2.70954e-9,
+      A8: 4.53124e-12,
+      A10: -5.11345e-16,
+      A12: 2.85627e-18,
+      A14: 0,
+    },
+    "13A": {
+      K: 0,
+      A4: -2.04866e-6,
+      A6: -6.82741e-10,
+      A8: -2.06847e-11,
+      A10: 9.28973e-14,
+      A12: -1.47499e-16,
+      A14: 0,
+    },
+    "18A": {
+      K: 0,
+      A4: 2.64029e-6,
+      A6: -2.43625e-9,
+      A8: -1.84031e-12,
+      A10: -2.30946e-17,
+      A12: 4.15861e-18,
+      A14: 0,
+    },
+    "29A": {
+      K: 0,
+      A4: -4.43289e-5,
+      A6: -1.56326e-8,
+      A8: 3.31996e-10,
+      A10: -1.13489e-12,
+      A12: 2.02156e-15,
+      A14: 0,
+    },
+    "30A": {
+      K: 0,
+      A4: -2.52968e-5,
+      A6: 2.32789e-8,
+      A8: 3.09529e-10,
+      A10: -9.01793e-13,
+      A12: 1.19241e-15,
+      A14: 0,
+    },
+  },
+
+  /* ── Zoom configuration ── */
+  zoomPositions: [28.9, 50.0, 67.9],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  /* ── Variable air spacings (zoom only — no close-focus data in patent) ──
+   *  All gaps use identical inf/close values (zoom-only movement).
+   *  "21" includes the absorbed flare-cut offset (−2.59 mm from patent S22).
+   *  "33" includes CG physical path (1.96 + 2.75 = 4.71 mm).
+   */
+  var: {
+    "5": [
+      [3.93, 3.93],
+      [20.98, 20.98],
+      [29.21, 29.21],
+    ],
+    "13A": [
+      [15.61, 15.61],
+      [6.51, 6.51],
+      [2.27, 2.27],
+    ],
+    "21": [
+      [6.08, 6.08],
+      [2.0, 2.0],
+      [1.02, 1.02],
+    ],
+    "33": [
+      [19.71, 19.71],
+      [28.93, 28.93],
+      [34.37, 34.37],
+    ],
+  },
+  varLabels: [
+    ["5", "D5"],
+    ["13A", "D13"],
+    ["21", "D21"],
+    ["33", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+105)", fromSurface: "1", toSurface: "5" },
+    { text: "G2 (−19)", fromSurface: "6A", toSurface: "13A" },
+    { text: "G3 (+47)", fromSurface: "STO", toSurface: "21" },
+    { text: "G4 (+45)", fromSurface: "22", toSurface: "33" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "D2", fromSurface: "8", toSurface: "10" },
+    { text: "D3", fromSurface: "11", toSurface: "13A" },
+    { text: "D4", fromSurface: "19", toSurface: "21" },
+    { text: "D5", fromSurface: "26", toSurface: "28" },
+    { text: "D6", fromSurface: "31", toSurface: "33" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.39,
+  focusDescription:
+    "Inner focusing via Group 3 (probable); ring-type USM. No close-focus data in patent — zoom-only model.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.0,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16, 22],
+  apertureBlades: 9,
+
+  /* ── Layout tuning ── */
+  scFill: 0.42,
+  yScFill: 0.55,
+  maxAspectRatio: 2.0,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/NikonNikkorZ24120mmf4S.analysis.md
+++ b/src/lens-data/NikonNikkorZ24120mmf4S.analysis.md
@@ -1,0 +1,266 @@
+# Nikon NIKKOR Z 24-120mm f/4 S — Optical Analysis
+
+**Patent:** WO 2022/259649 A1 (PCT/JP2022/008965)
+**Priority:** JP 2021-096938, filed 9 June 2021
+**Published:** 15 December 2022
+**Inventors:** Ono Takuro, Machida Kosuke, Makida Ayumu, Tsubonoya Keisuke
+**Assignee:** Nikon Corporation
+**Design Example:** Example 5 (Table 5, Figures 9–10)
+
+---
+
+## 1. Overview
+
+The NIKKOR Z 24-120mm f/4 S is a constant-aperture 5× zoom for the Nikon Z mount, covering a 24–120 mm focal range at f/4 across the full zoom travel. Nikon markets it as an S-Line optic — their premium tier — and lists the construction as **16 elements in 13 groups**, incorporating 3 ED (Extra-low Dispersion) glass elements, 1 aspherical ED glass element, and 3 aspherical elements. It uses ARNEO Coat and Nano Crystal Coat for flare suppression, a fluorine-coated front element, and an internal multi-focus system driven by dual stepping motors.
+
+Example 5 in the patent filing corresponds to this production design. The patent prescription gives a wide-angle EFL of 24.70 mm, a telephoto EFL of 116.50 mm, and f-numbers of f/4.00 (wide) and f/4.12 (tele) — closely matching the marketed 24–120 mm f/4 specification. These EFLs have been independently verified by paraxial ray trace (ABCD matrix / y-nu method) and match the patent's stated values to within rounding precision (computed: 24.6997 mm and 116.4998 mm).
+
+The 16 production elements yield 13 air-separated groups. However, the patent describes the design in terms of 7 *zoom groups* — units that move together during zooming — which is a different and coarser grouping. This distinction matters: the patent's G1–G7 are zoom-group designations, not the 13 optically air-separated groups that Nikon counts in its marketing specifications.
+
+---
+
+## 2. Design Parameters (Example 5)
+
+| Parameter | Wide | Tele |
+|-----------|------|------|
+| Focal length (design) | 24.70 mm | 116.50 mm |
+| f-number (design) | f/4.00 | f/4.12 |
+| Zoom ratio | 4.72× | |
+| Total track length | 130.96 mm | 185.96 mm |
+| Back focal distance | 13.555 mm | 45.147 mm |
+| Half-field angle | 41.2° | 10.5° |
+| Petzval sum | 0.001689 mm⁻¹ | |
+| Petzval radius | −592 mm | |
+
+The total track length changes by approximately 55 mm from wide to tele, consistent with the externally-telescoping zoom barrel visible in the production lens. The very long Petzval radius (−592 mm) indicates well-corrected field curvature — a signature of careful glass selection and group power balancing across the seven zoom groups. The patent's aberration plots also include evaluation at a mid-zoom position of f ≈ 69.98 mm (Figure 10B), confirming the intermediate-focal-length performance.
+
+---
+
+## 3. Zoom Group Architecture
+
+The seven zoom groups, their patent-stated focal lengths, and their constituent elements are:
+
+### G1 — Front Positive Group (f = +136.58 mm)
+
+**Elements:** L1 + L2 (cemented doublet)
+**Surfaces:** 1–3
+
+G1 is a cemented positive doublet comprising a negative meniscus (L1, convex toward the object) bonded to a positive meniscus (L2, also convex toward the object). Its long positive focal length means it contributes gentle convergence at wide angle while primarily serving as a field lens at longer focal lengths. In a retrofocus-derived wide-zoom design, G1 sits furthest from the stop and handles the widest beam diameters, so the high-index glasses used in L1 and L2 (nd = 1.9037 and 1.6180, respectively) help contain element diameters and sag.
+
+By cementing L1 and L2, Nikon eliminates an air gap and its attendant ghost reflections while simultaneously correcting lateral chromatic aberration across the large entrance pupil. The strong dispersion difference between L1 (νd = 31.27, high dispersion) and L2 (νd = 63.34, moderate dispersion) creates an effective achromatic corrector at the front of the system. The junction surface semi-diameter is constrained to approximately 27 mm by L2's edge thickness requirement, while L1's front surface extends to approximately 33 mm to accommodate the full tele-end marginal beam.
+
+### G2 — Variator Group (f = −24.06 mm)
+
+**Elements:** L3, L4, L5, L6 (four air-spaced singlets)
+**Surfaces:** 4–11
+
+G2 is the primary variator — the negative group that moves the most during zooming and provides the majority of the magnification change. Its short negative focal length (−24.06 mm) makes it the most powerful group in the system. It travels approximately 45 mm along the axis between wide and tele positions (d3 changes from 1.525 mm to 46.708 mm, while d11 changes from 24.145 mm to 2.370 mm).
+
+The four elements are:
+
+- **L3** (nd = 1.77503, νd = 47.31, f ≈ −27.8 mm): A negative meniscus with an aspherical front surface (*4). The base radius of 8892 mm is nearly flat — at the estimated production clear aperture (sd ≈ 13 mm), the base sphere contributes only ~10 µm of sag while the polynomial terms generate ~165 µm of aspherical departure. However, at wide angle the beam footprint on L3 extends much further due to the large chief ray, and at the full wide-angle envelope (sd ≈ 25 mm), the polynomial terms produce approximately 4 mm of departure — effectively defining the entire surface figure. This makes L3 a precision-glass-molded aspherical corrector plate, conceptually similar to a Schmidt corrector, that pre-conditions the beam to manage field-dependent aberrations such as astigmatism and distortion across the zoom range.
+
+- **L4** (nd = 1.83400, νd = 37.18, f ≈ −54.4 mm): A biconcave negative lens providing strong divergence. The high-index lanthanum glass keeps the surface curvatures moderate despite the strong negative power.
+
+- **L5** (nd = 1.85451, νd = 25.15, f ≈ +35.2 mm): A biconvex positive element in very high-dispersion glass, tagged **P1** in the patent (satisfying conditional expression (23): νdP1 < 45). This is the chromatic aberration corrector within the variator. By placing a high-dispersion positive element adjacent to the lower-dispersion negatives, Nikon creates an air-spaced achromatic pair (L4 + L5) that corrects both the Petzval contribution and the chromatic variation of G2's strong negative power. The symmetric curvature (R = ±60.170 mm) helps minimize coma generation.
+
+- **L6** (nd = 1.49782, νd = 82.57, f ≈ −69.2 mm): A negative meniscus in **S-FPL53** (fluorophosphate ED glass), tagged **N** in the patent (satisfying conditional expression (24): νdN > 60). This is the first of three S-FPL53 elements in the design. Its role is to correct secondary (residual) chromatic aberration that the conventional doublet structure of L4+L5 cannot eliminate. The extremely high Abbe number and anomalous partial dispersion of S-FPL53 make it uniquely effective at suppressing secondary spectrum.
+
+### G3 — First Relay Group (f = +59.44 mm)
+
+**Elements:** L7, L8 (two air-spaced singlets)
+**Surfaces:** 13–16
+
+G3 sits immediately behind the aperture stop and acts as the first positive relay group in the rear assembly. The stop's spacing to L7 (d = 0.880 mm) is fixed — not a variable gap — meaning the aperture diaphragm is physically mounted in the G3 barrel assembly and moves with it during zooming.
+
+- **L7** (nd = 1.59306, νd = 66.97, f ≈ +78.9 mm): A positive meniscus with an aspherical front surface (*13), tagged **P2** in the patent. Its aspherical departure (approximately −242 µm at the estimated sd of 13.5 mm) corrects spherical aberration generated by the f/4 axial beam passing through the stop region. The negative departure (surface becomes flatter toward the edge) reduces marginal ray refraction and tames overcorrected spherical aberration from the preceding elements.
+
+- **L8** (nd = 1.61800, νd = 63.34, f ≈ +256.9 mm): A weak positive meniscus, also tagged **P2**. L8 shares the same glass as L2 (S-PHM52 or equivalent) and adds mild convergence to the relay.
+
+### G4 — Second Relay Group (f = +67.49 mm)
+
+**Elements:** L9, L10 + L11 (cemented doublet)
+**Surfaces:** 17–21
+
+G4 is the second positive relay group, with total focal length of +67.49 mm — close to G3's, creating a near-symmetric positive relay pair behind the stop.
+
+- **L9** (nd = 1.49782, νd = 82.57, f ≈ +51.8 mm): A biconvex positive lens in **S-FPL53** (ED glass), tagged **P2**. This is the second S-FPL53 element. Its very low dispersion minimizes chromatic contribution from its strong positive power, and its anomalous partial dispersion helps suppress secondary spectrum.
+
+- **L10** (nd = 1.90043, νd = 37.38, f ≈ −30.6 mm): A negative meniscus bonded to L11. Its primary role in the cemented doublet is chromatic rather than refractive: the moderate Abbe number (νd = 37.38) provides the dispersive counterbalance to L11's extremely low dispersion.
+
+- **L11** (nd = 1.49782, νd = 82.57, f ≈ +36.4 mm): A positive meniscus in **S-FPL53** (ED glass), tagged **P2**. Together, L10 + L11 form a cemented doublet with a combined thin-lens focal length of approximately −194 mm. While weakly negative overall, the true purpose of this pair is chromatic: the enormous Abbe number contrast (37.38 vs. 82.57, Δνd ≈ 45) generates controlled negative chromatism to compensate for the positive chromatism of the upstream relay elements. The junction surface at R = 17.933 mm is strongly curved and limits the doublet's clear aperture to approximately 13.4 mm semi-diameter.
+
+### G5 — First Focus Group (f = +135.76 mm)
+
+**Elements:** L12, L13 (two air-spaced singlets)
+**Surfaces:** 22–25
+
+G5 is the first of two internal-focus groups. During close focusing, G5 moves toward the object side. Its long positive focal length (+135.76 mm) means it introduces only mild convergence, minimizing aberration sensitivity to focus position.
+
+- **L12** (nd = 1.78472, νd = 25.64, f ≈ −77.4 mm): A negative meniscus (concave toward the object). Despite being in a positively powered group, L12 is individually negative. Its very high-dispersion glass (consistent with OHARA S-TIM25) works as a chromatic corrector within G5.
+
+- **L13** (nd = 1.77250, νd = 49.62, f ≈ +51.6 mm): A biconvex positive element providing the group's net positive power. The glass code (1.77250/49.62) is consistent with the OHARA S-LAM66 family.
+
+### G6 — Second Focus Group (f = +79.64 mm)
+
+**Elements:** L14 (single element)
+**Surfaces:** 26–27
+
+G6 is a single positive meniscus (concave toward the object) that serves as the second internal-focus group. It also moves toward the object during close focusing, working in tandem with G5 to maintain image quality across the focus range.
+
+- **L14** (nd = 1.55332, νd = 71.67, f ≈ +80.2 mm): This is the **aspherical ED element** — the single element that combines both aspherical figuring and ED-class glass. Its glass code is an excellent match for **HOYA M-FCD500**, a mold-compatible fluorophosphate crown specifically designed for precision glass molding. The rear surface (*27) carries the aspherical profile, with approximately +419 µm of departure at the estimated sd of 12.8 mm. The choice to use moldable ED glass combines chromatic and wavefront correction in one precision-molded element, saving weight and an air–glass interface.
+
+### G7 — Rear Negative Group (f = −38.93 mm)
+
+**Elements:** L15 + L16 (cemented doublet)
+**Surfaces:** 28–30
+
+G7 is the final zoom group — a cemented negative doublet that acts as a negative relay/field-flattener at the rear of the system.
+
+- **L15** (nd = 1.77503, νd = 47.31, f ≈ −25.8 mm): A biconcave negative element with an aspherical front surface (*28). The aspherical departure is small (approximately +28 µm at sd 12.3 mm), fine-tuning the wavefront in the converging beam just before the image plane. The same glass (1.77503/47.31) appears in L3, suggesting it is a precision-moldable lanthanum crown suitable for PGM.
+
+- **L16** (nd = 1.92286, νd = 20.88, f ≈ +74.7 mm): A positive meniscus in extremely high-dispersion glass, tagged **P1**. The glass code matches **OHARA S-NPH2**, a dense flint with one of the highest refractive indices and lowest Abbe numbers in commercial production. Paired with L15 in the cemented doublet, the extreme Abbe number contrast (47.31 vs. 20.88, Δνd ≈ 26) provides a final stage of lateral color correction for off-axis beams at the image end.
+
+---
+
+## 4. Aspherical Surfaces
+
+Four surfaces in Example 5 are aspherical, distributed across three zones of the lens. All use K = 0 (spherical base) with even-order polynomial corrections. Surfaces *4 and *28 carry coefficients through A14; surfaces *13 and *27 carry coefficients through A10 only.
+
+| Surface | Element | Position | Key Coefficient | Departure (est. SD) |
+|---------|---------|----------|-----------------|---------------------|
+| *4 | L3 front | G2 variator | A4 = +6.78 × 10⁻⁶ | +165 µm @ 13.0 mm; ~+4040 µm @ 25 mm (wide beam) |
+| *13 | L7 front | G3 relay | A4 = −7.33 × 10⁻⁶ | −242 µm @ 13.5 mm |
+| *27 | L14 rear | G6 focus | A4 = +1.69 × 10⁻⁵ | +419 µm @ 12.8 mm |
+| *28 | L15 front | G7 rear | A4 = +2.41 × 10⁻⁶ | +28 µm @ 12.3 mm |
+
+**Surface *4 (L3)** is noteworthy for the dramatic variation of its aspherical departure with beam footprint. At the estimated tele-position clear aperture (sd ≈ 13 mm), the departure is modest (~165 µm). But at wide angle, where the chief ray sweeps across a much larger region of the surface, the beam footprint extends to approximately 25 mm and the departure reaches ~4 mm — effectively defining the entire surface figure. This is a hallmark of modern precision glass molding: the nearly flat base radius (R = 8892 mm) allows the polynomial terms to impose a complex, field-dependent wavefront correction without strong base curvature.
+
+**Surface *13 (L7)** has a negative departure, meaning the surface becomes progressively flatter than a sphere toward the edge. This is a textbook spherical aberration corrector for the axial beam near the stop.
+
+**Surface *27 (L14)** has the second-largest departure. As the sole element in G6 (the second focusing group), the aspherical rear surface provides field-dependent corrections that remain effective as the element translates during focusing.
+
+**Surface *28 (L15)** has the smallest departure (~28 µm) — a fine wavefront trim on the converging beam entering the final cemented doublet.
+
+---
+
+## 5. Glass Material Identification
+
+The following table summarizes the inferred glass identifications. Glasses labeled "confident" match catalog entries to better than ±0.0005 in nd and ±0.5 in νd. Those labeled "likely" are the closest catalog match with a small residual.
+
+| Element | nd | νd | Inferred Glass | Confidence | Notes |
+|---------|------|------|----------------|------------|-------|
+| L1 | 1.903660 | 31.27 | S-LAH79 (OHARA) | Confident | Dense lanthanum flint |
+| L2 | 1.618000 | 63.34 | S-PHM52 (OHARA) | Confident | Phosphate crown |
+| L3 | 1.775030 | 47.31 | Moldable lanthanum crown | Uncertain | No exact catalog match; nearest is HOYA M-TAFD305 (1.77377/47.17) |
+| L4 | 1.834000 | 37.18 | S-LAH66 (OHARA) | Confident | Dense lanthanum flint |
+| L5 | 1.854510 | 25.15 | S-TIM35 (OHARA) or K-VC89 (Sumita) | Likely | Very high-dispersion titanium flint |
+| L6 | 1.497820 | 82.57 | **S-FPL53 (OHARA)** | Confident | Fluorophosphate ED glass |
+| L7 | 1.593060 | 66.97 | Moldable phosphate crown | Uncertain | No exact catalog match; aspherical, requires mold glass |
+| L8 | 1.618000 | 63.34 | S-PHM52 (OHARA) | Confident | Same glass as L2 |
+| L9 | 1.497820 | 82.57 | **S-FPL53 (OHARA)** | Confident | Fluorophosphate ED glass |
+| L10 | 1.900430 | 37.38 | S-LAH58 (OHARA) | Likely | Dense lanthanum flint |
+| L11 | 1.497820 | 82.57 | **S-FPL53 (OHARA)** | Confident | Fluorophosphate ED glass |
+| L12 | 1.784720 | 25.64 | S-TIM25 (OHARA) | Likely | High-dispersion titanium flint |
+| L13 | 1.772500 | 49.62 | S-LAM66 (OHARA) | Likely | Lanthanum crown |
+| L14 | 1.553320 | 71.67 | **HOYA M-FCD500** | Confident | Moldable fluorophosphate ED glass |
+| L15 | 1.775030 | 47.31 | Same mold glass as L3 | Uncertain | Aspherical — shares glass with L3 |
+| L16 | 1.922860 | 20.88 | S-NPH2 (OHARA) | Confident | Ultra-high-dispersion dense flint |
+
+### Glass Strategy Summary
+
+The design employs three primary families of glass:
+
+1. **ED fluorophosphates** (L6, L9, L11 = S-FPL53; L14 = M-FCD500): These four elements provide the secondary chromatic correction that enables the lens to maintain low axial color from 24 mm to 120 mm. S-FPL53 is the premier conventional ED glass; M-FCD500 provides equivalent ED performance in a mold-compatible formulation.
+
+2. **High-dispersion flints** (L5, L16 = P1 elements; L12): These elements sit adjacent to the ED elements and provide the dispersive counterbalance needed for the achromatic corrections. The extreme Abbe number contrasts (e.g., L5 at νd = 25.15 paired near L6 at νd = 82.57, a Δνd of 57) generate the large chromatic leverage required to correct a 5× zoom.
+
+3. **Dense lanthanum crowns and flints** (L1, L4, L10, L13): High-index glasses that provide optical power in compact element geometries, minimizing element diameters and total track length.
+
+---
+
+## 6. Focus Mechanism
+
+Focusing is performed by **G5 (L12 + L13) and G6 (L14)**, which move along the optical axis independently as an internal multi-focus system. The patent description ([0254]) states that when focusing from infinity to a close-range object, both G5 and G6 move from the image side toward the object side.
+
+The variable spacing data from the patent shows the zoom-dependent gaps surrounding the focus groups at infinity:
+
+| Gap | Wide/∞ | Tele/∞ |
+|-----|--------|--------|
+| d25 (after G5) | 2.000 | 5.177 |
+| d27 (after G6) | 9.107 | 1.773 |
+
+The patent provides only infinity-focus spacings for each zoom position. Close-focus data is not given in Example 5, which limits the ability to characterize the exact focus travel. However, the dual-group internal focus architecture is clear: by moving two groups independently during focus, Nikon can correct aberrations (particularly field curvature and spherical aberration) that would shift if only a single group moved. This is what Nikon designates "Multi-Focus System" (Multi-FS) in their marketing.
+
+The production lens achieves a minimum focus distance of 0.35 m with a maximum reproduction ratio of 0.39× — remarkably high for a general-purpose zoom. This impressive close-focus performance is enabled by the large available travel of G5 and G6 within the barrel, and by the aspherical ED element L14 in G6.
+
+---
+
+## 7. Zoom Mechanism
+
+The seven zoom groups move in a complex cam pattern. The variable spacing data at the two extreme zoom positions is:
+
+| Gap | Description | Wide (24.70 mm) | Tele (116.50 mm) | Change |
+|-----|-------------|-----------------|-------------------|--------|
+| d3 | G1 → G2 | 1.525 | 46.708 | +45.183 |
+| d11 | G2 → Stop/G3 | 24.145 | 2.370 | −21.775 |
+| d16 | G3 → G4 | 9.007 | 1.400 | −7.607 |
+| d21 | G4 → G5 | 6.277 | 18.040 | +11.763 |
+| d25 | G5 → G6 | 2.000 | 5.177 | +3.177 |
+| d27 | G6 → G7 | 9.107 | 1.773 | −7.334 |
+| Bf | G7 → Image | 13.555 | 45.147 | +31.592 |
+| **Total var.** | | **65.616** | **120.615** | **+54.999** |
+
+The total variable gap sum increases by approximately 55 mm from wide to tele, confirming that the lens barrel extends during zooming (not an internally compensated zoom). The dominant motion is G2 moving away from G1 — d3 increases by 45 mm — which is the primary variator action. Simultaneously, G2 moves toward G3 (d11 decreases by 22 mm), concentrating the converging beam into the rear groups.
+
+The patent provides variable spacing data at only two zoom positions (wide and tele). Aberration plots at an intermediate focal length of approximately 69.98 mm (Figure 10B) confirm that the design was evaluated at a mid-zoom position, but the corresponding gap data is not tabulated in Example 5.
+
+---
+
+## 8. Conditional Expressions and Design Philosophy
+
+The patent specifies several conditional expressions that Example 5 must satisfy. Two families are particularly illuminating:
+
+### Dispersion Conditions
+
+- **(23)** νdP1 < 45.00 — At least one positive lens in the rear groups must have a low Abbe number (high dispersion).
+  - **Satisfied by:** L5 (νd = 25.15) and L16 (νd = 20.88)
+
+- **(24)** νdN > 60.00 — At least one negative lens in the rear groups must have a high Abbe number (low dispersion).
+  - **Satisfied by:** L6 (νd = 82.57)
+
+- **(25)** νdP2 > 60.00 — At least one positive lens in the rear groups must have a high Abbe number (low dispersion).
+  - **Satisfied by:** L7 (νd = 66.97), L8 (νd = 63.34), L9 (νd = 82.57), L11 (νd = 82.57), L14 (νd = 71.67)
+
+### Group Power Conditions
+
+- **(3)** 8.00 < f1 / D1 < 27.00 — For Example 5, f1 = 136.58 mm and D1 = 1.800 + 9.290 = 11.090 mm, giving f1/D1 = 12.32.
+
+---
+
+## 9. Special Elements Summary
+
+| Count | Type | Elements |
+|-------|------|----------|
+| 3 | ED glass | L6, L9, L11 (all S-FPL53) |
+| 1 | Aspherical ED glass | L14 (HOYA M-FCD500 equivalent) |
+| 3 | Aspherical | L3, L7, L15 |
+| **7** | **Total special elements** | |
+
+This count of 7 special elements out of 16 total matches Nikon's published specifications exactly. Nearly half the elements in the design are either aspherical, ED glass, or both — an unusually high ratio for a consumer-grade zoom.
+
+---
+
+## 10. Notes and Caveats
+
+1. **Semi-diameters** are not provided in the Example 5 prescription table. Values in the companion data file were estimated via combined marginal and chief ray trace at both zoom positions (60% off-axis field fraction, 8% mechanical clearance), subject to edge thickness ≥ 0.5 mm and cross-gap sag overlap constraints. The front group G1 SDs were capped by the 77 mm production filter thread. The L10/L11 cemented doublet junction is constrained to sd ≈ 13.4 mm by L11's edge thickness (the strongly curved junction at R = 17.933 mm limits the clear aperture). Semi-diameters should be treated as indicative rather than precise.
+
+2. **Close-focus variable spacings** are not provided for Example 5. The data file uses identical infinity/close values for all variable gaps. The actual close-focus cam trajectory cannot be characterized from the available data.
+
+3. **Glass identifications** marked "uncertain" use glasses without exact catalog matches. These may be proprietary mold-compatible formulations developed by the glass manufacturer for Nikon. The L3/L15 glass (1.77503/47.31) is particularly notable: it appears twice in the design, both times on aspherical surfaces, strongly suggesting a PGM-specific formulation.
+
+4. **Zoom positions:** The patent provides variable gap data at only two positions (wide and tele). The data file uses `zoomPositions: [24.70, 116.50]` with piecewise-linear interpolation. The production lens's zoom cam may include intermediate control points to handle non-monotonic group motions, which cannot be determined from the two-position data.
+
+5. **Manufacturing methods**: The P1 and P2 tags in the patent's prescription table refer to dispersion conditional expressions (23) and (25), *not* to manufacturing processes. However, the glass choices for the four aspherical elements (L3, L7, L14, L15) strongly suggest precision glass molding (PGM) — all four use glasses with optical properties consistent with known mold-compatible formulations.
+
+6. **Aperture stop behavior across zoom:** The physical iris diaphragm moves with G3 and the optics between the stop and the entrance pupil (principally G2's strong negative power) change dramatically during zooming. At wide angle, G2 sits far from the stop (d11 = 24.145 mm) and its divergent power makes the entrance pupil much smaller than the physical stop opening. At tele, G2 is compressed against the stop (d11 = 2.370 mm) and barely affects the pupil magnification, so the entrance pupil is close to the physical stop size. This mechanism enables the approximately constant f/4 aperture across the 4.72× zoom range.

--- a/src/lens-data/NikonNikkorZ24120mmf4S.data.ts
+++ b/src/lens-data/NikonNikkorZ24120mmf4S.data.ts
@@ -1,0 +1,450 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — NIKON NIKKOR Z 24-120mm f/4 S                    ║
+ * ╠══════════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: WO 2022/259649 A1 (PCT/JP2022/008965), Example 5        ║
+ * ║               (Table 5, Figures 9–10).                                 ║
+ * ║  Inventors: Ono Takuro, Machida Kosuke, Makida Ayumu,                  ║
+ * ║             Tsubonoya Keisuke — Nikon Corporation.                     ║
+ * ║  Priority: JP 2021-096938 (9 June 2021).                              ║
+ * ║  Published: 15 December 2022.                                         ║
+ * ║                                                                        ║
+ * ║  7-group zoom (G1–G7), 16 elements / 13 groups.                       ║
+ * ║  4 aspherical surfaces (*4, *13, *27, *28).                           ║
+ * ║  3 ED elements (L6, L9, L11 = S-FPL53) + 1 asph. ED (L14 = M-FCD500).║
+ * ║                                                                        ║
+ * ║  Focus: internal multi-focus (G5 + G6 move independently).            ║
+ * ║  Zoom: externally telescoping, non-constant overall length.            ║
+ * ║    Variable zoom gaps: d3, d11, d16, d21, d25, d27, Bf.              ║
+ * ║    Focus groups: G5 (d25) and G6 (d27).                              ║
+ * ║    Aperture stop moves with G3 (between d11 and S13).                 ║
+ * ║                                                                        ║
+ * ║  NOTE ON CLOSE-FOCUS DATA:                                             ║
+ * ║    Patent Example 5 provides infinity-focus spacings only at each      ║
+ * ║    zoom position. Close-focus variable gap data is not available.      ║
+ * ║    All var entries use identical d_inf / d_close values.               ║
+ * ║                                                                        ║
+ * ║  NOTE ON ZOOM POSITIONS:                                               ║
+ * ║    Patent provides variable gap data at only two positions (wide and   ║
+ * ║    tele). Aberration plots show a mid-zoom evaluation at f≈69.98 mm   ║
+ * ║    but gap data at that position is not tabulated in Example 5.       ║
+ * ║                                                                        ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                               ║
+ * ║    Not provided in the patent. Estimated via combined marginal +       ║
+ * ║    chief ray trace at both zoom positions (60% off-axis field          ║
+ * ║    fraction, 8% mechanical clearance). Front group capped by 77 mm    ║
+ * ║    filter thread (~33 mm max SD at S1). Junction SDs constrained by   ║
+ * ║    edge thickness ≥ 0.5 mm (L2 junction ≤ 27.0, L10/L11 junction     ║
+ * ║    ≤ 13.4). Cross-gap sag overlap verified at both zoom positions.    ║
+ * ╚══════════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "nikkor-z-24-120f4",
+  maker: "Nikon",
+  name: "NIKON NIKKOR Z 24-120mm f/4 S",
+  subtitle: "WO 2022/259649 A1 EXAMPLE 5 — NIKON / ONO, MACHIDA, MAKIDA, TSUBONOYA",
+  specs: [
+    "16 ELEMENTS / 13 GROUPS",
+    "f = 24.70 – 116.50 mm",
+    "F/4.00 – F/4.12",
+    "2ω ≈ 82.4° – 21.0°",
+    "4 ASPHERICAL SURFACES",
+    "3 ED + 1 ASPHERICAL ED",
+  ],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: [24, 120] as [number, number],
+  focalLengthDesign: [24.7, 116.5] as [number, number],
+  apertureMarketing: 4,
+  apertureDesign: 4.0,
+  patentYear: 2022,
+  elementCount: 16,
+  groupCount: 13,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.90366,
+      vd: 31.27,
+      fl: -166.4,
+      glass: "S-LAH79 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "Front negative meniscus of G1 cemented doublet; high-index dense lanthanum flint for compact diameter",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.618,
+      vd: 63.34,
+      fl: 75.9,
+      glass: "S-PHM52 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "Rear positive meniscus of G1 doublet; moderate-dispersion phosphate crown for lateral color correction",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.77503,
+      vd: 47.31,
+      fl: -27.8,
+      glass: "Moldable lanthanum crown (no exact catalog match; nearest HOYA M-TAFD305 1.77377/47.17)",
+      apd: false,
+      role: "Aspherical corrector plate at G2 entrance; nearly flat base R with dominant polynomial departure (~4 mm at rim)",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.834,
+      vd: 37.18,
+      fl: -54.4,
+      glass: "S-LAH66 (OHARA)",
+      apd: false,
+      role: "Strong negative diverger in G2 variator; high-index lanthanum flint keeps curvatures moderate",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.85451,
+      vd: 25.15,
+      fl: 35.2,
+      glass: "S-TIM35 (OHARA) or K-VC89 (Sumita)",
+      apd: false,
+      role: "High-dispersion positive in G2 (P1 element); forms air-spaced achromatic pair with L4 for Petzval/chromatic correction",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Negative Meniscus",
+      nd: 1.49782,
+      vd: 82.57,
+      fl: -69.2,
+      glass: "S-FPL53 (OHARA)",
+      apd: "patent",
+      apdNote: "ED glass; νd = 82.57, N-tagged in patent (cond. 24: νdN > 60)",
+      role: "First S-FPL53 ED element; secondary chromatic correction at image-side of G2 variator",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Pos. Meniscus (1× Asph)",
+      nd: 1.59306,
+      vd: 66.97,
+      fl: 78.9,
+      glass: "Moldable phosphate crown (no exact catalog match)",
+      apd: false,
+      role: "Aspherical positive meniscus immediately behind stop in G3; corrects spherical aberration in the axial beam",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Positive Meniscus",
+      nd: 1.618,
+      vd: 63.34,
+      fl: 256.9,
+      glass: "S-PHM52 (OHARA)",
+      apd: false,
+      role: "Weak positive meniscus in G3; distributes relay convergence and shares glass with L2",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Biconvex Positive",
+      nd: 1.49782,
+      vd: 82.57,
+      fl: 51.8,
+      glass: "S-FPL53 (OHARA)",
+      apd: "patent",
+      apdNote: "ED glass; νd = 82.57, P2-tagged in patent (cond. 25: νdP2 > 60)",
+      role: "Second S-FPL53 ED element in G4; low-dispersion positive for axial color suppression in the converging relay",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Negative Meniscus",
+      nd: 1.90043,
+      vd: 37.38,
+      fl: -30.6,
+      glass: "S-LAH58 (OHARA)",
+      apd: false,
+      cemented: "D4",
+      role: "Dense lanthanum flint in G4 cemented doublet; provides dispersive counterbalance to L11",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Positive Meniscus",
+      nd: 1.49782,
+      vd: 82.57,
+      fl: 36.4,
+      glass: "S-FPL53 (OHARA)",
+      apd: "patent",
+      apdNote: "ED glass; νd = 82.57, P2-tagged in patent",
+      cemented: "D4",
+      role: "Third S-FPL53 ED element; cemented with L10 for chromatic doublet (Δνd ≈ 45)",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Negative Meniscus",
+      nd: 1.78472,
+      vd: 25.64,
+      fl: -77.4,
+      glass: "S-TIM25 (OHARA)",
+      apd: false,
+      role: "High-dispersion negative meniscus in G5 focus group; chromatic corrector within the focusing assembly",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Biconvex Positive",
+      nd: 1.7725,
+      vd: 49.62,
+      fl: 51.6,
+      glass: "S-LAM66 (OHARA)",
+      apd: false,
+      role: "Positive power in G5 focus group; lanthanum crown provides net group convergence (f_G5 ≈ +135.76 mm)",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Pos. Meniscus (1× Asph)",
+      nd: 1.55332,
+      vd: 71.67,
+      fl: 80.2,
+      glass: "M-FCD500 (HOYA)",
+      apd: "patent",
+      apdNote: "Aspherical ED glass; νd = 71.67, P2-tagged in patent; mold-compatible fluorophosphate crown",
+      role: "Single aspherical ED element in G6 focus group; rear aspherical surface provides field-dependent correction across focus range",
+    },
+    {
+      id: 15,
+      name: "L15",
+      label: "Element 15",
+      type: "Biconcave Neg. (1× Asph)",
+      nd: 1.77503,
+      vd: 47.31,
+      fl: -25.8,
+      glass: "Moldable lanthanum crown (same as L3)",
+      apd: false,
+      cemented: "D7",
+      role: "Aspherical negative in G7 rear doublet; fine-tunes converging wavefront before image plane",
+    },
+    {
+      id: 16,
+      name: "L16",
+      label: "Element 16",
+      type: "Positive Meniscus",
+      nd: 1.92286,
+      vd: 20.88,
+      fl: 74.7,
+      glass: "S-NPH2 (OHARA)",
+      apd: false,
+      cemented: "D7",
+      role: "Ultra-high-dispersion dense flint in G7 doublet (P1 element); final lateral color correction (Δνd ≈ 26 with L15)",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    /* ── G1: Front positive cemented doublet (L1 + L2) ── */
+    { label: "1", R: 61.204, d: 1.8, nd: 1.90366, elemId: 1, sd: 33.0 },
+    { label: "2", R: 43.5, d: 9.29, nd: 1.618, elemId: 2, sd: 27.0 },
+    { label: "3", R: 599.325, d: 1.525, nd: 1.0, elemId: 0, sd: 27.0 },
+
+    /* ── G2: Variator — four air-spaced singlets (L3, L4, L5, L6) ── */
+    { label: "4A", R: 8892.243, d: 1.4, nd: 1.77503, elemId: 3, sd: 13.0 },
+    { label: "5", R: 21.486, d: 7.77, nd: 1.0, elemId: 0, sd: 12.8 },
+    { label: "6", R: -67.187, d: 1.5, nd: 1.834, elemId: 4, sd: 14.0 },
+    { label: "7", R: 139.906, d: 0.23, nd: 1.0, elemId: 0, sd: 14.2 },
+    { label: "8", R: 60.17, d: 4.73, nd: 1.85451, elemId: 5, sd: 13.8 },
+    { label: "9", R: -60.17, d: 1.96, nd: 1.0, elemId: 0, sd: 13.5 },
+    { label: "10", R: -27.165, d: 1.1, nd: 1.49782, elemId: 6, sd: 13.5 },
+    { label: "11", R: -128.171, d: 24.145, nd: 1.0, elemId: 0, sd: 14.7 },
+
+    /* ── Aperture stop (moves with G3) ── */
+    { label: "STO", R: 1e15, d: 0.88, nd: 1.0, elemId: 0, sd: 6.3 },
+
+    /* ── G3: First relay — two air-spaced singlets (L7, L8) ── */
+    { label: "13A", R: 34.508, d: 3.66, nd: 1.59306, elemId: 7, sd: 13.5 },
+    { label: "14", R: 131.359, d: 0.2, nd: 1.0, elemId: 0, sd: 14.0 },
+    { label: "15", R: 51.576, d: 2.03, nd: 1.618, elemId: 8, sd: 14.0 },
+    { label: "16", R: 76.388, d: 9.007, nd: 1.0, elemId: 0, sd: 14.2 },
+
+    /* ── G4: Second relay — L9 singlet + L10/L11 cemented doublet ── */
+    { label: "17", R: 33.398, d: 5.6, nd: 1.49782, elemId: 9, sd: 15.5 },
+    { label: "18", R: -112.939, d: 1.45, nd: 1.0, elemId: 0, sd: 15.5 },
+    { label: "19", R: 51.317, d: 1.1, nd: 1.90043, elemId: 10, sd: 15.2 },
+    { label: "20", R: 17.933, d: 6.55, nd: 1.49782, elemId: 11, sd: 13.4 },
+    { label: "21", R: 1939.354, d: 6.277, nd: 1.0, elemId: 0, sd: 13.4 },
+
+    /* ── G5: First focus group — two air-spaced singlets (L12, L13) ── */
+    { label: "22", R: -28.1, d: 1.1, nd: 1.78472, elemId: 12, sd: 13.2 },
+    { label: "23", R: -52.294, d: 0.2, nd: 1.0, elemId: 0, sd: 13.4 },
+    { label: "24", R: 156.708, d: 4.09, nd: 1.7725, elemId: 13, sd: 13.4 },
+    { label: "25", R: -53.421, d: 2.0, nd: 1.0, elemId: 0, sd: 13.6 },
+
+    /* ── G6: Second focus group — single element (L14) ── */
+    { label: "26", R: -214.076, d: 3.8, nd: 1.55332, elemId: 14, sd: 13.0 },
+    { label: "27A", R: -36.775, d: 9.107, nd: 1.0, elemId: 0, sd: 12.8 },
+
+    /* ── G7: Rear negative cemented doublet (L15 + L16) ── */
+    { label: "28A", R: -43.094, d: 1.3, nd: 1.77503, elemId: 15, sd: 12.3 },
+    { label: "29", R: 37.433, d: 3.6, nd: 1.92286, elemId: 16, sd: 12.3 },
+    { label: "30", R: 81.956, d: 13.555, nd: 1.0, elemId: 0, sd: 12.0 },
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "4A": {
+      K: 0.0,
+      A4: 6.78e-6,
+      A6: -9.11e-9,
+      A8: 2.14e-11,
+      A10: -6.61e-15,
+      A12: -7.48e-17,
+      A14: 1.46e-19,
+    },
+    "13A": {
+      K: 0.0,
+      A4: -7.33e-6,
+      A6: 1.12e-9,
+      A8: -3.78e-12,
+      A10: -5.24e-15,
+      A12: 0,
+      A14: 0,
+    },
+    "27A": {
+      K: 0.0,
+      A4: 1.69e-5,
+      A6: -8.63e-9,
+      A8: 5.71e-12,
+      A10: -9.88e-15,
+      A12: 0,
+      A14: 0,
+    },
+    "28A": {
+      K: 0.0,
+      A4: 2.41e-6,
+      A6: 1.5e-9,
+      A8: -1.37e-10,
+      A10: 6.99e-13,
+      A12: -1.28e-15,
+      A14: -1.88e-19,
+    },
+  },
+
+  /* ── Zoom lens fields ── */
+  zoomPositions: [24.7, 116.5],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  /* ── Variable air spacings (zoom + focus) ──
+   *  Two zoom positions: wide (24.70 mm) and tele (116.50 mm).
+   *  Close-focus data not available from patent — identical inf/close values used.
+   *  d3:  G1 → G2 (zoom only)
+   *  d11: G2 → STO/G3 (zoom only)
+   *  d16: G3 → G4 (zoom only)
+   *  d21: G4 → G5 (zoom only)
+   *  d25: G5 → G6 (zoom + focus — G5 is first focus group)
+   *  d27: G6 → G7 (zoom + focus — G6 is second focus group)
+   *  Bf:  G7 → image (zoom only)
+   */
+  var: {
+    "3": [
+      [1.525, 1.525],
+      [46.708, 46.708],
+    ],
+    "11": [
+      [24.145, 24.145],
+      [2.37, 2.37],
+    ],
+    "16": [
+      [9.007, 9.007],
+      [1.4, 1.4],
+    ],
+    "21": [
+      [6.277, 6.277],
+      [18.04, 18.04],
+    ],
+    "25": [
+      [2.0, 2.0],
+      [5.177, 5.177],
+    ],
+    "27A": [
+      [9.107, 9.107],
+      [1.773, 1.773],
+    ],
+    "30": [
+      [13.555, 13.555],
+      [45.147, 45.147],
+    ],
+  },
+  varLabels: [
+    ["3", "D3"],
+    ["11", "D11"],
+    ["16", "D16"],
+    ["21", "D21"],
+    ["25", "D25"],
+    ["27A", "D27"],
+    ["30", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+136.58)", fromSurface: "1", toSurface: "3" },
+    { text: "G2 (−24.06)", fromSurface: "4A", toSurface: "11" },
+    { text: "G3 (+59.44)", fromSurface: "13A", toSurface: "16" },
+    { text: "G4 (+67.49)", fromSurface: "17", toSurface: "21" },
+    { text: "G5 (+135.76)", fromSurface: "22", toSurface: "25" },
+    { text: "G6 (+79.64)", fromSurface: "26", toSurface: "27A" },
+    { text: "G7 (−38.93)", fromSurface: "28A", toSurface: "30" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "D4", fromSurface: "19", toSurface: "21" },
+    { text: "D7", fromSurface: "28A", toSurface: "30" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.35,
+  focusDescription:
+    "Internal multi-focus: G5 (L12+L13) and G6 (L14) move independently toward the object side when focusing from infinity to close range (Nikon Multi-Focus System).",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 4,
+  fstopSeries: [4, 4.5, 5, 5.6, 6.3, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.45,
+  yScFill: 0.28,
+  maxFstop: 22,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/NikonNikkorZ24120mmf4S.data.ts
+++ b/src/lens-data/NikonNikkorZ24120mmf4S.data.ts
@@ -22,14 +22,23 @@ import type { LensDataInput } from "../types/optics.js";
  * ║    Aperture stop moves with G3 (between d11 and S13).                 ║
  * ║                                                                        ║
  * ║  NOTE ON CLOSE-FOCUS DATA:                                             ║
- * ║    Patent Example 5 provides infinity-focus spacings only at each      ║
- * ║    zoom position. Close-focus variable gap data is not available.      ║
- * ║    All var entries use identical d_inf / d_close values.               ║
+ * ║    Patent Example 5 provides infinity-focus spacings only. Close-focus ║
+ * ║    group placements (Δ5, Δ6) were derived via ray-tracing: at each     ║
+ * ║    zoom position, solve for the minimum-norm (Δ5, Δ6) that images an   ║
+ * ║    on-axis object at MFD = 0.35 m on the image plane, subject to a     ║
+ * ║    0.5 mm mechanical-clearance floor on all variable gaps. Δ5 and Δ6   ║
+ * ║    denote displacement of G5 and G6 toward the object; total-track is  ║
+ * ║    conserved so d21 also varies with focus. See                        ║
+ * ║    __tests__/solveZ24120CloseFocus.test.ts for the derivation. At tele ║
+ * ║    the solver reproduces the published MRR (0.39×) to within ~5%.      ║
  * ║                                                                        ║
  * ║  NOTE ON ZOOM POSITIONS:                                               ║
- * ║    Patent provides variable gap data at only two positions (wide and   ║
- * ║    tele). Aberration plots show a mid-zoom evaluation at f≈69.98 mm   ║
- * ║    but gap data at that position is not tabulated in Example 5.       ║
+ * ║    Patent tabulates variable gaps only at wide (24.7) and tele (116.5).║
+ * ║    Intermediate positions (35/50/70/85) were added for improved        ║
+ * ║    close-focus fidelity; their infinity-gap values are linear          ║
+ * ║    interpolations of the two patent endpoints and therefore preserve   ║
+ * ║    the patent's infinity behavior exactly. Aberration plots show a     ║
+ * ║    mid-zoom evaluation at f≈69.98 mm in Example 5.                     ║
  * ║                                                                        ║
  * ║  NOTE ON SEMI-DIAMETERS:                                               ║
  * ║    Not provided in the patent. Estimated via combined marginal +       ║
@@ -361,48 +370,80 @@ const LENS_DATA = {
   },
 
   /* ── Zoom lens fields ── */
-  zoomPositions: [24.7, 116.5],
+  zoomPositions: [24.7, 35.0, 50.0, 70.0, 85.0, 116.5],
   zoomStep: 0.004,
   zoomLabels: ["Wide", "Tele"],
 
   /* ── Variable air spacings (zoom + focus) ──
-   *  Two zoom positions: wide (24.70 mm) and tele (116.50 mm).
-   *  Close-focus data not available from patent — identical inf/close values used.
+   *  Six zoom positions covering the ring marks 24–35–50–70–85–120 mm
+   *  (design focal lengths 24.7 and 116.5 at the endpoints).
+   *  Infinity gaps at 35/50/70/85 are linear interpolations of the patent's
+   *  wide/tele endpoints, preserving the patent's infinity behavior exactly.
+   *  Close-focus gaps were solved at each position via ray tracing with a
+   *  minimum-norm (Δ5, Δ6) objective and a 0.5 mm mechanical-clearance floor.
    *  d3:  G1 → G2 (zoom only)
    *  d11: G2 → STO/G3 (zoom only)
    *  d16: G3 → G4 (zoom only)
-   *  d21: G4 → G5 (zoom only)
-   *  d25: G5 → G6 (zoom + focus — G5 is first focus group)
-   *  d27: G6 → G7 (zoom + focus — G6 is second focus group)
-   *  Bf:  G7 → image (zoom only)
+   *  d21: G4 → G5 (zoom + focus — moves with G5 via −Δ5)
+   *  d25: G5 → G6 (zoom + focus — moves via +Δ5 − Δ6)
+   *  d27: G6 → G7 (zoom + focus — moves via +Δ6)
+   *  Bf:  G7 → image (zoom only — total track conserved during focus)
    */
   var: {
     "3": [
       [1.525, 1.525],
+      [6.587, 6.587],
+      [13.982, 13.982],
+      [23.825, 23.825],
+      [31.21, 31.21],
       [46.708, 46.708],
     ],
     "11": [
       [24.145, 24.145],
+      [21.702, 21.702],
+      [18.145, 18.145],
+      [13.401, 13.401],
+      [9.843, 9.843],
       [2.37, 2.37],
     ],
     "16": [
       [9.007, 9.007],
+      [8.154, 8.154],
+      [6.91, 6.91],
+      [5.253, 5.253],
+      [4.01, 4.01],
       [1.4, 1.4],
     ],
     "21": [
-      [6.277, 6.277],
-      [18.04, 18.04],
+      [6.277, 5.288],
+      [7.597, 7.075],
+      [9.519, 9.199],
+      [12.082, 11.198],
+      [14.004, 12.121],
+      [18.04, 10.574],
     ],
     "25": [
-      [2.0, 2.0],
-      [5.177, 5.177],
+      [2.0, 0.759],
+      [2.356, 1.699],
+      [2.876, 2.471],
+      [3.568, 2.439],
+      [4.087, 1.654],
+      [5.177, 0.5],
     ],
     "27A": [
-      [9.107, 9.107],
-      [1.773, 1.773],
+      [9.107, 11.337],
+      [8.284, 9.464],
+      [7.086, 7.81],
+      [5.488, 7.501],
+      [4.29, 8.605],
+      [1.773, 13.916],
     ],
     "30": [
       [13.555, 13.555],
+      [17.1, 17.1],
+      [22.264, 22.264],
+      [29.143, 29.143],
+      [34.306, 34.306],
       [45.147, 45.147],
     ],
   },
@@ -435,7 +476,7 @@ const LENS_DATA = {
   /* ── Focus configuration ── */
   closeFocusM: 0.35,
   focusDescription:
-    "Internal multi-focus: G5 (L12+L13) and G6 (L14) move independently toward the object side when focusing from infinity to close range (Nikon Multi-Focus System).",
+    "Internal multi-focus: G5 (L12+L13) and G6 (L14) move independently toward the object side when focusing from infinity to close range (Nikon Multi-Focus System). Close-focus group placements were derived by ray-tracing the minimum-norm (Δ5, Δ6) pair that images a 0.35 m object on the image plane at each zoom position.",
 
   /* ── Aperture configuration ── */
   nominalFno: 4,

--- a/src/lens-data/VoigtlanderNokton50f12XMount.data.ts
+++ b/src/lens-data/VoigtlanderNokton50f12XMount.data.ts
@@ -17,7 +17,7 @@ const LENS_DATA = {
   maker: "Voigtländer",
   subtitle: "JP 2025-058577 A — Example 1",
   specs: ["50 mm · f/1.2 · 9 elements / 8 groups", "APS-C · All-spherical · Unit focus"],
-
+  visible: false,
   focalLengthMarketing: 50,
   focalLengthDesign: 48.5,
   apertureMarketing: 1.2,

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -19,6 +19,12 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-04-15 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-04-15",
+    type: "fix",
+    summary: "Fixed semi-diameter shaping and rear-group clearance in the Canon RF 28-70mm F2 L USM",
+  },
   // ── 2026-04-14 ──────────────────────────────────────────────────────────
   {
     date: "2026-04-14",


### PR DESCRIPTION
## What changed
- refined the Canon RF 28-70mm f/2 L USM semi-diameters around L3 to clean up the first singlet silhouette
- rebalanced the rear-group SDs from L12 through L18 to add edge-thickness margin and remove crowding/collision risk
- added a homepage changelog entry and a short branch record for the user-visible rendering fix

## Why it changed
The lens was building and testing, but several SDs still produced odd element outlines and a cramped rear block. The latest pass tightens the visible silhouette without changing the underlying optical prescription.

## Impact
- the Canon RF 28-70mm f/2 L USM renders with a cleaner L3 profile
- the rear group has safer clearance and less visually awkward overlap pressure
- the homepage changelog now records the fix for users

## Root cause
The prescription depended on estimated semi-diameters, and a few of those estimates left elements with near-zero edge thickness or visually crowded adjacent gaps.

## Validation
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test`