### PR TITLE
[codex] Add four lenses and Canon RF 24-105 focus model

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `88` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
+- `92` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Nikon, Zeiss, Voigtlander, Canon, Ricoh, and Vivitar
 - Lens pages pair interactive diagrams with long-form optical analysis markdown
 

--- a/__tests__/canonRF24105Focus.test.ts
+++ b/__tests__/canonRF24105Focus.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import buildLens from "../src/optics/buildLens.js";
+import { conjugateK, thick } from "../src/optics/optics.js";
+import LENS_DEFAULTS from "../src/lens-data/defaults.js";
+import CanonRF24105Raw from "../src/lens-data/CanonRF24105mmf4L.data.js";
+import type { LensData } from "../src/types/optics.js";
+
+function buildCanonRF24105() {
+  return buildLens({ ...LENS_DEFAULTS, ...CanonRF24105Raw } as LensData);
+}
+
+describe("Canon RF 24-105mm f/4 L focus model", () => {
+  it("moves L4 rearward with equal-and-opposite D27/D29 gap changes", () => {
+    const L = buildCanonRF24105();
+    const d27Idx = L.labelIdx["26A"];
+    const d29Idx = L.labelIdx["28"];
+
+    for (const zoomT of [0, 0.5, 1]) {
+      const d27Inf = thick(d27Idx, 0, zoomT, L);
+      const d27Close = thick(d27Idx, 1, zoomT, L);
+      const d29Inf = thick(d29Idx, 0, zoomT, L);
+      const d29Close = thick(d29Idx, 1, zoomT, L);
+
+      expect(d27Close, `D27 should expand at zoomT=${zoomT}`).toBeGreaterThan(d27Inf);
+      expect(d29Close, `D29 should contract at zoomT=${zoomT}`).toBeLessThan(d29Inf);
+      expect(d27Close + d29Close, `L4 envelope should stay fixed at zoomT=${zoomT}`).toBeCloseTo(d27Inf + d29Inf, 8);
+    }
+  });
+
+  it("produces active close-focus convergence at all tabulated zoom positions", () => {
+    const L = buildCanonRF24105();
+    const targetK = 1 / 450;
+
+    for (const zoomT of [0, 0.5, 1]) {
+      const kInfinity = conjugateK(0, zoomT, L);
+      const kClose = conjugateK(1, zoomT, L);
+
+      expect(Math.abs(kInfinity), `infinity focus should stay neutral at zoomT=${zoomT}`).toBeLessThan(1e-8);
+      expect(kClose, `close focus should be active at zoomT=${zoomT}`).toBeGreaterThan(1e-3);
+      expect(kClose, `close focus should match the MFD-derived estimate at zoomT=${zoomT}`).toBeCloseTo(targetK, 4);
+    }
+  });
+});

--- a/src/lens-data/CanonRF24105mmf4L.analysis.md
+++ b/src/lens-data/CanonRF24105mmf4L.analysis.md
@@ -1,0 +1,271 @@
+# Canon RF 24-105mm f/4 L IS USM — Optical Design Analysis
+
+**Patent:** US 2019/0278068 A1 (Hatada, Canon Kabushiki Kaisha)
+**Example:** Numerical Example 2 (Fig. 3)
+**Published:** September 12, 2019
+**Priority:** JP 2018-042214, filed March 8, 2018
+
+---
+
+## 1. Identification and Confirmation
+
+The patent describes a family of compact zoom lenses with a positive first unit containing a high-dispersion negative front element, a negative second unit, and a multi-unit rear group employing a high-index positive lens (Grp) near the image plane. Example 2 was implemented as the **Canon RF 24-105mm f/4 L IS USM**, one of the four launch lenses for the Canon EOS R system in September 2018.
+
+The identification is confirmed by exact agreement across every published specification:
+
+| Parameter | Patent Example 2 | Canon RF 24-105mm f/4 L IS USM |
+|---|---|---|
+| Focal length range | 24.72 – 101.84 mm | 24 – 105 mm |
+| Maximum aperture | f/4.12 (design) | f/4 (marketed) |
+| Element / group count | 18 / 14 | 18 / 14 |
+| Aspherical elements | 3 (6 surfaces) | 3 glass-molded aspherics |
+| UD elements | 1 (S-FPL51, vd = 81.5) | 1 UD element |
+| Close focus distance | Not stated directly | 0.45 m |
+| Image circle | 2 × 21.64 = 43.28 mm | Full-frame (43.3 mm) |
+| Half-field (wide) | 41.19° (at f = 24.72 mm design) | 42° diagonal (84° at f = 24 mm marketed) |
+
+The paraxial ray trace of the prescription yields EFL values of 24.72, 50.92, and 101.83 mm at the three documented zoom positions, matching the patent to within 0.01%.
+
+---
+
+## 2. Optical Architecture
+
+The zoom lens consists of six lens units in a positive-negative-positive configuration with an extended rear group:
+
+| Unit | Power | Surfaces | f (mm) | Role |
+|---|---|---|---|---|
+| L1 | Positive | 1 – 5 | +88.25 | Front group (focusing collector) |
+| L2 | Negative | 6 – 13 | −18.38 | Variator (primary zoom power) |
+| L3 | Positive | 14 – 27* | +24.16 | Relay / compensator (aperture stop, IS) |
+| L4 | Negative | 28 – 29 | −40.84 | Focus group |
+| L5 | Negative | 30* – 31* | −68.35 | Field flattener / compensator |
+| L6 | Positive | 32 – 33 | +72.42 | Rear positive element (Grp) |
+
+The power distribution follows a modified retrofocus layout at the wide end, with L1 and L3 providing positive power while L2 provides the principal variator action. The first lens unit moves forward during zoom from wide to telephoto, increasing the L1–L2 separation from 0.75 mm to 34.38 mm and giving the design its characteristic extending barrel when zoomed to 105 mm.
+
+### 2.1 Zoom Mechanics
+
+All six units move toward the object side during zooming, but at different rates. The inter-unit spacings evolve as follows (infinity focus, millimeters):
+
+| Gap | 24.72 mm | 50.92 mm | 101.84 mm | Trend |
+|---|---|---|---|---|
+| d5 (L1→L2) | 0.75 | 15.82 | 34.38 | Monotonic increase |
+| d13 (L2→L3) | 21.53 | 9.07 | 2.38 | Monotonic decrease |
+| d27 (L3→L4) | 1.80 | 3.37 | 1.40 | Non-monotonic (reversal) |
+| d29 (L4→L5) | 11.59 | 10.02 | 11.99 | Non-monotonic (reversal) |
+| d31 (L5→L6) | 0.80 | 13.48 | 17.24 | Monotonic increase |
+| d33 (BFD) | 17.88 | 19.75 | 30.96 | Monotonic increase |
+
+Two gaps — d27 and d29 — exhibit non-monotonic behavior, meaning the cam mechanism driving L4 and L5 reverses direction relative to adjacent groups mid-zoom. This is a natural consequence of the piecewise-linear cam profile and is handled by the renderer's interpolation engine.
+
+The total track length grows from 125.3 mm at 24 mm to 169.3 mm at 102 mm, an increase of 44 mm. The back focal distance increases from 17.9 mm to 31.0 mm, yielding a ratio skt/skw = 1.73, which satisfies the patent's conditional expression (3) and is the mechanism by which Canon controls lateral color across the zoom range.
+
+### 2.2 Focus Mechanism
+
+The patent specifies that **L4** (a single negative meniscus element, L16) moves toward the image side for focusing from infinity to the closest distance. This is an inner-focusing architecture: the focus group sits between L3 and L5, well inside the barrel, so focusing does not change the overall lens length or rotate the filter thread. (The barrel does extend during *zoom*, as all units move forward at different rates, but this is independent of focus action.) Inner focusing is characteristic of modern Canon L-series zooms and is essential for compatibility with the Nano USM actuator.
+
+L4 consists of a single element (S-BAL14 glass, nd = 1.72916), which keeps the focus group mass extremely low — likely under two grams — enabling the rapid, silent focus response that was a key selling point for this lens as Canon's first L-series Nano USM design.
+
+**Note on close-focus data:** The patent does not provide variable-gap tables at close-focus distances. The Canon-specified minimum focus distance of 0.45 m is used in the data file, but all variable-gap pairs are coded as zoom-only (identical infinity/close values) because the close-focus air spacings cannot be derived from the patent alone. Gaps d27 (L3→L4) and d29 (L4→L5) are the focus-affected gaps — they change as L4 translates rearward — but their close-focus values remain unknown.
+
+### 2.3 Image Stabilization
+
+A subunit IS within L3 moves perpendicular to the optical axis for optical image stabilization. The patent text (§0069–0070) states that the IS subunit is within L3 and that "the positive lens Gfp is a lens arranged adjacent to, and on the image side of, the subunit IS." Since Gfp is identified as L14 (the UD glass element; see Section 3.3), the IS subunit must be the air-separated group immediately before L14 in L3. This identifies the IS group as the **L11 + L12** cemented doublet — the pair containing the S-NPH53 ultra-high-index glass (nd = 2.001). Canon's own block diagram on the Camera Museum page marks the IS unit with a distinct indicator, confirming its location between the stop and the UD element. The doublet has a thick-lens focal length of −46.8 mm.
+
+The choice of a negative doublet for IS is deliberate: a weakly powered IS group minimizes the optical aberrations introduced by the decentering motion required for stabilization. The use of the ultra-high-index S-NPH53 in this doublet allows the required optical power to be achieved with shallower surface curvatures, which in turn reduces the sensitivity of off-axis performance to the IS shift.
+
+---
+
+## 3. Element-by-Element Analysis
+
+The 18 elements span 12 distinct glass types. The following table summarizes each element's optical properties and role in the design.
+
+### 3.1 L1 — Front Positive Group (f = +88.25 mm)
+
+**L1 (G1n)** — Negative Meniscus, S-TIH6 (nd = 1.808, vd = 22.8)
+R₁ = +266.275, R₂ = +93.368 (cemented to L2). Center thickness 1.80 mm.
+Thin-lens f ≈ −178 mm. This is the patent's designated "negative lens G1n," the object-side negative element whose low Abbe number (vd = 22.8) is the key to the design's compactness. By using a high-dispersion material here, Canon increases the refractive power density of L1 while maintaining chromatic correction — but at the cost of increased lateral color at the telephoto end, which must be compensated by the rear Grp element.
+
+**L2 (G2p)** — Plano-Convex, S-BAL14 (nd = 1.729, vd = 54.7)
+R₁ = +93.368 (junction), R₂ = ∞ (plano rear). Center thickness 6.52 mm.
+Thin-lens f ≈ +128 mm. Cemented to L1 to form a doublet (f_doublet ≈ +456 mm via thick-lens ABCD trace). The cemented junction corrects axial chromatic aberration within L1, and the plano rear surface simplifies manufacture. The very long doublet focal length indicates that L1+L2 function primarily as a chromatic corrector rather than a strong positive contributor — the bulk of L1's positive power comes from G3p.
+
+**L3 (G3p)** — Positive Meniscus, S-BAL14 (nd = 1.729, vd = 54.7)
+R₁ = +49.826, R₂ = +126.155. Center thickness 6.97 mm.
+Thin-lens f ≈ +113 mm (thick-lens: +108.8 mm). Same glass as G2p, which allows both positive elements to share a glass melt in production. G3p carries most of L1's converging power and sets the marginal ray height entering L2.
+
+### 3.2 L2 — Variator (f = −18.38 mm)
+
+L2 is the high-power negative variator that drives the zoom magnification change. Its four elements span a wide range of glass types.
+
+**L4** — Negative Meniscus, S-NPH2 (nd = 1.954, vd = 32.3)
+R₁ = +65.832, R₂ = +15.019. Center thickness 1.25 mm.
+Thin-lens f ≈ −20.4 mm. The front element of the variator is a strongly curved meniscus in ultra-dense flint glass. Its high index allows steep curvatures without excessive thickness, and the meniscus form minimizes spherical aberration contribution. This is the single strongest-powered element in the variator.
+
+**L5** — Biconcave, L-BAL35 (nd = 1.583, vd = 59.4) — **Glass-Molded Aspheric #1**
+R₁ = −33.476, R₂ = +65.137. Center thickness 1.10 mm. Both surfaces aspherical (K = 0, even-order polynomial through A12/A6 respectively).
+Thin-lens f ≈ −37.9 mm. This is the first of three glass-molded aspherical elements. L-BAL35 is a low-Tg barium crown specifically formulated by OHARA for precision glass molding. The aspherical departures are modest — under 1 µm on the front surface and approximately 200 µm on the rear — consistent with the relatively small beam diameter at this position. The aspherization corrects residual spherical aberration and coma introduced by the steep curvatures of L4.
+
+**L6** — Biconvex (symmetric), S-TIH6 (nd = 1.808, vd = 22.8)
+R₁ = +40.325, R₂ = −40.325. Center thickness 5.03 mm.
+Thin-lens f ≈ +25.0 mm. A perfectly symmetric biconvex positive element in the same high-dispersion flint used for G1n. Its symmetry minimizes odd-order coma contribution, and the high-dispersion glass provides the chromatic counterbalance needed within the variator group. The positive power of L6 partially offsets the strong negative powers of L4 and L5, reducing the overall variator-group sensitivity to manufacturing tolerances.
+
+**L7** — Negative Meniscus, S-LAL18 (nd = 1.804, vd = 46.6)
+R₁ = −25.491, R₂ = −63.435. Center thickness 1.00 mm.
+Thin-lens f ≈ −53.0 mm. The rear element of L2 is a concave-toward-object meniscus in dense lanthanum crown. It acts as a field-flattening element within the variator, bending the Petzval surface closer to flat before the beam crosses the stop.
+
+### 3.3 L3 — Relay Group (f = +24.16 mm)
+
+L3 is the most complex unit, containing 8 elements across 5 air-separated groups, including the aperture stop, the IS subunit, the Gfp chromatic corrector, and the second glass-molded aspheric. Its strong positive power (+24.16 mm) re-images the exit pupil of L2 toward the focus and rear groups.
+
+**Aperture Stop (STO)** — Flat, d = 0.30 mm.
+Located at the very front of L3, consistent with all five patent examples.
+
+**L8** — Plano-Convex, S-LAH55V (nd = 1.911, vd = 35.3)
+R₁ = +44.965, R₂ = ∞ (plano rear). Center thickness 2.30 mm.
+Thin-lens f ≈ +49.4 mm. A dense lanthanum flint placed immediately after the stop to start converging the beam. Its high index allows the required power with relatively gentle curvature, keeping spherical aberration low at the stop where the marginal ray height is at its minimum.
+
+**L9 + L10** — Cemented Doublet (f = +54.84 mm thick-lens)
+
+L9: Negative meniscus, S-NPH2 (nd = 1.954, vd = 32.3). R₁ = +21.533, R₂ = +13.108 (junction). d = 1.00 mm.
+L10: Biconvex (nearly plano-convex), HOYA MC-7 (nd = 1.595, vd = 67.7). R_junction = +13.108, R₂ = −795.231 (nearly plano). d = 6.76 mm.
+
+This is an achromatizing doublet that corrects the axial chromatic aberration introduced by L8. The combination of a thin high-index negative meniscus (L9) cemented to a thick low-dispersion positive element (L10) is a classic telephoto-achromat configuration. The nearly-plano rear surface of L10 simplifies alignment.
+
+**L11 + L12** — Cemented Doublet / IS Group (f = −46.84 mm thick-lens)
+
+L11: Biconcave, S-TIM27 (nd = 1.750, vd = 35.3). R₁ = −152.936, R₂ = +16.038 (junction). d = 0.80 mm.
+L12: Positive meniscus, **S-NPH53 (nd = 2.001, vd = 25.5)**. R_junction = +16.038, R₂ = +30.717. d = 2.88 mm.
+
+This is the **image stabilization subunit** — the doublet that shifts perpendicular to the axis for shake correction. The nd = 2.001 glass in L12 is the highest-index material in the design, and one of the highest commercially available optical glasses. Its extreme refractive index serves two purposes: first, it contributes strongly to correcting the Petzval sum (the surface-by-surface Petzval contribution is proportional to (n'−n)/(nn'R), and a high n' at the cemented junction generates a large positive Petzval contribution that counteracts the overall negative Petzval contributions from the negative groups); second, the high index allows the IS doublet's net power to remain modest (−46.8 mm) despite steep junction curvatures, which keeps aberration sensitivity to the IS decentering shift manageable.
+
+**L13 + L14** — Cemented Doublet / Gfp (f = −211.87 mm thick-lens)
+
+L13: Negative meniscus, S-TIH53 (nd = 1.785, vd = 25.7). R₁ = +76.401, R₂ = +19.110 (junction). d = 0.75 mm.
+L14: Plano-convex, **S-FPL51 (nd = 1.497, vd = 81.5)** — **Canon UD Glass**. R_junction = +19.110, R₂ = ∞ (plano). d = 3.57 mm.
+
+This doublet contains the design's lone UD (Ultra-low Dispersion) element. The patent designates L14 specifically — not the entire doublet — as the positive lens "Gfp," defined as the element positioned on the image side of the IS subunit and adjacent to it. Its Abbe number of 81.5 satisfies conditional expression (13): 73.00 < vfp < 100.00. The fluorophosphate crown's low dispersion and positive anomalous partial dispersion work in tandem with the high-dispersion S-TIH53 flint of L13 to provide secondary-spectrum correction. The focal length of L14 alone (thin-lens f ≈ +38.5 mm) matches the patent's conditional expression (14) value of ffp/fw = 1.56, confirming ffp ≈ 38.6 mm. The combined thick-lens focal length of the L13+L14 doublet is −211.9 mm — weakly negative — because the strong individual powers (L13 negative, L14 positive) largely cancel.
+
+While the doublet's combined power is nearly neutral, the individual components have steep, opposing curvatures at the cemented junction (R = 19.110 mm), creating a powerful chromatic corrector that operates with minimal net influence on beam convergence. Its role is almost purely achromatizing.
+
+**L15** — Biconvex, L-BAL35 (nd = 1.583, vd = 59.4) — **Glass-Molded Aspheric #2**
+R₁ = +24.461, R₂ = −25.212. Center thickness 7.26 mm. Both surfaces aspherical (K = 0, even-order polynomial through A10).
+Thin-lens f ≈ +21.3 mm (thick-lens: +22.5 mm). This is the second glass-molded aspheric and the strongest positive element in L3. It sits at the rear of the relay group where the beam is diverging toward L4, and its aspherization corrects higher-order spherical aberration and coma that accumulate through the relay. The aspherical departures are substantial — approximately 190 µm on the front surface and 125 µm on the rear — indicating significant correction burden. The nearly-symmetric biconvex form provides a natural coma-balancing geometry.
+
+### 3.4 L4 — Focus Group (f = −40.84 mm)
+
+**L16** — Negative Meniscus, S-BAL14 (nd = 1.729, vd = 54.7)
+R₁ = +121.315, R₂ = +23.846. Center thickness 0.75 mm.
+Thin-lens f ≈ −40.7 mm. This single element constitutes the entire focus group. It translates toward the image during close focusing, changing the d27 and d29 air gaps. Its choice of barium crown glass — the same type used in L1's positive elements — keeps the weight extremely low (essential for the Nano USM actuator's speed and silence) and provides a moderate Abbe number that minimizes chromatic focus shift (the change in axial color balance as the focus group translates). The meniscus form (weakly convex front, strongly convex rear, both toward the object) is well suited for inner-focus applications because it introduces minimal change in the off-axis aberration balance as it translates along the axis.
+
+### 3.5 L5 — Rear Compensator (f = −68.35 mm)
+
+**L17** — Negative Meniscus, L-LAM69 (nd = 1.765, vd = 49.1) — **Glass-Molded Aspheric #3**
+R₁ = −43.071, R₂ = −248.821. Center thickness 1.50 mm. Both surfaces aspherical (K = 0, even-order polynomial through A12).
+Thin-lens f ≈ −68.1 mm.
+
+This is the most aggressively aspherized element in the entire design. The aspherical departures reach **−1.56 mm on the front surface and −1.67 mm on the rear** at the estimated semi-diameters — over 1.5 mm of departure from the base sphere. These are among the largest aspherical departures seen in any Canon interchangeable lens patent, and they are only achievable through precision glass molding (the L-LAM69 glass has a low glass-transition temperature specifically formulated for this process).
+
+The extreme aspherization on L17 serves a critical function: as the beam diameter expands rapidly between L4 and L6 (especially at the telephoto end, where d31 reaches 17.24 mm), L17 provides field curvature and distortion correction that would otherwise require multiple additional spherical elements. The negative meniscus form contributes a negative Petzval component that partially compensates for the strong positive Petzval from L6.
+
+### 3.6 L6 — Rear Positive Element / Grp (f = +72.43 mm)
+
+**L18** — Positive Meniscus, S-LAL18 (nd = 1.804, vd = 46.6)
+R₁ = −68.116, R₂ = −32.318. Center thickness 4.50 mm.
+Thin-lens f ≈ +76.5 mm (thick-lens: +72.4 mm).
+
+This is the patent's designated "positive lens Grp" — the element in the rearmost lens unit whose high refractive index (ndrp = 1.804, satisfying conditional expression (2): 1.70 < ndrp < 2.20) is central to the design's chromatic correction strategy. Positioned closest to the image plane, L18 operates at a height where the chief ray is tall relative to the marginal ray. This geometry means that the element's chromatic contribution is dominated by lateral color rather than axial color. Canon exploits this by using a dense lanthanum crown (moderate Abbe number of 46.6) to generate controlled lateral color that counteracts the lateral color produced by the high-dispersion G1n element at the telephoto end — without disturbing the axial chromatic balance that was already set by the relay group's achromatic doublets.
+
+The positive meniscus form (concave toward the object) also contributes a positive Petzval component that helps flatten the overall Petzval surface. The computed Petzval sum for the full system is +0.001355 mm⁻¹, corresponding to a Petzval radius of approximately −738 mm — a well-corrected value for a 4.1× zoom lens.
+
+---
+
+## 4. Glass Selection Summary
+
+The design uses 12 distinct glass types across 18 elements. All identifications match published catalog glasses (OHARA and HOYA) to within Δnd < 0.00001 and Δvd < 0.05, well within manufacturing tolerance.
+
+| Glass Code | OHARA ID | nd | vd | Elements | Category |
+|---|---|---|---|---|---|
+| 1808/228 | S-TIH6 | 1.80810 | 22.8 | L1, L6 | Dense flint |
+| 1729/547 | S-BAL14 | 1.72916 | 54.7 | L2, L3, L16 | Barium crown |
+| 1954/323 | S-NPH2 | 1.95375 | 32.3 | L4, L9 | Ultra-dense flint |
+| 1583/594 | L-BAL35 | 1.58313 | 59.4 | **L5, L15** | Moldable barium crown |
+| 1911/353 | S-LAH55V | 1.91082 | 35.3 | L8 | Dense lanthanum flint |
+| 1595/677 | HOYA MC-7 | 1.59522 | 67.7 | L10 | Phosphate crown |
+| 1750/353 | S-TIM27 | 1.74951 | 35.3 | L11 | Dense flint |
+| 2001/255 | S-NPH53 | 2.00069 | 25.5 | **L12** | Ultra-high-index flint |
+| 1785/257 | S-TIH53 | 1.78472 | 25.7 | L13 | High-dispersion flint |
+| 1497/815 | S-FPL51 | 1.49700 | 81.5 | **L14** | Fluorophosphate (UD) |
+| 1764/491 | L-LAM69 | 1.76450 | 49.1 | **L17** | Moldable lanthanum crown |
+| 1804/466 | S-LAL18 | 1.80400 | 46.6 | L7, L18 | Dense lanthanum crown |
+
+The three glass-molded aspherical elements use two moldable glasses: L-BAL35 (L5 and L15) and L-LAM69 (L17). Both carry the OHARA "L-" prefix indicating low glass-transition temperature, which is required for the precision glass-molding process that Canon describes as "glass-molded aspheric" in their specifications. Eleven of the twelve glass types match OHARA catalog designations; the twelfth (nd = 1.595, vd = 67.7 in L10) matches HOYA MC-7 exactly, confirming that Canon sources glass from multiple manufacturers. All catalog matches achieve residuals below Δnd = 0.00001 and Δvd = 0.05.
+
+---
+
+## 5. Aspherical Surface Summary
+
+All six aspherical surfaces use K = 0 (no conic term); all aspherization is carried by the even-order polynomial coefficients.
+
+| Surface | Element | R (mm) | Order | Max Departure |
+|---|---|---|---|---|
+| 8* (front) | L5 | −33.476 | A4–A12 | ~1 µm |
+| 9* (rear) | L5 | +65.137 | A4–A6 | ~200 µm |
+| 26* (front) | L15 | +24.461 | A4–A10 | ~190 µm |
+| 27* (rear) | L15 | −25.212 | A4–A10 | ~125 µm |
+| 30* (front) | L17 | −43.071 | A4–A12 | **~1,560 µm** |
+| 31* (rear) | L17 | −248.821 | A4–A12 | **~1,670 µm** |
+
+The aspherical departures on L17 (surfaces 30* and 31*) are remarkably large — over 1.5 mm — and dominate the correction of field curvature and distortion across the zoom range. Without these aggressive aspheres, the design would likely require two or three additional spherical elements to achieve comparable image quality.
+
+---
+
+## 6. Patent Conditional Expression Compliance
+
+The patent defines 15 conditional expressions governing the design space. Example 2's values are:
+
+| Expression | Range | Example 2 Value |
+|---|---|---|
+| (1) vd1n | 15.00 – 23.40 | 22.76 |
+| (2) ndrp | 1.70 – 2.20 | 1.80 |
+| (3) skt/skw | 1.50 – 2.60 | 1.73 |
+| (4) nd1p | 1.60 – 2.00 | 1.73 |
+| (5) vd1n/vdrp | 0.40 – 1.00 | 0.49 |
+| (6) |f2|/skw | 0.80 – 1.80 | 1.03 |
+| (7) f1/skt | 2.30 – 4.70 | 2.85 |
+| (8) frp/ft | 0.40 – 1.40 | 0.71 |
+| (9) (Fnot×f1)/ft | 3.00 – 5.50 | 3.57 |
+| (10) |f2|/fw | 0.50 – 1.00 | 0.74 |
+| (11) Lt/skt | 3.80 – 7.60 | 5.47 |
+| (12) (R1+R2)/(R1−R2) | 0.00 – 4.00 | 2.81 |
+| (13) vfp | 73.00 – 100.00 | 81.54 |
+| (14) ffp/fw | 1.40 – 2.00 | 1.56 |
+| (15) Lrp/Lw | 0.05 – 0.20 | 0.14 |
+
+All 15 expressions are satisfied, with most values falling within the tighter "preferred" sub-ranges (1a)–(15a).
+
+---
+
+## 7. Design Philosophy and Key Insights
+
+The RF 24-105mm f/4 L IS USM represents Canon's first full redesign of the 24-105 formula for the shorter flange distance of the RF mount (20 mm vs. 44 mm for EF). Several design choices reflect this:
+
+**Compact front group.** The cemented G1n+G2p doublet in L1, using a high-dispersion negative meniscus (vd = 22.8), allows Canon to achieve strong converging power in L1 while maintaining a modest front element diameter (effective diameter 63 mm). The patent notes that without the low Abbe number of G1n, the positive elements would need to be much stronger, increasing both thickness and diameter.
+
+**Lightweight internal focus.** L4 is a single 0.75 mm-thick meniscus in barium crown glass — likely weighing under 2 grams. This minimal mass is what enables the Nano USM motor to achieve the rapid, silent focus transitions that were a key marketing point of the lens.
+
+**Ultra-high-index IS doublet.** The use of S-NPH53 (nd = 2.001) in the IS group is unusual even for L-series designs. The extreme index provides strong Petzval correction within a compact doublet, and the relatively modest doublet power (−47 mm) keeps IS-shift aberration sensitivity low.
+
+**Aggressive rear aspherization.** The 1.5+ mm aspherical departures on L17 are among the largest in any Canon interchangeable lens. This single element replaces what would otherwise be a multi-element field-flattening group, contributing directly to the lens's compact 107.3 mm length — 10.7 mm shorter than the preceding EF 24-105mm f/4L IS II USM.
+
+**UD element placement.** Canon places the sole UD element (L14, S-FPL51) in the Gfp position — adjacent to and on the image side of the IS group. This location, partway through the relay and before the beam expands toward the rear groups, gives the UD glass maximum chromatic leverage with minimum required element diameter.
+
+---
+
+## 8. Production Lens Correspondence
+
+The patent prescription represents a design-stage optical layout. The production Canon RF 24-105mm f/4 L IS USM — marketed from October 2018 at a launch price of 155,000 yen (approximately $1,300 USD) — may differ in minor respects from the prescription, including slight reoptimization of aspherical coefficients, adjusted semi-diameters for manufacturing margin, and the incorporation of proprietary coatings not described in the patent.
+
+Canon applies two distinct coating technologies to this lens. **ASC (Air Sphere Coating)** — Canon's proprietary nano-structured anti-reflective coating, identified on the Canon Camera Museum block diagram — is applied to specific elements where near-vertical-incidence light is the primary source of ghosting and flare. Separately, **Super Spectra Coating** — Canon's broadband multi-layer dielectric AR coating — is applied to other elements for general reflectance reduction across the visible spectrum.
+
+The marketed focal length of "24–105 mm" reflects standard rounding from the design values of 24.72–101.84 mm, and the marketed f/4 aperture is rounded from the design f/4.12. The Canon Camera Museum notes that the lens achieves a barrel length of approximately 107.3 mm — a reduction of approximately 10.7 mm compared to the EF 24-105mm f/4L IS II USM. This barrel length refers to the collapsed (24 mm) position; the lens is an externally-zooming design whose barrel extends as the focal length increases toward 105 mm, consistent with the 44 mm increase in total optical track from wide to telephoto.

--- a/src/lens-data/CanonRF24105mmf4L.data.ts
+++ b/src/lens-data/CanonRF24105mmf4L.data.ts
@@ -11,7 +11,7 @@ import type { LensDataInput } from "../types/optics.js";
  * ║                                                                    ║
  * ║  Zoom variable gaps: D5, D13, D31, D33 (zoom only).              ║
  * ║  Focus variable gaps: D27, D29 (zoom + focus; close-focus data    ║
- * ║    unavailable from patent — coded as zoom-only pairs).           ║
+ * ║    unavailable from patent — estimated from 0.45 m MFD).          ║
  * ║  Reversing groups: D27 (non-monotonic), D29 (non-monotonic).      ║
  * ║                                                                    ║
  * ║  NOTE ON SEMI-DIAMETERS:                                           ║
@@ -393,9 +393,13 @@ const LENS_DATA = {
 
   /* ── Variable air spacings (zoom format) ──
    *  Patent provides infinity-focus spacings at 3 zoom positions.
-   *  Close-focus data is not available from the patent; all pairs
-   *  use [d_inf, d_inf].  Focus unit L4 (surfaces 27–28) moves
-   *  rearward during close focus, changing gaps D27 and D29.
+   *  Close-focus data is not available from the patent.  Focus unit L4
+   *  (surfaces 27–28) moves rearward during close focus, so D27 increases
+   *  and D29 decreases by equal travel to preserve the L3→L5 envelope.
+   *
+   *  Close-focus endpoints are computed estimates from Canon's published
+   *  0.45 m MFD by solving the real-ray paraxial conjugate at each zoom
+   *  stop: L4 travel ≈ 0.54 / 1.38 / 3.56 mm at W / M / T.
    */
   zoomPositions: [24.72, 50.92, 101.84],
   zoomStep: 0.004,
@@ -413,14 +417,14 @@ const LENS_DATA = {
       [2.38, 2.38],
     ],
     "26A": [
-      [1.8, 1.8],
-      [3.37, 3.37],
-      [1.4, 1.4],
+      [1.8, 2.34],
+      [3.37, 4.75],
+      [1.4, 4.96],
     ],
     "28": [
-      [11.59, 11.59],
-      [10.02, 10.02],
-      [11.99, 11.99],
+      [11.59, 11.05],
+      [10.02, 8.64],
+      [11.99, 8.43],
     ],
     "30A": [
       [0.8, 0.8],
@@ -462,7 +466,8 @@ const LENS_DATA = {
 
   /* ── Focus configuration ── */
   closeFocusM: 0.45,
-  focusDescription: "Inner focus — L4 (single element) translates toward image side. Nano USM actuator.",
+  focusDescription:
+    "Inner focus — L4 (single element) translates toward image side. Close-focus travel estimated from 0.45 m MFD; patent publishes infinity zoom spacings only.",
 
   /* ── Aperture configuration ── */
   nominalFno: 4,

--- a/src/lens-data/CanonRF24105mmf4L.data.ts
+++ b/src/lens-data/CanonRF24105mmf4L.data.ts
@@ -1,0 +1,477 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — CANON RF 24-105mm f/4 L IS USM                       ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2019/0278068 A1, Example 2 (Hatada / Canon).     ║
+ * ║  Six-unit zoom: +/−/+/−/−/+ with extended rear group.             ║
+ * ║  18 elements / 14 groups, 6 aspherical surfaces (3 GMo elements). ║
+ * ║  Focus: inner focus via L4 (single element, rearward motion).     ║
+ * ║                                                                    ║
+ * ║  Zoom variable gaps: D5, D13, D31, D33 (zoom only).              ║
+ * ║  Focus variable gaps: D27, D29 (zoom + focus; close-focus data    ║
+ * ║    unavailable from patent — coded as zoom-only pairs).           ║
+ * ║  Reversing groups: D27 (non-monotonic), D29 (non-monotonic).      ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent lists effective diameters; sd = effective_diameter / 2.  ║
+ * ║    Values taken directly from patent Table (Numerical Example 2). ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "canon-rf-24-105-f4-l",
+  maker: "Canon",
+  name: "CANON RF 24-105mm f/4 L IS USM",
+  subtitle: "US 2019/0278068 A1 EXAMPLE 2 — HATADA / CANON",
+  specs: [
+    "18 ELEMENTS / 14 GROUPS",
+    "f = 24.72 – 101.84 mm",
+    "F/4.12 (design)",
+    "2ω ≈ 82.4° – 24.0°",
+    "6 ASPHERICAL SURFACES (3 GMo ELEMENTS)",
+    "1 UD ELEMENT",
+  ],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: [24, 105] as [number, number],
+  focalLengthDesign: [24.72, 101.84] as [number, number],
+  apertureMarketing: 4,
+  apertureDesign: 4.12,
+  patentYear: 2019,
+  elementCount: 18,
+  groupCount: 14,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.8081,
+      vd: 22.8,
+      fl: -178.8,
+      glass: "S-TIH6 (OHARA)",
+      apd: false,
+      role: "G1n — high-dispersion negative front element; drives compactness via low Abbe number",
+      cemented: "D1",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Plano-Convex",
+      nd: 1.72916,
+      vd: 54.7,
+      fl: 128.1,
+      glass: "S-BAL14 (OHARA)",
+      apd: false,
+      role: "G2p — cemented to L1; chromatic corrector within front group",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.72916,
+      vd: 54.7,
+      fl: 108.8,
+      glass: "S-BAL14 (OHARA)",
+      apd: false,
+      role: "G3p — primary converging power of L1 unit",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.95375,
+      vd: 32.3,
+      fl: -20.7,
+      glass: "S-NPH2 (OHARA)",
+      apd: false,
+      role: "Front element of variator; strong negative power in ultra-dense flint",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconcave (2× Asph)",
+      nd: 1.58313,
+      vd: 59.4,
+      fl: -37.8,
+      glass: "L-BAL35 (OHARA)",
+      apd: false,
+      role: "Glass-molded aspheric #1 in variator; corrects SA and coma",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.8081,
+      vd: 22.8,
+      fl: 25.7,
+      glass: "S-TIH6 (OHARA)",
+      apd: false,
+      role: "Symmetric biconvex in variator; chromatic counterbalance to L4/L5",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.804,
+      vd: 46.6,
+      fl: -53.6,
+      glass: "S-LAL18 (OHARA)",
+      apd: false,
+      role: "Rear variator element; field-flattening meniscus",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Plano-Convex",
+      nd: 1.91082,
+      vd: 35.3,
+      fl: 49.4,
+      glass: "S-LAH55V (OHARA)",
+      apd: false,
+      role: "First element after stop; starts beam convergence in relay group",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Negative Meniscus",
+      nd: 1.95375,
+      vd: 32.3,
+      fl: -37.3,
+      glass: "S-NPH2 (OHARA)",
+      apd: false,
+      role: "Negative component of achromatic doublet in relay",
+      cemented: "D2",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.59522,
+      vd: 67.7,
+      fl: 21.7,
+      glass: "MC-7 (HOYA)",
+      apd: false,
+      role: "Positive component of achromatic doublet; phosphate crown for axial color correction",
+      cemented: "D2",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Biconcave Negative",
+      nd: 1.74951,
+      vd: 35.3,
+      fl: -19.3,
+      glass: "S-TIM27 (OHARA)",
+      apd: false,
+      role: "Negative component of IS doublet",
+      cemented: "D3",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Positive Meniscus",
+      nd: 2.00069,
+      vd: 25.5,
+      fl: 30.5,
+      glass: "S-NPH53 (OHARA)",
+      apd: false,
+      role: "IS subunit — ultra-high-index positive element for Petzval correction and IS shift control",
+      cemented: "D3",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Negative Meniscus",
+      nd: 1.78472,
+      vd: 25.7,
+      fl: -32.7,
+      glass: "S-TIH53 (OHARA)",
+      apd: false,
+      role: "Negative component of Gfp achromatizing doublet",
+      cemented: "D4",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Plano-Convex",
+      nd: 1.497,
+      vd: 81.5,
+      fl: 38.5,
+      glass: "S-FPL51 (OHARA)",
+      apd: "inferred",
+      apdNote: "Fluorophosphate crown (UD glass); anomalous partial dispersion for secondary spectrum correction",
+      role: "Gfp — UD element for secondary-spectrum correction adjacent to IS group",
+      cemented: "D4",
+    },
+    {
+      id: 15,
+      name: "L15",
+      label: "Element 15",
+      type: "Biconvex Positive (2× Asph)",
+      nd: 1.58313,
+      vd: 59.4,
+      fl: 22.5,
+      glass: "L-BAL35 (OHARA)",
+      apd: false,
+      role: "Glass-molded aspheric #2; strongest positive element in relay group",
+    },
+    {
+      id: 16,
+      name: "L16",
+      label: "Element 16",
+      type: "Negative Meniscus",
+      nd: 1.72916,
+      vd: 54.7,
+      fl: -40.8,
+      glass: "S-BAL14 (OHARA)",
+      apd: false,
+      role: "Focus group — single lightweight inner-focus element (Nano USM driven)",
+    },
+    {
+      id: 17,
+      name: "L17",
+      label: "Element 17",
+      type: "Neg. Meniscus (2× Asph)",
+      nd: 1.7645,
+      vd: 49.1,
+      fl: -68.4,
+      glass: "L-LAM69 (OHARA)",
+      apd: false,
+      role: "Glass-molded aspheric #3; aggressive aspherization (~1.6 mm departure) for field curvature/distortion",
+    },
+    {
+      id: 18,
+      name: "L18",
+      label: "Element 18",
+      type: "Positive Meniscus",
+      nd: 1.804,
+      vd: 46.6,
+      fl: 72.4,
+      glass: "S-LAL18 (OHARA)",
+      apd: false,
+      role: "Grp — high-index rear positive element; corrects lateral color vs G1n across zoom range",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── L1: Unit L1 (positive, f = +88.25 mm) ──
+    // L1 + L2 cemented doublet (D1)
+    { label: "1", R: 266.275, d: 1.8, nd: 1.8081, elemId: 1, sd: 31.5 },
+    { label: "2", R: 93.368, d: 6.52, nd: 1.72916, elemId: 2, sd: 30.65 }, // junction → L2
+    { label: "3", R: 1e15, d: 0.15, nd: 1.0, elemId: 0, sd: 30.44 }, // L2 rear → air
+    // L3 standalone
+    { label: "4", R: 49.826, d: 6.97, nd: 1.72916, elemId: 3, sd: 27.97 },
+    { label: "5", R: 126.155, d: 0.75, nd: 1.0, elemId: 0, sd: 27.37 }, // variable gap L1→L2
+
+    // ── L2: Unit L2 (negative, f = −18.38 mm) ──
+    // L4 standalone
+    { label: "6", R: 65.832, d: 1.25, nd: 1.95375, elemId: 4, sd: 15.69 },
+    { label: "7", R: 15.019, d: 8.19, nd: 1.0, elemId: 0, sd: 11.72 },
+    // L5 standalone (both surfaces aspherical)
+    { label: "8A", R: -33.476, d: 1.1, nd: 1.58313, elemId: 5, sd: 11.44 },
+    { label: "9A", R: 65.137, d: 0.15, nd: 1.0, elemId: 0, sd: 10.98 },
+    // L6 standalone (symmetric biconvex)
+    { label: "10", R: 40.325, d: 5.03, nd: 1.8081, elemId: 6, sd: 10.86 },
+    { label: "11", R: -40.325, d: 0.97, nd: 1.0, elemId: 0, sd: 10.42 },
+    // L7 standalone
+    { label: "12", R: -25.491, d: 1.0, nd: 1.804, elemId: 7, sd: 10.28 },
+    { label: "13", R: -63.435, d: 21.53, nd: 1.0, elemId: 0, sd: 10.05 }, // variable gap L2→L3
+
+    // ── L3: Unit L3 (positive, f = +24.16 mm) ──
+    // Aperture stop
+    { label: "STO", R: 1e15, d: 0.3, nd: 1.0, elemId: 0, sd: 9.68 },
+    // L8 standalone (plano-convex)
+    { label: "14", R: 44.965, d: 2.3, nd: 1.91082, elemId: 8, sd: 9.97 },
+    { label: "15", R: 1e15, d: 0.15, nd: 1.0, elemId: 0, sd: 9.97 },
+    // L9 + L10 cemented doublet (D2)
+    { label: "16", R: 21.533, d: 1.0, nd: 1.95375, elemId: 9, sd: 9.95 },
+    { label: "17", R: 13.108, d: 6.76, nd: 1.59522, elemId: 10, sd: 9.33 }, // junction → L10
+    { label: "18", R: -795.231, d: 1.37, nd: 1.0, elemId: 0, sd: 9.05 }, // L10 rear → air
+    // L11 + L12 cemented doublet (D3) — IS subunit
+    { label: "19", R: -152.936, d: 0.8, nd: 1.74951, elemId: 11, sd: 8.85 },
+    { label: "20", R: 16.038, d: 2.88, nd: 2.00069, elemId: 12, sd: 8.6 }, // junction → L12
+    { label: "21", R: 30.717, d: 3.81, nd: 1.0, elemId: 0, sd: 8.39 }, // L12 rear → air
+    // L13 + L14 cemented doublet (D4) — Gfp
+    { label: "22", R: 76.401, d: 0.75, nd: 1.78472, elemId: 13, sd: 8.4 },
+    { label: "23", R: 19.11, d: 3.57, nd: 1.497, elemId: 14, sd: 8.3 }, // junction → L14
+    { label: "24", R: 1e15, d: 0.15, nd: 1.0, elemId: 0, sd: 8.36 }, // L14 rear → air
+    // L15 standalone (both surfaces aspherical)
+    { label: "25A", R: 24.461, d: 7.26, nd: 1.58313, elemId: 15, sd: 9.31 },
+    { label: "26A", R: -25.212, d: 1.8, nd: 1.0, elemId: 0, sd: 9.88 }, // variable gap L3→L4
+
+    // ── L4: Unit L4 (negative, f = −40.84 mm) — Focus group ──
+    { label: "27", R: 121.315, d: 0.75, nd: 1.72916, elemId: 16, sd: 10.0 },
+    { label: "28", R: 23.846, d: 11.59, nd: 1.0, elemId: 0, sd: 9.95 }, // variable gap L4→L5
+
+    // ── L5: Unit L5 (negative, f = −68.35 mm) ──
+    { label: "29A", R: -43.071, d: 1.5, nd: 1.7645, elemId: 17, sd: 12.09 },
+    { label: "30A", R: -248.821, d: 0.8, nd: 1.0, elemId: 0, sd: 13.57 }, // variable gap L5→L6
+
+    // ── L6: Unit L6 (positive, f = +72.43 mm) — Grp ──
+    { label: "31", R: -68.116, d: 4.5, nd: 1.804, elemId: 18, sd: 17.55 },
+    { label: "32", R: -32.318, d: 17.88, nd: 1.0, elemId: 0, sd: 18.0 }, // BFD (variable)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "8A": {
+      K: 0,
+      A4: 5.17863e-6,
+      A6: -6.74704e-8,
+      A8: 5.22888e-10,
+      A10: -4.25942e-12,
+      A12: 1.45835e-14,
+      A14: 0,
+    },
+    "9A": {
+      K: 0,
+      A4: -7.7741e-6,
+      A6: -4.92259e-8,
+      A8: 0,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+    "25A": {
+      K: 0,
+      A4: -2.73692e-5,
+      A6: 5.32572e-8,
+      A8: -8.4482e-10,
+      A10: 5.56287e-12,
+      A12: 0,
+      A14: 0,
+    },
+    "26A": {
+      K: 0,
+      A4: 1.47893e-5,
+      A6: 2.32565e-9,
+      A8: -6.75778e-10,
+      A10: 4.79574e-12,
+      A12: 0,
+      A14: 0,
+    },
+    "29A": {
+      K: 0,
+      A4: -8.05959e-5,
+      A6: 1.99191e-7,
+      A8: -1.06561e-9,
+      A10: -7.47195e-13,
+      A12: 8.67762e-15,
+      A14: 0,
+    },
+    "30A": {
+      K: 0,
+      A4: -7.18829e-5,
+      A6: 2.81391e-7,
+      A8: -1.4432e-9,
+      A10: 4.2065e-12,
+      A12: -5.37088e-15,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (zoom format) ──
+   *  Patent provides infinity-focus spacings at 3 zoom positions.
+   *  Close-focus data is not available from the patent; all pairs
+   *  use [d_inf, d_inf].  Focus unit L4 (surfaces 27–28) moves
+   *  rearward during close focus, changing gaps D27 and D29.
+   */
+  zoomPositions: [24.72, 50.92, 101.84],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  var: {
+    "5": [
+      [0.75, 0.75],
+      [15.82, 15.82],
+      [34.38, 34.38],
+    ],
+    "13": [
+      [21.53, 21.53],
+      [9.07, 9.07],
+      [2.38, 2.38],
+    ],
+    "26A": [
+      [1.8, 1.8],
+      [3.37, 3.37],
+      [1.4, 1.4],
+    ],
+    "28": [
+      [11.59, 11.59],
+      [10.02, 10.02],
+      [11.99, 11.99],
+    ],
+    "30A": [
+      [0.8, 0.8],
+      [13.48, 13.48],
+      [17.24, 17.24],
+    ],
+    "32": [
+      [17.88, 17.88],
+      [19.75, 19.75],
+      [30.96, 30.96],
+    ],
+  },
+
+  varLabels: [
+    ["5", "D5"],
+    ["13", "D13"],
+    ["26A", "D27"],
+    ["28", "D29"],
+    ["30A", "D31"],
+    ["32", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "L1 (+)", fromSurface: "1", toSurface: "5" },
+    { text: "L2 (−)", fromSurface: "6", toSurface: "13" },
+    { text: "L3 (+)", fromSurface: "STO", toSurface: "26A" },
+    { text: "L4 (−)", fromSurface: "27", toSurface: "28" },
+    { text: "L5 (−)", fromSurface: "29A", toSurface: "30A" },
+    { text: "L6 (+)", fromSurface: "31", toSurface: "32" },
+  ],
+
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "D2", fromSurface: "16", toSurface: "18" },
+    { text: "D3", fromSurface: "19", toSurface: "21" },
+    { text: "D4", fromSurface: "22", toSurface: "24" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.45,
+  focusDescription: "Inner focus — L4 (single element) translates toward image side. Nano USM actuator.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 4,
+  fstopSeries: [4, 5.6, 8, 11, 16, 22],
+  apertureBlades: 9,
+
+  /* ── Layout tuning ── */
+  scFill: 0.55,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/NikonNikkorZ40mmf2.analysis.md
+++ b/src/lens-data/NikonNikkorZ40mmf2.analysis.md
@@ -1,0 +1,303 @@
+# Nikon NIKKOR Z 40mm f/2 — Optical Analysis
+
+**Patent:** JP 2021-189351A, Example 4 (Furuida Keigo, assignee: Nikon Corporation)  
+**Filed:** June 2, 2020 &nbsp;|&nbsp; **Published:** December 13, 2021  
+**Production lens:** NIKKOR Z 40mm f/2 (released September 2021); also sold as the NIKKOR Z 40mm f/2 (SE)
+
+---
+
+## 1. Identification and Overview
+
+JP 2021-189351A is a Nikon patent covering a family of compact, large-aperture prime lenses built around a three-group inner-focus architecture: a positive first group (G1), a positive second group (G2) serving as the focusing unit, and a negative third group (G3) acting as a field flattener. The patent presents seven numerical examples spanning focal lengths from 31 mm to 58 mm and maximum apertures from f/2.0 to f/2.9, all for full-frame (Ymax = 21.63 mm) coverage.
+
+Example 4 corresponds to the production NIKKOR Z 40mm f/2. The identification is established through a convergence of hard specifications: the patent's design focal length of 41.194 mm and f/2.04 working aperture match the marketed 40 mm f/2; the design uses exactly 6 glass elements and 2 aspherical surfaces; and the patent's image circle of Ymax = 21.63 mm confirms full-frame FX coverage. Nikon's published specification of 6 elements in 4 groups is consistent with the patent's three focusing groups once the manufacturer's convention of counting air-separated lens components is applied. No ED (Extra-low Dispersion) glass is used, which aligns with the production lens's budget positioning and the absence of any ED marking in Nikon's published specifications.
+
+### Key Parameters
+
+| Parameter | Design (patent) | Marketed (Nikon) |
+|-----------|:-----------:|:------------:|
+| Focal length | 41.194 mm | 40 mm |
+| Maximum aperture | f/2.04 | f/2 |
+| Half-field angle ω | 27.72° | 28.5° (57° full) |
+| Elements / groups | 6 / 3 (focusing groups) | 6 / 4 (optical components) |
+| Aspherical elements | 2 | 2 |
+| Close focus | β = −1/10 (patent label) | 0.29 m (MFD, β = −0.17) |
+| Total track TL(air) | 59.265 mm | — |
+| Back focus Bf(air) | 12.114 mm | — |
+| Filter size | — | 52 mm |
+| Diaphragm blades | — | 9 (rounded) |
+| Weight | — | 170 g |
+
+The patent labels its close-focus state as "β = −1/10," but this appears to be a notational convention used across all seven examples rather than a literal computed magnification. The production lens achieves a minimum focus distance of 0.29 m with a maximum reproduction ratio of 0.17×, extending well beyond the patent's documented close-focus example.
+
+---
+
+## 2. Optical Configuration
+
+The lens follows a positive–positive–negative three-group topology with an aperture stop positioned between G1 and G2. This is a Petzval-derived field-flattened architecture: the two positive front groups (G1 and G2) provide converging power, while the separated negative rear group (G3) flattens the strongly curved Petzval field surface that would otherwise result. The back focal distance is 12.114 mm (air-equivalent), comfortably clearing the Z-mount's 16 mm flange distance when the last lens element is recessed within the barrel. The telephoto ratio (TL/f) is 1.44, meaning the lens is moderately longer than its focal length — typical for a standard prime of this class.
+
+### Group Architecture
+
+**Group 1 (G1, positive, f = +63.3 mm):** A cemented doublet of a biconvex positive crown (L11) and a biconcave negative flint (L12). This is a classical Fraunhofer-type achromatic doublet that provides the bulk of the system's converging power while correcting primary longitudinal chromatic aberration. G1 is fixed during focusing.
+
+**Aperture Stop (S):** Located in the air space between G1 and G2, immediately behind G1. The stop position is fixed during focusing.
+
+**Group 2 (G2, positive, f = +35.5 mm):** The focusing group, composed of two air-separated lens components — a cemented doublet with a hybrid aspherical resin layer (L21 + L22 glass + L22 resin), followed by a positive meniscus singlet (L23). G2 provides strong positive power and carries the system's primary aspherical corrector (surface 8A). During focusing, G2 translates axially toward the object, moving 1.21 mm when focusing to the patent's close-focus state.
+
+**Group 3 (G3, negative, f = −54.7 mm):** A single negative element (L31) with a hybrid aspherical resin layer on its object-facing surface. G3 acts as a field flattener and telecentric corrector, bending the off-axis ray bundles to reduce the angle of incidence on the sensor. G3 is fixed during focusing.
+
+### Group Counting Convention
+
+The patent describes three "groups" (群, *gun*) defined by the focusing mechanism — units that move together during focus. However, Nikon's published specification lists 4 groups, using the optical convention where each air-separated lens component counts as a separate group:
+
+1. L11 + L12 (cemented doublet)
+2. L21 + L22 glass + L22 resin (cemented assembly with hybrid aspherical)
+3. L23 (singlet)
+4. L31 resin + L31 glass (hybrid aspherical composite)
+
+The air gap between components 2 and 3 (0.15 mm between surfaces 8A and 9) is the boundary that creates the fourth group in the manufacturer's count, even though components 2 and 3 move together mechanically as part of G2.
+
+---
+
+## 3. Element-by-Element Analysis
+
+### L11 — Front Positive Crown (G1)
+
+| Property | Value |
+|----------|-------|
+| Type | Biconvex positive |
+| Glass | S-LAH55 (OHARA), six-digit code 1835/427 |
+| nd / νd | 1.83481 / 42.73 |
+| Surfaces | R₁ = +28.707, R₂ = −105.070 |
+| Center thickness | 4.90 mm |
+| Focal length | +27.5 mm (thick-lens) |
+
+L11 is a high-index lanthanum-series crown (S-LAH55) with a strongly positive biconvex shape. It provides the dominant converging power in G1. The high refractive index (1.835) allows stronger surface curvatures at reduced ray bending per surface, which helps control spherical aberration. S-LAH55 is among the most widely used lanthanum crowns in the photographic optics industry, prized for its combination of high index with moderate dispersion (νd = 42.73). The sharply different curvature between the front and rear surfaces (R₁ = +28.7 vs. R₂ = −105.1) gives L11 a strongly asymmetric "bent" biconvex shape, with most of the optical power concentrated on the steeply curved front surface.
+
+The steep front curvature imposes a tight edge thickness constraint on the semi-diameter: at sd = 14.0 mm, the edge thickness is approximately 0.32 mm — close to the physical manufacturing minimum. This constrains the clear aperture of G1 and is the primary source of the production lens's known vignetting at f/2.
+
+### L12 — Rear Negative Flint (G1)
+
+| Property | Value |
+|----------|-------|
+| Type | Biconcave negative |
+| Glass | S-TIH23 (OHARA), six-digit code 1717/296 |
+| nd / νd | 1.71736 / 29.57 |
+| Surfaces | R₂ = −105.070 (cemented to L11), R₃ = +45.469 |
+| Center thickness | 0.90 mm |
+| Focal length | −44.1 mm (thick-lens) |
+| Cemented to | L11 |
+
+L12 is cemented to L11 to form the G1 achromatic doublet. S-TIH23 is a titanium-series flint glass with high dispersion (νd = 29.57), providing the chromatic correction counterpart to L11's crown glass. The doublet's combined focal length is +63.3 mm, roughly 1.54× the system focal length. The cement interface at R₂ = −105.070 is weakly curved, indicating that L12 primarily contributes negative power and dispersive correction without strongly affecting the doublet's net convergence. As a biconcave element, L12 grows thicker toward the edges, so its edge thickness is not a binding constraint.
+
+### L21 — Negative Flint (G2, cemented doublet front)
+
+| Property | Value |
+|----------|-------|
+| Type | Biconcave negative |
+| Glass | PBM18Y (OHARA) or equivalent S-TIM27, six-digit code 1755/276 |
+| nd / νd | 1.7552 / 27.57 |
+| Surfaces | R₅ = −16.536, R₆ = +105.597 |
+| Center thickness | 0.90 mm |
+| Focal length | −18.9 mm (thick-lens) |
+| Cemented to | L22 |
+
+L21 is a high-dispersion flint glass positioned at the front of G2's cemented assembly. Its strongly curved concave front surface (R₅ = −16.5 mm) gives it substantial negative power (f = −18.9 mm), making it the most powerfully diverging element in the system. This strong negative element, placed just behind the stop, is critical for correcting the spherical aberration and coma introduced by the preceding positive G1 doublet. The glass PBM18Y is an older OHARA phosphate-based flint; production may substitute the eco-compliant S-TIM27 (Δνd = 0.04, optically negligible).
+
+### L22 — Positive Crown with Hybrid Asphere (G2, cemented doublet rear)
+
+| Property | Value |
+|----------|-------|
+| Type | Biconvex positive (glass body) with cemented resin aspherical layer |
+| Glass body | S-LAH64 (OHARA), six-digit code 1804/466 |
+| Resin layer | UV-curable photopolymer, nd = 1.56093, νd = 36.64 |
+| Surfaces | R₆ = +105.597 (cemented to L21), R₇ = −33.838 (glass/resin junction), R₈* = −31.063 (resin rear, aspherical) |
+| Glass center thickness | 4.55 mm |
+| Resin center thickness | 0.10 mm |
+| Glass body focal length | +32.3 mm (thick-lens) |
+| Resin layer focal length | +666.5 mm (negligible power) |
+
+L22 is the most structurally complex element in the lens. The glass body (S-LAH64) provides strong positive power to balance L21's divergence, while the thin UV-curable resin layer bonded to its image-side surface carries the system's primary aspherical correction (surface 8A). This hybrid composite construction — where the aspherical shape is molded in low-melting-point resin rather than ground into the glass — is a classic Nikon cost-reduction technique that avoids the expense of glass-molded or polished aspherics. The resin layer itself has negligible optical power (f ≈ +667 mm); its sole purpose is to introduce the aspherical departure.
+
+The cemented glass doublet L21 + L22 (glass body only, exiting into air) has a combined focal length of −55.0 mm from the thick-lens ABCD computation, acting as an achromatizing diverger that corrects both spherical and chromatic aberrations simultaneously.
+
+### L23 — Positive Meniscus Singlet (G2, rear)
+
+| Property | Value |
+|----------|-------|
+| Type | Positive meniscus, concave toward the object |
+| Glass | S-LAH55 (OHARA), six-digit code 1835/427 |
+| nd / νd | 1.83481 / 42.73 |
+| Surfaces | R₉ = −397.823, R₁₀ = −21.512 |
+| Center thickness | 6.76 mm |
+| Focal length | +27.0 mm (thick-lens) |
+
+L23 is the strongest positive element in the system (f = +27.0 mm) and the thickest glass element (6.76 mm). It uses the same high-index S-LAH55 glass as L11. The strongly concave rear surface (R₁₀ = −21.5 mm) dominates its converging power, while the nearly flat front surface (R₉ = −397.8 mm) contributes almost nothing. This meniscus geometry — concave to the object, convex to the image — minimizes the angle of incidence on each surface relative to the marginal ray, which is the classical strategy for controlling higher-order spherical aberration in a strongly positive element.
+
+L23 is the element referenced by the patent's Condition (13), which requires that the highest-index glass in the system appear in G2's most image-side element. The patent notes that keeping Nmax below 1.8500 helps control field curvature and reduces cost — a deliberate constraint reflecting the lens's budget positioning.
+
+### L31 — Negative Field-Flattener with Hybrid Asphere (G3)
+
+| Property | Value |
+|----------|-------|
+| Type | Biconcave negative (glass body) with cemented resin aspherical layer on object side |
+| Resin layer | UV-curable photopolymer, nd = 1.56093, νd = 36.64 |
+| Glass body | E-CF6 (HOYA), six-digit code 1517/522 |
+| Surfaces | R₁₁* = −29.55 (resin front, aspherical), R₁₂ = −36.30 (resin/glass junction), R₁₃ = +1084.406 (glass rear, nearly flat) |
+| Resin center thickness | 0.10 mm |
+| Glass center thickness | 1.30 mm |
+| Glass body focal length | −67.9 mm (thick-lens) |
+| Resin layer focal length | −284.8 mm (weak negative) |
+| Composite focal length | −54.7 mm (thick-lens) |
+
+L31 is the sole element in G3 and serves as the system's field flattener. Its moderate negative power (f = −54.7 mm) flattens the Petzval field curvature generated by the strongly positive G1 and G2. The aspherical resin layer on the object side (surface 11A) provides field-dependent correction of astigmatism and coma, which is especially important at the wide half-field angle of 27.7°.
+
+The glass body is classified as biconcave by the patent: the front surface (R₁₂ = −36.3) is concave from the glass's perspective, and the rear surface (R₁₃ = +1084.4) is very weakly concave toward the image. In practice, R₁₃ is so nearly flat that the element behaves almost as plano-concave, but the finite curvature means it is technically biconcave as the patent describes.
+
+The glass body uses HOYA E-CF6, a low-index crown flint (nd = 1.517, νd = 52.2). This identification is notable — E-CF6 is the only exact catalog match among the major glass manufacturers. No OHARA equivalent exists at this nd/νd combination (the closest OHARA glass, S-NSL3, has νd = 52.43, a difference of 0.23 that exceeds normal catalog tolerance). The choice of a low-index glass for the field flattener keeps the Petzval contribution moderate (avoiding over-correction) while the nearly flat rear surface ensures that the exiting ray bundle is only weakly refracted, maintaining reasonable telecentricity for the sensor.
+
+---
+
+## 4. Aspherical Surfaces
+
+The lens employs two aspherical surfaces, both formed as thin UV-curable resin layers bonded to glass substrates — Nikon's hybrid composite ("複合型非球面") construction. This approach avoids the cost of glass-molded aspherics while providing the necessary wavefront correction for an f/2 aperture.
+
+### Sag Equation and Conic Convention
+
+The patent uses the sag formula:
+
+> X(y) = (y²/R) / {1 + √(1 − κ · y²/R²)} + A₄y⁴ + A₆y⁶ + A₈y⁸ + A₁₀y¹⁰ + A₁₂y¹²
+
+where κ is the conic parameter. In the standard notation used by the renderer (K = conic constant), the relationship is **K = κ − 1**. Both aspherical surfaces in this design use κ = 1.0000, giving **K = 0** — a spherical base curve with polynomial aspherical departure only.
+
+### Surface 8A (L22 Resin Rear — Primary Spherical Aberration Corrector)
+
+| Coefficient | Value |
+|-------------|-------|
+| R | −31.0626 mm |
+| K | 0 |
+| A₄ | +3.51503 × 10⁻⁵ |
+| A₆ | +5.19649 × 10⁻⁸ |
+| A₈ | +2.28989 × 10⁻¹⁰ |
+| A₁₀ | −1.66287 × 10⁻¹² |
+| A₁₂ | 0 |
+
+At an estimated working semi-diameter of ~10 mm, the total aspherical departure is approximately +329 μm (away from the base sphere, i.e., the surface becomes less steeply curved toward the rim). The A₄ term dominates (~231 μm at h = 9.8 mm), with A₆ contributing a secondary correction and higher orders providing fine refinement. The positive sign of A₄ means the surface flattens relative to the sphere at the margin — this is the classic correction profile for undercorrected spherical aberration in a fast positive system.
+
+Surface 8A sits near the convergence zone of the marginal ray within G2 and therefore has maximum leverage over on-axis spherical aberration. The aspherical departure here is the primary mechanism that allows the lens to achieve f/2 performance without additional glass elements.
+
+### Surface 11A (L31 Resin Front — Field Aberration Corrector)
+
+| Coefficient | Value |
+|-------------|-------|
+| R | −29.55 mm |
+| K | 0 |
+| A₄ | +7.47127 × 10⁻⁶ |
+| A₆ | +2.62883 × 10⁻⁸ |
+| A₈ | −6.53514 × 10⁻¹¹ |
+| A₁₀ | +1.25069 × 10⁻¹³ |
+| A₁₂ | −2.28970 × 10⁻¹⁷ |
+
+At an estimated working semi-diameter of ~15.5 mm, the aspherical departure profile is more complex than surface 8A. The A₆ term contributes a more substantial fraction relative to A₄ than on surface 8A, indicating a correction profile tuned to field-dependent aberrations. The oscillating signs of A₈ through A₁₂ suggest fine-tuning of the aspherical profile to balance astigmatism and field curvature across the image field.
+
+Surface 11A is located far from the stop, deep in the diverging rear group where chief ray heights are large. This is the optimal position for correcting field-dependent aberrations — astigmatism, field curvature, and oblique coma — because the aspherical departure experienced by off-axis ray bundles is substantially different from that experienced by on-axis rays.
+
+### Division of Labor
+
+The two aspherical surfaces implement a clean division of correction responsibilities: surface 8A handles on-axis (spherical) aberrations near the stop, while surface 11A handles off-axis (field) aberrations far from the stop. This is the textbook two-asphere strategy for a fast wide-normal prime, and it allows Nikon to achieve f/2 performance with only 6 glass elements — a remarkably low count for this specification.
+
+---
+
+## 5. Focusing Mechanism
+
+The lens uses inner focusing (IF), where only G2 translates axially while G1, the aperture stop, and G3 remain fixed relative to the image plane. This design choice has several practical consequences.
+
+### Variable Air Gaps
+
+| Gap | Surface | Infinity | Close (patent) | Change |
+|-----|---------|:--------:|:---------:|:------:|
+| D4 | STO → G2 front | 11.250 mm | 10.042 mm | −1.209 mm |
+| D10 | G2 rear → G3 front | 13.790 mm | 14.999 mm | +1.209 mm |
+
+The total track remains constant at 59.265 mm (air-equivalent). G2 moves 1.21 mm toward the object when focusing from infinity to the patent's close-focus state. The focusing movement is small because G2's image displacement coefficient γ = (1 − β₂²) · β₃² = 1.108 is close to unity — meaning the image shifts almost exactly as much as G2 moves. This near-unity γ value is by design: Condition (1) of the patent constrains γ to the range 0.90–1.50, optimizing for compact focus travel while maintaining good aberration balance during focus.
+
+### Practical Implications
+
+Because only G2 moves, the front element is fixed and the overall lens length does not change during focusing — the hallmark of an IF design. It also means the lens can use a lightweight stepping motor (STM) to drive only the relatively small and light G2 group, enabling the fast, quiet autofocus performance Nikon advertises for video work. The constant-length barrel also simplifies weather sealing and mechanical design, contributing to the lens's low weight of 170 g.
+
+---
+
+## 6. Chromatic Correction Strategy
+
+With no ED glass and no anomalous partial dispersion materials anywhere in the system, the lens relies entirely on classical achromatic doublet pairing for chromatic correction. The system uses two achromatic cemented pairs:
+
+**G1 doublet (L11 + L12):** S-LAH55 (νd = 42.73, crown) cemented with S-TIH23 (νd = 29.57, flint). The Abbe number difference of 13.16 provides moderate chromatic leverage. This pair corrects primary longitudinal chromatic aberration for the front converging group.
+
+**G2 cemented pair (L21 + L22):** PBM18Y (νd = 27.57, flint) cemented with S-LAH64 (νd = 46.60, crown). The Abbe number difference of 19.03 is larger, providing stronger chromatic correction in the group that carries the most optical power. The flint-ahead configuration (negative flint L21 in front, positive crown L22 behind) is the Steinheil achromat topology, which is preferred in post-stop positions because it reduces the Petzval contribution while maintaining chromatic correction.
+
+The absence of ED glass means that secondary spectrum (the residual chromatic aberration after primary achromatization) is not explicitly controlled. This is a deliberate trade-off consistent with the lens's budget positioning — secondary spectrum becomes increasingly visible at long focal lengths and very fast apertures, but at 40 mm f/2 its effect on image quality is modest, particularly when combined with Nikon's in-camera chromatic aberration correction algorithms.
+
+---
+
+## 7. Petzval Sum and Field Curvature
+
+The computed Petzval sum is **+0.00330 mm⁻¹**, corresponding to a Petzval radius of approximately 303 mm. The ratio of Petzval radius to focal length is 7.4×, which is a reasonable value for a standard prime but not exceptional — by comparison, well-corrected double-Gauss designs often achieve ratios above 10×.
+
+The negative G3 group is the key contributor to field flattening. Without G3, the strongly positive G1 and G2 would produce a Petzval radius much too short (field curvature too strong). L31's negative power lengthens the Petzval radius, while its aspherical surface (11A) provides additional field-dependent correction of astigmatism that the Petzval sum alone cannot address.
+
+---
+
+## 8. Glass Selection and Cost Philosophy
+
+The glass bill for this lens reflects Nikon's deliberate cost optimization. A few observations:
+
+**Repeated glass types reduce inventory cost.** Two of the six glass elements (L11 and L23) use the same glass, S-LAH55. This halves the number of distinct glass blanks that must be stocked for this element position.
+
+**No exotic or specialty glasses.** All six glass types are standard-catalog melts with no special coatings, fluorescence control, or anomalous dispersion requirements. Five of the six glass types match OHARA catalog entries exactly; the sixth (L31) matches HOYA E-CF6, a commodity crown flint.
+
+**Hybrid composite aspherics instead of glass-molded.** The two aspherical surfaces are formed in UV-curable resin (nd = 1.56093, νd = 36.64 — a standard Nikon photopolymer), bonded to conventionally polished glass substrates. This is substantially cheaper than precision-molded glass aspherics (as used in S-line lenses) or ground-and-polished aspherics, at the cost of slightly reduced environmental durability and coating flexibility.
+
+**Maximum refractive index constrained below 1.85.** Condition (13) of the patent explicitly limits the highest nd in the system to below 1.8500. This excludes expensive ultra-high-index glasses (such as S-LAH79, nd = 2.003) and keeps the glass bill within commodity pricing. The actual maximum of 1.83481 (S-LAH55) is well below this ceiling.
+
+These choices collectively enable the lens's remarkably low retail price of approximately $300 USD — less than half the cost of the S-line NIKKOR Z 50mm f/1.8 S, which uses 12 elements including 2 ED and 2 aspherical elements.
+
+---
+
+## 9. Semi-Diameter Estimation and Vignetting
+
+The patent does not list semi-diameters. SDs were estimated via combined marginal and chief ray trace at f/2.04 and ω = 27.72°, then constrained by physical limits: edge thickness ≥ 0.3 mm, sd/|R| < 0.90, and cross-gap sag overlap ≤ gap × 1.1.
+
+The binding constraint for the front group is L11's biconvex edge thickness. The strongly curved front surface (R = +28.7 mm) limits L11's semi-diameter to approximately 14.0 mm, where the edge thickness reaches 0.32 mm. The full off-axis marginal + chief ray envelope at surface 1 is approximately 23.5 mm (entrance pupil radius 10.1 mm + chief ray height 13.4 mm), far exceeding the physically achievable clear aperture.
+
+This means the front group introduces significant mechanical vignetting of off-axis ray bundles at full aperture — a deliberate design trade-off that keeps the front element compact and the lens lightweight (170 g). The production lens is indeed known for noticeable vignetting at f/2, particularly at the image corners, consistent with this analysis.
+
+The rear group (G3) has the largest semi-diameters in the system (~15.5–16.0 mm), which is expected because the field flattener sits far from the stop where chief ray heights are maximal.
+
+---
+
+## 10. Conditional Expression Verification
+
+The patent defines 16 conditional expressions that govern the design space. All computed values for Example 4 fall within the specified ranges and agree with the patent's tabulated values to within rounding tolerance:
+
+| Condition | Expression | Computed | Patent | Range |
+|-----------|-----------|:--------:|:------:|:-----:|
+| (1) | {1−β₂²}·β₃² | 1.107 | 1.108 | 0.90–1.50 |
+| (2) | (G1d+G2d+G3d)/DT | 0.417 | 0.417 | 0.28–0.45 |
+| (5) | (G1d+G2d)/G3d | 13.04 | 13.04 | 9.00–16.0 |
+| (8) | f₂/f | 0.861 | 0.858 | 0.70–1.00 |
+| (9) | (−f₃)/f | 1.329 | 1.325 | 0.60–2.50 |
+| (10) | f₁/f | 1.535 | 1.533 | 0.90–2.50 |
+| (13) | Nmax | 1.835 | 1.835 | < 1.850 |
+| (15) | f/Ymax | 1.905 | 1.904 | 1.30–3.00 |
+
+The small residuals between computed and patent values (typically < 0.5%) are consistent with rounding of the patent's tabulated surface data and are well within the tolerance expected for production optical systems.
+
+---
+
+## 11. Design Context
+
+The NIKKOR Z 40mm f/2 occupies a specific niche in Nikon's Z-mount lineup: a lightweight, affordable, non-S-line prime optimized for size, weight, and cost rather than peak optical performance. The 40 mm focal length sits between the classical 35 mm and 50 mm prime positions, offering a natural perspective that is wide enough for environmental portraits and street photography yet tight enough for subject isolation.
+
+The optical design achieves its compact form through several architectural decisions. The three-group IF topology eliminates the need for a complex floating-element rear group. The hybrid composite aspherics avoid the size and weight penalty of glass-molded elements. The constraint on maximum refractive index (Condition 13) keeps glass costs low. And the inner-focus mechanism, requiring only 1.2 mm of G2 travel, allows a short and lightweight stepping motor.
+
+The lens's optical trade-offs — acknowledged by reviewers — include the lack of advanced coatings (Nano Crystal Coat, ARNEO) and glass technology (ED, SR) found in Nikon's S-line optics. The result is somewhat elevated flare and ghosting in backlit conditions, modest vignetting at f/2, and uncorrected secondary spectrum. These are deliberate trade-offs that keep the lens at 170 g and $300, making it arguably the most accessible full-frame prime in the Z-mount system.

--- a/src/lens-data/NikonNikkorZ40mmf2.data.ts
+++ b/src/lens-data/NikonNikkorZ40mmf2.data.ts
@@ -1,0 +1,243 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — NIKON NIKKOR Z 40mm f/2                      ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: JP 2021-189351A Example 4 (Furuida Keigo / Nikon).   ║
+ * ║  Compact three-group inner-focus prime: G1(+) / S / G2(+) / G3(−).║
+ * ║  6 elements / 4 groups, 2 aspherical surfaces (hybrid composite).  ║
+ * ║  Focus: inner focus — G2 translates toward object.                 ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list SDs. Estimated via combined marginal +     ║
+ * ║    chief ray trace (f/2.04, ω = 27.72°), constrained by edge      ║
+ * ║    thickness ≥ 0.3 mm and cross-gap sag overlap ≤ gap × 1.1.      ║
+ * ║    Front group (G1) SDs constrained by L11 biconvex edge thickness ║
+ * ║    — significant off-axis vignetting at f/2 is expected and        ║
+ * ║    consistent with the production lens's known behavior.           ║
+ * ║                                                                    ║
+ * ║  NOTE ON COVER GLASS:                                              ║
+ * ║    Patent surfaces 14–15 (IR filter, nd = 1.5168, d = 1.6 mm)     ║
+ * ║    excluded. Last surface d = air-equivalent BFD = 12.114 mm.      ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "nikkor-z-40f2",
+  maker: "Nikon",
+  name: "NIKON NIKKOR Z 40mm f/2",
+  subtitle: "JP 2021-189351A EXAMPLE 4 — NIKON / FURUIDA",
+  specs: ["6 ELEMENTS / 4 GROUPS", "f ≈ 41.2 mm", "F/2.04", "2ω ≈ 55.4°", "2 ASPHERICAL SURFACES (HYBRID COMPOSITE)"],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: 40,
+  focalLengthDesign: 41.2,
+  apertureMarketing: 2,
+  apertureDesign: 2.04,
+  patentYear: 2021,
+  elementCount: 6,
+  groupCount: 4,
+
+  /* ── Elements ──
+   *  6 glass elements + 2 resin layers = 8 entries.
+   *  Nikon counts hybrid composites (glass + resin) as single elements;
+   *  elementCount = 6 matches the marketed specification.
+   */
+  elements: [
+    {
+      id: 1,
+      name: "L11",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.83481,
+      vd: 42.73,
+      fl: 27.5,
+      glass: "S-LAH55 (OHARA)",
+      apd: false,
+      role: "Front positive crown — dominant converging power in G1 achromatic doublet",
+      cemented: "D1",
+    },
+    {
+      id: 2,
+      name: "L12",
+      label: "Element 2",
+      type: "Biconcave Negative",
+      nd: 1.71736,
+      vd: 29.57,
+      fl: -44.1,
+      glass: "S-TIH23 (OHARA)",
+      apd: false,
+      role: "Negative flint — chromatic correction partner in G1 doublet",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L21",
+      label: "Element 3",
+      type: "Biconcave Negative",
+      nd: 1.7552,
+      vd: 27.57,
+      fl: -18.9,
+      glass: "PBM18Y (OHARA)",
+      apd: false,
+      role: "High-dispersion flint — spherical and chromatic corrector in G2 cemented assembly",
+      cemented: "H1",
+    },
+    {
+      id: 4,
+      name: "L22",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.804,
+      vd: 46.6,
+      fl: 32.3,
+      glass: "S-LAH64 (OHARA)",
+      apd: false,
+      role: "Positive crown body of hybrid composite — primary positive power in G2",
+      cemented: "H1",
+    },
+    {
+      id: 5,
+      name: "L22r",
+      label: "Element 4 (resin)",
+      type: "Pos. Meniscus (1× Asph)",
+      nd: 1.56093,
+      vd: 36.64,
+      fl: 666.5,
+      glass: "UV-curable photopolymer (Nikon)",
+      apd: false,
+      role: "Aspherical resin layer — primary spherical aberration corrector",
+      cemented: "H1",
+    },
+    {
+      id: 6,
+      name: "L23",
+      label: "Element 5",
+      type: "Positive Meniscus",
+      nd: 1.83481,
+      vd: 42.73,
+      fl: 27.0,
+      glass: "S-LAH55 (OHARA)",
+      apd: false,
+      role: "Strongest positive element — concave toward object, high-index meniscus reducing higher-order SA",
+    },
+    {
+      id: 7,
+      name: "L31r",
+      label: "Element 6 (resin)",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.56093,
+      vd: 36.64,
+      fl: -284.8,
+      glass: "UV-curable photopolymer (Nikon)",
+      apd: false,
+      role: "Aspherical resin layer — field-dependent aberration corrector (astigmatism, coma)",
+      cemented: "H2",
+    },
+    {
+      id: 8,
+      name: "L31",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.51742,
+      vd: 52.2,
+      fl: -67.9,
+      glass: "E-CF6 (HOYA)",
+      apd: false,
+      role: "Field flattener — negative power lengthens Petzval radius, corrects field curvature",
+      cemented: "H2",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    /* G1 — positive cemented doublet (L11 + L12), fixed during focus */
+    { label: "1", R: 28.7073, d: 4.9, nd: 1.83481, elemId: 1, sd: 14.0 },
+    { label: "2", R: -105.0698, d: 0.9, nd: 1.71736, elemId: 2, sd: 14.0 },
+    { label: "3", R: 45.4688, d: 2.45, nd: 1.0, elemId: 0, sd: 13.5 },
+
+    /* Aperture stop — between G1 and G2, fixed during focus */
+    { label: "STO", R: 1e15, d: 11.25, nd: 1.0, elemId: 0, sd: 8.8 },
+
+    /* G2 — positive focus group: cemented assembly (L21 + L22 + L22r) + singlet L23 */
+    { label: "5", R: -16.5359, d: 0.9, nd: 1.7552, elemId: 3, sd: 7.2 },
+    { label: "6", R: 105.5966, d: 4.55, nd: 1.804, elemId: 4, sd: 7.8 },
+    { label: "7", R: -33.838, d: 0.1, nd: 1.56093, elemId: 5, sd: 9.8 },
+    { label: "8A", R: -31.0626, d: 0.15, nd: 1.0, elemId: 0, sd: 10.0 },
+    { label: "9", R: -397.823, d: 6.76, nd: 1.83481, elemId: 6, sd: 10.2 },
+    { label: "10", R: -21.5121, d: 13.7904, nd: 1.0, elemId: 0, sd: 12.8 },
+
+    /* G3 — negative field flattener: hybrid composite (L31r + L31), fixed during focus */
+    { label: "11A", R: -29.55, d: 0.1, nd: 1.56093, elemId: 7, sd: 15.5 },
+    { label: "12", R: -36.3, d: 1.3, nd: 1.51742, elemId: 8, sd: 15.5 },
+    { label: "13", R: 1084.4056, d: 12.114, nd: 1.0, elemId: 0, sd: 16.0 },
+  ],
+
+  /* ── Aspherical coefficients ──
+   *  Patent conic parameter κ = 1.0000 → K = κ − 1 = 0 (spherical base).
+   *  Patent uses polynomial terms through A12; A12 = 0 for surface 8A.
+   */
+  asph: {
+    "8A": {
+      K: 0,
+      A4: 3.51503e-5,
+      A6: 5.19649e-8,
+      A8: 2.28989e-10,
+      A10: -1.66287e-12,
+      A12: 0,
+      A14: 0,
+    },
+    "11A": {
+      K: 0,
+      A4: 7.47127e-6,
+      A6: 2.62883e-8,
+      A8: -6.53514e-11,
+      A10: 1.25069e-13,
+      A12: -2.2897e-17,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (inner focus) ──
+   *  G2 translates 1.209 mm toward object from infinity to close focus.
+   *  Total track conserved: ΔD4 + ΔD10 = −1.209 + 1.209 = 0.
+   */
+  var: {
+    STO: [11.25, 10.0415],
+    "10": [13.7904, 14.9989],
+  },
+  varLabels: [
+    ["STO", "D4"],
+    ["10", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+)", fromSurface: "1", toSurface: "3" },
+    { text: "G2 (+)", fromSurface: "5", toSurface: "10" },
+    { text: "G3 (−)", fromSurface: "11A", toSurface: "13" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "H1", fromSurface: "5", toSurface: "8A" },
+    { text: "H2", fromSurface: "11A", toSurface: "13" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.29,
+  focusDescription:
+    "Inner focus (IF): G2 (L21–L23) translates toward the object. G1, aperture stop, and G3 remain fixed.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16],
+  apertureBlades: 9,
+
+  /* ── Layout tuning ── */
+  scFill: 0.55,
+  yScFill: 0.42,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/RicohGR218mmf28.analysis.md
+++ b/src/lens-data/RicohGR218mmf28.analysis.md
@@ -1,0 +1,388 @@
+# Ricoh GR 18.3mm f/2.8 — Optical Design Analysis
+
+*Companion to `RicohGR218mmf28.data.ts`*
+
+**Patent:** US 2013/0321936 A1 · Example 3  
+**Inventor / Applicant:** Kazuyasu Ohashi (Funabashi-shi, JP)  
+**Filed:** May 31, 2013 · Priority: JP 2012-127431 (June 4, 2012)  
+**Production lens:** Ricoh GR (2013), Ricoh GR II (2015)  
+**Note:** The published application lists no corporate assignee; the inventor filed individually. The described designs are clearly intended for Ricoh compact cameras and portable information terminals.
+
+---
+
+## 1. Identification and Context
+
+US 2013/0321936 A1 discloses the optical design behind the Ricoh GR's fixed 18.3mm f/2.8 lens — the first GR-series lens designed for an APS-C image sensor. Example 3 is the embodiment that matches the production specifications: 7 elements in 5 groups (per physical air-separated grouping), two aspherical elements, approximately 18.3mm focal length at f/2.81, and a half angle of view of 38.2° covering a 28.4mm image diagonal. This corresponds to a sensor format of approximately 23.5 × 15.6 mm (APS-C), consistent with the Sony-derived 16.2 MP CMOS sensor used in both the Ricoh GR and GR II.
+
+The lens was carried unchanged from the GR (April 2013) to the GR II (June 2015). The GR III (2019) introduced a redesigned 6-element/4-group lens, so this patent covers only the first two generations.
+
+The patent describes the design as an "approximately-symmetric-type" wide-angle lens — a deliberate departure from the retrofocus architecture typical of digital wide-angle lenses. By balancing negative and positive power symmetrically about the aperture stop, the design achieves unusually compact overall dimensions while maintaining high aberration correction. The patent explicitly states that this power arrangement makes it "easy to correct comatic aberration, distortion, and lateral chromatic aberration" — characteristics that reviewers consistently praised in the production GR.
+
+---
+
+## 2. Lens Structure and Group Architecture
+
+The patent defines four functional power groups (Groups I–IV), but the lens physically contains five air-separated groups when counted by air gaps. The discrepancy arises because the patent's "Group II" contains two air-separated sub-assemblies: a single negative lens and a cemented doublet. The manufacturer's published specification of "7 elements in 5 groups" uses the physical air-gap convention; the patent's four-group scheme describes the functional power arrangement.
+
+The structure, front (object side) to rear (image side):
+
+**Group I (negative):** Single negative meniscus lens (L1), with the concave surface facing the image side. This is the only element in the first air-separated group.
+
+**Group II (positive):** Two sub-assemblies — a single negative meniscus lens (L2) with its concave surface facing the object side, followed by an air gap of 0.20 mm, then a cemented doublet (L3+L4) with net positive power. This arrangement produces two physical air-separated groups (groups 2 and 3 in the manufacturer's convention) but functions as a single positive power group in the patent's scheme.
+
+**Aperture stop (S):** Located in the air gap between Groups II and III, 1.50 mm after the rear surface of the cemented doublet and 1.00 mm before the front surface of Group III.
+
+**Group III (positive):** A cemented doublet (L5+L6), consisting of a biconvex positive element cemented to a biconcave negative element (in that order from the object side). The rear surface of this group is concave — an important feature of the approximately-symmetric design.
+
+**Group IV (weak):** A single negative meniscus lens (L7), with the concave surface facing the object side and the convex surface facing the image side. This group has the weakest refractive power of all four groups (|f₄| ≈ 240 mm vs. |f₁| ≈ 28 mm).
+
+After Group IV, a parallel flat plate (F) represents the cover glass and/or infrared-cut filter of the image sensor, positioned so that its rear surface sits approximately 0.5 mm from the image plane. The Ricoh GR omits an optical low-pass (anti-aliasing) filter — a deliberate choice to maximize resolution at the expense of occasional moiré — so the parallel flat plate in the prescription represents only the IR-cut filter and sensor cover glass.
+
+---
+
+## 3. Surface Prescription (Example 3)
+
+| Surface | R (mm) | d (mm) | nd | νd | Glass | Element |
+|---------|--------|--------|-------|-------|-------|---------|
+| 01 | 816.141 | 0.80 | 1.49710 | 81.56 | HOYA M-FCD1 | L1 front |
+| 02* | 13.666 | 1.79 | 1.0 | — | air | L1 rear (asph) |
+| 03 | −23.543 | 0.80 | 1.68893 | 31.16 | HOYA E-FD8 | L2 front |
+| 04 | 200.425 | 0.20 | 1.0 | — | air | L2 rear |
+| 05 | 15.416 | 0.80 | 1.84666 | 23.78 | HOYA FDS90 | L3 front |
+| 06 | 9.513 | 2.34 | 1.88300 | 40.80 | HOYA TAFD30 | L3→L4 cement |
+| 07 | −34.121 | 1.50 | 1.0 | — | air | L4 rear |
+| STO | ∞ | 1.00 | 1.0 | — | air (stop) | — |
+| 09 | 14.691 | 2.59 | 1.88300 | 40.80 | HOYA TAFD30 | L5 front |
+| 10 | −9.087 | 0.89 | 1.68893 | 31.16 | HOYA E-FD8 | L5→L6 cement |
+| 11 | 12.917 | 1.73 | 1.0 | — | air | L6 rear |
+| 12 | −12.419 | 1.20 | 1.82080 | 42.71 | HOYA M-TAFD51 | L7 front |
+| 13* | −13.832 | 12.756 | 1.0 | — | air | L7 rear (asph) |
+| 14 | ∞ | 1.40 | 1.51680 | 64.20 | Filter | — |
+| 15 | ∞ | 0.50 | 1.0 | — | air → image | — |
+
+Surfaces marked * are aspherical (S02 and S13).
+
+---
+
+## 4. Computed Optical Parameters
+
+All values computed via full surface-by-surface paraxial (y-nu) ray trace and ABCD matrix methods, verified against the patent's stated conditional expressions.
+
+| Parameter | Computed | Patent stated |
+|-----------|----------|---------------|
+| System EFL (f) | 18.298 mm | 18.30 mm |
+| F-number | 2.81 | 2.81 |
+| Half angle of view (ω) | 37.8° (paraxial) | 38.2° (patent) |
+| Total track (L, S01 to image) | 30.30 mm | 30.30 mm (L/f = 1.656) |
+| Lens thickness (D_T, S01 to S13) | 15.64 mm | 15.66 mm (D_T/f = 0.855) |
+| BFD (air-equivalent, S13 to image) | 14.18 mm | — |
+| Petzval sum | 0.00468 mm⁻¹ | — |
+| Petzval radius | 213.7 mm | — |
+| Maximum image height (Y') | 14.2 mm | 14.2 mm |
+| Image diagonal | 28.4 mm | ~28.5 mm (APS-C) |
+
+The paraxial half angle of view (arctan Y'/f = 37.8°) is 0.4° less than the patent's stated 38.2°. This is typical: the patent value accounts for real (finite) ray tracing and barrel distortion, which slightly widens the effective field angle relative to the paraxial approximation. The telephoto ratio (L/f = 1.656) confirms the design is approximately-symmetric — longer than its focal length but substantially more compact than a typical retrofocus wide-angle (which would have L/f > 2).
+
+**Group focal lengths (thick-lens ABCD):**
+
+| Group | Focal length | Power character |
+|-------|-------------|-----------------|
+| Group I (L1) | −27.97 mm | Strong negative |
+| Group II (L2, L3+L4) | +19.07 mm | Moderate positive |
+| Group III (L5+L6) | +30.29 mm | Moderate positive |
+| Group IV (L7) | −240.0 mm | Very weak negative |
+| Groups I+II combined | +42.48 mm | Positive |
+| Groups III+IV combined | +35.32 mm | Positive |
+
+**Conditional expression verification:**
+
+| Expression | Computed | Patent | Description |
+|------------|----------|--------|-------------|
+| f₁/f₄ | 0.117 | 0.117 | First/fourth group power balance |
+| f₁₋₂/f₃₋₄ | 1.203 | 1.203 | Front/rear half power balance |
+| f₁/f | −1.529 | −1.529 | First group power relative to system |
+| r₂F/f | −1.287 | −1.287 | Group II front curvature ratio |
+| r₃R/f | 0.706 | 0.706 | Group III rear curvature ratio |
+| nd_p2-3 | 1.883 | 1.883 | Average nd of positive elements in II+III |
+| Y'/f | 0.776 | 0.776 | Image height to focal length ratio |
+| L/f | 1.656 | 1.656 | Total track ratio |
+| D_T/f | 0.855 | 0.855 | Lens thickness ratio |
+| r₂R/r₃F | −2.323 | −2.323 | Symmetry ratio across stop |
+
+All computed values agree with the patent to within rounding of the last digit.
+
+---
+
+## 5. Glass Identification and Properties
+
+The patent specifies five distinct glass types from the HOYA catalog. The HOYA naming convention provides significant information: the "M-" prefix denotes glasses developed specifically for precision glass molding (low glass transition temperature, Tg < 400°C), the "E-" prefix denotes eco-friendly (lead- and arsenic-free) glasses, "TAF" denotes tantalum-containing flint glasses, and "FCD" denotes fluoride crown glasses with anomalous partial dispersion.
+
+### L1 — HOYA M-FCD1 (nd = 1.49710, νd = 81.56, Pg,F = 0.5388)
+
+A moldable fluoride crown glass with very low refractive index and very high Abbe number. The "FCD" designation indicates a fluorophosphate crown with anomalous (positive) partial dispersion — the Pg,F value of 0.5388 lies well above the normal glass line, making this an APD glass. HOYA developed M-FCD1 specifically as a moldable equivalent of their conventional FCD1 glass, with a glass transition temperature low enough for aspherical surface molding. This is significant: L1 carries an aspherical surface (S02*), and the use of M-FCD1 means this asphere is a precision glass-molded optic, not a ground-and-polished element with a resin layer.
+
+The six-digit glass code is **497/816**, placing it in the extreme fluoride crown region of the glass map — low index, ultra-low dispersion.
+
+### L2 — HOYA E-FD8 (nd = 1.68893, νd = 31.16, Pg,F = 0.5989)
+
+A dense flint glass with moderately high refractive index and low Abbe number. The "E-" prefix indicates an eco-glass formulation. The Pg,F value of 0.5989 places it above the normal line, indicating mild anomalous partial dispersion (positive dPgF). This same glass is used for L6 in the rear cemented doublet, creating a symmetric pair of flint elements about the aperture stop — consistent with the approximately-symmetric design philosophy.
+
+Glass code: **689/312**.
+
+### L3 — HOYA FDS90 (nd = 1.84666, νd = 23.78, Pg,F = 0.6191)
+
+An extremely high-dispersion dense flint — one of the most dispersive optical glasses in the HOYA catalog. With νd < 25, this glass provides very strong chromatic dispersion per unit of refractive power. In the cemented doublet L3+L4, L3 acts as the high-dispersion negative element that, together with L4's positive power, enables achromatic correction within Group II. The very high dispersion of FDS90 means that only a thin element is needed to provide the necessary chromatic correction, keeping the doublet compact.
+
+Glass code: **847/238**.
+
+### L4 and L5 — HOYA TAFD30 (nd = 1.88300, νd = 40.80, Pg,F = 0.5654)
+
+The workhorses of this design. TAFD30 is a tantalum-containing dense flint glass with an exceptionally high refractive index combined with moderate Abbe number — an unusual combination that places it in the "high-index crown-like flint" region of the glass map. The nd of 1.883 is among the highest available in mass-produced optical glass, and the relatively moderate dispersion (νd = 40.80) means that strong refractive power can be achieved with moderate curvatures, reducing both aberrations and physical element size.
+
+Both L4 (in the Group II cemented doublet) and L5 (the biconvex element of the Group III doublet) use TAFD30. These are the primary positive-power elements of the system, flanking the aperture stop. The patent's Conditional Expression (6) requires nd_p2-3 > 1.75 for the positive elements in Groups II and III; at 1.883, this design exceeds that threshold substantially, which the patent states is essential for controlling field curvature and introverted coma at intermediate image heights.
+
+Glass code: **883/408**.
+
+### L7 — HOYA M-TAFD51 (nd = 1.82080, νd = 42.71, Pg,F = 0.5642)
+
+Another moldable tantalum flint, similar in optical properties to TAFD30 but with slightly lower index and slightly higher Abbe number. The "M-" prefix again confirms this is a precision-molding glass, consistent with the aspherical surface on S13*. Like L1, this element's asphere is produced by glass molding rather than by grinding or resin overlay.
+
+Glass code: **821/427**.
+
+### Glass Selection Summary
+
+| Element | Glass | nd | νd | Pg,F | dPg,F | Mfg. method |
+|---------|-------|------|------|------|-------|-------------|
+| L1 | M-FCD1 | 1.497 | 81.56 | 0.539 | +0.032 (strong positive) | Glass-molded asphere |
+| L2 | E-FD8 | 1.689 | 31.16 | 0.599 | +0.008 (slight positive) | Polished spherical |
+| L3 | FDS90 | 1.847 | 23.78 | 0.619 | +0.015 (moderate positive) | Polished spherical |
+| L4 | TAFD30 | 1.883 | 40.80 | 0.565 | −0.010 (slight negative) | Polished spherical |
+| L5 | TAFD30 | 1.883 | 40.80 | 0.565 | −0.010 (slight negative) | Polished spherical |
+| L6 | E-FD8 | 1.689 | 31.16 | 0.599 | +0.008 (slight positive) | Polished spherical |
+| L7 | M-TAFD51 | 1.821 | 42.71 | 0.564 | −0.008 (slight negative) | Glass-molded asphere |
+
+The dPg,F values are computed relative to the Schott normal glass line (Pg,F = 0.6438 − 0.001682 × νd). The combination of strongly positive-APD M-FCD1 in L1 with the moderate positive-APD FDS90 and slight negative-APD TAFD30 in the cemented doublets creates a secondary-spectrum correction budget across the system. This is what enables the low chromatic aberration observed in the production GR.
+
+---
+
+## 6. Aspherical Surfaces
+
+Two surfaces are aspherical: the rear surface of L1 (S02*) and the rear surface of L7 (S13*). Both are on elements made from moldable glass, as noted above. The patent recommends aspherical surfaces on the first and fourth groups specifically, noting that "the employment of the aspheric surface has a great effect in correction of astigmatism, comatic aberration, and distortion" (¶0107).
+
+Note: Some third-party reviews describe the lens as having "two double-sided aspherics," but the patent prescription clearly shows only one aspherical surface per element — the front surfaces of both L1 and L7 are spherical. Ricoh's own specification — "two high-precision aspherical optical elements" — is consistent with the patent. Each aspherical element has one spherical and one aspherical surface, totaling two aspherical surfaces across the entire system.
+
+### S02* — L1 rear surface (R = 13.666 mm)
+
+| Coefficient | Value |
+|-------------|-------|
+| K | +3.80085 |
+| A4 | +1.07069 × 10⁻⁴ |
+| A6 | −3.38949 × 10⁻⁶ |
+| A8 | −2.19205 × 10⁻⁷ |
+| A10 | −5.16455 × 10⁻⁹ |
+
+The positive conic constant K = +3.80 indicates a hyperboloidal base curve. At small heights, the aspherical departure is positive (the surface is slightly steeper than a sphere), reaching a peak departure of approximately +0.078 mm at h ≈ 4.8 mm. Beyond h ≈ 5.8 mm, the polynomial terms dominate and the departure reverses sign, flattening the surface relative to the sphere. This inflection behavior is characteristic of aspheres designed to correct field-dependent aberrations — the inner zone handles on-axis correction while the outer zone manages off-axis coma and astigmatism.
+
+### S13* — L7 rear surface (R = −13.832 mm)
+
+| Coefficient | Value |
+|-------------|-------|
+| K | −2.86234 |
+| A4 | +1.49055 × 10⁻⁴ |
+| A6 | +4.18583 × 10⁻⁶ |
+| A8 | +1.25343 × 10⁻⁷ |
+| A10 | −7.88154 × 10⁻¹⁰ |
+
+The strongly negative conic constant K = −2.86 places the base curve well beyond a paraboloid (K = −1), into the hyperboloidal regime on the concave side. This means the surface flattens significantly faster than a sphere at increasing aperture heights. The polynomial coefficients A4 through A8 are all positive, reinforcing this flattening effect. The combined result is dramatic: at h = 6 mm the aspherical departure exceeds +0.7 mm (the asphere is substantially flatter than the spherical reference). This large departure controls the chief ray angle at the image plane, helping the lens meet the exit pupil distance requirements for the on-chip microlens array of the image sensor. The patent's Conditional Expression (8) constrains tan(θP_max) to the range 0.6–0.95, and the computed value of 0.746 falls comfortably within this range.
+
+---
+
+## 7. Element-by-Element Optical Role Analysis
+
+### L1 — Front negative meniscus (Group I)
+
+**Shape:** Nearly plano-concave. The front surface R = 816 mm is almost flat (radius-to-semi-diameter ratio > 100), while the rear surface R = 13.67 mm is strongly curved and aspherical.
+
+**Focal length:** −27.97 mm (strong negative).
+
+**Role:** L1 is the primary negative element of the front group. Its strong negative power diverges the incoming beam, which is essential for achieving the wide 38° half angle of view while keeping the lens compact — by bending off-axis rays inward early, L1 reduces the required clear aperture of all subsequent elements. The aspherical rear surface corrects astigmatism and distortion introduced by the strong curvature. The use of M-FCD1 (νd = 81.56, anomalous partial dispersion) serves a dual purpose: the high Abbe number minimizes the chromatic aberration contribution of this strong negative element, and the anomalous dispersion (dPg,F = +0.032) enables secondary spectrum correction. The patent's Conditional Expression (12) requires 55 < νd_n1 < 85 for the first lens group's negative element; at νd = 81.56, this design sits near the upper limit, maximizing achromatic correction.
+
+As the front-most element exposed to the environment, the choice of glass also reflects durability considerations. The patent notes (¶0106) that glasses with νd > 85 tend to be "soft, easy to be scratched, and low in chemical durability," making them unsuitable for the most object-side element.
+
+### L2 — Negative meniscus (Group II, front sub-assembly)
+
+**Shape:** Negative meniscus with the concave surface facing the object side (R₃ = −23.54 mm, R₄ = +200.4 mm).
+
+**Focal length:** −30.54 mm (moderate negative).
+
+**Role:** L2 forms the front element of Group II and creates one half of the "biconvex air lens" between Groups I and II (the concave rear of L1 and the concave front of L2 define a biconvex air space with negative refractive power). The patent specifically notes that the concave object-side surface of L2 "has an effect to make a diameter of the first lens group smaller, and make it easy to correct comatic aberration of a lower ray" (¶0061). L2 uses HOYA E-FD8, a dense flint with high dispersion (νd = 31.16), providing a chromatic counterbalance to the low-dispersion L1 ahead of it.
+
+### L3+L4 — Cemented doublet (Group II, rear sub-assembly)
+
+**Shape:** L3 is a negative meniscus (R₅ = +15.42, R₆ = +9.51 — both surfaces convex toward the object side, with the rear surface more steeply curved), L4 is a biconvex element (R₆ = +9.51, R₇ = −34.12).
+
+**Combined focal length:** +12.19 mm (strong positive).
+
+**Role:** This cemented doublet provides the primary positive refractive power on the object side of the aperture. The use of FDS90 (νd = 23.78, extremely high dispersion) for L3 and TAFD30 (νd = 40.80, moderate dispersion, very high index) for L4 provides partial chromatic correction within the doublet — L3's high dispersion offsets roughly half of L4's chromatic contribution. The doublet is not a standalone achromat, however; full achromatic correction is achieved at the system level, where the five negative elements (L1, L2, L3, L6, L7) collectively balance the two strong positive elements (L4, L5). The cemented junction at R₆ = 9.513 mm (strongly curved) carries significant refractive power and helps correct lateral chromatic aberration.
+
+The very high refractive index of L4 (nd = 1.883) allows the positive power to be achieved with relatively gentle curvatures, reducing higher-order aberrations. The patent notes that separated negative and positive elements in Group II "secure degrees of freedom in various aberration correction" (¶0063).
+
+### L5+L6 — Cemented doublet (Group III)
+
+**Shape:** L5 is biconvex (R₉ = +14.69, R₁₀ = −9.09), L6 is biconcave (R₁₀ = −9.09, R₁₁ = +12.92).
+
+**Combined focal length:** +30.29 mm (moderate positive).
+
+**Role:** This doublet mirrors the power structure of the L3+L4 doublet across the aperture stop — both use TAFD30 for the positive element and E-FD8 for the negative element, reinforcing the approximately-symmetric design. The patent states that "only a cemented lens of a positive lens and a negative lens constitutes the third lens group" to prevent "an increase in a production error sensitivity" and achieve "ease of assembly" (¶0063). By using a single cemented pair rather than separated elements, manufacturing tolerances are relaxed — the cemented junction is self-centering and doesn't require the tight air-gap control of separated elements.
+
+The rear surface of L6 (R₁₁ = +12.917 mm, concave toward the image) forms one side of the second "biconvex air lens" between Groups III and IV, symmetrically matching the air lens between Groups I and II.
+
+### L7 — Weak negative meniscus (Group IV)
+
+**Shape:** Concave-convex meniscus (R₁₂ = −12.42, R₁₃ = −13.83), with both surfaces concave from the object side but the rear surface less strongly curved and aspherical.
+
+**Focal length:** −240.0 mm (very weak negative).
+
+**Role:** L7 is the field flattener and exit pupil controller. Its extremely weak power (|f₇/f| ≈ 13) means it contributes minimally to the system's refractive power but significantly affects the exit pupil position and field curvature. The patent explains that Group IV "controls the position of the exit pupil" and "sets the angle of the principal ray incident to the image plane in the peripheral image height to be in an appropriate state" (¶0065). The aspherical rear surface provides fine control over the chief ray angle at the image plane — critical for proper illumination of the sensor's microlens array.
+
+The concave object-side surface of L7 forms the rear half of the second biconvex air lens, completing the symmetric negative-positive-negative power distribution on the image side of the stop.
+
+---
+
+## 8. Symmetry and Aberration Correction Strategy
+
+The approximately-symmetric power arrangement is the defining feature of this design. The patent describes it as: positive power flanking the aperture on both sides (the L3+L4 cemented doublet and L5 biconvex element), with negative power on each outer side (Group I and the rear elements L6 + L7). This near-symmetry cancels odd-order aberrations (coma, distortion, lateral chromatic aberration) to first order, while the deliberate asymmetry (the rear half is slightly more powerful than the front — f₃₋₄ = 35.3 mm vs. f₁₋₂ = 42.5 mm, giving f₁₋₂/f₃₋₄ = 1.203) accommodates the reduced magnification at which a camera lens operates.
+
+The two "biconvex air lenses" — between Groups I and II, and between Groups III and IV — each contribute negative refractive power, further distributing the power budget and enabling finer aberration control. The patent notes that these air lenses make it possible to favorably adjust the "distribution of the refractive power" in those inter-group spaces (¶0060).
+
+The computed Petzval sum of 0.00468 mm⁻¹ yields a Petzval radius of approximately 214 mm, producing an inward Petzval field curvature of approximately 0.47 mm at the maximum image height (Y' = 14.2 mm). This is substantially larger than the geometric depth of focus at f/2.8 (approximately ±0.054 mm for a 4.8 µm pixel pitch sensor), which means the Petzval curvature alone cannot be tolerated — astigmatic correction must compensate. The patent's aberration diagrams for Example 3 (Fig. 11) confirm that the tangential and sagittal focal surfaces are balanced to bracket the image plane, yielding a composite best-focus surface that is much flatter than the Petzval surface. The mild corner softness observed in production reviews at f/2.8 (improving markedly by f/5.6) is consistent with this residual balance between Petzval curvature and astigmatic compensation.
+
+---
+
+## 9. Focus Mechanism
+
+The patent describes two focusing methods: "moving an entire lens groups, or by moving the image sensor to match an imaging plane" (¶0115). Notably, Example 3 provides no variable-spacing table — unlike zoom lens patents or designs with internal focusing, there are no tabulated air gap changes at different object distances. This is consistent with unit focusing, where the entire optical assembly translates along the optical axis as a rigid body.
+
+The Ricoh GR implements unit focusing: the entire optical assembly translates forward along the optical axis to focus at closer distances. (The lens barrel also extends from the collapsed body on power-up, but that is the startup deployment, not the focusing action.) The published close-focus distance is 30 cm in normal mode and 10 cm in macro mode. Computed unit-focus extensions are approximately 1.2 mm at 30 cm and 4.1 mm at 10 cm — modest movements consistent with the fast AF response reported by reviewers (0.2 seconds to focus lock).
+
+Because the entire lens moves as a unit, there is no change in the inter-element spacings during focusing, which means the aberration balance designed for infinity is maintained at all focus distances with only the inherent field curvature shift of a unit-focus system. This is a practical advantage for a compact camera where manufacturing simplicity and mechanical reliability are priorities.
+
+---
+
+## 10. Relationship to Other Examples in the Patent
+
+The patent provides eight examples, all sharing the same four-group architecture. Example 3 is distinguished by several features that likely led to its selection for production:
+
+**Highest-index positive elements:** Examples 3, 4, and 6 all use TAFD30 (nd = 1.883) for both primary positive elements — the highest refractive index among all eight examples. This enables the most compact design for a given focal length, consistent with the GR's emphasis on pocketability. The remaining examples use lower-index alternatives (TAFD5F at nd = 1.835, or TAF1 at nd = 1.773).
+
+**Anomalous dispersion front element:** Example 3 is the only example that uses M-FCD1 (nd = 1.497, νd = 81.56) for L1 — an anomalous partial dispersion glass with dPg,F = +0.032. The other examples predominantly use HOYA FC5 (nd = 1.487, νd = 70.45), which has lower Abbe number and less anomalous dispersion. M-FCD1's ultra-low dispersion enables better secondary spectrum correction, contributing to the low chromatic aberration observed in production reviews.
+
+**Balanced chromatic correction:** The combination of M-FCD1 (anomalous dispersion) with the symmetric use of E-FD8 in both doublets creates a chromatic correction strategy that addresses both primary and secondary spectrum — contributing to the low chromatic aberration observed in production reviews.
+
+**Intermediate field curvature:** The Petzval sum of Example 3 is moderate — not as aggressively corrected as some examples (which risk over-correction and astigmatism at the edges), nor as under-corrected as others. This balanced approach is consistent with the GR's reputation for uniform sharpness across the frame.
+
+---
+
+## 11. Production Considerations
+
+Several features of Example 3's design reflect production engineering priorities:
+
+**Glass-molded aspherics:** Both aspherical elements use HOYA's M-prefix moldable glasses. Precision glass molding produces aspherical surfaces with excellent centration (since the asphere and element are formed in a single pressing operation) and high throughput compared to diamond-turned or polished aspheres. This is critical for a mass-production consumer camera.
+
+**Cemented groups for tolerance control:** The use of cemented doublets in Groups II and III (rather than air-spaced doublets) eliminates an air gap and its associated axial, decenter, and tilt tolerances for each doublet. The patent explicitly cites "ease of assembly" as a motivation for using a cemented lens in Group III (¶0063).
+
+**Symmetric glass selection:** The mirror-image use of TAFD30 and E-FD8 in the two cemented doublets simplifies procurement and quality control — only five distinct glass types are needed for seven elements.
+
+**Compact total track:** The total track of 30.3 mm (L/f = 1.656) and lens thickness of 15.6 mm (D_T/f = 0.855) are among the most compact in the patent's examples. For a lens that must retract into a body only ~35 mm thick when powered off, minimizing the lens thickness is essential.
+
+---
+
+## 12. Summary of Key Findings
+
+The Ricoh GR 18.3mm f/2.8 is a 7-element, 5-group (4 functional groups) approximately-symmetric wide-angle design. Its defining characteristics are:
+
+1. **Two precision glass-molded aspherical elements** (L1 and L7) using HOYA's M-FCD1 and M-TAFD51 moldable glasses, positioned at the first and last elements where they have maximum leverage over field-dependent aberrations.
+
+2. **Very high refractive index positive elements** (nd = 1.883, HOYA TAFD30) flanking the aperture stop, enabling compact physical dimensions while maintaining strong positive power.
+
+3. **Anomalous partial dispersion** in L1 (M-FCD1, dPg,F = +0.032) for secondary spectrum correction, with system-level achromatic balancing achieved by distributing chromatic contributions across all seven elements — the five negative elements collectively offset the two strong positive elements (L4 and L5, both TAFD30).
+
+4. **Unit focusing** — the entire lens assembly translates for focusing, with no internal moving groups. This keeps the design mechanically simple and preserves aberration balance across the focus range.
+
+5. **Approximately-symmetric power distribution** about the aperture stop, with deliberate asymmetry (f₁₋₂/f₃₋₄ = 1.203) to optimize performance at the camera's working magnification. The weak fourth group (f₄ = −240 mm) serves primarily as an exit pupil controller and field flattener.
+
+---
+
+## 13. Semi-Diameter Estimation
+
+The patent does not list semi-diameters. Estimates were computed via paraxial ray tracing of both a marginal ray (at f/2.81 full aperture) and a chief ray at the maximum half-angle of view (ω = 38.2°), then validated against physical constraints.
+
+### Methodology
+
+The entrance pupil semi-diameter (EP_SD = EFL / 2F# = 3.26 mm) was traced through all surfaces to establish on-axis marginal ray heights. The chief ray was traced at several field fractions (0.5×, 0.7×, 0.85×, 1.0× full field) to model the off-axis beam envelope. Because a compact camera at f/2.8 with a wide field angle inevitably vignetted at the corners (consistent with production review observations of approximately 1–1.5 stops of vignetting at full field wide open), the beam envelope at 70% field was used as the primary sizing criterion for front and rear group elements, while elements near the stop were sized by the marginal ray with 5–8% mechanical clearance.
+
+### Binding Constraints
+
+Two constraints proved most restrictive:
+
+**Cemented junction edge thickness (L4 and L5):** The strongly curved cemented junctions at R₆ = 9.513 mm and R₁₀ = −9.087 mm create large sags that rapidly consume center thickness in the biconvex positive elements. L4 (ct = 2.34 mm) reaches minimum acceptable edge thickness (~0.55 mm) at SD ≈ 5.0 mm; L5 (ct = 2.59 mm) reaches ~0.51 mm at SD ≈ 4.7 mm. These constraints limit the doublet SDs to substantially less than the full beam envelope at those surfaces.
+
+**Cross-gap sag overlap (L1→L2 and L6→L7):** Both air gaps between Groups I–II and Groups III–IV feature surfaces that curve *into* the gap from both sides — creating a "pinching" geometry that limits the maximum SD at which the surfaces remain non-overlapping. The L1→L2 gap (1.79 mm) constrains the effective sdCheck to ~5.5 mm, while the L6→L7 gap (1.73 mm) constrains it to ~4.7 mm (both verified to satisfy intrusion ≤ gap × 1.1).
+
+### Final Semi-Diameter Values
+
+| Surface | SD (mm) | Constraint |
+|---------|---------|------------|
+| S01 (L1 front) | 7.50 | Wide-angle field acceptance |
+| S02A (L1 rear) | 6.50 | Cross-gap with S03 |
+| S03 (L2 front) | 5.50 | Cross-gap with S02A |
+| S04 (L2 rear) | 5.00 | Smooth progression toward doublet |
+| S05 (L3 front) | 5.00 | Edge thickness of L4 |
+| S06 (L3→L4 cement) | 5.00 | Matched to cemented pair |
+| S07 (L4 rear) | 5.00 | Matched to cemented pair |
+| STO | 3.55 | Gives F/2.80 at infinity |
+| S09 (L5 front) | 4.70 | Edge thickness of L5 |
+| S10 (L5→L6 cement) | 4.70 | Matched to cemented pair |
+| S11 (L6 rear) | 4.70 | Cross-gap with S12 |
+| S12 (L7 front) | 5.50 | Chief ray expansion after stop |
+| S13A (L7 rear) | 5.80 | Exit pupil geometry |
+
+All values validated: edge thickness ≥ 0.4 mm for all elements, cross-gap intrusion ≤ gap × 1.1 for all air gaps, sd/|R| < 0.55 for all surfaces. Front/rear SD ratios per element are all ≤ 1.23 (well within the 3.0 limit).
+
+These estimates are conservative. The actual production lens may have somewhat different clear apertures, particularly in the front group where the barrel design and filter thread constrain the physical element diameter. Renderer validation against the live ray trace may indicate adjustments needed, especially for the front group elements where vignetting behavior at the corners is sensitive to the chosen SDs.
+
+---
+
+## 14. Data File Transcription Notes
+
+### Cover Glass Handling
+
+The patent's parallel flat plate F (surfaces 14–15: nd = 1.51680, d = 1.40 mm glass + 0.50 mm air to image) is excluded from the data file's surface array. Its optical effect is folded into the last surface's thickness as the air-equivalent back focal distance:
+
+BFD_air-eq = 12.756 + 1.40/1.51680 + 0.50 = 14.179 mm
+
+where 12.756 mm is the patent's geometric distance from S13 to the filter front, 1.40/1.51680 = 0.923 mm is the air-equivalent thickness of the filter glass, and 0.50 mm is the air gap from filter rear to image plane.
+
+### Stop Position
+
+The patent lists the aperture stop as surface 08 (between surface 07 at R = −34.121 and surface 09 at R = 14.691). The air gap is split: d₇ = 1.50 mm from L4 rear to stop, d_STO = 1.00 mm from stop to L5 front. This placement is taken directly from the patent table.
+
+### Aspherical Coefficient Format
+
+The patent specifies coefficients up to 10th order (K, A4, A6, A8, A10) for both aspherical surfaces. The data file sets A12 and A14 to zero (required fields per the renderer spec). No higher-order terms (A16–A20) are needed.
+
+The conic constant convention matches the standard sag equation used by the renderer: K = 0 for a sphere, K = −1 for a paraboloid. The patent's "K" (labeled as conic constant in ¶0125) uses the same convention — verified by checking that the aspherical sag equation in the patent (¶0125) is algebraically identical to the renderer's sag equation.
+
+### Unit Focus Variable Gap
+
+Since the lens uses unit focusing, only the back focal distance changes with focus. The data file encodes this as a single variable gap on the last surface:
+
+- `var["13A"] = [14.179, 18.28]` — infinity and close focus (0.10 m macro MFD)
+- Close-focus BFD computed via thin-lens extension: Δ = f²/(s − f) = 18.30²/(100 − 18.30) = 4.10 mm
+- BFD_close = 14.179 + 4.10 = 18.28 mm
+
+The Ricoh GR's normal-mode MFD is 0.30 m (extension ~1.19 mm, BFD ~15.37 mm). The macro-mode MFD of 0.10 m is used as `closeFocusM` in the data file to represent the absolute minimum focus distance.
+
+### Numerical Precision
+
+All R, d, and nd values are transcribed exactly from the patent. The nd values for TAFD30 (1.88300) and E-FD8 (1.68893) appear at full five-decimal precision in the patent's glass column but are stored in the data file at the precision needed by the renderer: nd = 1.883 and nd = 1.68893 respectively. For elements where the glass appears at both positions in a symmetric pair (L4/L5 use TAFD30; L2/L6 use E-FD8), the same nd value is used consistently.

--- a/src/lens-data/RicohGR218mmf28.data.ts
+++ b/src/lens-data/RicohGR218mmf28.data.ts
@@ -1,0 +1,225 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — RICOH GR 18.3mm f/2.8                        ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2013/0321936 A1 Example 3 (Kazuyasu Ohashi).      ║
+ * ║  Approximately-symmetric wide-angle prime for APS-C compact.       ║
+ * ║  7 elements / 5 groups, 2 aspherical surfaces.                     ║
+ * ║  Focus: unit focusing (entire lens translates).                    ║
+ * ║                                                                    ║
+ * ║  Production: Ricoh GR (2013), Ricoh GR II (2015).                  ║
+ * ║  Patent filed May 31, 2013 · Priority JP 2012-127431 (Jun 4 2012) ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Not listed in patent. Estimated via combined marginal + chief   ║
+ * ║    ray envelope at 70% field, validated against edge thickness,    ║
+ * ║    cross-gap sag overlap, conic height, and rim-slope checks.      ║
+ * ║    Front group SDs accommodate wide-angle field; doublet SDs are   ║
+ * ║    limited by strongly curved cemented junctions.                  ║
+ * ║                                                                    ║
+ * ║  Cover glass: patent parallel flat plate F (nd=1.51680, d=1.40)   ║
+ * ║    with 0.50 mm air to image excluded; air-equivalent BFD folded  ║
+ * ║    into last surface d = 14.179 mm.                                ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "ricoh-gr-18p3-f2p8",
+  maker: "Ricoh",
+  name: "RICOH GR/GR2 18.3mm f/2.8",
+  subtitle: "US 2013/0321936 A1 EXAMPLE 3 — OHASHI",
+  specs: ["7 ELEMENTS / 5 GROUPS", "f ≈ 18.3 mm", "F/2.8", "2ω ≈ 76.4°", "2 ASPHERICAL SURFACES"],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: 18.3,
+  focalLengthDesign: 18.3,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.81,
+  patentYear: 2013,
+  elementCount: 7,
+  groupCount: 5,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.4971,
+      vd: 81.56,
+      fl: -27.97,
+      glass: "M-FCD1 (HOYA)",
+      apd: "inferred" as const,
+      apdNote: "dPgF ≈ +0.032 (strong positive APD); fluorophosphate crown, precision glass-molded",
+      role: "Front negative element — diverges incoming beam for wide-angle coverage; aspherical rear surface corrects astigmatism and distortion; anomalous dispersion for secondary spectrum correction",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.68893,
+      vd: 31.16,
+      fl: -30.54,
+      glass: "E-FD8 (HOYA)",
+      apd: "inferred" as const,
+      apdNote: "dPgF ≈ +0.008 (slight positive APD)",
+      role: "Front element of Group II — concave-to-object surface forms biconvex air lens with L1; chromatic counterbalance to L1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.84666,
+      vd: 23.78,
+      fl: -31.29,
+      glass: "FDS90 (HOYA)",
+      apd: "inferred" as const,
+      apdNote: "dPgF ≈ +0.015 (moderate positive APD); extremely high dispersion flint",
+      cemented: "D1",
+      role: "Negative element of pre-stop cemented doublet — high-dispersion flint provides chromatic correction within doublet",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 8.64,
+      glass: "TAFD30 (HOYA)",
+      apd: false,
+      cemented: "D1",
+      role: "Primary positive element of pre-stop doublet — very high index (nd=1.883) enables compact curvatures; flanks aperture with L5 in approximately-symmetric arrangement",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 6.7,
+      glass: "TAFD30 (HOYA)",
+      apd: false,
+      cemented: "D2",
+      role: "Primary positive element of post-stop doublet — mirrors L4 across the aperture in approximately-symmetric power distribution",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.68893,
+      vd: 31.16,
+      fl: -7.62,
+      glass: "E-FD8 (HOYA)",
+      apd: "inferred" as const,
+      apdNote: "dPgF ≈ +0.008 (slight positive APD); mirrors L2 glass in symmetric design",
+      cemented: "D2",
+      role: "Negative element of post-stop cemented doublet — mirrors L3 role across the aperture; concave rear surface forms biconvex air lens with L7",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.8208,
+      vd: 42.71,
+      fl: -240.0,
+      glass: "M-TAFD51 (HOYA)",
+      apd: false,
+      role: "Weak negative field flattener and exit pupil controller (Group IV) — aspherical rear surface controls chief ray angle at image plane for sensor microlens compatibility; precision glass-molded",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Group I (negative): L1 ──
+    { label: "1", R: 816.141, d: 0.8, nd: 1.4971, elemId: 1, sd: 7.0 }, // L1 front (nearly flat)
+    { label: "2A", R: 13.666, d: 1.79, nd: 1.0, elemId: 0, sd: 6.1 }, // L1 rear (asph) → air
+
+    // ── Group II (positive): L2 + cemented doublet L3+L4 ──
+    { label: "3", R: -23.543, d: 0.8, nd: 1.68893, elemId: 2, sd: 5.5 }, // L2 front
+    { label: "4", R: 200.425, d: 0.2, nd: 1.0, elemId: 0, sd: 5.0 }, // L2 rear → air
+    { label: "5", R: 15.416, d: 0.8, nd: 1.84666, elemId: 3, sd: 5.0 }, // L3 front
+    { label: "6", R: 9.513, d: 2.34, nd: 1.883, elemId: 4, sd: 5.0 }, // L3→L4 cement junction
+    { label: "7", R: -34.121, d: 1.5, nd: 1.0, elemId: 0, sd: 5.0 }, // L4 rear → air
+
+    // ── Aperture stop ──
+    { label: "STO", R: 1e15, d: 1.0, nd: 1.0, elemId: 0, sd: 3.55 }, // STO position from patent S08
+
+    // ── Group III (positive): cemented doublet L5+L6 ──
+    { label: "9", R: 14.691, d: 2.59, nd: 1.883, elemId: 5, sd: 4.7 }, // L5 front
+    { label: "10", R: -9.087, d: 0.89, nd: 1.68893, elemId: 6, sd: 4.7 }, // L5→L6 cement junction
+    { label: "11", R: 12.917, d: 1.73, nd: 1.0, elemId: 0, sd: 4.7 }, // L6 rear → air
+
+    // ── Group IV (weak negative): L7 ──
+    { label: "12", R: -12.419, d: 1.2, nd: 1.8208, elemId: 7, sd: 5.5 }, // L7 front
+    { label: "13A", R: -13.832, d: 14.179, nd: 1.0, elemId: 0, sd: 5.8 }, // L7 rear (asph) → air-eq BFD
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "2A": {
+      K: 3.80085,
+      A4: 1.07069e-4,
+      A6: -3.38949e-6,
+      A8: -2.19205e-7,
+      A10: -5.16455e-9,
+      A12: 0,
+      A14: 0,
+    },
+    "13A": {
+      K: -2.86234,
+      A4: 1.49055e-4,
+      A6: 4.18583e-6,
+      A8: 1.25343e-7,
+      A10: -7.88154e-10,
+      A12: 0,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (unit focus) ──
+   *  Unit focus: entire lens translates forward; only BFD changes.
+   *  BFD includes the folded sensor-cover path (12.756 + 1.40 / 1.51680 + 0.50 = 14.179 mm).
+   *  Extension at 0.10 m macro close focus: ≈ 4.10 mm (thin-lens estimate).
+   */
+  var: {
+    "13A": [14.179, 18.28],
+  },
+  varLabels: [["13A", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "I (neg)", fromSurface: "1", toSurface: "2A" },
+    { text: "II (pos)", fromSurface: "3", toSurface: "7" },
+    { text: "III (pos)", fromSurface: "9", toSurface: "11" },
+    { text: "IV (weak)", fromSurface: "12", toSurface: "13A" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "5", toSurface: "7" },
+    { text: "D2", fromSurface: "9", toSurface: "11" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.1,
+  focusDescription: "Unit focus — entire lens translates. MFD 0.30 m normal, 0.10 m macro mode.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.8,
+  apertureBlades: 9,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.55,
+  yScFill: 0.38,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/RicohGXRA1218mmf25.analysis.md
+++ b/src/lens-data/RicohGXRA1218mmf25.analysis.md
@@ -1,0 +1,270 @@
+# Ricoh GR LENS A12 28mm f/2.5 — Optical Analysis
+
+**Patent:** JP 2012-003015 A (filed 2010-06-16, published 2012-01-05)
+**Inventor:** Takashi Kubota (窪田 高士), Ricoh Co., Ltd.
+**Example analyzed:** Example 3 (実施例３), Figure 5
+**Design focal length:** 18.3 mm (28 mm equiv. on APS-C)
+**Design f-number:** f/2.56
+
+---
+
+## 1. Overview and Production Context
+
+The Ricoh GR LENS A12 28mm f/2.5 is a wide-angle prime module for the Ricoh GXR interchangeable-unit camera system, released at Photokina in September 2010. It pairs an 18.3 mm f/2.5 lens with a 23.6 × 15.7 mm (APS-C) CMOS sensor in a sealed, dust-free unit. The production module features a 40.5 mm filter thread, a minimum focus distance of approximately 20 cm from the front element, and a floating-focus lens structure.
+
+Patent JP 2012-003015 A presents seven numerical examples of a positive–positive two-group imaging lens design. All share the same fundamental architecture: a positive first group and a positive second group separated by an aperture stop, with floating focus achieved by advancing both groups toward the object at different rates.
+
+**Production specification versus Example 3:** Ricoh's published specifications describe a 9-element, 6-group design with "2 aspherical lens elements with 2 surfaces," whereas Example 3 is an 8-element, 6-group design with 2 aspherical elements bearing 3 aspherical surfaces (both surfaces of L1 plus the rear surface of L8). Example 1 from the same patent — a 9-element, 6-group design with exactly 2 aspherical surfaces — is a closer match to the published element/group count and aspherical surface count. The production lens is likely a refinement whose overall topology more closely follows Example 1 or a hybrid of the two. Nevertheless, Example 3 is among the closest designs in the patent family and shares all the fundamental architectural and focusing principles of the production lens.
+
+---
+
+## 2. Lens Architecture
+
+Example 3 is a 2-group, 8-element design arranged in 6 air-separated groups. The prescription was verified computationally via paraxial ray trace in the (y, nu) convention, yielding an EFL of 18.28 mm (within 0.1% of the patent's stated 18.3 mm).
+
+### Group and Element Layout
+
+| Position | Element(s) | Air-Separated Group | Description |
+|----------|-----------|---------------------|-------------|
+| Front | L1 | Group A | Negative meniscus, 2× aspherical |
+| | L2 | Group B | Positive meniscus, convex to object |
+| | L3 + L4 | Group C | Cemented doublet (neg + pos) |
+| *Stop* | — | — | Aperture diaphragm |
+| | L5 + L6 | Group D | Cemented doublet (pos + neg) |
+| | L7 | Group E | Negative meniscus |
+| Rear | L8 | Group F | Biconvex positive, 1× aspherical |
+
+The overall topology is a modified double-Gauss variant adapted for a wide-angle, positive-leading design. Rather than the classic negative-leading retrofocus architecture used in most wide-angle SLR lenses, this design places positive power first, which yields a compact total track (≈ 1.7× the sensor diagonal at infinity focus, per the patent text) at the cost of somewhat greater difficulty in correcting distortion and field curvature. The positive–positive power split also enables a near-telecentric exit pupil, well-suited to the large APS-C sensor.
+
+### Key Computed Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Effective focal length (EFL) | 18.28 mm |
+| Back focal distance (BFD, to cover glass front) | 14.26 mm (infinity) |
+| Half-field angle (ω) | 37.8° |
+| Full field of view (2ω) | 75.6° |
+| 35 mm equivalent focal length | 27.9 mm |
+| Petzval sum | 0.00700 mm⁻¹ |
+| Petzval radius | 142.9 mm |
+| Total optical track (surface 1 to image) | 50.4 mm |
+| Minimum focus distance | 200 mm (patent design value) |
+| Group 1 focal length | +240.2 mm |
+| Group 2 focal length | +23.4 mm |
+
+---
+
+## 3. Element-by-Element Analysis
+
+All individual element focal lengths below are thick-lens values computed in-air (standalone), which is the standard reporting convention. Cemented doublet focal lengths are computed as complete air-to-air subsystems using ABCD matrix trace. Within the cemented groups, each element's optical contribution differs from its standalone value due to the higher-index surrounding medium; these contextual values are noted where relevant.
+
+### L1 — Negative Meniscus with Two Aspherical Surfaces
+
+| Property | Value |
+|----------|-------|
+| Surfaces | 1\* (front, R = +23.77) / 2\* (rear, R = +9.53) |
+| Thickness | 1.1 mm |
+| nd / νd | 1.5163 / 64.1 |
+| Glass match | S-BSL7 (OHARA) or N-BK7 (SCHOTT) |
+| Focal length | −31.6 mm |
+
+L1 is the most optically distinctive element in the design. It is the lowest-dispersion element in this prescription (νd = 64.1), and it carries aspherical correction on both surfaces — a highly unusual choice for a front element in a compact wide-angle lens. Its glass is a standard borosilicate crown (BK7 family), selected here for its low dispersion and excellent moldability. This element is almost certainly produced by precision glass molding (PGM).
+
+As a negative meniscus with its convex side toward the object, L1 acts as a field-flattening element for the incoming wide-angle beam. Its negative power diverges the marginal ray bundle before it enters the high-power positive elements behind it, distributing the refraction across more surfaces and reducing the load on any single element.
+
+**Front surface (surface 1\*):** K = −6.163 (strong hyperboloid in standard convention). The aspherical departure reaches +230 µm at h = 8.5 mm relative to the best-fit sphere. The complex profile controls both spherical aberration contribution and the refraction angle of wide-angle off-axis bundles entering the lens.
+
+**Rear surface (surface 2\*):** K = −0.812 (prolate ellipsoid, approaching paraboloidal). This surface carries the most dramatic aspherical departure in the design: −796 µm at h = 7.5 mm. This strong flattening reduces the divergence of the marginal ray exiting L1 at large heights, directly controlling spherical aberration and coma. The departure profile through A18 (eight polynomial terms) provides extremely fine control over the wide-angle beam geometry.
+
+### L2 — Positive Meniscus
+
+| Property | Value |
+|----------|-------|
+| Surfaces | 3 (front, R = +32.35) / 4 (rear, R = +133.80) |
+| Thickness | 1.7 mm |
+| nd / νd | 1.8830 / 40.8 |
+| Glass match | S-LAH58 (OHARA) or N-LASF45HT (SCHOTT) |
+| Focal length | +47.9 mm |
+
+L2 is a positive meniscus with its convex surface toward the object. It is the primary positive-power element of Group 1, using a high-index lanthanum glass (nd = 1.883) to provide strong convergence with relatively gentle surface curvatures.
+
+L2 works in partnership with L1: the negative power of L1 partially pre-corrects the beam before L2 converges it. The patent's Condition (2) governs the focal-length ratio between L1 and L2, requiring −1.0 < f_L1/f_L2 < −0.1. The computed ratio is −0.66, indicating that L1 has about two-thirds the absolute power of L2.
+
+### L3 + L4 — Cemented Doublet (Group 1 Rear)
+
+| Property | L3 (front element) | L4 (rear element) |
+|----------|--------------------|--------------------|
+| Surfaces | 5 (R = −17.05) | 6 (junction, R = +17.77) / 7 (R = −29.70) |
+| Thickness | 0.9 mm | 3.0 mm |
+| nd / νd | 1.6200 / 36.3 | 1.8830 / 40.8 |
+| Glass match | S-TIM2 (OHARA) / N-F2 (SCHOTT) | S-LAH58 (OHARA) |
+| Individual focal length (standalone) | −13.9 mm | +13.0 mm |
+| **Doublet focal length** | **+99.3 mm** | |
+
+This cemented doublet is the achromatic corrector for Group 1. L3 is a biconcave negative element in a moderate-dispersion flint glass, while L4 is a biconvex positive element in the same high-index lanthanum crown used by L2. The combination provides weak net positive power (+99.3 mm focal length) while strongly correcting axial chromatic aberration.
+
+The cemented interface at R = +17.77 is convex toward the image and nearly symmetric with L5's front surface (R = +22.92) across the stop. This near-symmetry, cited by the patent as the basis for Claim 8, is crucial for suppressing lateral chromatic aberration, coma, and distortion.
+
+The doublet focal-length ratio between this doublet and the Group 2 front doublet (L5+L6) is governed by Condition (3): 2.0 < f₁c/f₂c < 7.9. The computed value is 3.49, indicating that the Group 1 doublet is substantially weaker than the Group 2 doublet.
+
+### Aperture Stop
+
+The stop is positioned between Group 1 and Group 2, in the air gap between L4 (rear surface 7) and L5 (front surface 9). At infinity focus, this gap is split as 2.2 mm (L4 rear to stop) + 5.58 mm (stop to L5 front) = 7.78 mm total. The surfaces flanking the stop — L4 rear (R = −29.70, convex toward image) and L5 front (R = +22.92, convex toward object) — are both convex toward the stop, creating the quasi-symmetric configuration described in Claim 8.
+
+### L5 + L6 — Cemented Doublet (Group 2 Front)
+
+| Property | L5 (front element) | L6 (rear element) |
+|----------|--------------------|--------------------|
+| Surfaces | 9 (R = +22.92) | 10 (junction, R = −11.87) / 11 (R = +30.47) |
+| Thickness | 4.2 mm | 0.8 mm |
+| nd / νd | 1.8830 / 40.8 | 1.6727 / 32.2 |
+| Glass match | S-LAH58 (OHARA) | S-TIF6 (OHARA) / N-SF5 (SCHOTT) |
+| Individual focal length (standalone) | +9.4 mm | −12.6 mm |
+| **Doublet focal length** | **+28.5 mm** | |
+
+This is the primary power-generating doublet of the entire system. L5 is a thick (4.2 mm) biconvex element — note that its standalone focal length of +9.4 mm makes it by far the strongest individual positive element when measured in air. Within the cemented group, its effective contribution is moderated by the high-index L6 glass (nd = 1.673) on its image side, which reduces the refraction at the junction compared to an air interface. L6 is a thin biconcave negative element providing chromatic correction.
+
+The patent's Condition (4) governs the glass-dispersion balance between the Group 1 and Group 2 cemented doublets. The computed value of 0.78 falls within the required range of 0.7–1.6.
+
+### L7 — Negative Meniscus
+
+| Property | Value |
+|----------|-------|
+| Surfaces | 12 (front, R = −15.38) / 13 (rear, R = −129.05) |
+| Thickness | 0.8 mm |
+| nd / νd | 1.8467 / 23.9 |
+| Glass match | S-TIH53 (OHARA) or N-SF57 (SCHOTT) |
+| Focal length | −20.7 mm |
+
+L7 is the most strongly dispersive element in the design (νd = 23.9), a dense flint glass with very high refractive index (nd = 1.847). It is a thin negative meniscus with its concave side toward the object. Its role is threefold: field flattener (pulling the Petzval sum toward zero), chromatic lever (extreme dispersion provides strong chromatic correction leverage with minimal power), and telephoto spacer (negative element between L5+L6 and L8 shortens the back focal distance).
+
+The separation between L7 and L8 is extremely thin (0.1 mm), suggesting they function almost as a compound doublet, though they are not cemented.
+
+### L8 — Biconvex Positive with One Aspherical Surface
+
+| Property | Value |
+|----------|-------|
+| Surfaces | 14 (front, R = +72.46) / 15\* (rear, R = −16.82) |
+| Thickness | 3.8 mm |
+| nd / νd | 1.8014 / 45.4 |
+| Glass match | S-LAH65V (OHARA) or N-LAF34 (SCHOTT) |
+| Focal length | +17.4 mm |
+
+L8 is the final optical element and the strongest individual positive element at its system position (f = +17.4 mm standalone). It is a biconvex lens with a relatively weak front surface (R = +72.46) and a strongly curved aspherical rear surface.
+
+**Rear surface (surface 15\*):** K = −0.542 (prolate ellipsoid) with significant positive polynomial departure (+260 µm at h = 6.5 mm). As the last refracting surface, it has maximum leverage over field-dependent aberrations — particularly astigmatism and field curvature at the edge of the APS-C frame.
+
+---
+
+## 4. Aspherical Surface Summary
+
+Example 3 uses three aspherical surfaces on two elements. The patent's sag formula uses the coefficient `k` in the position of `(1+K)` in the standard ISO sag equation. Therefore, K_standard = k_patent − 1. The polynomial coefficients transfer directly.
+
+| Surface | R (mm) | k (patent) | K (standard) | Shape | Dominant departure |
+|---------|--------|------------|-------------|-------|-------------------|
+| 1\* (L1 front) | +23.77 | −5.163 | −6.163 | Strong hyperboloid | +230 µm at h=8.5 mm |
+| 2\* (L1 rear) | +9.53 | +0.188 | −0.812 | Prolate ellipsoid | −796 µm at h=7.5 mm |
+| 15\* (L8 rear) | −16.82 | +0.458 | −0.542 | Prolate ellipsoid | +260 µm at h=6.5 mm |
+
+Surface 2\* specifies polynomial terms through A18, providing extremely fine control over the wide-angle beam at the rear of L1. Surfaces 1\* and 15\* use terms through A12.
+
+---
+
+## 5. Glass Selection and Material Strategy
+
+The design uses a deliberate material palette organized around two principles: high-index lanthanum glasses for the positive power elements, and moderate-to-high-dispersion flint glasses for the negative elements.
+
+| Element | nd | νd | Glass Type | Glass Code | Role |
+|---------|------|------|-----------|------------|------|
+| L1 | 1.5163 | 64.1 | Borosilicate crown | 516.641 | Low-dispersion aspherical corrector |
+| L2 | 1.8830 | 40.8 | Lanthanum crown | 883.408 | High-index positive power |
+| L3 | 1.6200 | 36.3 | Light flint | 620.363 | Chromatic corrector (neg.) |
+| L4 | 1.8830 | 40.8 | Lanthanum crown | 883.408 | Achromat positive element |
+| L5 | 1.8830 | 40.8 | Lanthanum crown | 883.408 | Primary positive power |
+| L6 | 1.6727 | 32.2 | Dense flint | 673.322 | Chromatic corrector (neg.) |
+| L7 | 1.8467 | 23.9 | Dense flint | 847.239 | Field flattener, chromatic lever |
+| L8 | 1.8014 | 45.4 | Lanthanum crown | 801.454 | Rear positive, aspherical corrector |
+
+Three elements (L2, L4, L5) share the identical glass — nd = 1.8830, νd = 40.8 — corresponding to OHARA S-LAH58 or equivalent. This simplifies procurement and manufacturing.
+
+L7's extreme dispersion (νd = 23.9) marks it as a dense flint, likely OHARA S-TIH53 or SCHOTT N-SF57. Despite its thin profile (0.8 mm center thickness), its high dispersion gives it disproportionate chromatic correction leverage.
+
+No anomalous partial dispersion (APD) glasses are used in this design.
+
+**A note on the "special low-dispersion lens" marketing claim:** Ricoh's marketing describes "one special low-dispersion lens." In Example 3, L1 (νd = 64.1, N-BK7/S-BSL7 type) is the lowest-dispersion element, but BK7 is not typically considered "special" by industry standards — that term usually denotes ED glass with νd > 80. Notably, Examples 4 and 5 in the same patent include elements with νd = 81.5 (likely S-FPL51 or equivalent fluorite crown), which would unambiguously qualify. The production design may incorporate glass selections from other examples in the patent family.
+
+---
+
+## 6. Focusing Mechanism
+
+The lens focuses by advancing both groups independently toward the object, with Group 1 moving farther than Group 2. This is the "floating focus" system described in the patent claims.
+
+| Parameter | Infinity | Close (200 mm) | Change |
+|-----------|---------|----------------|--------|
+| D1 (inter-group gap, stop to L5) | 5.58 mm | 5.06 mm | −0.52 mm |
+| D2 (BFD to cover glass front) | 14.26 mm | 15.92 mm | +1.66 mm |
+| Group 1 extension | — | — | 2.18 mm |
+| Group 2 extension | — | — | 1.66 mm |
+| Extension ratio (G1/G2) | — | — | 1.31× |
+
+The differential extension ratio of 1.31:1 is governed by Condition (7), which limits the log of the extension ratio to between −15 and −0.05. The computed value of −0.50 places this design comfortably mid-range.
+
+The floating focus system provides two key optical benefits: it corrects for the change in aberration balance that occurs at finite conjugates, and it allows the close-focus distance to be quite short (200 mm) while maintaining excellent correction.
+
+**Data file note:** The BFD values in the data file include the air-equivalent contribution of the cover glass (2.5 mm, nd = 1.5168), yielding air-equivalent BFDs of 15.91 mm (infinity) and 17.57 mm (close focus). The variable gap on the STO surface carries the inter-group spacing change.
+
+---
+
+## 7. Aberration Correction Strategy
+
+The Petzval sum of 0.00700 mm⁻¹ corresponds to a Petzval radius of 142.9 mm — approximately 5× the image diagonal. This is a well-corrected value for a wide-angle lens.
+
+**Spherical aberration** is controlled primarily by the aspherical surfaces on L1, which pre-shape the beam entering the high-power positive elements. The high refractive indices of L2, L4, and L5 (all nd = 1.883) further reduce spherical aberration by minimizing surface curvatures for a given power.
+
+**Axial chromatic aberration** is corrected by the two cemented doublets (L3+L4 and L5+L6), which bracket the aperture stop. L7's extreme dispersion provides additional fine-tuning.
+
+**Lateral chromatic aberration** is suppressed by the quasi-symmetric placement of the cemented doublets around the stop.
+
+**Astigmatism and field curvature** are managed by the distributed negative elements (especially L7 as a field flattener) and by the aspherical rear surface of L8.
+
+**Distortion** is controlled by the positive-leading architecture combined with the near-symmetric doublet placement. The patent claims distortion below 2.0% in absolute value.
+
+**Coma** is controlled by the differential bending of the cemented doublets and by the aspherical profile on L1's rear surface.
+
+---
+
+## 8. Conditional Expression Verification
+
+All seven patent conditional expressions were verified computationally for Example 3:
+
+| Condition | Expression | Required Range | Computed | Patent Stated | Status |
+|-----------|-----------|---------------|----------|---------------|--------|
+| (1) | d₁₂₋₃ / d₁₁₋₂ | 0.0 – 1.0 | 0.347 | 0.36 | ✓ |
+| (2) | f₁₁ / f₁₂ | −1.0 – −0.1 | −0.660 | −0.66 | ✓ |
+| (3) | f₁c / f₂c | 2.0 – 7.9 | 3.486 | 3.48 | ✓ |
+| (4) | (Nd₄·νd₄−Nd₃·νd₃)/(Nd₅·νd₅−Nd₆·νd₆) | 0.7 – 1.6 | 0.785 | 0.78 | ✓ |
+| (5) | \|R₁₁ / R₂e\| | 0.4 – 2.1 | 1.413 | 1.41 | ✓ |
+| (6) | \|R₁e / R₂₁\| | 1.2 – 2.6 | 1.296 | 1.30 | ✓ |
+| (7) | Log\|(D1∞−D1c)/(D2∞−D2c)\| | −15 – −0.05 | −0.504 | −0.50 | ✓ |
+
+The close agreement between computed and patent-stated values (all within rounding tolerance) confirms the accuracy of the prescription transcription.
+
+---
+
+## 9. Semi-Diameter Estimation
+
+The patent does not list semi-diameters. Values were estimated via combined marginal-ray and chief-ray paraxial trace at f/2.56 with a 37.8° half-field angle (APS-C sensor diagonal of 28.3 mm). The entrance pupil semi-diameter is 3.57 mm, located 10.1 mm behind surface 1.
+
+Marginal ray heights provide the on-axis beam size at each surface. Chief ray heights at 70% of the full field angle were used as the off-axis contribution, with 5–10% mechanical clearance added. The resulting estimates were validated against physical constraints: edge thickness > 0.3 mm for all elements, cross-gap sag intrusion < 1.1× the air gap, and sd/|R| < 0.90 for spherical surfaces. All constraints pass with the assigned values.
+
+The L2→L3 air gap (1.7 mm) and L4 edge thickness (0.38 mm at sd = 7.5) were the binding constraints that limited the doublet-region semi-diameters.
+
+---
+
+## 10. Design Philosophy and Context
+
+This lens represents Ricoh's approach to a difficult optical problem: designing a fast (f/2.5), wide-angle (28 mm equiv.), compact prime for a large (APS-C) sensor, with close-focus capability down to 20 cm, while maintaining image quality across the entire field that justifies the "GR LENS" designation.
+
+The positive-leading two-group architecture is a departure from the more common retrofocus design. Since the GXR module has no mirror, the designer was free to use the more optically efficient positive-first layout, which yields shorter total track and better distortion characteristics.
+
+The use of only 8 elements (or 9 in production) to achieve f/2.5 at 28 mm equivalent with APS-C coverage is remarkably efficient. This economy is enabled by three key design choices: the double-aspherical front element (L1), the high-index lanthanum glasses (nd ≈ 1.88) used throughout, and the floating focus system. The resulting lens achieves a total optical track of approximately 50 mm (≈ 1.77× the sensor diagonal).

--- a/src/lens-data/RicohGXRA1218mmf25.data.ts
+++ b/src/lens-data/RicohGXRA1218mmf25.data.ts
@@ -1,0 +1,261 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — RICOH GR LENS A12 28mm f/2.5                 ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: JP 2012-003015 A, Example 3 (Kubota / Ricoh).       ║
+ * ║  Positive–positive two-group wide-angle prime for APS-C sensor.   ║
+ * ║  8 elements / 6 groups, 3 aspherical surfaces on 2 elements.      ║
+ * ║  Focus: Floating — both groups advance independently.             ║
+ * ║                                                                    ║
+ * ║  NOTE ON PRODUCTION LENS:                                          ║
+ * ║    Production GR LENS A12 28mm is 9 elements / 6 groups with      ║
+ * ║    2 aspherical lenses bearing 2 aspherical surfaces. Example 3   ║
+ * ║    is 8 elements / 6 groups with 3 aspherical surfaces. The       ║
+ * ║    production design is likely a refinement blending features      ║
+ * ║    from multiple examples in the patent family.                    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    SDs estimated via marginal + chief ray paraxial trace with     ║
+ * ║    5–10% mechanical clearance, subject to edge-thickness and      ║
+ * ║    cross-gap sag intrusion constraints. Not patent-listed.        ║
+ * ║                                                                    ║
+ * ║  NOTE ON COVER GLASS:                                              ║
+ * ║    Patent surfaces 16–17 are a 2.5 mm cover glass (nd = 1.5168). ║
+ * ║    Air-equivalent BFD folded into last surface d value.           ║
+ * ║    Air-equiv offset = 2.5 / 1.5168 = 1.648 mm.                   ║
+ * ║                                                                    ║
+ * ║  CONIC CONSTANT CONVENTION:                                        ║
+ * ║    Patent sag uses k in place of (1+K). K_standard = k_patent − 1.║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "ricoh-gxr-a12-18f25",
+  maker: "Ricoh",
+  name: "RICOH GR LENS A12 28mm f/2.5",
+  subtitle: "JP 2012-003015 A EXAMPLE 3 — KUBOTA / RICOH",
+  specs: ["8 ELEMENTS / 6 GROUPS", "f = 18.28 mm (28 mm equiv.)", "F/2.56", "2ω ≈ 75.6°", "3 ASPHERICAL SURFACES"],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: 18.3,
+  focalLengthDesign: 18.28,
+  apertureMarketing: 2.5,
+  apertureDesign: 2.56,
+  patentYear: 2012,
+  elementCount: 8,
+  groupCount: 6,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Neg. Meniscus (2× Asph)",
+      nd: 1.5163,
+      vd: 64.1,
+      fl: -31.6,
+      glass: "S-BSL7 (OHARA) / N-BK7 (SCHOTT)",
+      apd: false,
+      role: "Wide-angle field-flattening corrector; both surfaces aspherical. PGM candidate.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.883,
+      vd: 40.8,
+      fl: +47.9,
+      glass: "S-LAH58 (OHARA)",
+      apd: false,
+      role: "Primary positive power, Group 1. High-index lanthanum crown.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconcave Negative",
+      nd: 1.62,
+      vd: 36.3,
+      fl: -13.9,
+      glass: "S-TIM2 (OHARA) / N-F2 (SCHOTT)",
+      apd: false,
+      cemented: "D1",
+      role: "Chromatic corrector in Group 1 rear doublet.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.8,
+      fl: +13.0,
+      glass: "S-LAH58 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "Achromatic positive element in Group 1 rear doublet.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.8,
+      fl: +9.4,
+      glass: "S-LAH58 (OHARA)",
+      apd: false,
+      cemented: "D2",
+      role: "Primary power-generating element. Thick positive biconvex in Group 2 front doublet.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.6727,
+      vd: 32.2,
+      fl: -12.6,
+      glass: "S-TIF6 (OHARA) / N-SF5 (SCHOTT)",
+      apd: false,
+      cemented: "D2",
+      role: "Chromatic corrector in Group 2 front doublet.",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.8467,
+      vd: 23.9,
+      fl: -20.7,
+      glass: "S-TIH53 (OHARA) / N-SF57 (SCHOTT)",
+      apd: false,
+      role: "Dense flint field flattener and chromatic lever. Highest dispersion in system.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconvex Positive (1× Asph)",
+      nd: 1.8014,
+      vd: 45.4,
+      fl: +17.4,
+      glass: "S-LAH65V (OHARA) / N-LAF34 (SCHOTT)",
+      apd: false,
+      role: "Strongest individual positive element. Rear asphere controls field-dependent aberrations.",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Group 1: L1 (Group A) ──
+    { label: "1A", R: 23.77, d: 1.1, nd: 1.5163, elemId: 1, sd: 9.5 }, // L1 front (asph)
+    { label: "2A", R: 9.53, d: 4.9, nd: 1.0, elemId: 0, sd: 8.0 }, // L1 rear (asph) → air
+
+    // ── Group 1: L2 (Group B) ──
+    { label: "3", R: 32.35, d: 1.7, nd: 1.883, elemId: 2, sd: 9.5 }, // L2 front
+    { label: "4", R: 133.8, d: 1.7, nd: 1.0, elemId: 0, sd: 8.0 }, // L2 rear → air
+
+    // ── Group 1: L3 + L4 cemented doublet (Group C) ──
+    { label: "5", R: -17.05, d: 0.9, nd: 1.62, elemId: 3, sd: 7.0 }, // L3 front
+    { label: "6", R: 17.77, d: 3.0, nd: 1.883, elemId: 4, sd: 7.5 }, // L3→L4 junction
+    { label: "7", R: -29.7, d: 2.2, nd: 1.0, elemId: 0, sd: 7.5 }, // L4 rear → air
+
+    // ── Aperture stop ──
+    { label: "STO", R: 1e15, d: 5.58, nd: 1.0, elemId: 0, sd: 4.4 }, // Stop (d = D1 at infinity)
+
+    // ── Group 2: L5 + L6 cemented doublet (Group D) ──
+    { label: "9", R: 22.92, d: 4.2, nd: 1.883, elemId: 5, sd: 7.0 }, // L5 front
+    { label: "10", R: -11.87, d: 0.8, nd: 1.6727, elemId: 6, sd: 6.5 }, // L5→L6 junction
+    { label: "11", R: 30.47, d: 2.9, nd: 1.0, elemId: 0, sd: 6.5 }, // L6 rear → air
+
+    // ── Group 2: L7 (Group E) ──
+    { label: "12", R: -15.38, d: 0.8, nd: 1.8467, elemId: 7, sd: 6.0 }, // L7 front
+    { label: "13", R: -129.05, d: 0.1, nd: 1.0, elemId: 0, sd: 6.0 }, // L7 rear → air
+
+    // ── Group 2: L8 (Group F) ──
+    { label: "14", R: 72.46, d: 3.8, nd: 1.8014, elemId: 8, sd: 6.5 }, // L8 front
+    { label: "15A", R: -16.82, d: 15.91, nd: 1.0, elemId: 0, sd: 7.0 }, // L8 rear (asph) → air (BFD)
+  ],
+
+  /* ── Aspherical coefficients ──
+   *  Patent conic convention: k_patent occupies (1+K) position.
+   *  K_standard = k_patent − 1 applied below.
+   */
+  asph: {
+    "1A": {
+      K: -6.163,
+      A4: 1.99e-4,
+      A6: -3.715e-6,
+      A8: 5.008e-8,
+      A10: -3.466e-10,
+      A12: 1.083e-12,
+      A14: 0,
+    },
+    "2A": {
+      K: -0.812,
+      A4: 1.317e-4,
+      A6: -5.317e-6,
+      A8: 6.213e-8,
+      A10: -6.522e-10,
+      A12: 1.333e-12,
+      A14: 1.496e-13,
+      A16: -3.28e-15,
+      A18: 1.898e-17,
+    },
+    "15A": {
+      K: -0.5418,
+      A4: 1.119e-4,
+      A6: 2.677e-7,
+      A8: 6.947e-9,
+      A10: -9.656e-11,
+      A12: 4.708e-13,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (floating focus) ──
+   *  Both groups advance toward object independently.
+   *  Group 1 extends 2.18 mm, Group 2 extends 1.66 mm at 200 mm focus.
+   *  D1 (inter-group gap) = STO surface d.
+   *  D2 (BFD) = S15A d, with cover glass folded as air-equivalent.
+   */
+  var: {
+    STO: [5.58, 5.06],
+    "15A": [15.91, 17.57],
+  },
+  varLabels: [
+    ["STO", "D1"],
+    ["15A", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "GROUP 1", fromSurface: "1A", toSurface: "7" },
+    { text: "GROUP 2", fromSurface: "9", toSurface: "15A" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "5", toSurface: "7" },
+    { text: "D2", fromSurface: "9", toSurface: "11" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.2,
+  focusDescription: "Floating focus — both groups advance independently toward the object at different rates.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.5,
+  fstopSeries: [2.5, 2.8, 4, 5.6, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.55,
+  yScFill: 0.45,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -19,6 +19,17 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-04-21 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-04-21",
+    type: "fix",
+    summary: "Fixed Canon RF 24-105mm f/4 L close-focus behavior",
+  },
+  {
+    date: "2026-04-21",
+    type: "lens",
+    summary: "Added Canon RF 24-105mm f/4 L, Nikon Z 40mm f/2, and two Ricoh GR lenses",
+  },
   // ── 2026-04-20 ──────────────────────────────────────────────────────────
   {
     date: "2026-04-20",


### PR DESCRIPTION
## Summary

Adds four catalog lenses with analysis writeups:

- Canon RF 24-105mm f/4 L IS USM
- Nikon Nikkor Z 40mm f/2
- Ricoh GR/GR II 18.3mm f/2.8
- Ricoh GR Lens A12 28mm f/2.5

Also updates the Canon RF 24-105 focus model so its L4 inner-focus group actively moves at close focus. The patent publishes infinity zoom spacings only, so the close-focus D27/D29 endpoints are estimated from Canon's 0.45 m MFD while preserving the L3-to-L5 envelope. The homepage changelog now lists the new lenses and the focus fix.

## Why

The branch added the new lens data, but the Canon RF 24-105 focus gaps were still encoded as identical infinity/close pairs. That made the focus slider display close distances without changing the optical prescription. The new model gives the renderer nonzero close-focus convergence at wide, mid, and tele positions.

## Validation

- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test -- __tests__/canonRF24105Focus.test.ts`
- `npm run test`