### PR TITLE
Rebuild homepage hierarchy, standardize branding, and add Updates page

### DIFF
--- a/scripts/build-metadata-lib.mjs
+++ b/scripts/build-metadata-lib.mjs
@@ -74,6 +74,7 @@ export function buildRouteFreshness({ lenses, articles, makerSlugs, makerDetails
   routeFreshness["/lenses"] = combineFreshnessEntries(allLensFreshness, fallbackDate);
   routeFreshness["/makers"] = combineFreshnessEntries([...allLensFreshness, makerDetailsFreshness], fallbackDate);
   routeFreshness["/articles"] = combineFreshnessEntries(allArticleFreshness, fallbackDate);
+  routeFreshness["/updates"] = combineFreshnessEntries(allLensFreshness, fallbackDate);
 
   for (const article of articles) {
     routeFreshness[`/articles/${article.slug}`] = {

--- a/scripts/generate-build-metadata.mjs
+++ b/scripts/generate-build-metadata.mjs
@@ -137,6 +137,7 @@ function collectRoutes(lenses, articles, makerSlugs) {
     "/lenses",
     "/makers",
     "/articles",
+    "/updates",
     ...articles.map((a) => `/articles/${a.slug}`),
     ...lenses.map((l) => `/lens/${l.key}`),
     ...makerSlugs.map((s) => `/makers/${s}`),

--- a/src/components/homepage/HomeFooter.tsx
+++ b/src/components/homepage/HomeFooter.tsx
@@ -37,8 +37,11 @@ export default function HomeFooter({ theme: t }: HomeFooterProps) {
       <Link to="/articles" style={linkStyle}>
         Articles
       </Link>
+      <Link to="/updates" style={linkStyle}>
+        Updates
+      </Link>
       <Link to="/articles/about-site" style={linkStyle}>
-        About
+        About Optical Bench
       </Link>
     </footer>
   );

--- a/src/components/homepage/QuickNavCards.tsx
+++ b/src/components/homepage/QuickNavCards.tsx
@@ -42,10 +42,10 @@ export default function QuickNavCards({ theme: t }: QuickNavCardsProps) {
       subtitle: viewerLens ? LENS_CATALOG[viewerLens].name : "Explore a lens",
       to: viewerLens ? `/lens/${viewerLens}` : "/lenses",
     },
+    { title: "Start Here", subtitle: "New to lens design? Begin with the basics", to: "/articles/optics-primer" },
   ];
 
-  const cardStyle = (hoverable: boolean): React.CSSProperties => ({
-    flex: isWide ? 1 : undefined,
+  const cardStyle = (): React.CSSProperties => ({
     background: t.panelBg,
     border: `1px solid ${t.panelBorder}`,
     borderRadius: 8,
@@ -53,20 +53,19 @@ export default function QuickNavCards({ theme: t }: QuickNavCardsProps) {
     textDecoration: "none",
     display: "block",
     transition: "border-color 0.2s, box-shadow 0.2s",
-    ...(hoverable ? {} : {}),
   });
 
   return (
     <section
       style={{
-        display: "flex",
-        flexDirection: isWide ? "row" : "column",
+        display: "grid",
+        gridTemplateColumns: isWide ? "1fr 1fr" : "1fr",
         gap: isWide ? "1rem" : "0.75rem",
         margin: "0 0 2.5rem",
       }}
     >
       {cards.map((card) => (
-        <Link key={card.to} to={card.to} style={cardStyle(true)}>
+        <Link key={card.to} to={card.to} style={cardStyle()}>
           <div style={{ fontSize: "0.9rem", fontWeight: 600, color: t.descLinkColor, marginBottom: "0.35rem" }}>
             {card.title}
           </div>

--- a/src/components/homepage/RecentLenses.tsx
+++ b/src/components/homepage/RecentLenses.tsx
@@ -14,6 +14,7 @@ import { LENS_CATALOG } from "../../utils/lensCatalog.js";
 interface RecentLensesProps {
   entries: RecentLensEntry[];
   theme: Theme;
+  showUpdatesLink?: boolean;
 }
 
 function formatDate(iso: string): string {
@@ -21,7 +22,7 @@ function formatDate(iso: string): string {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
-export default function RecentLenses({ entries, theme: t }: RecentLensesProps) {
+export default function RecentLenses({ entries, theme: t, showUpdatesLink }: RecentLensesProps) {
   const valid = entries.filter((e) => LENS_CATALOG[e.key]);
   if (valid.length === 0) return null;
 
@@ -66,6 +67,20 @@ export default function RecentLenses({ entries, theme: t }: RecentLensesProps) {
           </Link>
         );
       })}
+      {showUpdatesLink && (
+        <Link
+          to="/updates"
+          style={{
+            display: "inline-block",
+            marginTop: "0.75rem",
+            fontSize: "0.8rem",
+            color: t.descLinkColor,
+            textDecoration: "none",
+          }}
+        >
+          View all updates →
+        </Link>
+      )}
     </section>
   );
 }

--- a/src/components/homepage/TrustStrip.tsx
+++ b/src/components/homepage/TrustStrip.tsx
@@ -1,0 +1,79 @@
+import { Link } from "react-router";
+import type { Theme } from "../../types/theme.js";
+import { CATALOG_KEYS, LENS_CATALOG } from "../../utils/lensCatalog.js";
+import { deriveMaker } from "../../utils/lensMetadata.js";
+import { ARTICLES } from "../../utils/homepageContent.js";
+import useMediaQuery from "../../utils/useMediaQuery.js";
+
+interface TrustStripProps {
+  theme: Theme;
+}
+
+function countMakers(): number {
+  const slugs = new Set<string>();
+  for (const key of CATALOG_KEYS) {
+    slugs.add(deriveMaker(LENS_CATALOG[key].name, LENS_CATALOG[key].maker).slug);
+  }
+  return slugs.size;
+}
+
+export default function TrustStrip({ theme: t }: TrustStripProps) {
+  const isWide = useMediaQuery("(min-width: 720px)");
+  const makerCount = countMakers();
+
+  const stats = [
+    `${CATALOG_KEYS.length} interactive lens diagrams`,
+    `${makerCount} manufacturers`,
+    "Patent-derived optical models",
+    `${ARTICLES.length} articles & guides`,
+  ];
+
+  const links: { label: string; to: string }[] = [
+    { label: "About Optical Bench", to: "/articles/about-site" },
+    { label: "About the Author", to: "/articles/about-author" },
+  ];
+
+  return (
+    <section
+      style={{
+        textAlign: "center",
+        padding: isWide ? "1rem 1rem 1.25rem" : "0.75rem 0.5rem 1rem",
+        marginBottom: isWide ? "1.5rem" : "1rem",
+        borderRadius: 8,
+        border: `1px solid ${t.panelBorder}`,
+        background: t.panelBg,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "center",
+          gap: isWide ? "1.25rem" : "0.5rem 0.75rem",
+          fontSize: isWide ? "0.75rem" : "0.7rem",
+          color: t.muted,
+          lineHeight: 1.5,
+        }}
+      >
+        {stats.map((stat) => (
+          <span key={stat}>{stat}</span>
+        ))}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: "1.25rem",
+          marginTop: "0.6rem",
+          fontSize: "0.7rem",
+        }}
+      >
+        {links.map(({ label, to }) => (
+          <Link key={to} to={to} style={{ color: t.descLinkColor, textDecoration: "none" }}>
+            {label}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/content/AboutMe.md
+++ b/src/content/AboutMe.md
@@ -1,11 +1,11 @@
 ---
 slug: about-author
 title: About the Author
-summary: Meet the creator of Optical Bench — background in photography and optical engineering.
+summary: Meet the creator of Optical Bench — photographer and optical science enthusiast.
 tag: article
 ---
 
-# About Me
+# About the Author
 
 I'm Ron Buening, a photographer and optics enthusiast based in the Tampa Bay area. My work is rooted in a simple conviction: understanding the instrument is inseparable from understanding the image. That conviction drives both my photography and everything written here.
 

--- a/src/content/AboutSite.md
+++ b/src/content/AboutSite.md
@@ -5,9 +5,9 @@ summary: How this interactive lens visualization tool was built and what makes i
 tag: article
 ---
 
-# About This Site
+# About Optical Bench
 
-LensVisualizer is an interactive tool for exploring the optical design of real camera lenses. Each lens displayed here is derived from a published optical patent — the same surface prescriptions, glass types, and element arrangements that define the physical lens.
+Optical Bench is an interactive reference site for exploring the optical design of real camera lenses. Each lens displayed here is derived from a published optical patent — the same surface prescriptions, glass types, and element arrangements that define the physical lens.
 
 The goal is to make these designs tangible: to show how light actually moves through a lens, how elements are shaped and spaced, and how focus and aperture adjustments change the optical path. Rather than static diagrams, every cross-section is computed in real time from the patent data, with ray tracing that responds to your inputs.
 
@@ -24,3 +24,5 @@ This site is created by **Ron Buening**. The optical prescriptions are translate
 ---
 
 **[View on GitHub](https://github.com/ronbuening/LensVisualizer)** · **[Request a Lens](https://github.com/ronbuening/LensVisualizer/issues/new?labels=new+lens&title=New+Lens:+&body=Patent+%23:+)**
+
+*The source code for Optical Bench is maintained as the open-source [LensVisualizer](https://github.com/ronbuening/LensVisualizer) project on GitHub.*

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,8 @@
 /**
  * Home page — landing page for Optical Bench.
  *
- * Renders the site hero, navigation cards, recent articles, and lens
- * announcements. Preserves legacy ?lens=KEY redirects to /lens/KEY.
+ * Renders the site hero, trust strip, navigation cards, recent articles,
+ * and recently added lenses. Preserves legacy ?lens=KEY redirects to /lens/KEY.
  */
 
 import { useEffect } from "react";
@@ -10,10 +10,10 @@ import { Link, useSearchParams, useNavigate } from "react-router";
 import SEOHead from "../components/SEOHead.js";
 import PageNavBar from "../components/layout/PageNavBar.js";
 import HeroSection from "../components/homepage/HeroSection.js";
+import TrustStrip from "../components/homepage/TrustStrip.js";
 import QuickNavCards from "../components/homepage/QuickNavCards.js";
 import ArticleList from "../components/homepage/ArticleList.js";
 import RecentLenses from "../components/homepage/RecentLenses.js";
-import ChangelogBox from "../components/homepage/ChangelogBox.js";
 import HomeFooter from "../components/homepage/HomeFooter.js";
 import { CATALOG_KEYS, RECENT_LENS_KEYS } from "../utils/lensCatalog.js";
 import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
@@ -84,24 +84,15 @@ export default function HomePage() {
 
       <div style={PAGE_BASE_STYLE}>
         <HeroSection theme={t} />
+        <TrustStrip theme={t} />
         <QuickNavCards theme={t} />
         <div style={isDesktop ? { display: "flex", gap: "2rem", alignItems: "flex-start" } : {}}>
-          {/* Right column on desktop — RecentLenses + ChangelogBox stacked vertically.
-              On mobile this div has no styles, so its children stack in normal flow. */}
-          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0, order: 1 } : {}}>
-            <RecentLenses entries={RECENT_LENS_KEYS} theme={t} />
-            {/* Desktop copy: shown only on desktop so it sits under RecentLenses in the right column. */}
-            <div style={{ display: isDesktop ? "block" : "none" }}>
-              <ChangelogBox theme={t} />
-            </div>
-          </div>
-          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0, order: 0 } : {}}>
+          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0 } : {}}>
             <ArticleList articles={displayedArticles} theme={t} showMoreLink={showMoreLink} />
           </div>
-        </div>
-        {/* Mobile copy: shown only on mobile so it appears below ArticleList, before the footer. */}
-        <div style={{ display: isDesktop ? "none" : "block" }}>
-          <ChangelogBox theme={t} />
+          <div style={isDesktop ? { flex: "1 1 0", minWidth: 0 } : {}}>
+            <RecentLenses entries={RECENT_LENS_KEYS} theme={t} showUpdatesLink />
+          </div>
         </div>
         <HomeFooter theme={t} />
       </div>

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -1,0 +1,231 @@
+import { useEffect } from "react";
+import { Link } from "react-router";
+import SEOHead from "../components/SEOHead.js";
+import PageNavBar from "../components/layout/PageNavBar.js";
+import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
+import { collectionPageJsonLd } from "../utils/structuredData.js";
+import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
+import { ALL_LENSES_BY_DATE, LENS_CATALOG } from "../utils/lensCatalog.js";
+import { CHANGELOG } from "../utils/changelogData.js";
+import type { ChangelogEntry, ChangelogEntryType } from "../utils/changelogData.js";
+
+const PAGE_BASE_STYLE = {
+  maxWidth: 960,
+  margin: "0 auto",
+  padding: "0 1.5rem 2rem",
+  fontFamily: "'JetBrains Mono','SF Mono','Fira Code', monospace",
+  minHeight: "100vh",
+} satisfies React.CSSProperties;
+
+const ENTRY_TYPE_COLORS: Record<ChangelogEntryType, string> = {
+  feature: "#58c",
+  fix: "#c65",
+  lens: "#2a7",
+  improvement: "#c84",
+  article: "#a5c",
+};
+
+const ENTRY_TYPE_LABELS: Record<ChangelogEntryType, string> = {
+  feature: "new",
+  fix: "fix",
+  lens: "lens",
+  improvement: "improved",
+  article: "article",
+};
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default function UpdatesPage() {
+  const { theme: t, themeMode, highContrast, toggleTheme, toggleHC } = usePageThemeToggle();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0 });
+  }, []);
+
+  const grouped = new Map<string, ChangelogEntry[]>();
+  for (const entry of CHANGELOG) {
+    const bucket = grouped.get(entry.date) ?? [];
+    bucket.push(entry);
+    grouped.set(entry.date, bucket);
+  }
+
+  const seoDescription =
+    "Full update history for Optical Bench — recently added lenses and a complete changelog of features, fixes, and improvements.";
+
+  return (
+    <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
+      <SEOHead
+        title={`Updates — ${SITE_NAME}`}
+        description={seoDescription}
+        canonicalURL={`${SITE_URL}/updates`}
+        jsonLd={[
+          collectionPageJsonLd({
+            name: "Updates",
+            description: seoDescription,
+            url: `${SITE_URL}/updates`,
+            route: "/updates",
+          }),
+        ]}
+      />
+
+      <PageNavBar
+        theme={t}
+        themeMode={themeMode}
+        highContrast={highContrast}
+        onToggleTheme={toggleTheme}
+        onToggleHC={toggleHC}
+      >
+        <Link to="/" style={{ color: t.descLinkColor, textDecoration: "none" }}>
+          Home
+        </Link>
+        <span style={{ color: t.muted, margin: "0 0.35em" }}>/</span>
+        <span style={{ color: t.body }}>Updates</span>
+      </PageNavBar>
+
+      <div style={PAGE_BASE_STYLE}>
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 600, marginTop: "1.5rem", marginBottom: "0.5rem" }}>Updates</h1>
+        <p style={{ fontSize: "0.875rem", color: t.muted, marginBottom: "2rem" }}>
+          Recently added lenses and a complete development changelog.
+        </p>
+
+        {/* ── Lenses Added ──────────────────────────────────────────── */}
+        <section style={{ marginBottom: "2.5rem" }}>
+          <h2
+            style={{
+              fontSize: "1.125rem",
+              fontWeight: 600,
+              color: t.body,
+              marginBottom: "1rem",
+              paddingBottom: "0.25rem",
+              borderBottom: `1px solid ${t.panelBorder}`,
+            }}
+          >
+            Lenses Added
+          </h2>
+          {ALL_LENSES_BY_DATE.map((e) => {
+            const lens = LENS_CATALOG[e.key];
+            if (!lens) return null;
+            return (
+              <Link
+                key={e.key}
+                to={`/lens/${e.key}`}
+                style={{
+                  display: "block",
+                  padding: "0.75rem 1rem",
+                  marginBottom: "0.5rem",
+                  borderRadius: 6,
+                  border: `1px solid ${t.panelBorder}`,
+                  background: t.panelBg,
+                  textDecoration: "none",
+                  transition: "border-color 0.2s",
+                }}
+              >
+                <div style={{ fontSize: "0.875rem", fontWeight: 600, color: t.descLinkColor }}>{lens.name}</div>
+                <div style={{ fontSize: "0.7rem", color: t.label, margin: "0.2rem 0" }}>{formatDate(e.date)}</div>
+                {lens.specs && lens.specs.length > 0 && (
+                  <div style={{ fontSize: "0.75rem", color: t.muted, marginBottom: "0.2rem" }}>
+                    {lens.specs.slice(0, 3).join(" · ")}
+                  </div>
+                )}
+              </Link>
+            );
+          })}
+        </section>
+
+        {/* ── Changelog ─────────────────────────────────────────────── */}
+        <section style={{ marginBottom: "2.5rem" }}>
+          <h2
+            style={{
+              fontSize: "1.125rem",
+              fontWeight: 600,
+              color: t.body,
+              marginBottom: "1rem",
+              paddingBottom: "0.25rem",
+              borderBottom: `1px solid ${t.panelBorder}`,
+            }}
+          >
+            Changelog
+          </h2>
+
+          {Array.from(grouped.entries()).map(([date, entries]) => (
+            <div key={date} style={{ marginBottom: "0.75rem" }}>
+              <div
+                style={{
+                  fontSize: "0.7rem",
+                  color: t.label,
+                  fontWeight: 600,
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                  marginBottom: "0.4rem",
+                }}
+              >
+                {formatDate(date)}
+              </div>
+
+              {entries.map((entry, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: "0.5rem",
+                    padding: "0.5rem 0.75rem",
+                    marginBottom: "0.35rem",
+                    borderRadius: 6,
+                    border: `1px solid ${t.panelBorder}`,
+                    background: t.panelBg,
+                  }}
+                >
+                  <span
+                    style={{
+                      flexShrink: 0,
+                      fontSize: "0.6rem",
+                      padding: "1px 6px",
+                      borderRadius: 3,
+                      background: `${ENTRY_TYPE_COLORS[entry.type]}22`,
+                      color: ENTRY_TYPE_COLORS[entry.type],
+                      letterSpacing: "0.06em",
+                      textTransform: "uppercase",
+                      fontWeight: 600,
+                      marginTop: "0.15rem",
+                    }}
+                  >
+                    {ENTRY_TYPE_LABELS[entry.type]}
+                  </span>
+                  <span style={{ fontSize: "0.8rem", color: t.body, lineHeight: 1.4 }}>{entry.summary}</span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </section>
+
+        {/* ── Footer ────────────────────────────────────────────────── */}
+        <footer
+          style={{
+            borderTop: `1px solid ${t.panelBorder}`,
+            paddingTop: "1.5rem",
+            marginTop: "1rem",
+            display: "flex",
+            justifyContent: "center",
+            gap: "1.5rem",
+            flexWrap: "wrap",
+          }}
+        >
+          {[
+            { to: "/", label: "Home" },
+            { to: "/lenses", label: "Lens Library" },
+            { to: "/makers", label: "Makers" },
+            { to: "/articles", label: "Articles" },
+          ].map(({ to, label }) => (
+            <Link key={to} to={to} style={{ color: t.descLinkColor, textDecoration: "none", fontSize: "0.75rem" }}>
+              {label}
+            </Link>
+          ))}
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/routeManifest.tsx
+++ b/src/routes/routeManifest.tsx
@@ -14,6 +14,7 @@ import MakerPage from "../pages/MakerPage.js";
 import ComparePage from "../pages/ComparePage.js";
 import ArticlesPage from "../pages/ArticlesPage.js";
 import ArticlePage from "../pages/ArticlePage.js";
+import UpdatesPage from "../pages/UpdatesPage.js";
 import NotFoundPage from "../pages/NotFoundPage.js";
 
 export interface RouteManifestEntry {
@@ -30,6 +31,7 @@ const routeManifest: RouteManifestEntry[] = [
   { path: "/makers/:maker", element: <MakerPage /> },
   { path: "/articles", element: <ArticlesPage /> },
   { path: "/articles/:slug", element: <ArticlePage /> },
+  { path: "/updates", element: <UpdatesPage /> },
   { path: "*", element: <NotFoundPage /> },
 ];
 

--- a/src/utils/lensCatalog.ts
+++ b/src/utils/lensCatalog.ts
@@ -61,14 +61,16 @@ interface RecentLensEntry {
   date: string;
 }
 
-/** Up to 5 most recently added lenses, newest-first. */
-const RECENT_LENS_KEYS: RecentLensEntry[] = Object.entries(
+/** All visible lenses sorted newest-first by publication date. */
+const ALL_LENSES_BY_DATE: RecentLensEntry[] = Object.entries(
   buildMeta.lensFreshness as Record<string, { publishedOn: string; lastModified: string }>,
 )
   .filter(([key]) => CATALOG_KEYS.includes(key))
   .sort(([, a], [, b]) => b.publishedOn.localeCompare(a.publishedOn))
-  .slice(0, 5)
   .map(([key, freshness]) => ({ key, date: freshness.publishedOn }));
 
-export { LENS_CATALOG, CATALOG_KEYS, mdForKey, RECENT_LENS_KEYS };
+/** Up to 5 most recently added lenses, newest-first. */
+const RECENT_LENS_KEYS: RecentLensEntry[] = ALL_LENSES_BY_DATE.slice(0, 5);
+
+export { LENS_CATALOG, CATALOG_KEYS, mdForKey, RECENT_LENS_KEYS, ALL_LENSES_BY_DATE };
 export type { RecentLensEntry };


### PR DESCRIPTION
Addresses the site audit (issue #403):

- Standardize branding: "Optical Bench" as public brand everywhere,
  "LensVisualizer" reserved for the engine/repo. Fix About page headings,
  author descriptor, and footer link text.
- Restructure homepage: add TrustStrip with dynamic stats below hero,
  add "Start Here" nav card, remove inline changelog, fix mobile order
  to show articles before recently added lenses.
- Create /updates page with full lens-added list and complete changelog,
  linked from homepage RecentLenses section and footer.
- Add /updates route to manifest, build metadata, and sitemap.

https://claude.ai/code/session_01BMCy6iFmLC1ZmXLWwHkUDj