### PR TITLE
Fix exit pupil calculations: correct telecentric fallback and off-screen display

### DIFF
--- a/src/components/diagram/DiagramOverlayLayer.tsx
+++ b/src/components/diagram/DiagramOverlayLayer.tsx
@@ -126,12 +126,10 @@ export default function DiagramOverlayLayer({
           {(() => {
             const epSD = epAtZoom(zoomT, L);
             const xpSD = xpAtZoom(zoomT, L);
-            const epX = sx(zPos[L.stopIdx] + epZRelStopAtZoom(zoomT, L));
-            const xpX = sx(zPos[L.N - 1] + xpZRelLastSurfAtZoom(zoomT, L));
-            const epTopY = sy(-epSD);
-            const epBotY = sy(epSD);
-            const xpTopY = sy(-xpSD);
-            const xpBotY = sy(xpSD);
+            const epZRel = epZRelStopAtZoom(zoomT, L);
+            const xpZRel = xpZRelLastSurfAtZoom(zoomT, L);
+            const epX = isFinite(epZRel) ? sx(zPos[L.stopIdx] + epZRel) : NaN;
+            const xpX = isFinite(xpZRel) ? sx(zPos[L.N - 1] + xpZRel) : NaN;
             const midY = sy(0);
             const tickLen = 4;
             const color = t.stopLabel;
@@ -139,86 +137,152 @@ export default function DiagramOverlayLayer({
               pointerEvents: "none" as const,
               letterSpacing: "0.1em",
             };
+            const fontSize = L.lyStoPad * 1.4;
+            /* Margin allows ticks that extend slightly beyond the SVG edge */
+            const MARGIN = tickLen + 2;
+            const epInView = isFinite(epX) && epX >= -MARGIN && epX <= L.svgW + MARGIN;
+            const xpInView = isFinite(xpX) && xpX >= -MARGIN && xpX <= L.svgW + MARGIN;
+            /* Edge indicators for off-screen pupils (only for finite but distant XP/EP) */
+            const xpOffRight = !xpInView && isFinite(xpX) && xpX > L.svgW;
+            const xpOffLeft = !xpInView && isFinite(xpX) && xpX < 0;
+            const epOffLeft = !epInView && isFinite(epX) && epX < 0;
+            const epOffRight = !epInView && isFinite(epX) && epX > L.svgW;
             return (
               <>
-                <line
-                  x1={epX}
-                  y1={epTopY}
-                  x2={epX}
-                  y2={epBotY}
-                  stroke={color}
-                  strokeWidth={1.2}
-                  strokeDasharray="3,2"
-                  style={{ pointerEvents: "none" }}
-                />
-                <line
-                  x1={epX - tickLen}
-                  y1={epTopY}
-                  x2={epX + tickLen}
-                  y2={epTopY}
-                  stroke={color}
-                  strokeWidth={1.2}
-                  style={{ pointerEvents: "none" }}
-                />
-                <line
-                  x1={epX - tickLen}
-                  y1={epBotY}
-                  x2={epX + tickLen}
-                  y2={epBotY}
-                  stroke={color}
-                  strokeWidth={1.2}
-                  style={{ pointerEvents: "none" }}
-                />
-                <text
-                  x={epX}
-                  y={epTopY - L.lyStoPad}
-                  textAnchor="middle"
-                  fontSize={L.lyStoPad * 1.4}
-                  fill={color}
-                  style={labelStyle}
-                >
-                  EP
-                </text>
-                <line
-                  x1={xpX}
-                  y1={xpTopY}
-                  x2={xpX}
-                  y2={xpBotY}
-                  stroke={color}
-                  strokeWidth={1.2}
-                  strokeDasharray="3,2"
-                  style={{ pointerEvents: "none" }}
-                />
-                <line
-                  x1={xpX - tickLen}
-                  y1={xpTopY}
-                  x2={xpX + tickLen}
-                  y2={xpTopY}
-                  stroke={color}
-                  strokeWidth={1.2}
-                  style={{ pointerEvents: "none" }}
-                />
-                <line
-                  x1={xpX - tickLen}
-                  y1={xpBotY}
-                  x2={xpX + tickLen}
-                  y2={xpBotY}
-                  stroke={color}
-                  strokeWidth={1.2}
-                  style={{ pointerEvents: "none" }}
-                />
-                <text
-                  x={xpX}
-                  y={xpTopY - L.lyStoPad}
-                  textAnchor="middle"
-                  fontSize={L.lyStoPad * 1.4}
-                  fill={color}
-                  style={labelStyle}
-                >
-                  XP
-                </text>
-                <circle cx={epX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
-                <circle cx={xpX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
+                {epInView && (
+                  <>
+                    <line
+                      x1={epX}
+                      y1={sy(-epSD)}
+                      x2={epX}
+                      y2={sy(epSD)}
+                      stroke={color}
+                      strokeWidth={1.2}
+                      strokeDasharray="3,2"
+                      style={{ pointerEvents: "none" }}
+                    />
+                    <line
+                      x1={epX - tickLen}
+                      y1={sy(-epSD)}
+                      x2={epX + tickLen}
+                      y2={sy(-epSD)}
+                      stroke={color}
+                      strokeWidth={1.2}
+                      style={{ pointerEvents: "none" }}
+                    />
+                    <line
+                      x1={epX - tickLen}
+                      y1={sy(epSD)}
+                      x2={epX + tickLen}
+                      y2={sy(epSD)}
+                      stroke={color}
+                      strokeWidth={1.2}
+                      style={{ pointerEvents: "none" }}
+                    />
+                    <text
+                      x={epX}
+                      y={sy(-epSD) - L.lyStoPad}
+                      textAnchor="middle"
+                      fontSize={fontSize}
+                      fill={color}
+                      style={labelStyle}
+                    >
+                      EP
+                    </text>
+                    <circle cx={epX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
+                  </>
+                )}
+                {epOffLeft && (
+                  <text
+                    x={6}
+                    y={midY + fontSize / 2}
+                    textAnchor="start"
+                    fontSize={fontSize}
+                    fill={color}
+                    style={labelStyle}
+                  >
+                    ← EP
+                  </text>
+                )}
+                {epOffRight && (
+                  <text
+                    x={L.svgW - 6}
+                    y={midY + fontSize / 2}
+                    textAnchor="end"
+                    fontSize={fontSize}
+                    fill={color}
+                    style={labelStyle}
+                  >
+                    EP →
+                  </text>
+                )}
+                {xpInView && (
+                  <>
+                    <line
+                      x1={xpX}
+                      y1={sy(-xpSD)}
+                      x2={xpX}
+                      y2={sy(xpSD)}
+                      stroke={color}
+                      strokeWidth={1.2}
+                      strokeDasharray="3,2"
+                      style={{ pointerEvents: "none" }}
+                    />
+                    <line
+                      x1={xpX - tickLen}
+                      y1={sy(-xpSD)}
+                      x2={xpX + tickLen}
+                      y2={sy(-xpSD)}
+                      stroke={color}
+                      strokeWidth={1.2}
+                      style={{ pointerEvents: "none" }}
+                    />
+                    <line
+                      x1={xpX - tickLen}
+                      y1={sy(xpSD)}
+                      x2={xpX + tickLen}
+                      y2={sy(xpSD)}
+                      stroke={color}
+                      strokeWidth={1.2}
+                      style={{ pointerEvents: "none" }}
+                    />
+                    <text
+                      x={xpX}
+                      y={sy(-xpSD) - L.lyStoPad}
+                      textAnchor="middle"
+                      fontSize={fontSize}
+                      fill={color}
+                      style={labelStyle}
+                    >
+                      XP
+                    </text>
+                    <circle cx={xpX} cy={midY} r={2} fill={color} style={{ pointerEvents: "none" }} />
+                  </>
+                )}
+                {xpOffRight && (
+                  <text
+                    x={L.svgW - 6}
+                    y={midY + fontSize / 2}
+                    textAnchor="end"
+                    fontSize={fontSize}
+                    fill={color}
+                    style={labelStyle}
+                  >
+                    XP →
+                  </text>
+                )}
+                {xpOffLeft && (
+                  <text
+                    x={6}
+                    y={midY + fontSize / 2}
+                    textAnchor="start"
+                    fontSize={fontSize}
+                    fill={color}
+                    style={labelStyle}
+                  >
+                    ← XP
+                  </text>
+                )}
               </>
             );
           })()}

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -270,15 +270,15 @@ export default function buildLens(data: LensData): RuntimeLens {
      * (using real yRatio and B from the front-group traces above) */
     const xpY = realYRatio * cY - realB * mY;
     const xpU = realYRatio * cU - realB * mU;
-    xpZRelLastSurf = Math.abs(xpU) > 1e-9 ? -xpY / xpU : 0;
-    xpSD = Math.abs(mY + mU * xpZRelLastSurf) * EP.epSD;
+    xpZRelLastSurf = Math.abs(xpU) > 1e-9 ? -xpY / xpU : Infinity;
+    xpSD = isFinite(xpZRelLastSurf) ? Math.abs(mY + mU * xpZRelLastSurf) * EP.epSD : Infinity;
   } else {
     /* Fallback: paraxial exit pupil */
     const chiefFull = paraxialTrace(S, 0, 1, { skipLastTransfer: true });
     const xpNumer = -(epTrace.y * chiefFull.y - eflTrace.y * B);
     const xpDenom = epTrace.y * chiefFull.u - eflTrace.u * B;
-    xpZRelLastSurf = Math.abs(xpDenom) > 1e-9 ? xpNumer / xpDenom : 0;
-    xpSD = Math.abs(eflTrace.y + eflTrace.u * xpZRelLastSurf) * EP.epSD;
+    xpZRelLastSurf = Math.abs(xpDenom) > 1e-9 ? xpNumer / xpDenom : Infinity;
+    xpSD = isFinite(xpZRelLastSurf) ? Math.abs(eflTrace.y + eflTrace.u * xpZRelLastSurf) * EP.epSD : Infinity;
   }
 
   const stopPhysSD = S[stopIdx].sd;
@@ -486,17 +486,17 @@ export default function buildLens(data: LensData): RuntimeLens {
           zcU = zRealChiefFull.u / realEpDelta;
         const zXpY = zRealYRatio * zcY - zRealB * zmY;
         const zXpU = zRealYRatio * zcU - zRealB * zmU;
-        const zXpRelLast = Math.abs(zXpU) > 1e-9 ? -zXpY / zXpU : 0;
+        const zXpRelLast = Math.abs(zXpU) > 1e-9 ? -zXpY / zXpU : Infinity;
         zoomXpZRelLastSurfs.push(zXpRelLast);
-        zoomXpSDs.push(Math.abs(zmY + zmU * zXpRelLast) * zNomEP);
+        zoomXpSDs.push(isFinite(zXpRelLast) ? Math.abs(zmY + zmU * zXpRelLast) * zNomEP : Infinity);
       } else {
         /* Fallback: paraxial exit pupil */
         const zChiefFull = paraxialTrace(tmpS, 0, 1, { skipLastTransfer: true });
         const zXpNumer = -(epT.y * zChiefFull.y - zMargLast.y * zBValue);
         const zXpDenom = epT.y * zChiefFull.u - zMargLast.u * zBValue;
-        const zXpRelLast = Math.abs(zXpDenom) > 1e-9 ? zXpNumer / zXpDenom : 0;
+        const zXpRelLast = Math.abs(zXpDenom) > 1e-9 ? zXpNumer / zXpDenom : Infinity;
         zoomXpZRelLastSurfs.push(zXpRelLast);
-        zoomXpSDs.push(Math.abs(zMargLast.y + zMargLast.u * zXpRelLast) * zNomEP);
+        zoomXpSDs.push(isFinite(zXpRelLast) ? Math.abs(zMargLast.y + zMargLast.u * zXpRelLast) * zNomEP : Infinity);
       }
 
       /* Half-field (vignetting-limited) — paraxial estimate refined with real ray */

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -548,7 +548,9 @@ export function bAtZoom(zoomT: number, L: RuntimeLens): number {
 /** Interpolate exit pupil SD at a given zoom position. */
 export function xpAtZoom(zoomT: number, L: RuntimeLens): number {
   if (!L.isZoom) return L.xpSD;
-  return _lerpZoomArray(zoomT, L.zoomXpSDs!);
+  const arr = L.zoomXpSDs!;
+  if (arr.some((v) => !isFinite(v))) return Infinity;
+  return _lerpZoomArray(zoomT, arr);
 }
 
 /** Interpolate entrance pupil z-position relative to stop at a given zoom position. */
@@ -560,7 +562,9 @@ export function epZRelStopAtZoom(zoomT: number, L: RuntimeLens): number {
 /** Interpolate exit pupil z-position relative to last surface at a given zoom position. */
 export function xpZRelLastSurfAtZoom(zoomT: number, L: RuntimeLens): number {
   if (!L.isZoom) return L.xpZRelLastSurf;
-  return _lerpZoomArray(zoomT, L.zoomXpZRelLastSurfs!);
+  const arr = L.zoomXpZRelLastSurfs!;
+  if (arr.some((v) => !isFinite(v))) return Infinity;
+  return _lerpZoomArray(zoomT, arr);
 }
 
 /**

--- a/src/optics/pupilAberration.ts
+++ b/src/optics/pupilAberration.ts
@@ -212,10 +212,22 @@ export function computeExitPupilAberrationProfile(
   const { halfFieldDeg } = geom;
   const paraxialXpZRelLastSurf = xpZRelLastSurfAtZoom(zoomT, L);
 
+  const n = Math.max(sampleCount, 2);
+
+  // Guard: telecentric exit (XP at infinity) — shifts are undefined, return zero-shift profile.
+  if (!isFinite(paraxialXpZRelLastSurf)) {
+    const samples: ExitPupilAberrationSample[] = Array.from({ length: n }, (_, i) => ({
+      fieldFrac: i / (n - 1),
+      fieldDeg: (i / (n - 1)) * halfFieldDeg,
+      xpZRelLastSurf: Infinity,
+      xpShiftMm: 0,
+    }));
+    return { samples, paraxialXpZRelLastSurf: Infinity, maxAbsShiftMm: 0, halfFieldDeg };
+  }
+
   // zPos is required by traceRay for building visualization paths; compute once.
   const { z: zPos } = doLayout(focusT, zoomT, L);
 
-  const n = Math.max(sampleCount, 2);
   const samples: ExitPupilAberrationSample[] = [];
 
   for (let i = 0; i < n; i++) {


### PR DESCRIPTION
Previously, when the exit pupil slope was near zero (telecentric exit beam),
xpZRelLastSurf fell back to 0, placing the XP marker incorrectly at the last
lens surface. Changed to Infinity so the marker is properly hidden.

For lenses where EP or XP is far outside the SVG viewport, the marker was
silently absent with no indication. Added bounds checking in
DiagramOverlayLayer: markers only render when within SVG bounds, and off-screen
pupils show a directional edge label (e.g. "XP →", "← EP") so users know
where to look.

Also guarded the zoom array interpolation against Infinity values
(xpAtZoom / xpZRelLastSurfAtZoom), and added an early-return path in
computeExitPupilAberrationProfile for the telecentric case.

The underlying two-ray decomposition math is correct. A virtual exit pupil
(xpZRelLastSurf < 0, XP appearing inside or in front of the glass) is
physically accurate for some lens designs such as retrofocus or strongly
diverging rear groups — the marker position is real, not a bug.

https://claude.ai/code/session_019EydccxgUjvFimzLdw7LJ2