### PR TITLE
Add SVG illustrations for pupil-series diagrams

### DIFF
--- a/public/diagrams/pupils/entrance-pupil.svg
+++ b/public/diagrams/pupils/entrance-pupil.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 360" role="img" aria-labelledby="t d">
+  <title id="t">Entrance pupil as virtual image of the aperture stop</title>
+  <desc id="d">Cross section with front group, iris stop, and a magnified virtual entrance pupil with dashed construction rays.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#334155"/>
+    </marker>
+  </defs>
+  <rect width="900" height="360" fill="#f8fafc"/>
+  <line x1="40" y1="180" x2="860" y2="180" stroke="#94a3b8" stroke-width="2" stroke-dasharray="7 5"/>
+
+  <path d="M160,105 Q198,180 160,255 Q245,255 275,180 Q245,105 160,105Z" fill="#cbd5e1" stroke="#64748b" stroke-width="2"/>
+  <path d="M275,95 Q315,180 275,265 Q360,265 390,180 Q360,95 275,95Z" fill="#e2e8f0" stroke="#64748b" stroke-width="2"/>
+
+  <rect x="485" y="120" width="10" height="120" fill="#475569"/>
+  <rect x="495" y="148" width="18" height="64" fill="#0f172a"/>
+  <rect x="513" y="120" width="10" height="120" fill="#475569"/>
+
+  <ellipse cx="360" cy="180" rx="40" ry="54" fill="none" stroke="#2563eb" stroke-width="3" stroke-dasharray="8 6"/>
+
+  <line x1="504" y1="148" x2="330" y2="126" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="7 5"/>
+  <line x1="504" y1="212" x2="330" y2="234" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="7 5"/>
+
+  <text x="165" y="80" font-size="21" fill="#0f172a" font-family="Arial, sans-serif">Front group</text>
+  <line x1="248" y1="88" x2="255" y2="110" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <text x="530" y="95" font-size="21" fill="#0f172a" font-family="Arial, sans-serif">Aperture stop (iris)</text>
+  <line x1="620" y1="100" x2="522" y2="130" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <text x="72" y="322" font-size="20" fill="#1d4ed8" font-family="Arial, sans-serif">Entrance pupil (virtual image of stop)</text>
+  <line x1="310" y1="309" x2="345" y2="236" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arrow)"/>
+</svg>

--- a/public/diagrams/pupils/exit-pupil-cra.svg
+++ b/public/diagrams/pupils/exit-pupil-cra.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img" aria-labelledby="t d">
+  <title id="t">Exit pupil and chief-ray angle at center and corner pixels</title>
+  <desc id="d">Diagram with exit pupil, image plane, on-axis chief ray, and off-axis chief ray with CRA and labeled distances.</desc>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/>
+    </marker>
+  </defs>
+  <rect width="920" height="360" fill="#f8fafc"/>
+  <line x1="60" y1="180" x2="870" y2="180" stroke="#94a3b8" stroke-width="2" stroke-dasharray="7 5"/>
+
+  <ellipse cx="340" cy="180" rx="26" ry="74" fill="none" stroke="#2563eb" stroke-width="3"/>
+  <text x="288" y="95" font-size="20" fill="#1e3a8a" font-family="Arial, sans-serif">Exit pupil</text>
+
+  <line x1="750" y1="60" x2="750" y2="300" stroke="#334155" stroke-width="4"/>
+  <text x="702" y="48" font-size="19" fill="#0f172a" font-family="Arial, sans-serif">Image plane</text>
+
+  <circle cx="750" cy="180" r="7" fill="#0ea5e9"/>
+  <circle cx="750" cy="110" r="7" fill="#0ea5e9"/>
+  <path d="M734 96 q16 8 0 16" fill="none" stroke="#94a3b8" stroke-width="2"/>
+  <path d="M734 166 q16 8 0 16" fill="none" stroke="#94a3b8" stroke-width="2"/>
+
+  <line x1="340" y1="180" x2="750" y2="180" stroke="#16a34a" stroke-width="3" marker-end="url(#a)"/>
+  <text x="500" y="170" font-size="17" fill="#166534" font-family="Arial, sans-serif">Chief ray to on-axis pixel (CRA = 0°)</text>
+
+  <line x1="340" y1="180" x2="750" y2="110" stroke="#dc2626" stroke-width="3" marker-end="url(#a)"/>
+  <path d="M708 178 A52 52 0 0 1 706 124" fill="none" stroke="#dc2626" stroke-width="2.5"/>
+  <text x="648" y="148" font-size="16" fill="#b91c1c" font-family="Arial, sans-serif">CRA &gt; 0°</text>
+
+  <line x1="340" y1="232" x2="750" y2="232" stroke="#475569" stroke-width="2" stroke-dasharray="6 6"/>
+  <text x="502" y="252" font-size="16" fill="#334155" font-family="Arial, sans-serif">dXP (exit pupil to image plane)</text>
+
+  <line x1="766" y1="180" x2="766" y2="110" stroke="#475569" stroke-width="2"/>
+  <text x="774" y="148" font-size="16" fill="#334155" font-family="Arial, sans-serif">y'</text>
+</svg>

--- a/public/diagrams/pupils/projection-center.svg
+++ b/public/diagrams/pupils/projection-center.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 350" role="img" aria-labelledby="t d">
+  <title id="t">Panorama rotation: entrance pupil versus tripod socket</title>
+  <desc id="d">Side-by-side views showing no parallax when rotating about entrance pupil and visible parallax when rotating about tripod socket.</desc>
+  <rect width="920" height="350" fill="#f8fafc"/>
+  <line x1="460" y1="20" x2="460" y2="330" stroke="#cbd5e1" stroke-width="2"/>
+
+  <text x="80" y="40" font-size="20" font-family="Arial, sans-serif" fill="#065f46">Rotate about entrance pupil (no parallax)</text>
+  <text x="520" y="40" font-size="20" font-family="Arial, sans-serif" fill="#991b1b">Rotate about tripod socket (parallax)</text>
+
+  <circle cx="220" cy="190" r="16" fill="#10b981"/>
+  <rect x="184" y="205" width="72" height="20" rx="8" fill="#475569"/>
+  <line x1="220" y1="190" x2="220" y2="92" stroke="#10b981" stroke-width="3" stroke-dasharray="7 5"/>
+  <rect x="120" y="84" width="38" height="120" fill="#f59e0b"/>
+  <rect x="296" y="72" width="42" height="132" fill="#60a5fa"/>
+  <line x1="220" y1="190" x2="139" y2="144" stroke="#059669" stroke-width="3"/>
+  <line x1="220" y1="190" x2="317" y2="138" stroke="#059669" stroke-width="3"/>
+  <text x="120" y="230" font-size="16" fill="#334155" font-family="Arial, sans-serif">near target</text>
+  <text x="285" y="225" font-size="16" fill="#334155" font-family="Arial, sans-serif">far target</text>
+  <text x="174" y="88" font-size="15" fill="#065f46" font-family="Arial, sans-serif">aligned in both frames</text>
+
+  <circle cx="680" cy="190" r="16" fill="#ef4444"/>
+  <rect x="644" y="205" width="72" height="20" rx="8" fill="#475569"/>
+  <line x1="680" y1="215" x2="680" y2="96" stroke="#ef4444" stroke-width="3" stroke-dasharray="7 5"/>
+  <rect x="580" y="84" width="38" height="120" fill="#f59e0b"/>
+  <rect x="756" y="72" width="42" height="132" fill="#60a5fa"/>
+  <line x1="680" y1="215" x2="598" y2="152" stroke="#dc2626" stroke-width="3"/>
+  <line x1="680" y1="215" x2="777" y2="138" stroke="#dc2626" stroke-width="3"/>
+  <line x1="680" y1="190" x2="598" y2="126" stroke="#f97316" stroke-width="2" stroke-dasharray="6 6"/>
+  <line x1="680" y1="190" x2="777" y2="126" stroke="#f97316" stroke-width="2" stroke-dasharray="6 6"/>
+  <text x="566" y="230" font-size="16" fill="#334155" font-family="Arial, sans-serif">near target</text>
+  <text x="745" y="225" font-size="16" fill="#334155" font-family="Arial, sans-serif">far target</text>
+  <text x="548" y="88" font-size="15" fill="#991b1b" font-family="Arial, sans-serif">near target shifts vs far target</text>
+</svg>

--- a/public/diagrams/pupils/telecentricity-modes.svg
+++ b/public/diagrams/pupils/telecentricity-modes.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 320" role="img" aria-labelledby="t d">
+  <title id="t">Object-space, image-space, and double telecentric layouts</title>
+  <desc id="d">Three panel sketch comparing chief-ray parallelism and pupil at infinity conditions.</desc>
+  <rect width="1080" height="320" fill="#f8fafc"/>
+
+  <g transform="translate(20,0)">
+    <rect x="0" y="20" width="330" height="280" rx="10" fill="#ecfeff" stroke="#99f6e4"/>
+    <text x="16" y="48" font-size="18" font-family="Arial, sans-serif" fill="#0f172a">Object-space telecentric</text>
+    <line x1="25" y1="160" x2="305" y2="160" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6 5"/>
+    <line x1="40" y1="120" x2="160" y2="120" stroke="#0891b2" stroke-width="3"/>
+    <line x1="40" y1="200" x2="160" y2="200" stroke="#0891b2" stroke-width="3"/>
+    <path d="M160,110 L205,160 L160,210" fill="none" stroke="#0f766e" stroke-width="3"/>
+    <line x1="205" y1="160" x2="290" y2="90" stroke="#dc2626" stroke-width="3"/>
+    <line x1="205" y1="160" x2="290" y2="230" stroke="#dc2626" stroke-width="3"/>
+    <text x="24" y="85" font-size="14" fill="#0f766e" font-family="Arial, sans-serif">Entrance pupil at infinity</text>
+  </g>
+
+  <g transform="translate(375,0)">
+    <rect x="0" y="20" width="330" height="280" rx="10" fill="#eff6ff" stroke="#bfdbfe"/>
+    <text x="24" y="48" font-size="18" font-family="Arial, sans-serif" fill="#0f172a">Image-space telecentric</text>
+    <line x1="25" y1="160" x2="305" y2="160" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6 5"/>
+    <line x1="40" y1="90" x2="165" y2="160" stroke="#dc2626" stroke-width="3"/>
+    <line x1="40" y1="230" x2="165" y2="160" stroke="#dc2626" stroke-width="3"/>
+    <path d="M165,110 L210,160 L165,210" fill="none" stroke="#1d4ed8" stroke-width="3"/>
+    <line x1="210" y1="120" x2="290" y2="120" stroke="#0ea5e9" stroke-width="3"/>
+    <line x1="210" y1="200" x2="290" y2="200" stroke="#0ea5e9" stroke-width="3"/>
+    <text x="169" y="90" font-size="14" fill="#1e3a8a" font-family="Arial, sans-serif">Exit pupil at infinity</text>
+  </g>
+
+  <g transform="translate(730,0)">
+    <rect x="0" y="20" width="330" height="280" rx="10" fill="#f5f3ff" stroke="#ddd6fe"/>
+    <text x="72" y="48" font-size="18" font-family="Arial, sans-serif" fill="#0f172a">Double telecentric</text>
+    <line x1="25" y1="160" x2="305" y2="160" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6 5"/>
+    <line x1="38" y1="120" x2="152" y2="120" stroke="#7c3aed" stroke-width="3"/>
+    <line x1="38" y1="200" x2="152" y2="200" stroke="#7c3aed" stroke-width="3"/>
+    <path d="M152,110 L195,160 L152,210" fill="none" stroke="#6d28d9" stroke-width="3"/>
+    <line x1="195" y1="120" x2="292" y2="120" stroke="#a78bfa" stroke-width="3"/>
+    <line x1="195" y1="200" x2="292" y2="200" stroke="#a78bfa" stroke-width="3"/>
+    <text x="32" y="85" font-size="13" fill="#6d28d9" font-family="Arial, sans-serif">Entrance pupil at infinity</text>
+    <text x="178" y="85" font-size="13" fill="#6d28d9" font-family="Arial, sans-serif">Exit pupil at infinity</text>
+  </g>
+</svg>

--- a/public/diagrams/pupils/working-f-number.svg
+++ b/public/diagrams/pupils/working-f-number.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 340" role="img" aria-labelledby="t d">
+  <title id="t">Working f-number increases at close focus</title>
+  <desc id="d">Two side-by-side lens sketches showing same exit pupil but longer image conjugate and narrower cone at close focus.</desc>
+  <rect width="940" height="340" fill="#f8fafc"/>
+  <line x1="470" y1="20" x2="470" y2="320" stroke="#cbd5e1" stroke-width="2"/>
+
+  <g transform="translate(25,0)">
+    <text x="36" y="42" font-size="20" font-family="Arial, sans-serif" fill="#065f46">Infinity focus</text>
+    <line x1="20" y1="170" x2="410" y2="170" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6 6"/>
+    <path d="M140,110 Q190,170 140,230 Q230,230 260,170 Q230,110 140,110Z" fill="#dbeafe" stroke="#64748b" stroke-width="2"/>
+    <ellipse cx="255" cy="170" rx="12" ry="45" fill="none" stroke="#2563eb" stroke-width="3"/>
+    <line x1="255" y1="125" x2="390" y2="150" stroke="#16a34a" stroke-width="3"/>
+    <line x1="255" y1="215" x2="390" y2="190" stroke="#16a34a" stroke-width="3"/>
+    <line x1="390" y1="120" x2="390" y2="220" stroke="#334155" stroke-width="4"/>
+    <text x="333" y="240" font-size="15" fill="#334155" font-family="Arial, sans-serif">Image plane</text>
+    <text x="84" y="278" font-size="16" fill="#166534" font-family="Arial, sans-serif">Wide cone at sensor ⇒ marked N</text>
+  </g>
+
+  <g transform="translate(495,0)">
+    <text x="24" y="42" font-size="20" font-family="Arial, sans-serif" fill="#9a3412">Close focus (extended conjugate)</text>
+    <line x1="20" y1="170" x2="410" y2="170" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6 6"/>
+    <path d="M110,110 Q160,170 110,230 Q200,230 230,170 Q200,110 110,110Z" fill="#dbeafe" stroke="#64748b" stroke-width="2"/>
+    <ellipse cx="225" cy="170" rx="12" ry="45" fill="none" stroke="#2563eb" stroke-width="3"/>
+    <line x1="225" y1="125" x2="400" y2="157" stroke="#dc2626" stroke-width="3"/>
+    <line x1="225" y1="215" x2="400" y2="183" stroke="#dc2626" stroke-width="3"/>
+    <line x1="400" y1="110" x2="400" y2="230" stroke="#334155" stroke-width="4"/>
+    <text x="343" y="252" font-size="15" fill="#334155" font-family="Arial, sans-serif">Image plane farther back</text>
+    <text x="96" y="278" font-size="16" fill="#991b1b" font-family="Arial, sans-serif">Narrower cone ⇒ Neff &gt; N</text>
+  </g>
+</svg>

--- a/src/content/pupils/EntrancePupil.md
+++ b/src/content/pupils/EntrancePupil.md
@@ -24,7 +24,7 @@ The entrance pupil is the image of the aperture stop, formed by the optical elem
 
 **A hands-on demonstration.** Hold a 50 mm f/2 lens at arm's length and look into the front element. The bright disk you see is approximately 25 mm across — about the width of a U.S. quarter. That is the entrance pupil. The physical iris diaphragm inside the lens barrel is almost certainly a different size, sitting at a different position along the optical axis. What you are seeing is that iris, magnified and repositioned by the front group of lens elements.
 
-*[Diagram: A simple cross-section showing the physical iris inside the lens barrel, the front group of elements, and the entrance pupil as a virtual image of the iris — displaced and potentially magnified. Labels: "Front group," "Aperture stop (iris)," "Entrance pupil (virtual image of stop)," with dashed lines showing the imaging relationship.]*
+![Diagram showing the aperture stop and entrance pupil virtual image.](/diagrams/pupils/entrance-pupil.svg)
 
 ## How the Front Group Creates the Entrance Pupil
 

--- a/src/content/pupils/ExitPupil.md
+++ b/src/content/pupils/ExitPupil.md
@@ -66,7 +66,7 @@ $$\text{CRA} \approx \arctan(21.6 / 40) \approx 28.4°$$
 
 That nearly doubled CRA — from 15° to 28° — illustrates why exit-pupil distance matters so much for digital sensors.
 
-*[Diagram: Cross-section showing exit pupil, chief ray to on-axis pixel (CRA = 0°), and chief ray to a corner pixel (CRA > 0°). Show microlens over each pixel. Label exit-pupil distance $d_{\text{XP}}$ and image height $y'$.]*
+![Diagram showing exit pupil geometry and chief-ray angle at the sensor.](/diagrams/pupils/exit-pupil-cra.svg)
 
 ### The venetian-blind analogy
 

--- a/src/content/pupils/ProjectionCenter.md
+++ b/src/content/pupils/ProjectionCenter.md
@@ -24,7 +24,7 @@ The answer is the **entrance pupil** — the apparent aperture of the lens as se
 
 When the rotation axis is displaced from the entrance pupil — for example, when the camera rotates about the tripod socket, which is typically well behind the entrance pupil — near objects shift laterally relative to far objects between frames. This relative shift is **parallax**, and it is the direct cause of the stitching artifacts described above.
 
-*[Diagram: Two side-by-side views of a camera on a panorama head. Left: rotation axis at entrance pupil (no parallax — near and far targets stay aligned). Right: rotation axis at tripod socket (parallax — near target shifts relative to far target).]*
+![Diagram comparing panorama rotation around entrance pupil versus tripod socket.](/diagrams/pupils/projection-center.svg)
 
 ## Why the Entrance Pupil? The Projection Center
 

--- a/src/content/pupils/Telecentricity.md
+++ b/src/content/pupils/Telecentricity.md
@@ -32,7 +32,7 @@ There are three forms:
 
 Each form is a geometric condition, not an optical quality metric.
 
-*[Diagram: Three simple side-by-side sketches. Left: object-space telecentric — chief rays parallel on the scene side, converging on the sensor side. Center: image-space telecentric — chief rays converging on the scene side, parallel on the sensor side. Right: double telecentric — chief rays parallel on both sides. Label pupil positions as "at infinity" on the relevant side.]*
+![Diagram comparing object-space, image-space, and double telecentric ray geometry.](/diagrams/pupils/telecentricity-modes.svg)
 
 **Most photographic lenses are not telecentric — and that's fine.** Strict telecentricity requires the aperture stop to sit at a specific location (a group focal point), and that placement conflicts with compactness, zoom-range flexibility, aberration correction, and the ability to focus from infinity to close range [^1] [^5]. What many modern digital-era lens designs actually pursue is **reduced CRA** — more favorable image-side chief-ray geometry than earlier film-era or SLR-era designs could achieve. This is a **design tendency on a continuum**, not a binary telecentric/non-telecentric classification. Saying a lens has "reduced CRA" or "more favorable rear-ray geometry" is accurate; saying it "is telecentric" implies a strict condition most photo lenses don't satisfy.
 

--- a/src/content/pupils/WorkingFNumber.md
+++ b/src/content/pupils/WorkingFNumber.md
@@ -28,7 +28,7 @@ The f-number engraved on a lens barrel is the **infinity-conjugate f-number** �
 
 As the lens focuses closer, the image conjugate lengthens: the image forms farther from the exit pupil (the apparent aperture on the sensor side; see [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor)). The exit pupil subtends a smaller angle as seen from the image plane, so less light per unit area reaches the sensor.
 
-*[Diagram: Two side-by-side cross-sections. Left: lens focused at infinity — exit pupil subtends a wide angle from the image plane, labeled $N$. Right: lens extended for close focus — image plane farther away, exit pupil subtends a narrower angle, labeled $N_{\text{eff}} > N$. Show the longer image conjugate explicitly.]*
+![Diagram comparing infinity-focus and close-focus cone geometry for working f-number.](/diagrams/pupils/working-f-number.svg)
 
 For a conventional lens — one that focuses by changing the overall lens-to-sensor distance without altering its internal optics — the relationship is [^1] [^2]:
 


### PR DESCRIPTION
### Motivation
- Replace plaintext diagram callouts in the pupil/aperture article series with concrete, accessible illustrations that better communicate entrance/exit-pupil, projection center, telecentricity, and working f-number concepts. 
- Provide inline, versioned assets so the articles render consistent, high-quality diagrams in the static site build.

### Description
- Added five authored SVG assets under `public/diagrams/pupils/` (`entrance-pupil.svg`, `projection-center.svg`, `exit-pupil-cra.svg`, `telecentricity-modes.svg`, `working-f-number.svg`).
- Replaced the `[Diagram: ...]` placeholders with embedded image references in the five article source files: `src/content/pupils/EntrancePupil.md`, `src/content/pupils/ProjectionCenter.md`, `src/content/pupils/ExitPupil.md`, `src/content/pupils/Telecentricity.md`, and `src/content/pupils/WorkingFNumber.md`.
- Applied repository formatting and saved the updated markdown and SVG assets so the illustrations are served from the project's `public/` path.

### Testing
- Ran `npm run format` and `npm run format:check` and both completed successfully. 
- Generated site metadata with `npm run generate:metadata` to ensure `src/generated/build-metadata.json` exists for type checking, and that step succeeded. 
- Ran `npm run lint` and `npm run typecheck` (the `typecheck` initially failed before metadata generation but passed after `generate:metadata`).
- Executed the test suite with `npm run test` (Vitest), with all tests passing (`92 test files`, `1292 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7db17c8a48326b1edbb353b681109)