### PR TITLE
Add Pupil Geometry article series with diagrams and footnote citations

### DIFF
--- a/__tests__/pageRenders.test.tsx
+++ b/__tests__/pageRenders.test.tsx
@@ -10,7 +10,7 @@ import ArticlesPage from "../src/pages/ArticlesPage.js";
 import ArticlePage from "../src/pages/ArticlePage.js";
 import ComparePage from "../src/pages/ComparePage.js";
 import NotFoundPage from "../src/pages/NotFoundPage.js";
-import { ARTICLE_CONTENT, ARTICLES } from "../src/utils/homepageContent.js";
+import { ARTICLE_CONTENT, ARTICLES, HOMEPAGE_ARTICLES } from "../src/utils/homepageContent.js";
 import { CATALOG_KEYS, LENS_CATALOG } from "../src/utils/lensCatalog.js";
 import { clearBrowserState, installMatchMediaMock, renderWithRouter } from "./testUtils.js";
 
@@ -65,7 +65,7 @@ describe("static page renders", () => {
     expect(screen.getAllByRole("link", { name: /Lens Library/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Browse by Maker/i }).length).toBeGreaterThan(0);
     expect(screen.getByText("Articles & Guides")).toBeTruthy();
-    expect(screen.getByText(ARTICLES[0].title)).toBeTruthy();
+    expect(screen.getByText(HOMEPAGE_ARTICLES[0].title)).toBeTruthy();
   });
 
   it("redirects legacy lens query URLs on the homepage", async () => {
@@ -114,7 +114,7 @@ describe("static page renders", () => {
   });
 
   it("renders an article page for a known slug", () => {
-    const article = ARTICLES[0];
+    const article = HOMEPAGE_ARTICLES[0];
     const entry = ARTICLE_CONTENT[article.slug];
 
     renderRoutes(

--- a/public/diagrams/pupils/entrance-pupil.svg
+++ b/public/diagrams/pupils/entrance-pupil.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 220" width="100%" height="auto" role="img" aria-label="Entrance pupil diagram">
+  <defs>
+    <style>
+      .bg { fill: #12151e; }
+      .border { fill: none; stroke: rgba(150,170,210,0.18); stroke-width: 1; }
+      .axis { stroke: rgba(150,170,210,0.35); stroke-width: 1; stroke-dasharray: 5,4; fill: none; }
+      .lens-fill { fill: rgba(70,130,180,0.22); }
+      .lens-stroke { fill: none; stroke: rgba(120,170,220,0.80); stroke-width: 1.5; }
+      .stop { stroke: #ff8c20; stroke-width: 3; stroke-linecap: round; }
+      .ep-stroke { fill: none; stroke: #28d8ff; stroke-width: 1.5; stroke-dasharray: 5,3; }
+      .ep-fill { fill: rgba(40,216,255,0.06); }
+      .ray { stroke: rgba(40,216,255,0.45); stroke-width: 1; stroke-dasharray: 6,4; fill: none; }
+      .label { fill: #c8d8f0; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-accent { fill: #28d8ff; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-stop { fill: #ff8c20; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .muted { fill: rgba(150,170,200,0.65); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 10px; }
+      .tick { stroke: rgba(150,170,210,0.4); stroke-width: 1; }
+      @media (prefers-color-scheme: light) {
+        .bg { fill: #eff2f8; }
+        .border { stroke: rgba(60,80,120,0.18); }
+        .axis { stroke: rgba(60,80,120,0.32); }
+        .lens-fill { fill: rgba(30,80,160,0.10); }
+        .lens-stroke { stroke: rgba(30,80,160,0.65); }
+        .stop { stroke: #c05000; }
+        .ep-stroke { stroke: #006878; }
+        .ep-fill { fill: rgba(0,104,120,0.06); }
+        .ray { stroke: rgba(0,104,120,0.40); }
+        .label { fill: #1a2540; }
+        .label-accent { fill: #006878; }
+        .label-stop { fill: #c05000; }
+        .muted { fill: rgba(60,80,120,0.60); }
+        .tick { stroke: rgba(60,80,120,0.35); }
+      }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="640" height="220" rx="6" class="bg"/>
+  <rect width="640" height="220" rx="6" class="border"/>
+
+  <!-- Optical axis -->
+  <line x1="30" y1="110" x2="600" y2="110" class="axis"/>
+
+  <!-- ── Entrance pupil (virtual, dashed) ── -->
+  <!-- filled ellipse body -->
+  <ellipse cx="92" cy="110" rx="13" ry="48" class="ep-fill"/>
+  <!-- dashed ellipse outline (two halves for dashed effect on ellipse) -->
+  <ellipse cx="92" cy="110" rx="13" ry="48" class="ep-stroke"/>
+  <!-- center marker on optical axis -->
+  <line x1="92" y1="108" x2="92" y2="112" class="tick"/>
+
+  <!-- ── Front group (two biconvex elements) ── -->
+  <!-- Element 1 -->
+  <path d="M 258,68 Q 241,110 258,152 L 276,152 Q 293,110 276,68 Z" class="lens-fill"/>
+  <path d="M 258,68 Q 241,110 258,152" class="lens-stroke"/>
+  <path d="M 276,68 Q 293,110 276,152" class="lens-stroke"/>
+  <line x1="258" y1="68" x2="276" y2="68" class="lens-stroke"/>
+  <line x1="258" y1="152" x2="276" y2="152" class="lens-stroke"/>
+  <!-- Element 2 -->
+  <path d="M 298,68 Q 281,110 298,152 L 316,152 Q 333,110 316,68 Z" class="lens-fill"/>
+  <path d="M 298,68 Q 281,110 298,152" class="lens-stroke"/>
+  <path d="M 316,68 Q 333,110 316,68" class="lens-stroke"/>
+  <line x1="298" y1="68" x2="316" y2="68" class="lens-stroke"/>
+  <line x1="298" y1="152" x2="316" y2="152" class="lens-stroke"/>
+  <!-- Element 2 right surface (closed) -->
+  <path d="M 316,68 Q 333,110 316,152" class="lens-stroke"/>
+
+  <!-- ── Aperture stop (iris) ── -->
+  <!-- upper blade -->
+  <line x1="445" y1="30" x2="445" y2="72" class="stop"/>
+  <!-- lower blade -->
+  <line x1="445" y1="148" x2="445" y2="190" class="stop"/>
+  <!-- small tick on optical axis -->
+  <line x1="443" y1="108" x2="447" y2="112" class="stop" style="stroke-width:1;opacity:0.5"/>
+
+  <!-- ── Construction dashed rays ── -->
+  <!-- upper: EP top edge → aperture stop top edge -->
+  <line x1="92" y1="62" x2="445" y2="72" class="ray"/>
+  <!-- lower: EP bottom edge → aperture stop bottom edge -->
+  <line x1="92" y1="158" x2="445" y2="148" class="ray"/>
+
+  <!-- ── Labels ── -->
+  <!-- Entrance pupil label -->
+  <text x="92" y="20" text-anchor="middle" class="label-accent">Entrance pupil</text>
+  <text x="92" y="33" text-anchor="middle" class="muted">(virtual image of stop)</text>
+  <line x1="92" y1="36" x2="92" y2="60" class="tick" style="stroke-dasharray:3,2"/>
+
+  <!-- Front group label -->
+  <text x="287" y="180" text-anchor="middle" class="label">Front group</text>
+  <!-- bracket under front group -->
+  <path d="M 255,170 L 255,175 L 319,175 L 319,170" fill="none" class="tick"/>
+
+  <!-- Aperture stop label -->
+  <text x="460" y="52" text-anchor="start" class="label-stop">Aperture stop</text>
+  <text x="460" y="65" text-anchor="start" class="label-stop">(iris)</text>
+
+  <!-- dashed arrow from stop label to stop line -->
+  <line x1="457" y1="55" x2="449" y2="55" class="tick" style="stroke-dasharray:2,2"/>
+
+  <!-- Right side: beyond aperture stop (rear group hint) -->
+  <text x="510" y="107" text-anchor="start" class="muted">rear group</text>
+  <text x="510" y="119" text-anchor="start" class="muted">→ sensor</text>
+
+  <!-- EP ↔ stop distance annotation -->
+  <line x1="92" y1="200" x2="445" y2="200" class="tick" style="stroke-dasharray:none"/>
+  <line x1="92" y1="196" x2="92" y2="204" class="tick"/>
+  <line x1="445" y1="196" x2="445" y2="204" class="tick"/>
+  <text x="268" y="214" text-anchor="middle" class="muted">EP displaced from stop (magnification by front group)</text>
+</svg>

--- a/public/diagrams/pupils/entrance-pupil.svg
+++ b/public/diagrams/pupils/entrance-pupil.svg
@@ -43,9 +43,9 @@
 
   <!-- ── Entrance pupil (virtual, dashed) ── -->
   <!-- filled ellipse body -->
-  <ellipse cx="92" cy="110" rx="13" ry="48" class="ep-fill"/>
+  <ellipse cx="92" cy="110" rx="13" ry="68" class="ep-fill"/>
   <!-- dashed ellipse outline (two halves for dashed effect on ellipse) -->
-  <ellipse cx="92" cy="110" rx="13" ry="48" class="ep-stroke"/>
+  <ellipse cx="92" cy="110" rx="13" ry="68" class="ep-stroke"/>
   <!-- center marker on optical axis -->
   <line x1="92" y1="108" x2="92" y2="112" class="tick"/>
 
@@ -75,15 +75,15 @@
 
   <!-- ── Construction dashed rays ── -->
   <!-- upper: EP top edge → aperture stop top edge -->
-  <line x1="92" y1="62" x2="445" y2="72" class="ray"/>
+  <line x1="92" y1="42" x2="445" y2="72" class="ray"/>
   <!-- lower: EP bottom edge → aperture stop bottom edge -->
-  <line x1="92" y1="158" x2="445" y2="148" class="ray"/>
+  <line x1="92" y1="178" x2="445" y2="148" class="ray"/>
 
   <!-- ── Labels ── -->
   <!-- Entrance pupil label -->
   <text x="92" y="20" text-anchor="middle" class="label-accent">Entrance pupil</text>
   <text x="92" y="33" text-anchor="middle" class="muted">(virtual image of stop)</text>
-  <line x1="92" y1="36" x2="92" y2="60" class="tick" style="stroke-dasharray:3,2"/>
+  <line x1="92" y1="36" x2="92" y2="41" class="tick" style="stroke-dasharray:3,2"/>
 
   <!-- Front group label -->
   <text x="287" y="180" text-anchor="middle" class="label">Front group</text>

--- a/public/diagrams/pupils/exit-pupil.svg
+++ b/public/diagrams/pupils/exit-pupil.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 220" width="100%" height="auto" role="img" aria-label="Exit pupil and chief ray angle diagram">
+  <defs>
+    <style>
+      .bg { fill: #12151e; }
+      .border { fill: none; stroke: rgba(150,170,210,0.18); stroke-width: 1; }
+      .axis { stroke: rgba(150,170,210,0.32); stroke-width: 1; stroke-dasharray: 5,4; fill: none; }
+      .lens-fill { fill: rgba(70,130,180,0.22); }
+      .lens-stroke { fill: none; stroke: rgba(120,170,220,0.80); stroke-width: 1.5; }
+      .xp-fill { fill: rgba(217,140,255,0.10); }
+      .xp-stroke { fill: none; stroke: #d98cff; stroke-width: 2; }
+      .sensor { stroke: rgba(180,200,240,0.80); stroke-width: 2.5; fill: none; }
+      .sensor-fill { fill: rgba(80,140,220,0.12); }
+      .microlens { fill: none; stroke: rgba(120,180,230,0.70); stroke-width: 1.2; }
+      .pixel-fill { fill: rgba(40,100,180,0.20); }
+      .ray-axial { stroke: rgba(40,216,255,0.75); stroke-width: 1.4; fill: none; }
+      .ray-chief { stroke: rgba(255,200,60,0.80); stroke-width: 1.4; fill: none; }
+      .dim { stroke: rgba(150,170,210,0.40); stroke-width: 1; fill: none; stroke-dasharray: 3,2; }
+      .dim-solid { stroke: rgba(150,170,210,0.40); stroke-width: 1; fill: none; }
+      .label { fill: #c8d8f0; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-xp { fill: #d98cff; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-axial { fill: #28d8ff; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-chief { fill: #ffc83c; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .muted { fill: rgba(150,170,200,0.65); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 10px; }
+      .tick { stroke: rgba(150,170,210,0.40); stroke-width: 1; fill: none; }
+      @media (prefers-color-scheme: light) {
+        .bg { fill: #eff2f8; }
+        .border { stroke: rgba(60,80,120,0.18); }
+        .axis { stroke: rgba(60,80,120,0.30); }
+        .lens-fill { fill: rgba(30,80,160,0.10); }
+        .lens-stroke { stroke: rgba(30,80,160,0.65); }
+        .xp-fill { fill: rgba(120,46,184,0.07); }
+        .xp-stroke { stroke: #7a2eb8; }
+        .sensor { stroke: rgba(40,80,160,0.75); }
+        .sensor-fill { fill: rgba(40,80,160,0.07); }
+        .microlens { stroke: rgba(30,80,160,0.60); }
+        .pixel-fill { fill: rgba(30,80,160,0.12); }
+        .ray-axial { stroke: rgba(0,104,120,0.75); }
+        .ray-chief { stroke: rgba(160,100,0,0.80); }
+        .dim { stroke: rgba(60,80,120,0.35); }
+        .dim-solid { stroke: rgba(60,80,120,0.35); }
+        .label { fill: #1a2540; }
+        .label-xp { fill: #7a2eb8; }
+        .label-axial { fill: #006878; }
+        .label-chief { fill: #a06000; }
+        .muted { fill: rgba(60,80,120,0.60); }
+        .tick { stroke: rgba(60,80,120,0.35); }
+      }
+    </style>
+    <marker id="arr" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="rgba(150,170,210,0.60)"/>
+    </marker>
+    <marker id="arr-chief" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="rgba(255,200,60,0.90)"/>
+    </marker>
+    <marker id="arr-axial" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="rgba(40,216,255,0.90)"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="640" height="220" rx="6" class="bg"/>
+  <rect width="640" height="220" rx="6" class="border"/>
+
+  <!-- Optical axis -->
+  <line x1="30" y1="110" x2="600" y2="110" class="axis"/>
+
+  <!-- ── Exit pupil ── -->
+  <ellipse cx="120" cy="110" rx="14" ry="52" class="xp-fill"/>
+  <ellipse cx="120" cy="110" rx="14" ry="52" class="xp-stroke"/>
+  <text x="120" y="18" text-anchor="middle" class="label-xp">Exit pupil (XP)</text>
+  <line x1="120" y1="21" x2="120" y2="56" class="tick" style="stroke-dasharray:3,2"/>
+
+  <!-- ── Simplified rear lens group ── -->
+  <path d="M 170,70 Q 155,110 170,150 L 188,150 Q 203,110 188,70 Z" class="lens-fill"/>
+  <path d="M 170,70 Q 155,110 170,150" class="lens-stroke"/>
+  <path d="M 188,70 Q 203,110 188,150" class="lens-stroke"/>
+  <line x1="170" y1="70" x2="188" y2="70" class="lens-stroke"/>
+  <line x1="170" y1="150" x2="188" y2="150" class="lens-stroke"/>
+
+  <!-- ── Image sensor ── -->
+  <!-- Sensor body -->
+  <rect x="490" y="60" width="14" height="100" rx="2" class="sensor-fill"/>
+  <line x1="497" y1="60" x2="497" y2="160" class="sensor"/>
+
+  <!-- Pixels on sensor (5 pixels shown) -->
+  <!-- pixel 1: center (on-axis) y=110 -->
+  <rect x="488" y="104" width="14" height="12" class="pixel-fill"/>
+  <!-- pixel 2: y=90 -->
+  <rect x="488" y="88" width="14" height="12" class="pixel-fill"/>
+  <!-- pixel 3: y=130 -->
+  <rect x="488" y="124" width="14" height="12" class="pixel-fill"/>
+  <!-- pixel 4: y=70 -->
+  <rect x="488" y="72" width="14" height="12" class="pixel-fill"/>
+  <!-- pixel 5: corner y=148 -->
+  <rect x="488" y="144" width="14" height="12" class="pixel-fill"/>
+
+  <!-- Microlenses (arcs above each pixel on the left face of sensor) -->
+  <!-- center -->
+  <path d="M 490,104 Q 486,110 490,116" class="microlens"/>
+  <!-- y=88 -->
+  <path d="M 490,88 Q 486,94 490,100" class="microlens"/>
+  <!-- y=124 -->
+  <path d="M 490,124 Q 486,130 490,136" class="microlens"/>
+  <!-- y=72 -->
+  <path d="M 490,72 Q 486,78 490,84" class="microlens"/>
+  <!-- corner y=144 -->
+  <path d="M 490,144 Q 486,150 490,156" class="microlens"/>
+  <text x="502" y="57" text-anchor="start" class="muted">sensor</text>
+
+  <!-- ── Chief ray: on-axis pixel (CRA = 0°) ── -->
+  <line x1="120" y1="110" x2="490" y2="110" class="ray-axial" marker-end="url(#arr-axial)"/>
+  <text x="290" y="104" text-anchor="middle" class="label-axial" style="font-size:10px">CRA = 0°</text>
+
+  <!-- ── Chief ray: corner pixel (CRA > 0°) ── -->
+  <!-- From XP center to corner pixel at y=78 (inside the pixel at top ~y=72+6=78) -->
+  <line x1="120" y1="110" x2="490" y2="78" class="ray-chief" marker-end="url(#arr-chief)"/>
+
+  <!-- CRA angle arc at the corner pixel end -->
+  <path d="M 490,78 L 470,78 A 20,20 0 0,1 473,66" fill="none" stroke="rgba(255,200,60,0.60)" stroke-width="1"/>
+  <text x="455" y="65" text-anchor="middle" class="label-chief" style="font-size:10px">CRA &gt; 0°</text>
+
+  <!-- ── d_XP dimension line ── -->
+  <line x1="120" y1="170" x2="490" y2="170" class="dim-solid" marker-end="url(#arr)"/>
+  <line x1="490" y1="170" x2="120" y2="170" class="dim-solid" marker-end="url(#arr)"/>
+  <line x1="120" y1="165" x2="120" y2="175" class="tick"/>
+  <line x1="490" y1="165" x2="490" y2="175" class="tick"/>
+  <text x="305" y="184" text-anchor="middle" class="label-xp" style="font-size:11px">d&#x2093;&#x2097; (exit-pupil distance)</text>
+
+  <!-- ── y′ image height dimension ── -->
+  <line x1="510" y1="110" x2="510" y2="78" class="dim-solid"/>
+  <line x1="506" y1="110" x2="514" y2="110" class="tick"/>
+  <line x1="506" y1="78" x2="514" y2="78" class="tick"/>
+  <text x="525" y="96" text-anchor="start" class="label" style="font-size:10px">y′</text>
+  <text x="521" y="107" text-anchor="start" class="muted">(image height)</text>
+
+  <!-- Legend -->
+  <line x1="40" y1="200" x2="70" y2="200" class="ray-axial"/>
+  <text x="75" y="204" class="label-axial" style="font-size:10px">on-axis chief ray (CRA=0°)</text>
+  <line x1="300" y1="200" x2="330" y2="200" class="ray-chief"/>
+  <text x="335" y="204" class="label-chief" style="font-size:10px">off-axis chief ray (CRA&gt;0°)</text>
+</svg>

--- a/public/diagrams/pupils/projection-center.svg
+++ b/public/diagrams/pupils/projection-center.svg
@@ -1,0 +1,175 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 260" width="100%" height="auto" role="img" aria-label="Parallax and entrance pupil rotation center diagram">
+  <defs>
+    <style>
+      .bg { fill: #12151e; }
+      .border { fill: none; stroke: rgba(150,170,210,0.18); stroke-width: 1; }
+      .divider { stroke: rgba(150,170,210,0.20); stroke-width: 1; stroke-dasharray: 4,4; }
+      .cam-fill { fill: rgba(70,100,160,0.18); }
+      .cam-stroke { fill: none; stroke: rgba(120,150,210,0.70); stroke-width: 1.5; }
+      .lens-fill { fill: rgba(70,130,180,0.22); }
+      .lens-stroke { fill: none; stroke: rgba(120,170,220,0.80); stroke-width: 1.5; }
+      .ep-dot { fill: #28d8ff; }
+      .ep-ring { fill: none; stroke: #28d8ff; stroke-width: 1.5; }
+      .rot-axis { fill: rgba(255,140,32,0.90); }
+      .rot-ring { fill: none; stroke: #ff8c20; stroke-width: 1.5; }
+      .arc { fill: none; stroke: rgba(150,170,210,0.45); stroke-width: 1; stroke-dasharray: 5,3; }
+      .ray-good { stroke: rgba(40,216,255,0.60); stroke-width: 1.2; fill: none; }
+      .ray-bad { stroke: rgba(255,100,80,0.65); stroke-width: 1.2; fill: none; }
+      .obj-near { fill: rgba(80,220,140,0.90); }
+      .obj-far { fill: rgba(200,180,80,0.80); }
+      .label { fill: #c8d8f0; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-good { fill: #28d8ff; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; font-weight: 600; }
+      .label-bad { fill: #ff6e50; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; font-weight: 600; }
+      .muted { fill: rgba(150,170,200,0.65); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 10px; }
+      .tick { stroke: rgba(150,170,210,0.40); stroke-width: 1; fill: none; }
+      @media (prefers-color-scheme: light) {
+        .bg { fill: #eff2f8; }
+        .border { stroke: rgba(60,80,120,0.18); }
+        .divider { stroke: rgba(60,80,120,0.20); }
+        .cam-fill { fill: rgba(40,70,140,0.10); }
+        .cam-stroke { stroke: rgba(40,70,140,0.60); }
+        .lens-fill { fill: rgba(30,80,160,0.10); }
+        .lens-stroke { stroke: rgba(30,80,160,0.65); }
+        .ep-dot { fill: #006878; }
+        .ep-ring { stroke: #006878; }
+        .rot-axis { fill: #c05000; }
+        .rot-ring { stroke: #c05000; }
+        .arc { stroke: rgba(60,80,120,0.40); }
+        .ray-good { stroke: rgba(0,104,120,0.60); }
+        .ray-bad { stroke: rgba(200,60,40,0.65); }
+        .label { fill: #1a2540; }
+        .label-good { fill: #006878; }
+        .label-bad { fill: #c03020; }
+        .muted { fill: rgba(60,80,120,0.60); }
+        .tick { stroke: rgba(60,80,120,0.35); }
+      }
+    </style>
+    <marker id="arr-good" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" class="ep-dot"/>
+    </marker>
+    <marker id="arr-bad" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="rgba(255,100,80,0.90)"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="640" height="260" rx="6" class="bg"/>
+  <rect width="640" height="260" rx="6" class="border"/>
+
+  <!-- Centre divider -->
+  <line x1="320" y1="30" x2="320" y2="240" class="divider"/>
+
+  <!-- ═══ LEFT PANEL: correct — rotation at EP ═══ -->
+  <text x="160" y="22" text-anchor="middle" class="label-good">✓ Rotation axis at entrance pupil</text>
+
+  <!-- Objects on the left scene side (far left) -->
+  <!-- Far object: building silhouette -->
+  <rect x="20" y="90" width="18" height="50" class="obj-far" rx="1"/>
+  <rect x="14" y="108" width="6" height="32" class="obj-far" rx="1"/>
+  <!-- Near object: pole -->
+  <rect x="62" y="95" width="5" height="70" class="obj-near" rx="1"/>
+
+  <!-- Camera body (position 1, pointing right) -->
+  <rect x="148" y="95" width="52" height="36" rx="3" class="cam-fill"/>
+  <rect x="148" y="95" width="52" height="36" rx="3" class="cam-stroke"/>
+  <!-- Lens barrel on camera -->
+  <rect x="140" y="103" width="12" height="20" rx="2" class="lens-fill"/>
+  <rect x="140" y="103" width="12" height="20" rx="2" class="lens-stroke"/>
+
+  <!-- Camera body (position 2, rotated slightly right, top-down rotation shown) -->
+  <!-- Rotated camera: shift body slightly up and right -->
+  <rect x="158" y="60" width="52" height="36" rx="3" class="cam-fill" style="opacity:0.5"/>
+  <rect x="158" y="60" width="52" height="36" rx="3" class="cam-stroke" style="opacity:0.5"/>
+  <rect x="150" y="68" width="12" height="20" rx="2" class="lens-fill" style="opacity:0.5"/>
+  <rect x="150" y="68" width="12" height="20" rx="2" class="lens-stroke" style="opacity:0.5"/>
+
+  <!-- EP dot (rotation pivot) -->
+  <circle cx="146" cy="113" r="5" class="ep-ring"/>
+  <circle cx="146" cy="113" r="2.5" class="ep-dot"/>
+  <!-- EP label -->
+  <text x="134" y="134" text-anchor="middle" class="label-good" style="font-size:10px">EP</text>
+  <text x="134" y="145" text-anchor="middle" class="muted">(pivot)</text>
+
+  <!-- Rotation arc -->
+  <path d="M 146,82 A 31,31 0 0,1 175,100" class="arc"/>
+
+  <!-- Rays from near and far objects through EP in pos 1 -->
+  <line x1="38" y1="110" x2="146" y2="113" class="ray-good"/>
+  <line x1="64" y1="108" x2="146" y2="113" class="ray-good"/>
+
+  <!-- Rays in pos 2 (offset slightly) -->
+  <line x1="38" y1="110" x2="153" y2="78" class="ray-good" style="opacity:0.45;stroke-dasharray:4,3"/>
+  <line x1="64" y1="108" x2="153" y2="78" class="ray-good" style="opacity:0.45;stroke-dasharray:4,3"/>
+
+  <!-- No-parallax label -->
+  <text x="160" y="165" text-anchor="middle" class="muted">Near &amp; far stay aligned</text>
+  <text x="160" y="178" text-anchor="middle" class="muted">between frames → no parallax</text>
+
+  <!-- Object labels -->
+  <text x="29" y="85" text-anchor="middle" class="muted">far</text>
+  <text x="64" y="88" text-anchor="middle" class="muted">near</text>
+
+  <!-- ═══ RIGHT PANEL: wrong — rotation at tripod socket ═══ -->
+  <text x="480" y="22" text-anchor="middle" class="label-bad">✗ Rotation axis at tripod socket</text>
+
+  <!-- Objects on right scene side (far right) -->
+  <rect x="340" y="90" width="18" height="50" class="obj-far" rx="1"/>
+  <rect x="334" y="108" width="6" height="32" class="obj-far" rx="1"/>
+  <rect x="382" y="95" width="5" height="70" class="obj-near" rx="1"/>
+
+  <!-- Camera body pos 1 -->
+  <rect x="468" y="95" width="52" height="36" rx="3" class="cam-fill"/>
+  <rect x="468" y="95" width="52" height="36" rx="3" class="cam-stroke"/>
+  <rect x="460" y="103" width="12" height="20" rx="2" class="lens-fill"/>
+  <rect x="460" y="103" width="12" height="20" rx="2" class="lens-stroke"/>
+
+  <!-- Camera body pos 2 (rotated) -->
+  <rect x="474" y="60" width="52" height="36" rx="3" class="cam-fill" style="opacity:0.5"/>
+  <rect x="474" y="60" width="52" height="36" rx="3" class="cam-stroke" style="opacity:0.5"/>
+  <rect x="466" y="68" width="12" height="20" rx="2" class="lens-fill" style="opacity:0.5"/>
+  <rect x="466" y="68" width="12" height="20" rx="2" class="lens-stroke" style="opacity:0.5"/>
+
+  <!-- EP dot position (NOT at pivot) -->
+  <circle cx="466" cy="113" r="4" class="ep-ring" style="opacity:0.6"/>
+  <circle cx="466" cy="113" r="2" class="ep-dot" style="opacity:0.6"/>
+  <text x="455" y="134" text-anchor="middle" class="label-good" style="font-size:9px;opacity:0.7">EP</text>
+
+  <!-- Tripod socket (rotation pivot, wrong place) -->
+  <circle cx="510" cy="131" r="5" class="rot-ring"/>
+  <circle cx="510" cy="131" r="2.5" class="rot-axis"/>
+  <text x="524" y="135" text-anchor="start" class="label-bad" style="font-size:10px">tripod socket</text>
+  <text x="524" y="146" text-anchor="start" class="muted">(pivot)</text>
+
+  <!-- Rotation arc -->
+  <path d="M 510,100 A 31,31 0 0,1 535,118" class="arc"/>
+
+  <!-- Rays from far object — mostly unchanged -->
+  <line x1="358" y1="110" x2="466" y2="113" class="ray-good"/>
+  <line x1="358" y1="110" x2="473" y2="78" class="ray-good" style="opacity:0.45;stroke-dasharray:4,3"/>
+
+  <!-- Rays from near object — shifts more dramatically -->
+  <line x1="384" y1="108" x2="466" y2="113" class="ray-bad"/>
+  <line x1="384" y1="100" x2="473" y2="75" class="ray-bad" style="stroke-dasharray:4,3"/>
+
+  <!-- Parallax shift annotation: near object appears to shift -->
+  <line x1="384" y1="108" x2="384" y2="100" stroke="rgba(255,100,80,0.80)" stroke-width="1.5" marker-end="url(#arr-bad)"/>
+  <text x="395" y="100" text-anchor="start" class="label-bad" style="font-size:10px">near shifts</text>
+
+  <!-- Object labels -->
+  <text x="349" y="85" text-anchor="middle" class="muted">far</text>
+  <text x="384" y="88" text-anchor="middle" class="muted">near</text>
+
+  <!-- Parallax label -->
+  <text x="480" y="165" text-anchor="middle" class="muted">Near shifts relative to far</text>
+  <text x="480" y="178" text-anchor="middle" class="muted">between frames → parallax</text>
+
+  <!-- Bottom legend -->
+  <circle cx="100" cy="232" r="4" class="ep-ring"/><circle cx="100" cy="232" r="2" class="ep-dot"/>
+  <text x="109" y="236" class="label-good" style="font-size:10px">Entrance pupil</text>
+  <circle cx="240" cy="232" r="4" class="rot-ring"/><circle cx="240" cy="232" r="2" class="rot-axis"/>
+  <text x="249" y="236" class="label-bad" style="font-size:10px">Tripod socket (wrong pivot)</text>
+  <rect x="400" y="228" width="10" height="8" rx="1" class="obj-near"/>
+  <text x="415" y="236" class="muted">near obj</text>
+  <rect x="480" y="228" width="10" height="8" rx="1" class="obj-far"/>
+  <text x="495" y="236" class="muted">far obj</text>
+</svg>

--- a/public/diagrams/pupils/telecentricity.svg
+++ b/public/diagrams/pupils/telecentricity.svg
@@ -112,15 +112,15 @@
   <line x1="408" y1="80" x2="408" y2="160" class="plane"/>
   <text x="408" y="172" text-anchor="middle" class="plane-label">sensor</text>
 
-  <!-- Converging rays on scene side (non-parallel) -->
-  <line x1="234" y1="98" x2="319" y2="114" class="ray" marker-end="url(#arrY)"/>
+  <!-- Diverging rays on scene side (from single point at object plane) -->
+  <line x1="234" y1="120" x2="319" y2="100" class="ray" marker-end="url(#arrY)"/>
   <line x1="234" y1="120" x2="319" y2="120" class="ray" marker-end="url(#arrY)"/>
-  <line x1="234" y1="142" x2="319" y2="126" class="ray" marker-end="url(#arrY)"/>
+  <line x1="234" y1="120" x2="319" y2="140" class="ray" marker-end="url(#arrY)"/>
 
   <!-- Parallel rays on sensor side (horizontal) -->
-  <line x1="319" y1="114" x2="408" y2="98" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="319" y1="100" x2="408" y2="100" class="ray-parallel" marker-end="url(#arrB)"/>
   <line x1="319" y1="120" x2="408" y2="120" class="ray-parallel" marker-end="url(#arrB)"/>
-  <line x1="319" y1="126" x2="408" y2="142" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="319" y1="140" x2="408" y2="140" class="ray-parallel" marker-end="url(#arrB)"/>
 
   <!-- XP∞ label -->
   <text x="420" y="96" text-anchor="start" class="inf-label">XP</text>
@@ -190,8 +190,8 @@
   <text x="533" y="207" text-anchor="middle" class="sublabel">both sides</text>
 
   <!-- Legend -->
-  <line x1="220" y1="222" x2="245" y2="222" class="ray-parallel"/>
-  <text x="249" y="226" class="inf-label" style="font-size:9px">parallel (telecentric side)</text>
-  <line x1="380" y1="222" x2="405" y2="222" class="ray"/>
-  <text x="409" y="226" style="fill:rgba(255,200,60,0.80);font-family:'JetBrains Mono',monospace;font-size:9px">converging (non-telecentric side)</text>
+  <line x1="40" y1="222" x2="65" y2="222" class="ray-parallel"/>
+  <text x="69" y="226" class="inf-label" style="font-size:9px">parallel (telecentric side)</text>
+  <line x1="365" y1="222" x2="390" y2="222" class="ray"/>
+  <text x="394" y="226" style="fill:rgba(255,200,60,0.80);font-family:'JetBrains Mono',monospace;font-size:9px">converging (non-telecentric side)</text>
 </svg>

--- a/public/diagrams/pupils/telecentricity.svg
+++ b/public/diagrams/pupils/telecentricity.svg
@@ -1,0 +1,197 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 230" width="100%" height="auto" role="img" aria-label="Three forms of telecentricity diagram">
+  <defs>
+    <style>
+      .bg { fill: #12151e; }
+      .border { fill: none; stroke: rgba(150,170,210,0.18); stroke-width: 1; }
+      .panel-div { stroke: rgba(150,170,210,0.18); stroke-width: 1; }
+      .plane { stroke: rgba(150,170,210,0.45); stroke-width: 1.5; stroke-linecap: round; fill: none; }
+      .plane-label { fill: rgba(150,170,200,0.65); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 9px; }
+      .lens-fill { fill: rgba(70,130,180,0.22); }
+      .lens-stroke { fill: none; stroke: rgba(120,170,220,0.80); stroke-width: 1.5; }
+      .ray { stroke: rgba(255,200,60,0.75); stroke-width: 1.3; fill: none; }
+      .ray-parallel { stroke: rgba(40,216,255,0.75); stroke-width: 1.3; fill: none; }
+      .pupil-inf { fill: none; stroke: rgba(150,170,210,0.50); stroke-width: 1; stroke-dasharray: 4,3; }
+      .axis { stroke: rgba(150,170,210,0.25); stroke-width: 1; stroke-dasharray: 4,4; fill: none; }
+      .label { fill: #c8d8f0; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; font-weight: 600; }
+      .sublabel { fill: rgba(150,170,200,0.75); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 9.5px; }
+      .inf-label { fill: rgba(40,216,255,0.85); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 9px; }
+      .muted { fill: rgba(150,170,200,0.60); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 9px; }
+      @media (prefers-color-scheme: light) {
+        .bg { fill: #eff2f8; }
+        .border { stroke: rgba(60,80,120,0.18); }
+        .panel-div { stroke: rgba(60,80,120,0.18); }
+        .plane { stroke: rgba(60,80,120,0.45); }
+        .plane-label { fill: rgba(60,80,120,0.60); }
+        .lens-fill { fill: rgba(30,80,160,0.10); }
+        .lens-stroke { stroke: rgba(30,80,160,0.65); }
+        .ray { stroke: rgba(160,100,0,0.75); }
+        .ray-parallel { stroke: rgba(0,104,120,0.75); }
+        .pupil-inf { stroke: rgba(60,80,120,0.45); }
+        .axis { stroke: rgba(60,80,120,0.22); }
+        .label { fill: #1a2540; }
+        .sublabel { fill: rgba(60,80,120,0.70); }
+        .inf-label { fill: rgba(0,104,120,0.85); }
+        .muted { fill: rgba(60,80,120,0.55); }
+      }
+    </style>
+    <marker id="arrY" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="rgba(255,200,60,0.90)"/>
+    </marker>
+    <marker id="arrB" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="rgba(40,216,255,0.90)"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="640" height="230" rx="6" class="bg"/>
+  <rect width="640" height="230" rx="6" class="border"/>
+
+  <!-- Panel dividers -->
+  <line x1="213" y1="30" x2="213" y2="210" class="panel-div"/>
+  <line x1="427" y1="30" x2="427" y2="210" class="panel-div"/>
+
+  <!-- ════ PANEL 1: Object-space telecentric ════ -->
+  <!-- Panel label -->
+  <text x="106" y="20" text-anchor="middle" class="label">Object-space</text>
+  <text x="106" y="33" text-anchor="middle" class="sublabel">telecentric</text>
+
+  <!-- Optical axis -->
+  <line x1="18" y1="120" x2="205" y2="120" class="axis"/>
+
+  <!-- Object plane (left) -->
+  <line x1="30" y1="80" x2="30" y2="160" class="plane"/>
+  <text x="30" y="172" text-anchor="middle" class="plane-label">object</text>
+
+  <!-- Lens -->
+  <path d="M 110,82 Q 97,120 110,158 L 124,158 Q 137,120 124,82 Z" class="lens-fill"/>
+  <path d="M 110,82 Q 97,120 110,158" class="lens-stroke"/>
+  <path d="M 124,82 Q 137,120 124,158" class="lens-stroke"/>
+  <line x1="110" y1="82" x2="124" y2="82" class="lens-stroke"/>
+  <line x1="110" y1="158" x2="124" y2="158" class="lens-stroke"/>
+
+  <!-- Image plane (right) -->
+  <line x1="195" y1="80" x2="195" y2="160" class="plane"/>
+  <text x="195" y="172" text-anchor="middle" class="plane-label">sensor</text>
+
+  <!-- EP at infinity: parallel rays on scene side (left of lens) -->
+  <!-- Three parallel chief rays entering from left, horizontal (parallel to axis) -->
+  <line x1="30" y1="98" x2="117" y2="98" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="30" y1="120" x2="117" y2="120" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="30" y1="142" x2="117" y2="142" class="ray-parallel" marker-end="url(#arrB)"/>
+
+  <!-- After lens, rays converge to image-side focal point area -->
+  <line x1="117" y1="98" x2="195" y2="120" class="ray" marker-end="url(#arrY)"/>
+  <line x1="117" y1="120" x2="195" y2="120" class="ray" marker-end="url(#arrY)"/>
+  <line x1="117" y1="142" x2="195" y2="120" class="ray" marker-end="url(#arrY)"/>
+
+  <!-- EP∞ label with arrow pointing left off-panel -->
+  <text x="15" y="95" text-anchor="middle" class="inf-label">EP</text>
+  <text x="15" y="106" text-anchor="middle" class="inf-label">at ∞</text>
+  <text x="106" y="195" text-anchor="middle" class="sublabel">Chief rays parallel</text>
+  <text x="106" y="207" text-anchor="middle" class="sublabel">on scene side</text>
+
+  <!-- ════ PANEL 2: Image-space telecentric ════ -->
+  <text x="320" y="20" text-anchor="middle" class="label">Image-space</text>
+  <text x="320" y="33" text-anchor="middle" class="sublabel">telecentric</text>
+
+  <!-- Optical axis -->
+  <line x1="222" y1="120" x2="419" y2="120" class="axis"/>
+
+  <!-- Object plane -->
+  <line x1="234" y1="80" x2="234" y2="160" class="plane"/>
+  <text x="234" y="172" text-anchor="middle" class="plane-label">object</text>
+
+  <!-- Lens -->
+  <path d="M 312,82 Q 299,120 312,158 L 326,158 Q 339,120 326,82 Z" class="lens-fill"/>
+  <path d="M 312,82 Q 299,120 312,158" class="lens-stroke"/>
+  <path d="M 326,82 Q 339,120 326,158" class="lens-stroke"/>
+  <line x1="312" y1="82" x2="326" y2="82" class="lens-stroke"/>
+  <line x1="312" y1="158" x2="326" y2="158" class="lens-stroke"/>
+
+  <!-- Image plane -->
+  <line x1="408" y1="80" x2="408" y2="160" class="plane"/>
+  <text x="408" y="172" text-anchor="middle" class="plane-label">sensor</text>
+
+  <!-- Converging rays on scene side (non-parallel) -->
+  <line x1="234" y1="98" x2="319" y2="114" class="ray" marker-end="url(#arrY)"/>
+  <line x1="234" y1="120" x2="319" y2="120" class="ray" marker-end="url(#arrY)"/>
+  <line x1="234" y1="142" x2="319" y2="126" class="ray" marker-end="url(#arrY)"/>
+
+  <!-- Parallel rays on sensor side (horizontal) -->
+  <line x1="319" y1="114" x2="408" y2="98" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="319" y1="120" x2="408" y2="120" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="319" y1="126" x2="408" y2="142" class="ray-parallel" marker-end="url(#arrB)"/>
+
+  <!-- XP∞ label -->
+  <text x="420" y="96" text-anchor="start" class="inf-label">XP</text>
+  <text x="420" y="107" text-anchor="start" class="inf-label">at ∞</text>
+  <text x="320" y="195" text-anchor="middle" class="sublabel">Chief rays parallel</text>
+  <text x="320" y="207" text-anchor="middle" class="sublabel">on sensor side</text>
+
+  <!-- ════ PANEL 3: Double telecentric ════ -->
+  <text x="533" y="20" text-anchor="middle" class="label">Double</text>
+  <text x="533" y="33" text-anchor="middle" class="sublabel">telecentric</text>
+
+  <!-- Optical axis -->
+  <line x1="435" y1="120" x2="628" y2="120" class="axis"/>
+
+  <!-- Object plane -->
+  <line x1="447" y1="80" x2="447" y2="160" class="plane"/>
+  <text x="447" y="172" text-anchor="middle" class="plane-label">object</text>
+
+  <!-- Two-lens system for double telecentric -->
+  <!-- Lens 1 -->
+  <path d="M 503,85 Q 492,120 503,155 L 515,155 Q 526,120 515,85 Z" class="lens-fill"/>
+  <path d="M 503,85 Q 492,120 503,155" class="lens-stroke"/>
+  <path d="M 515,85 Q 526,120 515,155" class="lens-stroke"/>
+  <line x1="503" y1="85" x2="515" y2="85" class="lens-stroke"/>
+  <line x1="503" y1="155" x2="515" y2="155" class="lens-stroke"/>
+
+  <!-- Aperture stop between lenses -->
+  <line x1="534" y1="95" x2="534" y2="108" stroke="rgba(255,140,32,0.85)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="534" y1="132" x2="534" y2="145" stroke="rgba(255,140,32,0.85)" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Lens 2 -->
+  <path d="M 551,85 Q 540,120 551,155 L 563,155 Q 574,120 563,85 Z" class="lens-fill"/>
+  <path d="M 551,85 Q 540,120 551,155" class="lens-stroke"/>
+  <path d="M 563,85 Q 574,120 563,155" class="lens-stroke"/>
+  <line x1="551" y1="85" x2="563" y2="85" class="lens-stroke"/>
+  <line x1="551" y1="155" x2="563" y2="155" class="lens-stroke"/>
+
+  <!-- Image plane -->
+  <line x1="620" y1="80" x2="620" y2="160" class="plane"/>
+  <text x="620" y="172" text-anchor="middle" class="plane-label">sensor</text>
+
+  <!-- Parallel rays on scene side -->
+  <line x1="447" y1="100" x2="510" y2="100" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="447" y1="120" x2="510" y2="120" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="447" y1="140" x2="510" y2="140" class="ray-parallel" marker-end="url(#arrB)"/>
+
+  <!-- Rays between lenses converging through stop -->
+  <line x1="510" y1="100" x2="534" y2="120" stroke="rgba(200,180,100,0.55)" stroke-width="1.1" fill="none"/>
+  <line x1="510" y1="120" x2="534" y2="120" stroke="rgba(200,180,100,0.55)" stroke-width="1.1" fill="none"/>
+  <line x1="510" y1="140" x2="534" y2="120" stroke="rgba(200,180,100,0.55)" stroke-width="1.1" fill="none"/>
+
+  <!-- Parallel rays on sensor side -->
+  <line x1="557" y1="100" x2="620" y2="100" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="557" y1="120" x2="620" y2="120" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="557" y1="140" x2="620" y2="140" class="ray-parallel" marker-end="url(#arrB)"/>
+  <line x1="534" y1="120" x2="557" y2="100" stroke="rgba(200,180,100,0.55)" stroke-width="1.1" fill="none"/>
+  <line x1="534" y1="120" x2="557" y2="120" stroke="rgba(200,180,100,0.55)" stroke-width="1.1" fill="none"/>
+  <line x1="534" y1="120" x2="557" y2="140" stroke="rgba(200,180,100,0.55)" stroke-width="1.1" fill="none"/>
+
+  <!-- EP∞ and XP∞ labels -->
+  <text x="435" y="96" text-anchor="middle" class="inf-label">EP</text>
+  <text x="435" y="107" text-anchor="middle" class="inf-label">at ∞</text>
+  <text x="628" y="96" text-anchor="start" class="inf-label">XP</text>
+  <text x="628" y="107" text-anchor="start" class="inf-label">at ∞</text>
+
+  <text x="533" y="195" text-anchor="middle" class="sublabel">Chief rays parallel on</text>
+  <text x="533" y="207" text-anchor="middle" class="sublabel">both sides</text>
+
+  <!-- Legend -->
+  <line x1="220" y1="222" x2="245" y2="222" class="ray-parallel"/>
+  <text x="249" y="226" class="inf-label" style="font-size:9px">parallel (telecentric side)</text>
+  <line x1="380" y1="222" x2="405" y2="222" class="ray"/>
+  <text x="409" y="226" style="fill:rgba(255,200,60,0.80);font-family:'JetBrains Mono',monospace;font-size:9px">converging (non-telecentric side)</text>
+</svg>

--- a/public/diagrams/pupils/working-fnumber.svg
+++ b/public/diagrams/pupils/working-fnumber.svg
@@ -71,37 +71,37 @@
   <line x1="20" y1="110" x2="300" y2="110" class="axis"/>
 
   <!-- Exit pupil -->
-  <ellipse cx="60" cy="110" rx="11" ry="42" class="xp-fill"/>
-  <ellipse cx="60" cy="110" rx="11" ry="42" class="xp-stroke"/>
-  <text x="60" y="22" text-anchor="middle" class="label-xp" style="font-size:10px">XP</text>
-  <line x1="60" y1="25" x2="60" y2="66" class="tick" style="stroke-dasharray:2,2"/>
+  <ellipse cx="130" cy="110" rx="11" ry="42" class="xp-fill"/>
+  <ellipse cx="130" cy="110" rx="11" ry="42" class="xp-stroke"/>
+  <text x="130" y="22" text-anchor="middle" class="label-xp" style="font-size:10px">XP</text>
+  <line x1="130" y1="25" x2="130" y2="66" class="tick" style="stroke-dasharray:2,2"/>
 
   <!-- Lens group (simplified) -->
-  <path d="M 120,76 Q 107,110 120,144 L 134,144 Q 147,110 134,76 Z" class="lens-fill"/>
-  <path d="M 120,76 Q 107,110 120,144" class="lens-stroke"/>
-  <path d="M 134,76 Q 147,110 134,144" class="lens-stroke"/>
-  <line x1="120" y1="76" x2="134" y2="76" class="lens-stroke"/>
-  <line x1="120" y1="144" x2="134" y2="144" class="lens-stroke"/>
+  <path d="M 190,76 Q 177,110 190,144 L 204,144 Q 217,110 204,76 Z" class="lens-fill"/>
+  <path d="M 190,76 Q 177,110 190,144" class="lens-stroke"/>
+  <path d="M 204,76 Q 217,110 204,144" class="lens-stroke"/>
+  <line x1="190" y1="76" x2="204" y2="76" class="lens-stroke"/>
+  <line x1="190" y1="144" x2="204" y2="144" class="lens-stroke"/>
 
   <!-- Sensor (close to lens — short image conjugate) -->
   <line x1="240" y1="76" x2="240" y2="144" class="sensor"/>
   <text x="249" y="112" class="muted">sensor</text>
 
   <!-- Light cone from XP to sensor -->
-  <polygon points="60,68 60,152 240,110" class="cone-fill"/>
-  <line x1="60" y1="68" x2="240" y2="110" class="cone"/>
-  <line x1="60" y1="152" x2="240" y2="110" class="cone"/>
+  <polygon points="130,68 130,152 240,110" class="cone-fill"/>
+  <line x1="130" y1="68" x2="240" y2="110" class="cone"/>
+  <line x1="130" y1="152" x2="240" y2="110" class="cone"/>
 
   <!-- Angle arc at sensor -->
   <path d="M 220,110 A 20,20 0 0,0 224,93" fill="none" stroke="rgba(40,216,255,0.55)" stroke-width="1"/>
   <path d="M 220,110 A 20,20 0 0,1 224,127" fill="none" stroke="rgba(40,216,255,0.55)" stroke-width="1"/>
-  <text x="196" y="107" text-anchor="end" class="label-N">N</text>
+  <text x="222" y="100" text-anchor="start" class="label-N">N</text>
 
   <!-- Image conjugate dimension (XP to sensor) -->
-  <line x1="60" y1="158" x2="240" y2="158" class="dim" marker-end="url(#dimArr)" marker-start="url(#dimArrL)"/>
-  <line x1="60" y1="154" x2="60" y2="162" class="tick"/>
+  <line x1="130" y1="158" x2="240" y2="158" class="dim" marker-end="url(#dimArr)" marker-start="url(#dimArrL)"/>
+  <line x1="130" y1="154" x2="130" y2="162" class="tick"/>
   <line x1="240" y1="154" x2="240" y2="162" class="tick"/>
-  <text x="150" y="171" text-anchor="middle" class="muted">image conjugate v</text>
+  <text x="185" y="171" text-anchor="middle" class="muted">image conjugate v</text>
 
   <!-- ════ RIGHT PANEL: close focus (extended) ════ -->
   <text x="480" y="18" text-anchor="middle" class="label">Close focus (extended)</text>

--- a/public/diagrams/pupils/working-fnumber.svg
+++ b/public/diagrams/pupils/working-fnumber.svg
@@ -1,0 +1,153 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 230" width="100%" height="auto" role="img" aria-label="Working f-number vs nominal f-number diagram">
+  <defs>
+    <style>
+      .bg { fill: #12151e; }
+      .border { fill: none; stroke: rgba(150,170,210,0.18); stroke-width: 1; }
+      .divider { stroke: rgba(150,170,210,0.18); stroke-width: 1; }
+      .axis { stroke: rgba(150,170,210,0.30); stroke-width: 1; stroke-dasharray: 5,4; fill: none; }
+      .lens-fill { fill: rgba(70,130,180,0.22); }
+      .lens-stroke { fill: none; stroke: rgba(120,170,220,0.80); stroke-width: 1.5; }
+      .xp-fill { fill: rgba(217,140,255,0.10); }
+      .xp-stroke { fill: none; stroke: #d98cff; stroke-width: 2; }
+      .sensor { stroke: rgba(180,200,240,0.80); stroke-width: 2.5; stroke-linecap: round; fill: none; }
+      .cone-fill { fill: rgba(40,216,255,0.07); }
+      .cone { stroke: rgba(40,216,255,0.55); stroke-width: 1.2; fill: none; }
+      .cone-narrow { fill: rgba(255,200,60,0.06); }
+      .cone-narrow-stroke { stroke: rgba(255,200,60,0.55); stroke-width: 1.2; fill: none; }
+      .dim { stroke: rgba(150,170,210,0.40); stroke-width: 1; fill: none; }
+      .ext-arrow { stroke: rgba(255,160,50,0.70); stroke-width: 1.5; fill: none; }
+      .label { fill: #c8d8f0; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-xp { fill: #d98cff; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 11px; }
+      .label-N { fill: #28d8ff; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 12px; font-weight: 700; }
+      .label-Neff { fill: #ffc83c; font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 12px; font-weight: 700; }
+      .muted { fill: rgba(150,170,200,0.65); font-family: 'JetBrains Mono','SF Mono',monospace; font-size: 9.5px; }
+      .tick { stroke: rgba(150,170,210,0.40); stroke-width: 1; fill: none; }
+      @media (prefers-color-scheme: light) {
+        .bg { fill: #eff2f8; }
+        .border { stroke: rgba(60,80,120,0.18); }
+        .divider { stroke: rgba(60,80,120,0.18); }
+        .axis { stroke: rgba(60,80,120,0.28); }
+        .lens-fill { fill: rgba(30,80,160,0.10); }
+        .lens-stroke { stroke: rgba(30,80,160,0.65); }
+        .xp-fill { fill: rgba(120,46,184,0.07); }
+        .xp-stroke { stroke: #7a2eb8; }
+        .sensor { stroke: rgba(40,80,160,0.75); }
+        .cone-fill { fill: rgba(0,104,120,0.07); }
+        .cone { stroke: rgba(0,104,120,0.55); }
+        .cone-narrow { fill: rgba(160,100,0,0.06); }
+        .cone-narrow-stroke { stroke: rgba(160,100,0,0.55); }
+        .dim { stroke: rgba(60,80,120,0.38); }
+        .ext-arrow { stroke: rgba(200,100,0,0.70); }
+        .label { fill: #1a2540; }
+        .label-xp { fill: #7a2eb8; }
+        .label-N { fill: #006878; }
+        .label-Neff { fill: #a06000; }
+        .muted { fill: rgba(60,80,120,0.60); }
+        .tick { stroke: rgba(60,80,120,0.35); }
+      }
+    </style>
+    <marker id="dimArr" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="rgba(150,170,210,0.60)"/>
+    </marker>
+    <marker id="dimArrL" markerWidth="5" markerHeight="5" refX="1" refY="2.5" orient="auto">
+      <path d="M5,0 L0,2.5 L5,5 Z" fill="rgba(150,170,210,0.60)"/>
+    </marker>
+    <marker id="extArr" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="rgba(255,160,50,0.80)"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="640" height="230" rx="6" class="bg"/>
+  <rect width="640" height="230" rx="6" class="border"/>
+
+  <!-- Panel divider -->
+  <line x1="320" y1="22" x2="320" y2="215" class="divider"/>
+
+  <!-- ════ LEFT PANEL: focus at infinity ════ -->
+  <text x="160" y="18" text-anchor="middle" class="label">Focus at infinity</text>
+
+  <!-- Optical axis -->
+  <line x1="20" y1="110" x2="300" y2="110" class="axis"/>
+
+  <!-- Exit pupil -->
+  <ellipse cx="60" cy="110" rx="11" ry="42" class="xp-fill"/>
+  <ellipse cx="60" cy="110" rx="11" ry="42" class="xp-stroke"/>
+  <text x="60" y="22" text-anchor="middle" class="label-xp" style="font-size:10px">XP</text>
+  <line x1="60" y1="25" x2="60" y2="66" class="tick" style="stroke-dasharray:2,2"/>
+
+  <!-- Lens group (simplified) -->
+  <path d="M 120,76 Q 107,110 120,144 L 134,144 Q 147,110 134,76 Z" class="lens-fill"/>
+  <path d="M 120,76 Q 107,110 120,144" class="lens-stroke"/>
+  <path d="M 134,76 Q 147,110 134,144" class="lens-stroke"/>
+  <line x1="120" y1="76" x2="134" y2="76" class="lens-stroke"/>
+  <line x1="120" y1="144" x2="134" y2="144" class="lens-stroke"/>
+
+  <!-- Sensor (close to lens — short image conjugate) -->
+  <line x1="240" y1="76" x2="240" y2="144" class="sensor"/>
+  <text x="249" y="112" class="muted">sensor</text>
+
+  <!-- Light cone from XP to sensor -->
+  <polygon points="60,68 60,152 240,110" class="cone-fill"/>
+  <line x1="60" y1="68" x2="240" y2="110" class="cone"/>
+  <line x1="60" y1="152" x2="240" y2="110" class="cone"/>
+
+  <!-- Angle arc at sensor -->
+  <path d="M 220,110 A 20,20 0 0,0 224,93" fill="none" stroke="rgba(40,216,255,0.55)" stroke-width="1"/>
+  <path d="M 220,110 A 20,20 0 0,1 224,127" fill="none" stroke="rgba(40,216,255,0.55)" stroke-width="1"/>
+  <text x="196" y="107" text-anchor="end" class="label-N">N</text>
+
+  <!-- Image conjugate dimension (XP to sensor) -->
+  <line x1="60" y1="158" x2="240" y2="158" class="dim" marker-end="url(#dimArr)" marker-start="url(#dimArrL)"/>
+  <line x1="60" y1="154" x2="60" y2="162" class="tick"/>
+  <line x1="240" y1="154" x2="240" y2="162" class="tick"/>
+  <text x="150" y="171" text-anchor="middle" class="muted">image conjugate v</text>
+
+  <!-- ════ RIGHT PANEL: close focus (extended) ════ -->
+  <text x="480" y="18" text-anchor="middle" class="label">Close focus (extended)</text>
+
+  <!-- Optical axis -->
+  <line x1="330" y1="110" x2="620" y2="110" class="axis"/>
+
+  <!-- Exit pupil (same position relative to lens) -->
+  <ellipse cx="370" cy="110" rx="11" ry="42" class="xp-fill"/>
+  <ellipse cx="370" cy="110" rx="11" ry="42" class="xp-stroke"/>
+  <text x="370" y="22" text-anchor="middle" class="label-xp" style="font-size:10px">XP</text>
+  <line x1="370" y1="25" x2="370" y2="66" class="tick" style="stroke-dasharray:2,2"/>
+
+  <!-- Lens group -->
+  <path d="M 430,76 Q 417,110 430,144 L 444,144 Q 457,110 444,76 Z" class="lens-fill"/>
+  <path d="M 430,76 Q 417,110 430,144" class="lens-stroke"/>
+  <path d="M 444,76 Q 457,110 444,144" class="lens-stroke"/>
+  <line x1="430" y1="76" x2="444" y2="76" class="lens-stroke"/>
+  <line x1="430" y1="144" x2="444" y2="144" class="lens-stroke"/>
+
+  <!-- Sensor — pushed farther right (longer image conjugate) -->
+  <line x1="570" y1="76" x2="570" y2="144" class="sensor"/>
+  <text x="579" y="112" class="muted">sensor</text>
+
+  <!-- Extension arrow (showing the lens has been pushed out) -->
+  <line x1="444" y1="185" x2="568" y2="185" class="ext-arrow" marker-end="url(#extArr)"/>
+  <line x1="444" y1="181" x2="444" y2="189" class="tick"/>
+  <text x="506" y="198" text-anchor="middle" class="muted">extended (longer conjugate)</text>
+
+  <!-- Light cone from XP to sensor — NARROWER angle -->
+  <polygon points="370,68 370,152 570,110" class="cone-narrow"/>
+  <line x1="370" y1="68" x2="570" y2="110" class="cone-narrow-stroke"/>
+  <line x1="370" y1="152" x2="570" y2="110" class="cone-narrow-stroke"/>
+
+  <!-- Narrower angle arc at sensor -->
+  <path d="M 550,110 A 20,20 0 0,0 553,97" fill="none" stroke="rgba(255,200,60,0.55)" stroke-width="1"/>
+  <path d="M 550,110 A 20,20 0 0,1 553,123" fill="none" stroke="rgba(255,200,60,0.55)" stroke-width="1"/>
+  <text x="525" y="107" text-anchor="end" class="label-Neff">N&#x1D452;&#x1D453;&#x1D453; &gt; N</text>
+
+  <!-- Image conjugate dimension (XP to sensor) — longer -->
+  <line x1="370" y1="158" x2="570" y2="158" class="dim" marker-end="url(#dimArr)" marker-start="url(#dimArrL)"/>
+  <line x1="370" y1="154" x2="370" y2="162" class="tick"/>
+  <line x1="570" y1="154" x2="570" y2="162" class="tick"/>
+  <text x="470" y="171" text-anchor="middle" class="muted">image conjugate v′ &gt; v</text>
+
+  <!-- Bottom explanation -->
+  <text x="160" y="212" text-anchor="middle" class="muted">XP subtends wide angle → fast (low N)</text>
+  <text x="480" y="212" text-anchor="middle" class="muted">XP subtends narrow angle → slow (high N&#x1D452;&#x1D453;&#x1D453;)</text>
+</svg>

--- a/scripts/generate-build-metadata.mjs
+++ b/scripts/generate-build-metadata.mjs
@@ -147,7 +147,9 @@ function collectRoutes(lenses, articles, makerSlugs) {
 /* ── Article metadata ─────────────────────────────────────────────────── */
 
 function collectArticles(fallbackDate) {
-  const mdFiles = readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".md"));
+  const mdFiles = readdirSync(CONTENT_DIR, { recursive: true })
+    .filter((f) => typeof f === "string" && f.endsWith(".md"))
+    .map((f) => f.replace(/\\/g, "/"));
   const articles = [];
 
   for (const file of mdFiles) {

--- a/src/components/diagram/EntrancePupilDiagram.tsx
+++ b/src/components/diagram/EntrancePupilDiagram.tsx
@@ -1,0 +1,149 @@
+interface Colors {
+  bg: string;
+  border: string;
+  axis: string;
+  lensFill: string;
+  lensStroke: string;
+  stop: string;
+  epStroke: string;
+  epFill: string;
+  ray: string;
+  label: string;
+  labelAccent: string;
+  labelStop: string;
+  muted: string;
+  tick: string;
+}
+
+const DARK: Colors = {
+  bg: "#12151e",
+  border: "rgba(150,170,210,0.18)",
+  axis: "rgba(150,170,210,0.35)",
+  lensFill: "rgba(70,130,180,0.22)",
+  lensStroke: "rgba(120,170,220,0.80)",
+  stop: "#ff8c20",
+  epStroke: "#28d8ff",
+  epFill: "rgba(40,216,255,0.06)",
+  ray: "rgba(40,216,255,0.45)",
+  label: "#c8d8f0",
+  labelAccent: "#28d8ff",
+  labelStop: "#ff8c20",
+  muted: "rgba(150,170,200,0.65)",
+  tick: "rgba(150,170,210,0.4)",
+};
+
+const LIGHT: Colors = {
+  bg: "#eff2f8",
+  border: "rgba(60,80,120,0.18)",
+  axis: "rgba(60,80,120,0.32)",
+  lensFill: "rgba(30,80,160,0.10)",
+  lensStroke: "rgba(30,80,160,0.65)",
+  stop: "#c05000",
+  epStroke: "#006878",
+  epFill: "rgba(0,104,120,0.06)",
+  ray: "rgba(0,104,120,0.40)",
+  label: "#1a2540",
+  labelAccent: "#006878",
+  labelStop: "#c05000",
+  muted: "rgba(60,80,120,0.60)",
+  tick: "rgba(60,80,120,0.35)",
+};
+
+const FONT = "'JetBrains Mono','SF Mono',monospace";
+
+export default function EntrancePupilDiagram({ isDark }: { isDark: boolean }) {
+  const c = isDark ? DARK : LIGHT;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 640 220"
+      width="100%"
+      height="auto"
+      role="img"
+      aria-label="Entrance pupil diagram"
+    >
+      {/* Background */}
+      <rect width="640" height="220" rx="6" fill={c.bg} />
+      <rect width="640" height="220" rx="6" fill="none" stroke={c.border} strokeWidth={1} />
+
+      {/* Optical axis */}
+      <line x1="30" y1="110" x2="600" y2="110" stroke={c.axis} strokeWidth={1} strokeDasharray="5,4" />
+
+      {/* Entrance pupil (virtual, dashed) */}
+      <ellipse cx="92" cy="110" rx="13" ry="68" fill={c.epFill} />
+      <ellipse
+        cx="92"
+        cy="110"
+        rx="13"
+        ry="68"
+        fill="none"
+        stroke={c.epStroke}
+        strokeWidth={1.5}
+        strokeDasharray="5,3"
+      />
+      <line x1="92" y1="108" x2="92" y2="112" stroke={c.tick} strokeWidth={1} />
+
+      {/* Front group element 1 */}
+      <path d="M 258,68 Q 241,110 258,152 L 276,152 Q 293,110 276,68 Z" fill={c.lensFill} />
+      <path d="M 258,68 Q 241,110 258,152" fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <path d="M 276,68 Q 293,110 276,152" fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1="258" y1="68" x2="276" y2="68" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1="258" y1="152" x2="276" y2="152" stroke={c.lensStroke} strokeWidth={1.5} />
+
+      {/* Front group element 2 */}
+      <path d="M 298,68 Q 281,110 298,152 L 316,152 Q 333,110 316,68 Z" fill={c.lensFill} />
+      <path d="M 298,68 Q 281,110 298,152" fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <path d="M 316,68 Q 333,110 316,68" fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1="298" y1="68" x2="316" y2="68" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1="298" y1="152" x2="316" y2="152" stroke={c.lensStroke} strokeWidth={1.5} />
+      <path d="M 316,68 Q 333,110 316,152" fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+
+      {/* Aperture stop (iris) */}
+      <line x1="445" y1="30" x2="445" y2="72" stroke={c.stop} strokeWidth={3} strokeLinecap="round" />
+      <line x1="445" y1="148" x2="445" y2="190" stroke={c.stop} strokeWidth={3} strokeLinecap="round" />
+      <line x1="443" y1="108" x2="447" y2="112" stroke={c.stop} strokeWidth={1} opacity={0.5} />
+
+      {/* Construction rays: EP edges → stop edges */}
+      <line x1="92" y1="42" x2="445" y2="72" stroke={c.ray} strokeWidth={1} strokeDasharray="6,4" />
+      <line x1="92" y1="178" x2="445" y2="148" stroke={c.ray} strokeWidth={1} strokeDasharray="6,4" />
+
+      {/* Labels */}
+      <text x="92" y="20" textAnchor="middle" fill={c.labelAccent} fontFamily={FONT} fontSize={11}>
+        Entrance pupil
+      </text>
+      <text x="92" y="33" textAnchor="middle" fill={c.muted} fontFamily={FONT} fontSize={10}>
+        (virtual image of stop)
+      </text>
+      <line x1="92" y1="36" x2="92" y2="41" stroke={c.tick} strokeWidth={1} strokeDasharray="3,2" />
+
+      <text x="287" y="180" textAnchor="middle" fill={c.label} fontFamily={FONT} fontSize={11}>
+        Front group
+      </text>
+      <path d="M 255,170 L 255,175 L 319,175 L 319,170" fill="none" stroke={c.tick} strokeWidth={1} />
+
+      <text x="460" y="52" textAnchor="start" fill={c.labelStop} fontFamily={FONT} fontSize={11}>
+        Aperture stop
+      </text>
+      <text x="460" y="65" textAnchor="start" fill={c.labelStop} fontFamily={FONT} fontSize={11}>
+        (iris)
+      </text>
+      <line x1="457" y1="55" x2="449" y2="55" stroke={c.tick} strokeWidth={1} strokeDasharray="2,2" />
+
+      <text x="510" y="107" textAnchor="start" fill={c.muted} fontFamily={FONT} fontSize={10}>
+        rear group
+      </text>
+      <text x="510" y="119" textAnchor="start" fill={c.muted} fontFamily={FONT} fontSize={10}>
+        → sensor
+      </text>
+
+      {/* EP ↔ stop distance annotation */}
+      <line x1="92" y1="200" x2="445" y2="200" stroke={c.tick} strokeWidth={1} />
+      <line x1="92" y1="196" x2="92" y2="204" stroke={c.tick} strokeWidth={1} />
+      <line x1="445" y1="196" x2="445" y2="204" stroke={c.tick} strokeWidth={1} />
+      <text x="268" y="214" textAnchor="middle" fill={c.muted} fontFamily={FONT} fontSize={10}>
+        EP displaced from stop (magnification by front group)
+      </text>
+    </svg>
+  );
+}

--- a/src/components/diagram/ExitPupilDiagram.tsx
+++ b/src/components/diagram/ExitPupilDiagram.tsx
@@ -1,0 +1,197 @@
+interface Colors {
+  bg: string;
+  border: string;
+  axis: string;
+  lensFill: string;
+  lensStroke: string;
+  xpFill: string;
+  xpStroke: string;
+  sensor: string;
+  sensorFill: string;
+  microlens: string;
+  pixelFill: string;
+  rayAxial: string;
+  rayChief: string;
+  dim: string;
+  label: string;
+  labelXp: string;
+  labelAxial: string;
+  labelChief: string;
+  muted: string;
+  tick: string;
+  arrDim: string;
+  arrChief: string;
+  arrAxial: string;
+  craArc: string;
+}
+
+const DARK: Colors = {
+  bg: "#12151e",
+  border: "rgba(150,170,210,0.18)",
+  axis: "rgba(150,170,210,0.32)",
+  lensFill: "rgba(70,130,180,0.22)",
+  lensStroke: "rgba(120,170,220,0.80)",
+  xpFill: "rgba(217,140,255,0.10)",
+  xpStroke: "#d98cff",
+  sensor: "rgba(180,200,240,0.80)",
+  sensorFill: "rgba(80,140,220,0.12)",
+  microlens: "rgba(120,180,230,0.70)",
+  pixelFill: "rgba(40,100,180,0.20)",
+  rayAxial: "rgba(40,216,255,0.75)",
+  rayChief: "rgba(255,200,60,0.80)",
+  dim: "rgba(150,170,210,0.40)",
+  label: "#c8d8f0",
+  labelXp: "#d98cff",
+  labelAxial: "#28d8ff",
+  labelChief: "#ffc83c",
+  muted: "rgba(150,170,200,0.65)",
+  tick: "rgba(150,170,210,0.40)",
+  arrDim: "rgba(150,170,210,0.60)",
+  arrChief: "rgba(255,200,60,0.90)",
+  arrAxial: "rgba(40,216,255,0.90)",
+  craArc: "rgba(255,200,60,0.60)",
+};
+
+const LIGHT: Colors = {
+  bg: "#eff2f8",
+  border: "rgba(60,80,120,0.18)",
+  axis: "rgba(60,80,120,0.30)",
+  lensFill: "rgba(30,80,160,0.10)",
+  lensStroke: "rgba(30,80,160,0.65)",
+  xpFill: "rgba(120,46,184,0.07)",
+  xpStroke: "#7a2eb8",
+  sensor: "rgba(40,80,160,0.75)",
+  sensorFill: "rgba(40,80,160,0.07)",
+  microlens: "rgba(30,80,160,0.60)",
+  pixelFill: "rgba(30,80,160,0.12)",
+  rayAxial: "rgba(0,104,120,0.75)",
+  rayChief: "rgba(160,100,0,0.80)",
+  dim: "rgba(60,80,120,0.35)",
+  label: "#1a2540",
+  labelXp: "#7a2eb8",
+  labelAxial: "#006878",
+  labelChief: "#a06000",
+  muted: "rgba(60,80,120,0.60)",
+  tick: "rgba(60,80,120,0.35)",
+  arrDim: "rgba(60,80,120,0.50)",
+  arrChief: "rgba(160,100,0,0.90)",
+  arrAxial: "rgba(0,104,120,0.90)",
+  craArc: "rgba(160,100,0,0.60)",
+};
+
+const FONT = "'JetBrains Mono','SF Mono',monospace";
+
+export default function ExitPupilDiagram({ isDark }: { isDark: boolean }) {
+  const c = isDark ? DARK : LIGHT;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 640 220"
+      width="100%"
+      height="auto"
+      role="img"
+      aria-label="Exit pupil and chief ray angle diagram"
+    >
+      <defs>
+        <marker id="xp-arr" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" fill={c.arrDim} />
+        </marker>
+        <marker id="xp-arr-chief" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" fill={c.arrChief} />
+        </marker>
+        <marker id="xp-arr-axial" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" fill={c.arrAxial} />
+        </marker>
+      </defs>
+
+      {/* Background */}
+      <rect width="640" height="220" rx="6" fill={c.bg} />
+      <rect width="640" height="220" rx="6" fill="none" stroke={c.border} strokeWidth={1} />
+
+      {/* Optical axis */}
+      <line x1="30" y1="110" x2="600" y2="110" stroke={c.axis} strokeWidth={1} strokeDasharray="5,4" />
+
+      {/* Exit pupil */}
+      <ellipse cx="120" cy="110" rx="14" ry="52" fill={c.xpFill} />
+      <ellipse cx="120" cy="110" rx="14" ry="52" fill="none" stroke={c.xpStroke} strokeWidth={2} />
+      <text x="120" y="18" textAnchor="middle" fill={c.labelXp} fontFamily={FONT} fontSize={11}>
+        Exit pupil (XP)
+      </text>
+      <line x1="120" y1="21" x2="120" y2="56" stroke={c.tick} strokeWidth={1} strokeDasharray="3,2" />
+
+      {/* Simplified rear lens group */}
+      <path d="M 170,70 Q 155,110 170,150 L 188,150 Q 203,110 188,70 Z" fill={c.lensFill} />
+      <path d="M 170,70 Q 155,110 170,150" fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <path d="M 188,70 Q 203,110 188,150" fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1="170" y1="70" x2="188" y2="70" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1="170" y1="150" x2="188" y2="150" stroke={c.lensStroke} strokeWidth={1.5} />
+
+      {/* Image sensor body */}
+      <rect x="490" y="60" width="14" height="100" rx="2" fill={c.sensorFill} />
+      <line x1="497" y1="60" x2="497" y2="160" stroke={c.sensor} strokeWidth={2.5} />
+
+      {/* Pixels */}
+      <rect x="488" y="104" width="14" height="12" fill={c.pixelFill} />
+      <rect x="488" y="88" width="14" height="12" fill={c.pixelFill} />
+      <rect x="488" y="124" width="14" height="12" fill={c.pixelFill} />
+      <rect x="488" y="72" width="14" height="12" fill={c.pixelFill} />
+      <rect x="488" y="144" width="14" height="12" fill={c.pixelFill} />
+
+      {/* Microlenses */}
+      <path d="M 490,104 Q 486,110 490,116" fill="none" stroke={c.microlens} strokeWidth={1.2} />
+      <path d="M 490,88 Q 486,94 490,100" fill="none" stroke={c.microlens} strokeWidth={1.2} />
+      <path d="M 490,124 Q 486,130 490,136" fill="none" stroke={c.microlens} strokeWidth={1.2} />
+      <path d="M 490,72 Q 486,78 490,84" fill="none" stroke={c.microlens} strokeWidth={1.2} />
+      <path d="M 490,144 Q 486,150 490,156" fill="none" stroke={c.microlens} strokeWidth={1.2} />
+      <text x="502" y="57" textAnchor="start" fill={c.muted} fontFamily={FONT} fontSize={10}>
+        sensor
+      </text>
+
+      {/* On-axis chief ray (CRA = 0°) */}
+      <line x1="120" y1="110" x2="490" y2="110" stroke={c.rayAxial} strokeWidth={1.4} markerEnd="url(#xp-arr-axial)" />
+      <text x="290" y="104" textAnchor="middle" fill={c.labelAxial} fontFamily={FONT} fontSize={10}>
+        CRA = 0°
+      </text>
+
+      {/* Off-axis chief ray (CRA > 0°) */}
+      <line x1="120" y1="110" x2="490" y2="78" stroke={c.rayChief} strokeWidth={1.4} markerEnd="url(#xp-arr-chief)" />
+
+      {/* CRA angle arc at corner pixel */}
+      <path d="M 490,78 L 470,78 A 20,20 0 0,1 473,66" fill="none" stroke={c.craArc} strokeWidth={1} />
+      <text x="455" y="65" textAnchor="middle" fill={c.labelChief} fontFamily={FONT} fontSize={10}>
+        CRA &gt; 0°
+      </text>
+
+      {/* d_XP dimension line */}
+      <line x1="120" y1="170" x2="490" y2="170" stroke={c.dim} strokeWidth={1} markerEnd="url(#xp-arr)" />
+      <line x1="490" y1="170" x2="120" y2="170" stroke={c.dim} strokeWidth={1} markerEnd="url(#xp-arr)" />
+      <line x1="120" y1="165" x2="120" y2="175" stroke={c.tick} strokeWidth={1} />
+      <line x1="490" y1="165" x2="490" y2="175" stroke={c.tick} strokeWidth={1} />
+      <text x="305" y="184" textAnchor="middle" fill={c.labelXp} fontFamily={FONT} fontSize={11}>
+        d&#x2093;&#x2097; (exit-pupil distance)
+      </text>
+
+      {/* y′ image height dimension */}
+      <line x1="510" y1="110" x2="510" y2="78" stroke={c.dim} strokeWidth={1} />
+      <line x1="506" y1="110" x2="514" y2="110" stroke={c.tick} strokeWidth={1} />
+      <line x1="506" y1="78" x2="514" y2="78" stroke={c.tick} strokeWidth={1} />
+      <text x="525" y="96" textAnchor="start" fill={c.label} fontFamily={FONT} fontSize={10}>
+        y′
+      </text>
+      <text x="521" y="107" textAnchor="start" fill={c.muted} fontFamily={FONT} fontSize={10}>
+        (image height)
+      </text>
+
+      {/* Legend */}
+      <line x1="40" y1="200" x2="70" y2="200" stroke={c.rayAxial} strokeWidth={1.4} />
+      <text x="75" y="204" fill={c.labelAxial} fontFamily={FONT} fontSize={10}>
+        on-axis chief ray (CRA=0°)
+      </text>
+      <line x1="300" y1="200" x2="330" y2="200" stroke={c.rayChief} strokeWidth={1.4} />
+      <text x="335" y="204" fill={c.labelChief} fontFamily={FONT} fontSize={10}>
+        off-axis chief ray (CRA&gt;0°)
+      </text>
+    </svg>
+  );
+}

--- a/src/components/diagram/TelecentricityDiagram.tsx
+++ b/src/components/diagram/TelecentricityDiagram.tsx
@@ -1,0 +1,281 @@
+interface Colors {
+  bg: string;
+  border: string;
+  panelDiv: string;
+  plane: string;
+  planeLabel: string;
+  lensFill: string;
+  lensStroke: string;
+  ray: string;
+  rayParallel: string;
+  axis: string;
+  label: string;
+  sublabel: string;
+  infLabel: string;
+  stop: string;
+  interLens: string;
+  arrY: string;
+  arrB: string;
+  legendChief: string;
+}
+
+const DARK: Colors = {
+  bg: "#12151e",
+  border: "rgba(150,170,210,0.18)",
+  panelDiv: "rgba(150,170,210,0.18)",
+  plane: "rgba(150,170,210,0.45)",
+  planeLabel: "rgba(150,170,200,0.65)",
+  lensFill: "rgba(70,130,180,0.22)",
+  lensStroke: "rgba(120,170,220,0.80)",
+  ray: "rgba(255,200,60,0.75)",
+  rayParallel: "rgba(40,216,255,0.75)",
+  axis: "rgba(150,170,210,0.25)",
+  label: "#c8d8f0",
+  sublabel: "rgba(150,170,200,0.75)",
+  infLabel: "rgba(40,216,255,0.85)",
+  stop: "rgba(255,140,32,0.85)",
+  interLens: "rgba(200,180,100,0.55)",
+  arrY: "rgba(255,200,60,0.90)",
+  arrB: "rgba(40,216,255,0.90)",
+  legendChief: "rgba(255,200,60,0.80)",
+};
+
+const LIGHT: Colors = {
+  bg: "#eff2f8",
+  border: "rgba(60,80,120,0.18)",
+  panelDiv: "rgba(60,80,120,0.18)",
+  plane: "rgba(60,80,120,0.45)",
+  planeLabel: "rgba(60,80,120,0.60)",
+  lensFill: "rgba(30,80,160,0.10)",
+  lensStroke: "rgba(30,80,160,0.65)",
+  ray: "rgba(160,100,0,0.75)",
+  rayParallel: "rgba(0,104,120,0.75)",
+  axis: "rgba(60,80,120,0.22)",
+  label: "#1a2540",
+  sublabel: "rgba(60,80,120,0.70)",
+  infLabel: "rgba(0,104,120,0.85)",
+  stop: "rgba(180,80,0,0.85)",
+  interLens: "rgba(120,100,30,0.50)",
+  arrY: "rgba(160,100,0,0.90)",
+  arrB: "rgba(0,104,120,0.90)",
+  legendChief: "rgba(160,100,0,0.80)",
+};
+
+const FONT = "'JetBrains Mono','SF Mono',monospace";
+
+function Lens({ x, y1, y2, c }: { x: number; y1: number; y2: number; c: Colors }) {
+  const mx = x + 14;
+  const cy = (y1 + y2) / 2;
+  return (
+    <>
+      <path
+        d={`M ${x},${y1} Q ${x - 13},${cy} ${x},${y2} L ${mx},${y2} Q ${mx + 13},${cy} ${mx},${y1} Z`}
+        fill={c.lensFill}
+      />
+      <path d={`M ${x},${y1} Q ${x - 13},${cy} ${x},${y2}`} fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <path d={`M ${mx},${y1} Q ${mx + 13},${cy} ${mx},${y2}`} fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1={x} y1={y1} x2={mx} y2={y1} stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1={x} y1={y2} x2={mx} y2={y2} stroke={c.lensStroke} strokeWidth={1.5} />
+    </>
+  );
+}
+
+export default function TelecentricityDiagram({ isDark }: { isDark: boolean }) {
+  const c = isDark ? DARK : LIGHT;
+
+  const ray = { stroke: c.ray, strokeWidth: 1.3, fill: "none" } as const;
+  const rayP = { stroke: c.rayParallel, strokeWidth: 1.3, fill: "none" } as const;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 640 230"
+      width="100%"
+      height="auto"
+      role="img"
+      aria-label="Three forms of telecentricity diagram"
+    >
+      <defs>
+        <marker id="tc-arrY" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+          <path d="M0,0 L5,2.5 L0,5 Z" fill={c.arrY} />
+        </marker>
+        <marker id="tc-arrB" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+          <path d="M0,0 L5,2.5 L0,5 Z" fill={c.arrB} />
+        </marker>
+      </defs>
+
+      {/* Background */}
+      <rect width="640" height="230" rx="6" fill={c.bg} />
+      <rect width="640" height="230" rx="6" fill="none" stroke={c.border} strokeWidth={1} />
+
+      {/* Panel dividers */}
+      <line x1="213" y1="30" x2="213" y2="210" stroke={c.panelDiv} strokeWidth={1} />
+      <line x1="427" y1="30" x2="427" y2="210" stroke={c.panelDiv} strokeWidth={1} />
+
+      {/* ── PANEL 1: Object-space telecentric ── */}
+      <text x="106" y="20" textAnchor="middle" fill={c.label} fontFamily={FONT} fontSize={11} fontWeight={600}>
+        Object-space
+      </text>
+      <text x="106" y="33" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        telecentric
+      </text>
+
+      <line x1="18" y1="120" x2="205" y2="120" stroke={c.axis} strokeWidth={1} strokeDasharray="4,4" />
+
+      <line x1="30" y1="80" x2="30" y2="160" stroke={c.plane} strokeWidth={1.5} strokeLinecap="round" />
+      <text x="30" y="172" textAnchor="middle" fill={c.planeLabel} fontFamily={FONT} fontSize={9}>
+        object
+      </text>
+
+      <Lens x={110} y1={82} y2={158} c={c} />
+
+      <line x1="195" y1="80" x2="195" y2="160" stroke={c.plane} strokeWidth={1.5} strokeLinecap="round" />
+      <text x="195" y="172" textAnchor="middle" fill={c.planeLabel} fontFamily={FONT} fontSize={9}>
+        sensor
+      </text>
+
+      {/* Parallel rays — scene side */}
+      <line x1="30" y1="98" x2="117" y2="98" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="30" y1="120" x2="117" y2="120" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="30" y1="142" x2="117" y2="142" {...rayP} markerEnd="url(#tc-arrB)" />
+
+      {/* Converging rays — sensor side */}
+      <line x1="117" y1="98" x2="195" y2="120" {...ray} markerEnd="url(#tc-arrY)" />
+      <line x1="117" y1="120" x2="195" y2="120" {...ray} markerEnd="url(#tc-arrY)" />
+      <line x1="117" y1="142" x2="195" y2="120" {...ray} markerEnd="url(#tc-arrY)" />
+
+      <text x="15" y="95" textAnchor="middle" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        EP
+      </text>
+      <text x="15" y="106" textAnchor="middle" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        at ∞
+      </text>
+      <text x="106" y="195" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        Chief rays parallel
+      </text>
+      <text x="106" y="207" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        on scene side
+      </text>
+
+      {/* ── PANEL 2: Image-space telecentric ── */}
+      <text x="320" y="20" textAnchor="middle" fill={c.label} fontFamily={FONT} fontSize={11} fontWeight={600}>
+        Image-space
+      </text>
+      <text x="320" y="33" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        telecentric
+      </text>
+
+      <line x1="222" y1="120" x2="419" y2="120" stroke={c.axis} strokeWidth={1} strokeDasharray="4,4" />
+
+      <line x1="234" y1="80" x2="234" y2="160" stroke={c.plane} strokeWidth={1.5} strokeLinecap="round" />
+      <text x="234" y="172" textAnchor="middle" fill={c.planeLabel} fontFamily={FONT} fontSize={9}>
+        object
+      </text>
+
+      <Lens x={312} y1={82} y2={158} c={c} />
+
+      <line x1="408" y1="80" x2="408" y2="160" stroke={c.plane} strokeWidth={1.5} strokeLinecap="round" />
+      <text x="408" y="172" textAnchor="middle" fill={c.planeLabel} fontFamily={FONT} fontSize={9}>
+        sensor
+      </text>
+
+      {/* Diverging rays — scene side (from single point) */}
+      <line x1="234" y1="120" x2="319" y2="100" {...ray} markerEnd="url(#tc-arrY)" />
+      <line x1="234" y1="120" x2="319" y2="120" {...ray} markerEnd="url(#tc-arrY)" />
+      <line x1="234" y1="120" x2="319" y2="140" {...ray} markerEnd="url(#tc-arrY)" />
+
+      {/* Parallel rays — sensor side */}
+      <line x1="319" y1="100" x2="408" y2="100" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="319" y1="120" x2="408" y2="120" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="319" y1="140" x2="408" y2="140" {...rayP} markerEnd="url(#tc-arrB)" />
+
+      <text x="420" y="96" textAnchor="start" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        XP
+      </text>
+      <text x="420" y="107" textAnchor="start" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        at ∞
+      </text>
+      <text x="320" y="195" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        Chief rays parallel
+      </text>
+      <text x="320" y="207" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        on sensor side
+      </text>
+
+      {/* ── PANEL 3: Double telecentric ── */}
+      <text x="533" y="20" textAnchor="middle" fill={c.label} fontFamily={FONT} fontSize={11} fontWeight={600}>
+        Double
+      </text>
+      <text x="533" y="33" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        telecentric
+      </text>
+
+      <line x1="435" y1="120" x2="628" y2="120" stroke={c.axis} strokeWidth={1} strokeDasharray="4,4" />
+
+      <line x1="447" y1="80" x2="447" y2="160" stroke={c.plane} strokeWidth={1.5} strokeLinecap="round" />
+      <text x="447" y="172" textAnchor="middle" fill={c.planeLabel} fontFamily={FONT} fontSize={9}>
+        object
+      </text>
+
+      <Lens x={503} y1={85} y2={155} c={c} />
+
+      {/* Aperture stop between lenses */}
+      <line x1="534" y1="95" x2="534" y2="108" stroke={c.stop} strokeWidth={2} strokeLinecap="round" />
+      <line x1="534" y1="132" x2="534" y2="145" stroke={c.stop} strokeWidth={2} strokeLinecap="round" />
+
+      <Lens x={551} y1={85} y2={155} c={c} />
+
+      <line x1="620" y1="80" x2="620" y2="160" stroke={c.plane} strokeWidth={1.5} strokeLinecap="round" />
+      <text x="620" y="172" textAnchor="middle" fill={c.planeLabel} fontFamily={FONT} fontSize={9}>
+        sensor
+      </text>
+
+      {/* Parallel rays — scene side */}
+      <line x1="447" y1="100" x2="510" y2="100" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="447" y1="120" x2="510" y2="120" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="447" y1="140" x2="510" y2="140" {...rayP} markerEnd="url(#tc-arrB)" />
+
+      {/* Inter-lens rays converging through stop */}
+      <line x1="510" y1="100" x2="534" y2="120" stroke={c.interLens} strokeWidth={1.1} />
+      <line x1="510" y1="120" x2="534" y2="120" stroke={c.interLens} strokeWidth={1.1} />
+      <line x1="510" y1="140" x2="534" y2="120" stroke={c.interLens} strokeWidth={1.1} />
+      <line x1="534" y1="120" x2="557" y2="100" stroke={c.interLens} strokeWidth={1.1} />
+      <line x1="534" y1="120" x2="557" y2="120" stroke={c.interLens} strokeWidth={1.1} />
+      <line x1="534" y1="120" x2="557" y2="140" stroke={c.interLens} strokeWidth={1.1} />
+
+      {/* Parallel rays — sensor side */}
+      <line x1="557" y1="100" x2="620" y2="100" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="557" y1="120" x2="620" y2="120" {...rayP} markerEnd="url(#tc-arrB)" />
+      <line x1="557" y1="140" x2="620" y2="140" {...rayP} markerEnd="url(#tc-arrB)" />
+
+      <text x="435" y="96" textAnchor="middle" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        EP
+      </text>
+      <text x="435" y="107" textAnchor="middle" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        at ∞
+      </text>
+      <text x="628" y="96" textAnchor="start" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        XP
+      </text>
+      <text x="628" y="107" textAnchor="start" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        at ∞
+      </text>
+      <text x="533" y="195" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        Chief rays parallel on
+      </text>
+      <text x="533" y="207" textAnchor="middle" fill={c.sublabel} fontFamily={FONT} fontSize={9.5}>
+        both sides
+      </text>
+
+      {/* Legend */}
+      <line x1="40" y1="222" x2="65" y2="222" stroke={c.rayParallel} strokeWidth={1.3} />
+      <text x="69" y="226" fill={c.infLabel} fontFamily={FONT} fontSize={9}>
+        parallel (telecentric side)
+      </text>
+      <line x1="365" y1="222" x2="390" y2="222" stroke={c.ray} strokeWidth={1.3} />
+      <text x="394" y="226" fill={c.legendChief} fontFamily={FONT} fontSize={9}>
+        converging (non-telecentric side)
+      </text>
+    </svg>
+  );
+}

--- a/src/components/diagram/WorkingFNumberDiagram.tsx
+++ b/src/components/diagram/WorkingFNumberDiagram.tsx
@@ -1,0 +1,251 @@
+interface Colors {
+  bg: string;
+  border: string;
+  divider: string;
+  axis: string;
+  lensFill: string;
+  lensStroke: string;
+  xpFill: string;
+  xpStroke: string;
+  sensor: string;
+  coneFill: string;
+  cone: string;
+  coneNarrow: string;
+  coneNarrowStroke: string;
+  coneArc: string;
+  coneNarrowArc: string;
+  dim: string;
+  extArrow: string;
+  label: string;
+  labelXp: string;
+  labelN: string;
+  labelNeff: string;
+  muted: string;
+  tick: string;
+  arrDim: string;
+  extArrHead: string;
+}
+
+const DARK: Colors = {
+  bg: "#12151e",
+  border: "rgba(150,170,210,0.18)",
+  divider: "rgba(150,170,210,0.18)",
+  axis: "rgba(150,170,210,0.30)",
+  lensFill: "rgba(70,130,180,0.22)",
+  lensStroke: "rgba(120,170,220,0.80)",
+  xpFill: "rgba(217,140,255,0.10)",
+  xpStroke: "#d98cff",
+  sensor: "rgba(180,200,240,0.80)",
+  coneFill: "rgba(40,216,255,0.07)",
+  cone: "rgba(40,216,255,0.55)",
+  coneNarrow: "rgba(255,200,60,0.06)",
+  coneNarrowStroke: "rgba(255,200,60,0.55)",
+  coneArc: "rgba(40,216,255,0.55)",
+  coneNarrowArc: "rgba(255,200,60,0.55)",
+  dim: "rgba(150,170,210,0.40)",
+  extArrow: "rgba(255,160,50,0.70)",
+  label: "#c8d8f0",
+  labelXp: "#d98cff",
+  labelN: "#28d8ff",
+  labelNeff: "#ffc83c",
+  muted: "rgba(150,170,200,0.65)",
+  tick: "rgba(150,170,210,0.40)",
+  arrDim: "rgba(150,170,210,0.60)",
+  extArrHead: "rgba(255,160,50,0.80)",
+};
+
+const LIGHT: Colors = {
+  bg: "#eff2f8",
+  border: "rgba(60,80,120,0.18)",
+  divider: "rgba(60,80,120,0.18)",
+  axis: "rgba(60,80,120,0.28)",
+  lensFill: "rgba(30,80,160,0.10)",
+  lensStroke: "rgba(30,80,160,0.65)",
+  xpFill: "rgba(120,46,184,0.07)",
+  xpStroke: "#7a2eb8",
+  sensor: "rgba(40,80,160,0.75)",
+  coneFill: "rgba(0,104,120,0.07)",
+  cone: "rgba(0,104,120,0.55)",
+  coneNarrow: "rgba(160,100,0,0.06)",
+  coneNarrowStroke: "rgba(160,100,0,0.55)",
+  coneArc: "rgba(0,104,120,0.55)",
+  coneNarrowArc: "rgba(160,100,0,0.55)",
+  dim: "rgba(60,80,120,0.38)",
+  extArrow: "rgba(200,100,0,0.70)",
+  label: "#1a2540",
+  labelXp: "#7a2eb8",
+  labelN: "#006878",
+  labelNeff: "#a06000",
+  muted: "rgba(60,80,120,0.60)",
+  tick: "rgba(60,80,120,0.35)",
+  arrDim: "rgba(60,80,120,0.50)",
+  extArrHead: "rgba(200,100,0,0.80)",
+};
+
+const FONT = "'JetBrains Mono','SF Mono',monospace";
+
+function Lens({ x, c }: { x: number; c: Colors }) {
+  const x2 = x + 14;
+  return (
+    <>
+      <path d={`M ${x},76 Q ${x - 13},110 ${x},144 L ${x2},144 Q ${x2 + 13},110 ${x2},76 Z`} fill={c.lensFill} />
+      <path d={`M ${x},76 Q ${x - 13},110 ${x},144`} fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <path d={`M ${x2},76 Q ${x2 + 13},110 ${x2},144`} fill="none" stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1={x} y1={76} x2={x2} y2={76} stroke={c.lensStroke} strokeWidth={1.5} />
+      <line x1={x} y1={144} x2={x2} y2={144} stroke={c.lensStroke} strokeWidth={1.5} />
+    </>
+  );
+}
+
+export default function WorkingFNumberDiagram({ isDark }: { isDark: boolean }) {
+  const c = isDark ? DARK : LIGHT;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 640 230"
+      width="100%"
+      height="auto"
+      role="img"
+      aria-label="Working f-number vs nominal f-number diagram"
+    >
+      <defs>
+        <marker id="wfn-dimArr" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+          <path d="M0,0 L5,2.5 L0,5 Z" fill={c.arrDim} />
+        </marker>
+        <marker id="wfn-dimArrL" markerWidth="5" markerHeight="5" refX="1" refY="2.5" orient="auto">
+          <path d="M5,0 L0,2.5 L5,5 Z" fill={c.arrDim} />
+        </marker>
+        <marker id="wfn-extArr" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+          <path d="M0,0 L5,2.5 L0,5 Z" fill={c.extArrHead} />
+        </marker>
+      </defs>
+
+      {/* Background */}
+      <rect width="640" height="230" rx="6" fill={c.bg} />
+      <rect width="640" height="230" rx="6" fill="none" stroke={c.border} strokeWidth={1} />
+
+      {/* Panel divider */}
+      <line x1="320" y1="22" x2="320" y2="215" stroke={c.divider} strokeWidth={1} />
+
+      {/* ── LEFT PANEL: focus at infinity ── */}
+      <text x="160" y="18" textAnchor="middle" fill={c.label} fontFamily={FONT} fontSize={11}>
+        Focus at infinity
+      </text>
+
+      <line x1="20" y1="110" x2="300" y2="110" stroke={c.axis} strokeWidth={1} strokeDasharray="5,4" />
+
+      {/* Exit pupil */}
+      <ellipse cx="130" cy="110" rx="11" ry="42" fill={c.xpFill} />
+      <ellipse cx="130" cy="110" rx="11" ry="42" fill="none" stroke={c.xpStroke} strokeWidth={2} />
+      <text x="130" y="22" textAnchor="middle" fill={c.labelXp} fontFamily={FONT} fontSize={10}>
+        XP
+      </text>
+      <line x1="130" y1="25" x2="130" y2="66" stroke={c.tick} strokeWidth={1} strokeDasharray="2,2" />
+
+      <Lens x={190} c={c} />
+
+      {/* Sensor */}
+      <line x1="240" y1="76" x2="240" y2="144" stroke={c.sensor} strokeWidth={2.5} strokeLinecap="round" />
+      <text x="249" y="112" fill={c.muted} fontFamily={FONT} fontSize={9.5}>
+        sensor
+      </text>
+
+      {/* Light cone */}
+      <polygon points="130,68 130,152 240,110" fill={c.coneFill} />
+      <line x1="130" y1="68" x2="240" y2="110" stroke={c.cone} strokeWidth={1.2} />
+      <line x1="130" y1="152" x2="240" y2="110" stroke={c.cone} strokeWidth={1.2} />
+
+      {/* Angle arc */}
+      <path d="M 220,110 A 20,20 0 0,0 224,93" fill="none" stroke={c.coneArc} strokeWidth={1} />
+      <path d="M 220,110 A 20,20 0 0,1 224,127" fill="none" stroke={c.coneArc} strokeWidth={1} />
+      <text x="222" y="100" textAnchor="start" fill={c.labelN} fontFamily={FONT} fontSize={12} fontWeight={700}>
+        N
+      </text>
+
+      {/* Image conjugate dimension */}
+      <line
+        x1="130"
+        y1="158"
+        x2="240"
+        y2="158"
+        stroke={c.dim}
+        strokeWidth={1}
+        markerEnd="url(#wfn-dimArr)"
+        markerStart="url(#wfn-dimArrL)"
+      />
+      <line x1="130" y1="154" x2="130" y2="162" stroke={c.tick} strokeWidth={1} />
+      <line x1="240" y1="154" x2="240" y2="162" stroke={c.tick} strokeWidth={1} />
+      <text x="185" y="171" textAnchor="middle" fill={c.muted} fontFamily={FONT} fontSize={9.5}>
+        image conjugate v
+      </text>
+
+      {/* ── RIGHT PANEL: close focus (extended) ── */}
+      <text x="480" y="18" textAnchor="middle" fill={c.label} fontFamily={FONT} fontSize={11}>
+        Close focus (extended)
+      </text>
+
+      <line x1="330" y1="110" x2="620" y2="110" stroke={c.axis} strokeWidth={1} strokeDasharray="5,4" />
+
+      {/* Exit pupil */}
+      <ellipse cx="370" cy="110" rx="11" ry="42" fill={c.xpFill} />
+      <ellipse cx="370" cy="110" rx="11" ry="42" fill="none" stroke={c.xpStroke} strokeWidth={2} />
+      <text x="370" y="22" textAnchor="middle" fill={c.labelXp} fontFamily={FONT} fontSize={10}>
+        XP
+      </text>
+      <line x1="370" y1="25" x2="370" y2="66" stroke={c.tick} strokeWidth={1} strokeDasharray="2,2" />
+
+      <Lens x={430} c={c} />
+
+      {/* Sensor */}
+      <line x1="570" y1="76" x2="570" y2="144" stroke={c.sensor} strokeWidth={2.5} strokeLinecap="round" />
+      <text x="579" y="112" fill={c.muted} fontFamily={FONT} fontSize={9.5}>
+        sensor
+      </text>
+
+      {/* Extension arrow */}
+      <line x1="444" y1="185" x2="568" y2="185" stroke={c.extArrow} strokeWidth={1.5} markerEnd="url(#wfn-extArr)" />
+      <line x1="444" y1="181" x2="444" y2="189" stroke={c.tick} strokeWidth={1} />
+      <text x="506" y="198" textAnchor="middle" fill={c.muted} fontFamily={FONT} fontSize={9.5}>
+        extended (longer conjugate)
+      </text>
+
+      {/* Light cone — narrower angle */}
+      <polygon points="370,68 370,152 570,110" fill={c.coneNarrow} />
+      <line x1="370" y1="68" x2="570" y2="110" stroke={c.coneNarrowStroke} strokeWidth={1.2} />
+      <line x1="370" y1="152" x2="570" y2="110" stroke={c.coneNarrowStroke} strokeWidth={1.2} />
+
+      {/* Narrower angle arc */}
+      <path d="M 550,110 A 20,20 0 0,0 553,97" fill="none" stroke={c.coneNarrowArc} strokeWidth={1} />
+      <path d="M 550,110 A 20,20 0 0,1 553,123" fill="none" stroke={c.coneNarrowArc} strokeWidth={1} />
+      <text x="525" y="107" textAnchor="end" fill={c.labelNeff} fontFamily={FONT} fontSize={12} fontWeight={700}>
+        N&#x1D452;&#x1D453;&#x1D453; &gt; N
+      </text>
+
+      {/* Image conjugate dimension — longer */}
+      <line
+        x1="370"
+        y1="158"
+        x2="570"
+        y2="158"
+        stroke={c.dim}
+        strokeWidth={1}
+        markerEnd="url(#wfn-dimArr)"
+        markerStart="url(#wfn-dimArrL)"
+      />
+      <line x1="370" y1="154" x2="370" y2="162" stroke={c.tick} strokeWidth={1} />
+      <line x1="570" y1="154" x2="570" y2="162" stroke={c.tick} strokeWidth={1} />
+      <text x="470" y="171" textAnchor="middle" fill={c.muted} fontFamily={FONT} fontSize={9.5}>
+        image conjugate v′ &gt; v
+      </text>
+
+      {/* Bottom captions */}
+      <text x="160" y="212" textAnchor="middle" fill={c.muted} fontFamily={FONT} fontSize={9.5}>
+        XP subtends wide angle → fast (low N)
+      </text>
+      <text x="480" y="212" textAnchor="middle" fill={c.muted} fontFamily={FONT} fontSize={9.5}>
+        XP subtends narrow angle → slow (high N&#x1D452;&#x1D453;&#x1D453;)
+      </text>
+    </svg>
+  );
+}

--- a/src/content/pupils/ApertureStopMonograph.md
+++ b/src/content/pupils/ApertureStopMonograph.md
@@ -1,0 +1,385 @@
+---
+slug: aperture-stop-in-practice
+title: "The Aperture Stop in Practice: Entrance Pupil, Exit Pupil, and Telecentricity"
+summary: A graduate-level treatment of aperture stops, entrance and exit pupils, and their photographic consequences — working f-number, panorama stitching, sensor CRA compatibility, corner illumination, telecentricity, and mirrorless design advantages.
+tag: guide
+series: pupil-geometry
+seriesOrder: 8
+toc: true
+---
+
+# The Aperture Stop in Practice: Entrance Pupil, Exit Pupil, and Telecentricity
+
+*Part 1 of a series on pupil geometry in photographic lenses. This monograph is written at a graduate level and assumes familiarity with basic geometric optics.*
+
+---
+
+## 1. Introduction: The Aperture You Set Is Not the Aperture the System "Sees"
+
+When a photographer adjusts the aperture ring or command dial, the intuition is straightforward: the iris diaphragm opens or closes, admitting more or less light. The f-number changes, depth of field shifts, and the exposure follows. In daily practice, this mental model is sufficient. But it is also incomplete — and the gap between the simple model and the physical reality explains a surprising number of optical behaviors that photographers encounter but rarely trace to their source.
+
+In optical design, the physical diaphragm — the *aperture stop* — is only the starting point. The quantities that actually govern image formation are the **entrance pupil** and **exit pupil**: virtual images of the stop, formed by the lens elements on either side of it. The entrance pupil is what the optical system presents to object space; the exit pupil is what it presents to image space. Together, they determine the geometry of every light cone that enters and exits the lens. That geometry, in turn, controls the effective f-number, the perspective projection center, the angular distribution of light arriving at the sensor, and the illumination uniformity across the image field.
+
+This article develops these ideas from first-order definitions through practical photographic consequences, connecting classical optics to real design tradeoffs. Along the way, it covers working f-number, panorama stitching, the chief-ray angle that matters to digital sensors, the three distinct causes of corner light loss, and the concept of telecentricity as a specific structural condition rather than a vague quality label. Detailed case studies of three photographic lenses appear in Part 2.
+
+The central claim is simple: photographers adjust a physical aperture stop, but lenses and sensors *see* the entrance and exit pupils. Understanding the distinction is the first step toward understanding nearly every design tradeoff in modern photographic optics.
+
+---
+
+## 2. First-Order Definitions: Stop, Pupils, Chief Ray, Marginal Ray
+
+### 2.1 The Aperture Stop
+
+Every imaging system contains one aperture that limits the cone of light accepted from the on-axis object point. This is the **aperture stop** [^1] [^2]. In most photographic lenses, the aperture stop is a variable-diameter iris diaphragm located somewhere between the front and rear lens groups. It is physical hardware — metal blades that form a roughly polygonal or circular opening.
+
+The aperture stop is defined by function, not by intent. Any aperture in the system — a lens-element rim, a barrel wall, a filter ring — *could* act as the aperture stop if it happens to be the most restrictive for the axial bundle. In a well-designed photographic lens, the iris diaphragm is deliberately sized and positioned so that it is always the limiting aperture for the on-axis beam at every marked f-number. Other apertures may clip off-axis beams (producing vignetting), but the stop is the one that governs the axial cone.
+
+### 2.2 Entrance Pupil and Exit Pupil
+
+The **entrance pupil** is the image of the aperture stop as seen from object space — that is, the image formed by all optical elements located in front of the stop [^1] [^2]. If you look into the front of a camera lens, the bright disk you see is the entrance pupil. It is not the physical diaphragm itself; it is an image of the diaphragm, magnified or demagnified by the front group and potentially shifted in position along the optical axis.
+
+The **exit pupil** is the image of the aperture stop as seen from image space — the image formed by all optical elements located behind the stop [^1] [^2]. If you could look into the rear of the lens from the sensor plane, the apparent aperture you would see is the exit pupil.
+
+Put simply, the entrance pupil, the exit pupil, and the physical stop are three views of the same limiting aperture, formed by the optics on either side of the stop. More precisely, they are *conjugate* to each other through the optical system: every ray that passes through the edge of the entrance pupil also passes through the edge of the exit pupil and through the edge of the physical stop. This conjugacy means that the pupils carry exactly the same aperture-limiting information, expressed in different optical spaces.
+
+### 2.3 Marginal Ray and Chief Ray
+
+Two reference rays define the geometry of any rotationally symmetric optical system [^1] [^2]:
+
+The **marginal ray** originates from the on-axis object point and grazes the edge of the aperture stop (or, equivalently, the rim of the entrance or exit pupil). It defines the system's maximum acceptance angle and therefore its light-gathering capacity. The marginal ray height at the image plane is zero (it converges to the axial image point), while its height at the stop equals the stop's semi-diameter.
+
+The **chief ray** (also called the *principal ray* in some European texts) originates from an off-axis object point and passes through the *center* of the aperture stop. In object space, it appears to pass through the center of the entrance pupil; in image space, it appears to emerge from the center of the exit pupil. The chief ray defines the field geometry: the angle it makes with the optical axis in object space is the **field angle** (or semi-field angle, $W$), and the height at which it crosses the image plane defines the **image height**, $y'$.
+
+Together, the marginal ray and the chief ray carry all first-order information about the system [^1] [^2] [^18]. The marginal ray encodes the aperture (how much light), and the chief ray encodes the field (where the light goes). Every first-order imaging property — f-number, magnification, field of view, pupil locations — can be extracted from these two rays traced through the paraxial system.
+
+### 2.4 The f-Number and the Entrance Pupil
+
+The f-number of a lens focused at infinity is defined as [^1] [^2]:
+
+$$N = \frac{f}{D_{\text{EP}}}$$
+
+where $f$ is the effective focal length and $D_{\text{EP}}$ is the diameter of the entrance pupil. This is not the diameter of the physical iris — it is the diameter of the iris's *image in object space*. The distinction matters. A lens whose mechanical diaphragm is 12 mm across may present a 25 mm entrance pupil if the front group magnifies the stop by a factor of approximately 2×. The photographer sees "f/2" on the lens barrel, and that f/2 is computed from the entrance-pupil diameter, not from the physical iris size. Two lenses with identical physical iris diameters can have different f-numbers if their front groups magnify the stop differently.
+
+The image-side geometry can equivalently be described in terms of the exit pupil. The image-space numerical aperture, $\text{NA}'$, is related to the half-angle $\theta'$ subtended by the exit pupil as seen from the axial image point:
+
+$$\text{NA}' = n' \sin \theta'$$
+
+where $n'$ is the refractive index of the image-space medium (unity for air). For a lens focused at infinity, the paraxial relationship between f-number and numerical aperture is:
+
+$$N \approx \frac{1}{2\,\text{NA}'}$$
+
+This holds regardless of the pupil magnification $m_p$ (introduced in Section 4). The reason is instructive: a lens with $m_p \neq 1$ has an exit pupil that differs in diameter from the entrance pupil, but it also has an exit pupil that sits at a different distance from the image plane — specifically, at $d_{\text{XP}} = m_p \cdot f$. The $m_p$ factor in the exit-pupil diameter and the $m_p$ factor in the exit-pupil distance cancel exactly, so that $\text{NA}' = D_{\text{XP}} / (2\,d_{\text{XP}}) = m_p D_{\text{EP}} / (2\,m_p f) = D_{\text{EP}} / (2f) = 1/(2N)$. The pupil magnification does not independently appear in the $N$-to-$\text{NA}'$ relationship at infinity — its practical consequences emerge instead in the working f-number at finite conjugates (Section 3.4) and in the image-side chief-ray angle geometry (Section 4).
+
+Either way, the f-number and the numerical aperture encode the same underlying physics — the solid angle of the light cone — viewed from opposite ends of the optical system. The f-number describes it from object space via the entrance pupil; the numerical aperture describes it from image space via the exit pupil.
+
+---
+
+## 3. Entrance Pupil in Practice: Apparent Aperture, Projection Center, and Panorama Rotation
+
+### 3.1 The Entrance Pupil as Apparent Aperture
+
+The entrance pupil is the aperture that the object "sees." Looking into the front of a photographic lens, the luminous disk visible within the glass is the entrance pupil — the virtual image of the iris diaphragm, formed by refraction through the front optical group. Its diameter, position along the axis, and apparent shape are all determined by the imaging properties of the elements in front of the stop.
+
+This is one of the few "invisible" optical quantities that photographers can estimate directly. Hold a 50 mm f/2 lens at arm's length, look into the front element, and the bright disk you see is the entrance pupil. From the f-number equation, its diameter is $D_{\text{EP}} = f/N = 50/2 = 25$ mm — roughly the width of a U.S. quarter. The physical iris inside the lens may be considerably smaller; what you are seeing is that iris magnified by the front group.
+
+Because the front group acts as an imaging system for the stop, the entrance pupil may be larger or smaller than the physical diaphragm, and it may be located in front of, behind, or within the front group. In a simple design where the stop is the frontmost element (as in some view-camera lenses or pinhole cameras), the entrance pupil coincides with the physical stop. But in any lens with optical elements ahead of the stop — which includes virtually all modern photographic lenses — the entrance pupil is displaced and scaled relative to the stop.
+
+For the Leica APO-Summicron-M 35 f/2 ASPH., Leica explicitly publishes the entrance-pupil position: **13.8 mm in front of the lens bayonet mount** [^15]. The f-number equation gives $D_{\text{EP}} = 35/2 = 17.5$ mm — the bright disk you see looking into the front of this lens is roughly 17.5 mm across, even though the physical iris and barrel are substantially different in both size and location. This is one of the few cases where a manufacturer publishes a hard number for entrance-pupil position, making it a useful reference. (A detailed examination of this lens's pupil behavior appears in Part 2.)
+
+### 3.2 Projection Center and Perspective Geometry
+
+In rectilinear (non-fisheye) imaging, the entrance pupil acts as the **projection center** — the point from which the lens maps angular positions in object space to linear positions on the image plane [^2] [^3]. The fundamental relationship for a rectilinear lens focused at infinity is:
+
+$$y' = f \tan W$$
+
+where $y'$ is the image height (distance from the optical axis on the image plane), $f$ is the effective focal length, and $W$ is the semi-field angle — the angle the chief ray from an off-axis object point makes with the optical axis in object space. This equation describes ideal rectilinear projection: straight lines in the scene map to straight lines in the image, and the mapping is governed by the tangent of the field angle.
+
+The projection center is the point from which these angular relationships are measured. In paraxial theory, it is located at the center of the entrance pupil. This is the reason the entrance pupil, rather than the front element or the lens's center of mass, is the geometrically meaningful reference point for perspective.
+
+### 3.3 Panorama Rotation and the No-Parallax Point
+
+The projection-center property of the entrance pupil has a direct practical consequence: when stitching panoramic images, the camera should be rotated about the entrance pupil to minimize parallax between overlapping frames.
+
+When the rotation axis coincides with the entrance pupil, near and far objects maintain the same angular relationships across frames, and the overlapping regions register correctly. When the rotation axis is displaced from the entrance pupil — for example, when the camera rotates about the tripod socket — near objects shift laterally relative to far objects between frames. This parallax shift produces visible misregistration in the stitched panorama, particularly when the scene contains objects at substantially different distances from the camera.
+
+In practice, panorama-head manufacturers provide adjustment rails that allow the photographer to position the rotation axis at the entrance pupil. The adjustment is lens-specific because the entrance pupil position depends on the lens design. For lenses that publish the entrance pupil location (such as the Leica APO-Summicron-M 35 f/2 ASPH., at 13.8 mm before the bayonet), the setup is straightforward. For lenses that do not, the position must be found empirically by adjusting the camera position on the rail until parallax vanishes between near and far targets.
+
+> **Sidebar: "Nodal Point" versus Entrance Pupil**
+>
+> Photographers frequently refer to the panorama rotation point as the "nodal point." This is technically inaccurate. The **nodal points** are cardinal points defined by unit angular magnification — a property of the principal planes, not of the aperture stop [^2] [^3]. In the simplest single-thin-lens teaching model — especially when the stop is treated as lying in the lens plane — the nodal points, principal points, and pupils are all represented as coincident. That simplification likely explains why the conflation persists. In a real multi-element lens, they generally do not coincide. The **entrance pupil** is the correct term for the no-parallax point, because it is the entrance pupil that defines the projection center.
+
+### 3.4 Working f-Number: Why f/2.8 Changes at Close Range
+
+The f-number engraved on a lens barrel is the *infinity-conjugate* f-number — valid when the lens is focused at infinity. At closer working distances, the effective f-number increases because the image conjugate lengthens: the image is formed farther from the rear principal plane, and the exit pupil subtends a smaller angle as seen from the image plane. The light per unit area on the sensor decreases accordingly.
+
+For a conventional lens (one that focuses by changing the overall lens-to-sensor distance without altering its internal optics), the effective f-number at magnification $m$ is [^2] [^4]:
+
+$$N_{\text{eff}} = N\,(1 + m)$$
+
+where $N$ is the marked (infinity-conjugate) f-number and $m$ is the image magnification (positive, defined as the ratio of image height to object height). At 1:1 macro magnification ($m = 1$), the effective f-number doubles: a lens marked f/2.8 behaves as f/5.6, a two-stop loss. Every macro photographer has experienced the practical consequence — significant exposure compensation at high magnification — even though the physical iris has not changed.
+
+When pupil magnification ($m_p$, defined in Section 4) differs from unity, the more general expression is [^2] [^4]:
+
+$$N_{\text{eff}} = N\left(1 + \frac{m}{m_p}\right)$$
+
+This accounts for the fact that the exit pupil, not the entrance pupil, determines the solid angle subtended at the image plane. For lenses with $m_p \neq 1$, the exposure penalty at a given magnification differs from the simple $(1 + m)$ rule.
+
+Internally focusing lenses partially decouple this relationship because they change the effective focal length and pupil geometry as they focus, rather than simply extending the image conjugate. The effective f-number still changes, but the relationship between magnification and exposure loss becomes design-specific and cannot be predicted from the infinity f-number alone. (For a detailed treatment of how internal focusing architectures affect pupil and conjugate geometry, see the [*Internal Focusing in Photographic Lens Design*](/articles/internal-focusing-monograph) monograph elsewhere on this site.)
+
+---
+
+## 4. Exit Pupil in Practice: Image-Side Light Cones, Chief-Ray Angle, and Sensors
+
+### 4.1 The Exit Pupil and Image-Side Geometry
+
+The exit pupil is the image-side apparent aperture — the image of the stop formed by the optical elements behind it. It is the aperture from which, in the paraxial model, all image-side ray bundles appear to originate. This means that if you trace any ray from the image plane backward through the rear group, it will appear to have come from the exit pupil — just as, in object space, every ray that enters the lens appears to pass through the entrance pupil.
+
+The exit pupil's diameter and axial position jointly determine the geometry of the light cones that converge onto the image plane. A large exit pupil close to the sensor produces wide, steeply angled cones; a smaller exit pupil farther from the sensor produces narrower cones at shallower angles. These two parameters — size and distance — control everything the sensor experiences: the f-number of the arriving light, the angular spread of each image-forming bundle, and the obliquity at which off-axis bundles strike the sensor surface.
+
+For the axial image point, the exit pupil subtends a half-angle $\theta'$ whose sine gives the image-space numerical aperture. For off-axis image points, the angle between the chief ray and the optical axis at the image plane is the **chief-ray angle (CRA)** — a quantity of central importance to digital sensor performance, as we shall see.
+
+### 4.2 Pupil Magnification
+
+The **pupil magnification** is the ratio of the exit-pupil diameter to the entrance-pupil diameter [^2] [^4]:
+
+$$m_p = \frac{D_{\text{XP}}}{D_{\text{EP}}}$$
+
+where $D_{\text{XP}}$ and $D_{\text{EP}}$ are the diameters of the exit and entrance pupils, respectively. This ratio links the object-side and image-side cone geometries and participates directly in the generalized illumination law (discussed below) and in the effective f-number expression at finite conjugates.
+
+For most photographic lenses, $m_p \neq 1$, meaning the exit pupil is a different size than the entrance pupil:
+
+- **Telephoto designs** typically have $m_p < 1$ (often in the range 0.5–0.8 for long telephotos): the exit pupil is smaller than the entrance pupil. The rear group acts as a telephoto relay, compressing the beam. This is a natural consequence of the positive-front / negative-rear power distribution that shortens the physical length below the focal length.
+
+- **Retrofocus (inverted telephoto) wide-angle designs** typically have $m_p > 1$ (commonly 1.2–2.0 or higher for ultra-wides): the exit pupil is larger than the entrance pupil. The negative-front / positive-rear power distribution that produces a long back focal distance also magnifies the stop image in image space.
+
+Pupil magnification matters because the exit pupil — not the entrance pupil — is what the sensor "sees." Two lenses with identical f-numbers (identical entrance-pupil diameters relative to focal length) can deliver different image-side cone geometries if their pupil magnifications differ.
+
+Pupil magnification also affects close-range depth-of-field behavior. In simplified photographic formulae, front and rear depth of field are often treated using assumptions that ignore pupil asymmetry. When $m_p \neq 1$, the near/far balance of depth of field is modified because the image-side and object-side cone geometries are no longer symmetric. For telephoto designs with $m_p < 1$, the rear depth of field tends to be compressed relative to the front; for retrofocus designs with $m_p > 1$, the tendency is reversed. The effect is usually modest at ordinary working distances but becomes more significant at high magnification, where it compounds with the working-f-number shift discussed in Section 3.4.
+
+### 4.3 Chief-Ray Angle and Sensor Compatibility
+
+The **chief-ray angle (CRA)** at the image plane is the angle the chief ray makes with the optical axis where it crosses the sensor surface. In the paraxial model, the CRA at any image height $y'$ is determined by the position of the exit pupil:
+
+$$\tan(\text{CRA}) = \frac{y'}{d_{\text{XP}}}$$
+
+where $d_{\text{XP}}$ is the distance from the exit pupil to the image plane (positive when the exit pupil is in front of the image plane). When the exit pupil is close to the sensor, the CRA increases steeply toward the field corners. When the exit pupil is far from the sensor, the CRA remains small even at large image heights.
+
+For film-based cameras, the CRA was of relatively minor importance — silver halide emulsion responds to photons largely regardless of their angle of incidence. For digital sensors, the CRA is critical [^20].
+
+The intuition is straightforward: think of venetian blinds. When light arrives perpendicular to the slats, it passes through efficiently. As the angle of incidence steepens, the slats progressively block it. Modern CMOS sensor pixels present a similar geometry. Microlens arrays positioned over each pixel concentrate incoming light onto the photodiode, but these microlenses are optimized for a specific range of incidence angles [^20]. When the CRA exceeds the design angle, light arriving at the pixel well is partially blocked by the walls of the pixel structure or directed to the wrong photodiode, causing:
+
+- **Reduced corner illumination** — luminance falloff beyond what the natural radiometric law predicts.
+- **Color crosstalk** — light intended for one pixel spills into adjacent pixels, degrading color accuracy and resolution [^20].
+- **Color cast in corners** — if the microlens offset pattern does not match the lens's CRA distribution, the red, green, and blue channels may exhibit different falloff rates, producing a visible color shift.
+
+Sensor manufacturers address this by shifting the microlens positions progressively outward toward the sensor edges (a technique called *microlens offset optimization* or *CRA matching*), but this optimization is tuned to a specific expected CRA profile [^20] [^21]. Lenses that deviate significantly from the expected profile may produce visible artifacts on sensors not designed for their CRA distribution. A well-known example is the behavior of rangefinder-type wide-angle lenses — such as the Leica Elmarit-M 28 mm or the Zeiss Biogon 21 mm — on digital bodies. These designs place the rear optical group relatively close to the sensor and can produce substantially steeper image-side chief-ray angles at the field corners than retrofocus SLR-type wide-angles. On sensors whose microlens arrays are optimized for the more moderate CRA profiles of SLR-type retrofocus designs, the result is visible magenta or cyan color casts in the corners — a direct, practical consequence of CRA mismatch [^14].
+
+It is worth noting that the sensor-side consequences depend not only on the lens's CRA distribution, but also on the specific sensor stack, microlens offsets, pixel geometry, and color filter arrangement. The same lens may behave differently on two sensors with different CRA optimization profiles. The visible severity of corner color cast, in particular, is a joint property of the lens-sensor system — not a stable characteristic of the lens by itself.
+
+The exit pupil, pupil magnification, and chief-ray angle together form the image-side counterpart to the entrance-pupil geometry discussed in Section 3. The entrance pupil governs how the lens collects light; the exit pupil governs how that light is delivered to the sensor. The next section turns to the question of *how much* light arrives at each point across the image field — the problem of corner illumination.
+
+---
+
+## 5. Corner Illumination: The cos⁴ Law, Vignetting, and Pupil Aberrations
+
+### 5.1 Natural Radiometric Falloff and the cos⁴ Law
+
+Corner illumination falloff in a photographic image has multiple contributing causes, and conflating them leads to confusion. The most fundamental is the **natural (radiometric) falloff** that arises from the geometry of oblique imaging itself, independent of any lens defect.
+
+For an idealized thin lens imaging a Lambertian (uniformly bright) scene, the relative irradiance $E$ at an image point corresponding to an off-axis object at semi-field angle $W$ (measured in object space at the entrance pupil) follows [^2] [^8] [^17] [^19]:
+
+$$\frac{E(W)}{E(0)} = \cos^4 W$$
+
+This is the classical **cos⁴ law** of illumination falloff. To understand where the four powers of cosine come from, imagine two small patches of a uniformly bright scene — one on the optical axis, one at semi-field angle $W$. Consider the imaging of each patch through the same thin lens, and compare the irradiance each produces on the image plane.
+
+Three things change for the off-axis patch relative to the on-axis one:
+
+First, the entrance pupil appears **foreshortened**. Seen from the off-axis object point, the circular pupil is viewed obliquely and appears as an ellipse with its area reduced by a factor of $\cos W$. Less pupil area means less light collected: one factor of $\cos W$.
+
+Second, the off-axis image point is **farther from the lens** (and from the exit pupil, which for a thin lens sits at the lens). The axial image point is at distance $f$ from the lens; the off-axis image point is at distance $f / \cos W$, because the chief ray to that point travels along a longer, oblique path. Irradiance falls off as the inverse square of distance, so the distance increase by a factor of $1/\cos W$ introduces a factor of $\cos^2 W$: two more powers of cosine.
+
+Third, the light cone arriving at the off-axis image point strikes the sensor surface **obliquely**, spreading its energy over a larger area than a normally-incident cone would. The area increase is $1/\cos W$, giving one more factor of $\cos W$ in irradiance.
+
+The product of these three contributions — one from foreshortening, two from inverse-square distance, and one from oblique incidence — yields $\cos^4 W$.
+
+**Critical clarification:** The angle $W$ in this classical derivation is the *object-space semi-field angle* — the angle the chief ray makes with the axis as measured at the entrance pupil. For a thin lens, this equals the image-space chief-ray angle because the entrance and exit pupils coincide. But in a real multi-element lens, the object-space field angle and the image-space CRA are generally different quantities related through the pupil magnification and the lens's power distribution. The distinction is essential: the entire point of telecentric design (Section 6) is to make the image-space CRA approach zero even when the object-space field angle is large.
+
+The following table gives the classical $\cos^4 W$ values for representative field angles:
+
+| $W$ (degrees) | $\cos^4 W$ | Relative illumination | Falloff (stops) |
+|:-:|:-:|:-:|:-:|
+| 0° | 1.000 | 100.0% | 0.0 |
+| 5° | 0.985 | 98.5% | 0.0 |
+| 10° | 0.941 | 94.1% | 0.1 |
+| 15° | 0.871 | 87.1% | 0.2 |
+| 20° | 0.780 | 78.0% | 0.4 |
+| 25° | 0.675 | 67.5% | 0.6 |
+| 30° | 0.563 | 56.3% | 0.8 |
+| 35° | 0.450 | 45.0% | 1.2 |
+| 40° | 0.344 | 34.4% | 1.5 |
+
+For a 35 mm focal length on a full-frame sensor (43.3 mm image diagonal), the corner half-field angle is approximately 31.8°, giving a classical cos⁴ falloff to about 52% — nearly a full stop of light loss in the corners from radiometric geometry alone, before any vignetting enters the picture.
+
+In real lenses, the actual illumination falloff is governed by a more general expression. Three additional factors modify the classical cos⁴ result: the off-axis pupil area may differ from the on-axis area (due to pupil aberrations), the effective ray angle depends on the full system geometry (not just the paraxial field angle), and image distortion changes the local image-area scaling. The generalized illumination law incorporates these factors. The following expression collects, in schematic first-order form, the principal modifying factors identified across several treatments [^4] [^5] [^8] [^9] [^10]:
+
+$$\frac{E(W)}{E(0)} \approx \frac{A_{\text{EP}}(W)}{A_{\text{EP}}(0)} \cdot \cos^4 W_{\text{eff}} \cdot (1 + D)^2$$
+
+where $A_{\text{EP}}(W)/A_{\text{EP}}(0)$ is the ratio of the off-axis entrance-pupil area to the on-axis area (accounting for pupil aberrations), $W_{\text{eff}}$ incorporates corrections for the actual ray geometry, and $D$ is the fractional image distortion at that field position. (Strictly, the distortion correction involves the Jacobian of the distortion mapping — for radially symmetric distortion, the full form is $[(1+D) + y'\,dD/dy']^2$ rather than $(1+D)^2$ — but the simplified form captures the leading-order effect for moderate distortion levels.)
+
+> **Sidebar: Three Distinct Sources of Corner Light Loss**
+>
+> Corner darkening in a photographic image can arise from three fundamentally different mechanisms, each with its own cause, aperture dependence, and correction strategy [^2] [^13]:
+>
+> 1. **Natural (radiometric) falloff** — the cos⁴-type dependence arising from the geometry of oblique imaging: reduced projected aperture area, increased image distance, and oblique incidence on the image surface. This falloff depends on the field angle and the pupil geometry; it is *independent of f-number* and cannot be reduced by stopping down.
+>
+> 2. **Optical vignetting (cat's-eye effect)** — off-axis beams are clipped by lens-element rims, barrel edges, or other internal apertures that are not the stop itself. The result is that the exit pupil, as seen from an off-axis image point, appears truncated into a cat's-eye or lemon shape rather than a circle. Optical vignetting is typically the *dominant* source of corner falloff at wide apertures in fast lenses, and it *does* decrease with stopping down.
+>
+> 3. **Mechanical vignetting** — physical obstruction by non-optical hardware: lens hoods, filter rings, extension tubes, mount flanges, or adapter rings. This produces a sharp falloff or complete blackening at the image periphery and is corrected by removing the obstruction.
+
+### 5.2 Pupil Aberrations: A Brief Acknowledgment
+
+The entrance and exit pupils as described so far are paraxial idealizations — they are fixed in size, shape, and position regardless of where in the field the light originates. In real lenses, the pupils shift in position, change in size, and distort in shape as a function of field angle. These are the **pupil aberrations**, and they are the image-space analogs of the familiar image aberrations (spherical, coma, astigmatism, etc.), applied to the pupil rather than to the image.
+
+Pupil aberrations have practical consequences [^4] [^7]. Pupil coma, for example, causes the apparent entrance-pupil area to vary with field angle, directly modifying the relative illumination profile. If pupil coma reduces the effective pupil area for off-axis field points, the illumination falls off faster than cos⁴ — sometimes approximated as cos⁵ for designs with significant pupil coma [^4] [^11]. Conversely, if pupil coma enlarges the off-axis pupil, the illumination can be partially compensated.
+
+Pupil aberrations are related to, but distinct from, the **cat's-eye effect** visible in the out-of-focus highlights of fast lenses. The cat's-eye shape is primarily a consequence of *optical vignetting* — hard clipping of off-axis beams by lens-element rims and barrel edges that are not the stop itself. This clipping truncates the circular exit pupil into an elongated or lemon-shaped outline as seen from off-axis image points. Pupil aberrations further modify this shape by shifting, scaling, or distorting the underlying pupil, but the dominant cause of the characteristic cat's-eye truncation is the off-axis clipping by internal apertures — that is, optical vignetting — rather than the pupil aberration itself.
+
+The full treatment of pupil aberrations — their classification within the Seidel framework, their relationship to stop-shift equations, and their practical consequences for illumination and CRA prediction — belongs in a dedicated article.
+
+---
+
+## 6. Telecentricity: Object-Space, Image-Space, and Double Telecentric Systems
+
+### 6.1 Definitions
+
+Telecentricity is a specific geometric condition of the pupil, not a vague synonym for "digital-friendly" or "well-corrected." It has a precise definition with two independent forms [^6] [^12]:
+
+- A lens is **object-space telecentric** when the entrance pupil is located at infinity in object space. The chief rays in object space are then parallel to the optical axis for all field angles.
+
+- A lens is **image-space telecentric** when the exit pupil is located at infinity in image space. The chief rays in image space are then parallel to the optical axis for all field points — that is, the CRA is zero everywhere across the image plane.
+
+- A lens is **double telecentric** (or *bi-telecentric*) when both conditions hold simultaneously.
+
+Note also that telecentricity is independent of distortion: a telecentric lens can still exhibit barrel or pincushion distortion, and a non-telecentric lens can be well-corrected for distortion.
+
+### 6.2 The Structural Mechanism: How Telecentricity Is Achieved
+
+Telecentricity is not an emergent property that appears when a lens happens to be well-designed. It is a consequence of a specific geometric relationship between the aperture stop and the optical groups surrounding it.
+
+**Object-space telecentricity** requires placing the aperture stop at the **rear focal point of the front optical group** [^1] [^6] [^12]. When the stop sits at this location, the front group images it to infinity in object space: rays from the stop center, traced backward through the front group, emerge parallel to the axis. The entrance pupil is therefore at infinity, and all chief rays in object space are parallel to the axis.
+
+**Image-space telecentricity** requires the complementary arrangement: the aperture stop must be placed at the **front focal point of the rear optical group**. The rear group then images the stop to infinity in image space, placing the exit pupil at infinity. All chief rays in image space emerge parallel to the optical axis, and the CRA is zero at every point on the sensor.
+
+**Double telecentricity** requires that both conditions be satisfied simultaneously. This imposes tight constraints on the power distribution and physical layout of the system: the inter-group spacing, the focal lengths of the front and rear groups, and the total system length are all coupled.
+
+### 6.3 Practical Consequences
+
+**Object-space telecentricity** stabilizes magnification against changes in object distance. Because the chief rays are parallel in object space, objects at different distances within the depth of field are imaged at the same magnification. This property is essential in machine-vision gauging and metrology. It is also why telecentric lenses in these applications have a field of view limited by the physical diameter of the front element — since the chief rays are parallel, the lens cannot "look around" an object larger than itself.
+
+**Image-space telecentricity** means the chief rays arrive perpendicular to the sensor across the entire field. Recall from Section 4.3 that the CRA at image height $y'$ is given by $\tan(\text{CRA}) = y'/d_{\text{XP}}$, where $d_{\text{XP}}$ is the exit-pupil-to-sensor distance. When the exit pupil moves to infinity ($d_{\text{XP}} \to \infty$), the CRA goes to zero at every field position. This removes the image-side chief-ray obliquity that causes the sensor-angle-sensitivity problems discussed in Section 4.3.
+
+**Double telecentricity** combines both benefits but imposes the tightest constraints. Double telecentric designs are used in metrology, lithography, and inspection — not in general-purpose photography.
+
+### 6.4 Most Photographic Lenses Are Not Strictly Telecentric
+
+Strict telecentricity requires the aperture stop to be placed at a group focal point, and this placement conflicts with other design goals: compactness, zoom-range flexibility, aberration correction across the field, and the requirement to focus from infinity to close range. General-purpose photographic lenses are *not* telecentric.
+
+What many modern digital-era lens designs do pursue is *more favorable rear-ray geometry* than earlier designs could achieve. By careful placement and power distribution of the rear group — enabled in part by the design freedoms of mirrorless mounts (Section 7) — designers can reduce the maximum image-side CRA at the field corners. This reduction is genuinely beneficial for sensor compatibility, but it is a **design tendency on a continuum**, not a binary telecentric/non-telecentric classification.
+
+---
+
+## 7. From Theory to Photographic Practice: Why Mirrorless Mount Geometry Matters
+
+### 7.1 Flange Distance and Design Freedom
+
+The transition from SLR to mirrorless camera systems removed one of the most constraining geometric requirements in lens design: the need to provide clearance for a swinging reflex mirror between the rear of the lens and the image plane. SLR mount systems — the Nikon F-mount (46.5 mm flange distance), Canon EF (44 mm), Pentax K (45.5 mm) — required that no optical or mechanical element intrude into the mirror box volume. This forced the rearmost lens element to sit far from the sensor, limiting the designer's control over the image-side ray geometry.
+
+Mirrorless mounts dramatically reduce this constraint. The Nikon Z mount, for example, provides a 55 mm inner diameter and a 16 mm flange focal distance [^16]. The difference in flange distance — 46.5 mm for the F-mount versus 16 mm for the Z mount — does not translate directly into "30.5 mm of extra space for optics." Even F-mount lenses routinely extend rear elements behind the flange plane into the mirror box. What changes is that the region between the mount plane and the sensor, which in an SLR must remain clear for mirror swing, is now available for optical elements. The designer can place glass closer to the sensor without competing for space with the mirror mechanism.
+
+### 7.2 What Short Flange Distance Changes Optically
+
+The increased freedom has several consequences for pupil geometry. The following claims are *design inferences* — they follow from first-order optical principles applied to the changed geometric constraints. They are not derived from published manufacturer data on specific pupil positions or CRA distributions.
+
+**Exit-pupil placement.** The short flange distance and large mount throat can make favorable image-side chief-ray control easier to achieve, because they give the designer more freedom in rear-group placement and power distribution. The benefit is especially relevant for wide-angle and ultra-wide-angle designs, where the large object-space field angle would otherwise tend to produce correspondingly large image-side chief-ray angles.
+
+**Rear-group power distribution.** Placing optical elements closer to the sensor allows the rear group to carry more negative or corrective power near the image plane, where it can most effectively influence field curvature, astigmatism, and chief-ray angle distribution.
+
+**Entrance-pupil freedom (indirect).** When the rear group carries more of the burden of field-curvature correction, CRA control, and astigmatism management, the front group may be optimized more aggressively for entrance-pupil size and spherical-aberration control. This is consistent with the trend toward very fast primes (f/1.2, f/0.95) in mirrorless systems.
+
+### 7.3 What Mount Geometry Does Not Prove
+
+The expanded design envelope of a mirrorless mount does **not** prove that any particular lens built for that mount is telecentric, achieves a specific maximum CRA, or delivers superior corner illumination. These are design outcomes that depend on the specific optical prescription, not on the mount specification alone.
+
+---
+
+## 8. Common Misconceptions and Clean Corrections
+
+**"The aperture stop and the entrance pupil are the same thing."** They are not. The aperture stop is a physical piece of hardware — the iris diaphragm. The entrance pupil is its virtual image, formed in object space by the optics in front of the stop. They coincide only in the special case where there are no optical elements in front of the stop.
+
+**"Telecentric means distortion-free."** Telecentricity and distortion are related only indirectly. An image-space telecentric lens produces zero CRA at the sensor, but telecentricity does not eliminate optical distortion. A telecentric lens can exhibit barrel or pincushion distortion; a non-telecentric lens can be well-corrected for distortion.
+
+**"A telecentric lens sends all rays perpendicular to the sensor."** In an image-space telecentric lens, the **chief rays** in image space are parallel to the optical axis — they arrive perpendicular to the sensor. But the full cone of rays from each field point still has angular extent determined by the f-number. What telecentricity ensures is that the *center* of each cone is normal to the sensor, not that every ray within the cone is.
+
+**"The panorama rotation point is the nodal point."** The entrance pupil is the correct and less misleading term for the no-parallax rotation point. The nodal points describe unit angular magnification — a different property — and are not, in general, coincident with the entrance pupil.
+
+**"Wide-angle corner shading is all just vignetting."** Corner darkening in wide-angle images arises from at least three distinct mechanisms: natural radiometric falloff (cos⁴-type), optical vignetting (beam clipping by element rims), and mechanical vignetting (obstruction by hoods, filters, or adapters). Each has different causes, different aperture dependencies, and different correction strategies.
+
+**"Stopping down always fixes corner shading."** Stopping down does reduce the contribution from optical vignetting, often dramatically. But the natural cos⁴-type falloff persists at all apertures because it depends on the obliquity of the imaging geometry, not on the size of the aperture.
+
+---
+
+## 9. Conclusion: The Invisible Geometry Behind Visible Imaging Behavior
+
+The aperture stop is what the photographer touches — a mechanical iris with metal blades that open and close. But the optical system negotiates something more subtle: two invisible apertures, the entrance pupil and exit pupil, that exist only as images of the physical stop, formed by the lens groups on either side.
+
+The entrance pupil governs what the lens presents to the world: the effective aperture diameter that determines the f-number, the projection center that defines perspective geometry, the no-parallax point that matters for panoramic stitching, and the working f-number that changes with magnification. The exit pupil governs what the lens presents to the sensor: the image-side light cone geometry, the chief-ray angle distribution, and the angular compatibility with microlens arrays and pixel structures. Between them, these two images of the stop encode nearly every first-order property of the imaging system.
+
+Telecentricity — the condition in which one or both pupils sit at infinity — reveals what chief-ray control actually does and what it costs. Placing the exit pupil at infinity forces the chief rays to arrive normal to the sensor at every field position, suppressing the angular-dependent illumination and color-response problems that constrain digital imaging. But achieving this requires a specific structural commitment: the stop must sit at a group focal point, and that placement imposes constraints on the power distribution, physical size, and aberration-correction flexibility of the lens. It is a design tradeoff, not a free improvement.
+
+The photographer turns a ring and watches the diaphragm open or close. But what the lens actually negotiates — between object space and image space, between collection angle and incidence angle, between design freedom and physical constraint — is the geometry of two invisible apertures that exist only as images of the one the photographer can touch.
+
+---
+
+*This article is Part 1 of a series on pupil geometry in photographic lenses. For the companion primer series, see [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry). Part 2 — "Pupils in Practice: Case Studies" — examines entrance-pupil, exit-pupil, and telecentric design tradeoffs in three specific photographic lenses.*
+
+[^1]: J. E. Greivenkamp, "Stops and pupils," OPTI 502 course notes, College of Optical Sciences, Univ. Arizona, 2019.
+
+[^2]: W. J. Smith, *Modern Optical Engineering*, 4th ed. McGraw-Hill, 2008, chs. 6, 8.
+
+[^3]: R. Kingslake and R. B. Johnson, *Lens Design Fundamentals*, 2nd ed. Academic Press (Elsevier), 2010.
+
+[^4]: W. T. Welford, *Aberrations of Optical Systems*. Adam Hilger (IOP Publishing), 1986, ch. 9.
+
+[^5]: J. Sasián, *Introduction to Aberrations in Optical Imaging Systems*. Cambridge Univ. Press, 2013.
+
+[^6]: J. Sasián, *Introduction to Lens Design*. Cambridge Univ. Press, 2019.
+
+[^7]: J. Sasián, "Pupil aberrations," OPTI 518 lecture notes, College of Optical Sciences, Univ. Arizona, 2014; rev. 2021.
+
+[^8]: M. Reiss, "The cos⁴ law of illumination," *J. Opt. Soc. Am.*, vol. 35, no. 4, pp. 283–288, 1945.
+
+[^9]: M. Reiss, "Notes on the cos⁴ law of illumination," *J. Opt. Soc. Am.*, vol. 38, no. 11, pp. 980–986, 1948.
+
+[^10]: D. Reshidko and J. Sasián, "Geometrical irradiance changes in a symmetric optical system," *Opt. Eng.*, vol. 56, no. 1, p. 015104, 2017.
+
+[^11]: H. Slevogt, "Zur Definition der Lichtstärke optischer Systeme," *Phys. Z.*, vol. 40, pp. 658–667, 1939.
+
+[^12]: Edmund Optics, "Telecentric design topics," *Imaging Resource Guide*, sec. 4.4. [Online]. Available: https://www.edmundoptics.com/knowledge-center/application-notes/imaging/telecentric-design-topics/. Accessed: Apr. 2026.
+
+[^13]: Edmund Optics, "Sensor relative illumination, roll-off, and vignetting," *Imaging Resource Guide*. [Online]. Available: https://www.edmundoptics.com/knowledge-center/application-notes/imaging/sensor-relative-illumination-roll-off-and-vignetting/. Accessed: Apr. 2026.
+
+[^14]: H. H. Nasse, "Distagon, Biogon and Hologon," Carl Zeiss AG Camera Lens Division, technical article, Dec. 2011. [Online]. Available: https://lenspire.zeiss.com/photo/app/uploads/2018/02/en_CLB41_Nasse_LensNames_Distagon.pdf
+
+[^15]: Leica Camera AG, "APO-Summicron-M 35 f/2 ASPH. — Technical specification." [Online]. Available: https://leica-camera.com/en-US/photography/lenses/m/apo-summicron-m-35-f2-asph-black-anodized-finish/technical-specification. Accessed: Apr. 2026.
+
+[^16]: Nikon Corp., "Nikon Z series: Z mount system." [Online]. Available: https://www.nikonusa.com/learn-and-explore/c/products-and-innovation/nikon-z-series-z-mount-system. Accessed: Apr. 2026.
+
+[^17]: D. A. Kerr, "Derivation of the 'cosine fourth' law for falloff of illuminance across a camera image," technical note, 2007.
+
+[^18]: M. Born and E. Wolf, *Principles of Optics*, 7th ed. Cambridge Univ. Press, 1999, ch. 4.
+
+[^19]: V. N. Mahajan, *Optical Imaging and Aberrations*, Part I: Ray Geometrical Optics. SPIE Press, 1998.
+
+[^20]: G. Agranov, V. Berezin, and R. H. Tsai, "Crosstalk and microlens study in a color CMOS image sensor," *IEEE Trans. Electron Devices*, vol. 50, no. 1, pp. 4–11, 2003.
+
+[^21]: STMicroelectronics, "Lens CRA matching recommendations for optimal colorization," Application Note AN6472, Rev. 1, Mar. 2026. [Online]. Available: https://www.st.com/resource/en/application_note/an6472-lens-cra-matching-recommendations-for-optimal-colorization-stmicroelectronics.pdf

--- a/src/content/pupils/CornerIllumination.md
+++ b/src/content/pupils/CornerIllumination.md
@@ -1,0 +1,123 @@
+---
+slug: corner-illumination
+title: Why Corners Go Dark — The Three Causes of Light Falloff in Photographic Lenses
+summary: The three distinct causes of corner light falloff — natural radiometric falloff (the cos⁴ law), optical vignetting, and mechanical vignetting — and why stopping down fixes only one of them.
+tag: guide
+series: pupil-geometry
+seriesOrder: 4
+toc: true
+---
+
+# Why Corners Go Dark — The Three Causes of Light Falloff in Photographic Lenses
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series.*
+
+---
+
+## The Problem: Corners Are Darker Than the Center
+
+Pick up almost any wide-angle or fast lens, shoot a uniformly lit surface, and examine the resulting image. The corners will be darker than the center. This is one of the most visible optical effects in photography, and most photographers have noticed it. The temptation is to label the entire effect "vignetting" and move on.
+
+But that label obscures a physically important distinction. Corner darkening arises from three fundamentally different mechanisms *within the lens and its immediate mechanical system* — and they respond differently to the photographer's controls [^1] [^7]. (A fourth source — the angular sensitivity of the digital sensor itself — is treated separately in [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor).)
+
+Understanding the three-cause breakdown matters, because "stop down to fix corner shading" is a half-truth. It addresses one of the three causes and does nothing to the other two.
+
+## The Three Causes at a Glance
+
+| Cause | What it is | Gets better when stopped down? | Visual signature |
+|---|---|:-:|---|
+| Natural radiometric falloff | Geometric light loss from oblique imaging (cos⁴ law) | No | Smooth, gradual darkening toward corners |
+| Optical vignetting | Off-axis beams clipped by element rims | Yes (often dramatically) | Cat's-eye or lemon-shaped bokeh highlights |
+| Mechanical vignetting | Obstruction by hoods, filters, adapters | No (remove the obstruction) | Sharp, abrupt darkening or blackening at edges |
+
+## Cause 1: Natural Radiometric Falloff (the cos⁴ Law)
+
+The most fundamental source of corner darkening has nothing to do with any defect in the lens. It is a consequence of the geometry of oblique imaging itself. For an idealized thin lens imaging a uniformly bright scene, the relative illumination at an off-axis image point corresponding to semi-field angle $W$ follows the classical **cos⁴ law** [^1] [^2] [^3]:
+
+$$\frac{E(W)}{E(0)} = \cos^4 W$$
+
+The four powers of cosine come from three geometrically distinct effects:
+
+**One factor from pupil foreshortening.** From an off-axis object point, the entrance pupil — the apparent aperture on the scene side of the lens — is seen obliquely and appears as an ellipse with reduced area. The projected area decreases by $\cos W$: one factor [^1].
+
+**Two factors from increased image distance.** The off-axis image point lies at distance $f / \cos W$ from the lens (the chief ray travels a longer oblique path), versus $f$ for the on-axis point. Irradiance falls as the inverse square of distance: two more factors [^1] [^3].
+
+**One factor from oblique incidence.** The arriving light cone strikes the sensor at an angle, spreading its energy over a larger area: one final factor [^1] [^3].
+
+**A clarification that matters.** The angle $W$ in this derivation is the **object-space semi-field angle** — the angle the chief ray makes with the axis as measured at the entrance pupil. For a thin lens, this equals the image-side chief-ray angle (CRA — the angle at which the chief ray strikes the sensor) because the entrance and exit pupils coincide. But in a real multi-element lens, the object-space field angle and the image-side CRA are generally different quantities. This distinction is the entire basis for understanding why image-space telecentricity helps digital sensors: a telecentric lens forces the image-side CRA to zero even when the object-space $W$ is large (see [*Telecentricity Explained*](/articles/telecentricity)).
+
+### How Severe Is It?
+
+| $W$ (degrees) | cos⁴ $W$ | Relative illumination | Falloff (stops) |
+|:-:|:-:|:-:|:-:|
+| 0° | 1.000 | 100% | 0.0 |
+| 10° | 0.941 | 94% | 0.1 |
+| 20° | 0.780 | 78% | 0.4 |
+| 25° | 0.675 | 68% | 0.6 |
+| 30° | 0.563 | 56% | 0.8 |
+| 35° | 0.450 | 45% | 1.2 |
+| 40° | 0.344 | 34% | 1.5 |
+
+For a 35 mm lens on a full-frame sensor (43.3 mm image diagonal), the corner half-field angle is approximately 31.8°. The classical cos⁴ prediction gives about **52% relative illumination** in the extreme corners — nearly a full stop of light loss from pure geometry, before any vignetting enters the picture [^1].
+
+**The critical point:** This falloff depends on the **field angle**, not the aperture size. Stopping down does *not* reduce natural radiometric falloff [^1] [^2]. It persists at every f-number.
+
+## Cause 2: Optical Vignetting (the Cat's-Eye Effect)
+
+The second source of corner darkening is **optical vignetting**: off-axis light beams clipped by lens-element rims, barrel walls, or other internal apertures that are not the aperture stop itself [^1] [^4].
+
+The aperture stop limits the on-axis beam. But for off-axis beams, the light travels obliquely through the lens and passes closer to the edges of surrounding elements, which may clip part of the beam. The visual signature is the **cat's-eye effect** in out-of-focus highlights: bright bokeh spots near the image corners appear as elongated, lemon-shaped blobs rather than circles. This shape is the truncated exit pupil — the circular pupil clipped into an asymmetric outline by nearby element rims [^1].
+
+Optical vignetting is typically the **dominant** source of corner falloff at wide apertures in fast lenses. A fast lens at f/1.4 may lose two or more stops in the extreme corners from vignetting alone.
+
+**Why stopping down helps:** when the iris closes, the beam narrows and is less likely to be clipped by surrounding element rims. By f/4 or f/5.6, the beam has typically cleared the internal obstructions entirely. This is the practical experience every photographer knows: cat's-eye bokeh at f/1.4 transitions to nearly circular highlights by f/4.
+
+## Cause 3: Mechanical Vignetting
+
+The simplest source: **mechanical vignetting** is physical obstruction by non-optical hardware — lens hoods, filter rings, extension tubes, adapter rings, or the camera mount throat itself [^1] [^4] [^7].
+
+Mechanical vignetting produces a distinctly different pattern: a sharp, often abrupt darkening or complete blackening at the extreme periphery. Unlike the smooth, gradual profiles of radiometric falloff and optical vignetting, mechanical vignetting may produce a hard boundary where illumination drops to zero.
+
+The fix is equally simple: remove the obstruction.
+
+## Why Stopping Down Helps Some — But Not All — Corner Darkening
+
+This is the practical payoff of the three-cause framework:
+
+Stopping down **reduces optical vignetting**, often dramatically — this is the dominant improvement from f/1.4 to f/4. But stopping down **does not reduce natural radiometric falloff** (the cos⁴ geometry persists at every f-number) and **does not fix mechanical vignetting** (a hood obstructs at f/16 just as much as at f/1.4).
+
+At f/16, a 35 mm lens on a full-frame sensor may have negligible optical vignetting, but it will still show approximately 50–55% relative illumination at the extreme corners from radiometric geometry alone. In-camera shading correction compensates for the combined effect, but that is a computational lookup-table adjustment, not a physical fix.
+
+## What the Simple Model Leaves Out
+
+The cos⁴ law is the first-order baseline. Real lenses can fall off faster or slower, for reasons the parent monograph develops in full [^5]:
+
+**Pupil aberrations** cause the entrance pupil's apparent area to change with field angle. If the effective off-axis area shrinks, falloff can be steeper than cos⁴; if it grows, falloff can be shallower [^4] [^6]. **Non-unit pupil magnification** ($m_p \neq 1$, introduced in [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor)) modifies the radiometric geometry for lenses with asymmetric power distributions. **Distortion** changes local area scaling across the field, partially counteracting or worsening the falloff depending on its sign.
+
+The full treatment of pupil aberrations and their relationship to illumination prediction is planned for a dedicated article: *Pupil Aberrations in Practice*.
+
+> **Key Takeaways**
+>
+> 1. Corner darkening has **three distinct optical causes**: natural radiometric falloff (cos⁴), optical vignetting (cat's-eye clipping), and mechanical vignetting (hood/filter obstruction).
+> 2. Stopping down **reduces optical vignetting** but **does not reduce natural radiometric falloff**. A 35 mm lens on full frame loses nearly a stop in the extreme corners from geometry alone, at every f-number.
+> 3. The cos⁴ law uses the **object-space field angle** — distinct from the image-side CRA. This distinction is the key to understanding why telecentricity helps digital sensors.
+
+*For the graduate-level mathematical treatment, including the generalized illumination law, see Section 5 of [The Aperture Stop in Practice](/articles/aperture-stop-in-practice).*
+
+---
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series. · Previous: [The Exit Pupil and Your Digital Sensor](/articles/exit-pupil-sensor) · Next: [Telecentricity Explained](/articles/telecentricity)*
+
+[^1]: W. J. Smith, *Modern Optical Engineering*, 4th ed. New York, NY, USA: McGraw-Hill, 2008, chs. 6, 8.
+
+[^2]: D. A. Kerr, "Derivation of the 'cosine fourth' law for falloff of illuminance across a camera image," tech. note, 2007.
+
+[^3]: M. Reiss, "The cos⁴ law of illumination," *J. Opt. Soc. Am.*, vol. 35, no. 4, pp. 283–288, Apr. 1945.
+
+[^4]: V. N. Mahajan, *Optical Imaging and Aberrations*, Part I: Ray Geometrical Optics. Bellingham, WA, USA: SPIE Press, 1998.
+
+[^5]: Edmund Optics, "Sensor relative illumination, roll-off, and vignetting," *Imaging Resource Guide*. [Online]. Available: https://www.edmundoptics.com/knowledge-center/application-notes/imaging/sensor-relative-illumination-roll-off-and-vignetting/. [Accessed: Apr. 2026].
+
+[^6]: W. T. Welford, *Aberrations of Optical Systems*. Bristol, UK: Adam Hilger (IOP Publishing), 1986, ch. 9.
+
+[^7]: S. Ray, *Applied Photographic Optics*, 3rd ed. Oxford, UK: Focal Press (Elsevier), 2002.

--- a/src/content/pupils/EntrancePupil.md
+++ b/src/content/pupils/EntrancePupil.md
@@ -1,0 +1,84 @@
+---
+slug: entrance-pupil
+title: What Is the Entrance Pupil? The Aperture Your Lens Shows the World
+summary: The aperture stop, the entrance pupil, and why the f-number is defined by the image of the iris — not the physical hardware inside the lens.
+tag: guide
+series: pupil-geometry
+seriesOrder: 1
+toc: true
+---
+
+# What Is the Entrance Pupil? The Aperture Your Lens Shows the World
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series.*
+
+---
+
+## The Aperture You Adjust vs. the Aperture the System Uses
+
+Every camera lens contains an iris diaphragm — a set of metal blades that form an adjustable opening, controlling how much light passes through the lens. Photographers interact with this hardware every time they change the f-number. This physical opening is the **aperture stop**: the component that limits the cone of light the lens accepts from an on-axis subject [^1] [^2].
+
+But the aperture stop is not what the optical system actually "shows" to the outside world. That role belongs to the **entrance pupil** — and understanding the distinction between these two things is the single most important conceptual upgrade a photographer can make to their mental model of how lenses work.
+
+The entrance pupil is the image of the aperture stop, formed by the optical elements in front of it [^1] [^2] [^4]. It is what you see when you look into the front of a camera lens: a bright, luminous disk floating somewhere inside the glass. That disk is not the physical iris itself. It is a virtual image of the iris, produced by the front lens group acting as an imaging system for the stop. Because this image exists on the scene side of the lens — what optical engineers call **object space** (everything on the subject's side, as opposed to the sensor side) — it is the aperture that the world "sees" when light enters the lens.
+
+**A hands-on demonstration.** Hold a 50 mm f/2 lens at arm's length and look into the front element. The bright disk you see is approximately 25 mm across — about the width of a U.S. quarter. That is the entrance pupil. The physical iris diaphragm inside the lens barrel is almost certainly a different size, sitting at a different position along the optical axis. What you are seeing is that iris, magnified and repositioned by the front group of lens elements.
+
+*[Diagram: A simple cross-section showing the physical iris inside the lens barrel, the front group of elements, and the entrance pupil as a virtual image of the iris — displaced and potentially magnified. Labels: "Front group," "Aperture stop (iris)," "Entrance pupil (virtual image of stop)," with dashed lines showing the imaging relationship.]*
+
+## How the Front Group Creates the Entrance Pupil
+
+The front optical group — all the lens elements between the front of the lens and the iris diaphragm — acts as a complete imaging system for the physical stop. Just as a magnifying glass creates a magnified virtual image of a page of text, the front group creates an image of the iris in object space. This image is the entrance pupil.
+
+Because the front group is an imaging system, the entrance pupil can differ from the physical iris in both size and location. It may be larger (the front group magnifies the stop), smaller (the front group demagnifies it), or — uncommonly — the same size. It may appear to be located in front of the front element, behind it, or within the front group, depending on the imaging geometry.
+
+In most modern photographic lenses, the entrance pupil is a virtual image — it appears to float somewhere inside the lens barrel, behind the front element. In certain designs, the entrance pupil can instead be a real image located physically in front of the lens. This distinction does not affect the f-number calculation or the entrance pupil's role as a projection center, but it matters when locating the no-parallax point for panoramic stitching (see [*The Entrance Pupil as Projection Center*](/articles/entrance-pupil-projection-center)).
+
+## The f-Number Is Defined by the Entrance Pupil
+
+The f-number of a lens focused at infinity is [^1] [^2]:
+
+$$N = \frac{f}{D_{\text{EP}}}$$
+
+where $f$ is the effective focal length and $D_{\text{EP}}$ is the diameter of the **entrance pupil** — not the diameter of the physical iris. The number printed on a lens barrel or displayed on a camera screen is computed from the size of the entrance pupil, not from the physical hardware inside the lens.
+
+This means that two lenses with identical physical iris diameters can have different f-numbers if their front groups magnify the stop differently. Consider a concrete example: a lens with a physical iris opening of 12 mm and a front group that magnifies the stop by a factor of 2×. The entrance pupil is $12 \times 2 = 24$ mm. If the lens has a focal length of 48 mm, the f-number is $48 / 24 = f/2$. A different lens with the same 12 mm iris but a front group providing 1.5× magnification presents an 18 mm entrance pupil. At the same 48 mm focal length, this lens would be $48 / 18 \approx f/2.7$.
+
+As a real-world reference, Leica publishes the entrance-pupil **position** for the APO-Summicron-M 35 f/2 ASPH.: 13.8 mm in front of the bayonet mount [^3]. (Leica does not directly publish the entrance-pupil diameter, but it follows from the f-number relation: $D_{\text{EP}} = 35 / 2 = 17.5$ mm.) That 17.5 mm disk is what you see looking into the front of the lens — regardless of the physical iris dimensions inside.
+
+## When the Entrance Pupil and the Physical Stop Coincide
+
+There is one special case where the entrance pupil *is* the physical stop: when there are no optical elements in front of the aperture stop. A pinhole camera is the clearest example — the pinhole is both the aperture stop and the entrance pupil, because no optics intervene. Landscape lenses of the 19th century, such as simple meniscus designs with a front-mounted Waterhouse stop, share this property [^5].
+
+But this is the exception. Virtually every modern photographic lens places several optical elements in front of the iris diaphragm, so the entrance pupil is always a separate optical entity — related to the physical stop, but distinct from it in both size and position.
+
+## Why It Matters: A Preview of Consequences
+
+The entrance pupil is not merely a theoretical construct. It drives several practical effects that photographers encounter regularly, each covered in a companion article in this series:
+
+- **Perspective and panoramas.** The entrance pupil is the projection center — the no-parallax rotation point for panoramic stitching. (See [*The Entrance Pupil as Projection Center*](/articles/entrance-pupil-projection-center).)
+- **Sensor compatibility.** The entrance pupil's image-side counterpart — the exit pupil — governs how light arrives at the sensor. (See [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor).)
+- **Corner illumination.** The entrance pupil's apparent area, as seen from off-axis angles, is one factor in the radiometric falloff that darkens image corners. (See [*Why Corners Go Dark*](/articles/corner-illumination).)
+- **Working f-number.** At close focus, the effective f-number increases even though the iris hasn't moved. (See [*Working f-Number*](/articles/working-f-number).)
+
+> **Key Takeaways**
+>
+> 1. The **aperture stop** is physical hardware — the iris diaphragm with its metal blades.
+> 2. The **entrance pupil** is the image of that stop, formed by the front lens group. It is the bright disk you see when you look into the front of a lens.
+> 3. The **f-number** is defined by the entrance-pupil diameter, not the physical iris diameter. Two lenses with identical irises can have different f-numbers if their front groups magnify the stop differently.
+
+*For the graduate-level mathematical treatment, see Sections 2–3.1 of [The Aperture Stop in Practice](/articles/aperture-stop-in-practice).*
+
+---
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series. · Next: [The Entrance Pupil as Projection Center](/articles/entrance-pupil-projection-center)*
+
+[^1]: W. J. Smith, *Modern Optical Engineering*, 4th ed. New York, NY, USA: McGraw-Hill, 2008, chs. 6, 8.
+
+[^2]: R. Kingslake and R. B. Johnson, *Lens Design Fundamentals*, 2nd ed. Burlington, MA, USA: Academic Press (Elsevier), 2010.
+
+[^3]: Leica Camera AG, "APO-Summicron-M 35 f/2 ASPH. — Technical specification." [Online]. Available: https://leica-camera.com/en-US/photography/lenses/m/apo-summicron-m-35-f2-asph-black-anodized-finish/technical-specification. [Accessed: Apr. 2026].
+
+[^4]: E. Hecht, *Optics*, 5th ed. Boston, MA, USA: Pearson, 2017, ch. 5.
+
+[^5]: S. Ray, *Applied Photographic Optics*, 3rd ed. Oxford, UK: Focal Press (Elsevier), 2002.

--- a/src/content/pupils/EntrancePupil.md
+++ b/src/content/pupils/EntrancePupil.md
@@ -24,7 +24,7 @@ The entrance pupil is the image of the aperture stop, formed by the optical elem
 
 **A hands-on demonstration.** Hold a 50 mm f/2 lens at arm's length and look into the front element. The bright disk you see is approximately 25 mm across — about the width of a U.S. quarter. That is the entrance pupil. The physical iris diaphragm inside the lens barrel is almost certainly a different size, sitting at a different position along the optical axis. What you are seeing is that iris, magnified and repositioned by the front group of lens elements.
 
-*[Diagram: A simple cross-section showing the physical iris inside the lens barrel, the front group of elements, and the entrance pupil as a virtual image of the iris — displaced and potentially magnified. Labels: "Front group," "Aperture stop (iris)," "Entrance pupil (virtual image of stop)," with dashed lines showing the imaging relationship.]*
+![Cross-section showing the front lens group imaging the aperture stop to form the entrance pupil. The virtual entrance pupil appears magnified and displaced to the left of the front group, connected by dashed construction lines to the physical aperture stop.](/diagrams/pupils/entrance-pupil.svg)
 
 ## How the Front Group Creates the Entrance Pupil
 

--- a/src/content/pupils/ExitPupil.md
+++ b/src/content/pupils/ExitPupil.md
@@ -66,7 +66,7 @@ $$\text{CRA} \approx \arctan(21.6 / 40) \approx 28.4°$$
 
 That nearly doubled CRA — from 15° to 28° — illustrates why exit-pupil distance matters so much for digital sensors.
 
-*[Diagram: Cross-section showing exit pupil, chief ray to on-axis pixel (CRA = 0°), and chief ray to a corner pixel (CRA > 0°). Show microlens over each pixel. Label exit-pupil distance $d_{\text{XP}}$ and image height $y'$.]*
+![Cross-section showing the exit pupil at left and the image sensor at right. The on-axis chief ray (cyan) arrives at the center pixel with CRA = 0°. The off-axis chief ray (gold) strikes the corner pixel at CRA greater than 0°. Microlenses are shown above each pixel. The exit-pupil distance d_XP and image height y′ are annotated.](/diagrams/pupils/exit-pupil.svg)
 
 ### The venetian-blind analogy
 

--- a/src/content/pupils/ExitPupil.md
+++ b/src/content/pupils/ExitPupil.md
@@ -1,0 +1,129 @@
+---
+slug: exit-pupil-sensor
+title: The Exit Pupil and Your Digital Sensor — Chief-Ray Angle, Microlens Arrays, and Color Cast
+summary: How the exit pupil diameter and distance from the sensor determine chief-ray angle, why digital sensors are sensitive to CRA, and how CRA mismatch produces corner color casts.
+tag: guide
+series: pupil-geometry
+seriesOrder: 3
+toc: true
+---
+
+# The Exit Pupil and Your Digital Sensor — Chief-Ray Angle, Microlens Arrays, and Color Cast
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series.*
+
+---
+
+## The Exit Pupil: The Aperture the Sensor Sees
+
+The previous articles established the entrance pupil as the lens's apparent aperture on the scene side — the aperture the world "sees." The **exit pupil** is its counterpart on the sensor side: the image of the aperture stop formed by all the optical elements behind the stop [^1] [^2].
+
+If you could look into the rear of a lens from the sensor's position, the apparent opening you would see is the exit pupil. Its diameter and its distance from the sensor together determine the geometry of every light cone arriving at every pixel — how wide each cone is, and at what angle it arrives.
+
+In the film era, this geometry was of relatively minor importance. Silver halide emulsion is generally far less sensitive to the angle of incoming light than modern digital sensors are [^3]. Digital sensors, however, care deeply about the *direction* from which light arrives — and that direction is governed by the exit pupil.
+
+## Pupil Magnification: Why Entrance and Exit Pupils Differ
+
+In general, the entrance pupil and exit pupil are not the same size. The ratio between them is the **pupil magnification** [^1] [^4]:
+
+$$m_p = \frac{D_{\text{XP}}}{D_{\text{EP}}}$$
+
+where $D_{\text{XP}}$ is the exit-pupil diameter and $D_{\text{EP}}$ is the entrance-pupil diameter. What determines this ratio? The rear optical group — all the elements behind the stop — acts as a complete imaging system for the physical aperture stop, just as the front group does for the entrance pupil. Whether the rear group magnifies or demagnifies the stop image depends on its power distribution: its focal length, element arrangement, and the location of the stop within that arrangement [^1] [^4].
+
+Two broad patterns emerge from common lens architectures:
+
+**Telephoto designs** (long focal-length lenses physically shorter than their focal length) typically have $m_p < 1$, often in the range 0.5–0.8. The exit pupil is smaller than the entrance pupil. The positive-front, negative-rear power distribution that shortens the barrel also compresses the stop image in image space [^1].
+
+**Retrofocus wide-angle designs** typically have $m_p > 1$, commonly 1.2–2.0 or higher. The exit pupil is larger than the entrance pupil. The negative-front, positive-rear power distribution that produces a long back focal distance also magnifies the stop image [^1].
+
+Why does this matter? Because two lenses with identical f-numbers — identical entrance-pupil diameters relative to focal length — can deliver different light-cone geometries at the sensor if their pupil magnifications differ. The sensor does not see the entrance pupil; it sees the exit pupil.
+
+> **Sidebar: Pupil magnification and depth of field**
+>
+> Pupil magnification has a secondary effect on the near/far balance of depth of field. When $m_p \neq 1$, the object-side and image-side cone geometries are no longer symmetric. For telephoto designs ($m_p < 1$), the rear depth of field tends to be somewhat compressed relative to the front; for retrofocus designs ($m_p > 1$), the balance shifts the other way [^1]. The effect is modest at typical shooting distances but becomes noticeable at macro magnifications, where it compounds with the working-f-number shift discussed in [*Working f-Number*](/articles/working-f-number).
+
+## Chief-Ray Angle: The Angle That Matters for Sensors
+
+The **chief-ray angle (CRA)** at the image plane is the angle at which the chief ray — the central ray of each image-forming bundle — strikes the sensor surface. In the paraxial model [^1]:
+
+$$\tan(\text{CRA}) = \frac{y'}{d_{\text{XP}}}$$
+
+where $y'$ is the image height (distance from the optical axis to the pixel) and $d_{\text{XP}}$ is the distance from the exit pupil to the image plane.
+
+### A worked example
+
+Consider a full-frame sensor (36 × 24 mm) with a lens whose exit pupil sits 80 mm in front of the image plane. At the corner of the long edge ($y' = 18$ mm), the CRA is:
+
+$$\tan(\text{CRA}) = \frac{18}{80} = 0.225 \quad \Rightarrow \quad \text{CRA} \approx 12.7°$$
+
+At the extreme diagonal corner ($y' = 21.6$ mm):
+
+$$\text{CRA} \approx \arctan(21.6 / 80) \approx 15.1°$$
+
+Now suppose a different lens places the exit pupil only 40 mm from the sensor. At the same diagonal corner:
+
+$$\text{CRA} \approx \arctan(21.6 / 40) \approx 28.4°$$
+
+That nearly doubled CRA — from 15° to 28° — illustrates why exit-pupil distance matters so much for digital sensors.
+
+*[Diagram: Cross-section showing exit pupil, chief ray to on-axis pixel (CRA = 0°), and chief ray to a corner pixel (CRA > 0°). Show microlens over each pixel. Label exit-pupil distance $d_{\text{XP}}$ and image height $y'$.]*
+
+### The venetian-blind analogy
+
+A useful mental picture: think of venetian blinds [^5]. When light arrives perpendicular to the slats, it passes through efficiently. As the angle steepens, the slats progressively block it. Modern CMOS sensor pixels present a roughly analogous geometry — each pixel has a tiny **microlens** that concentrates incoming light onto the photodiode, but the microlens is optimized for a limited range of incidence angles [^5]. (This is only a conceptual analogy; the actual sensor stack — with color filters, wiring layers, and photodiode geometry — is considerably more complex.)
+
+When the CRA exceeds the sensor's design range, light is partially blocked by the pixel-well walls or directed to the wrong photodiode.
+
+## What Happens When the CRA Is Too Steep
+
+When the chief-ray angle at the sensor corners exceeds the sensor's design tolerance, three distinct problems can emerge [^5] [^6]:
+
+**Reduced corner illumination.** Light reaching the corner pixels is partially blocked or misdirected by the pixel structure, producing luminance falloff beyond what the natural radiometric law (the cos⁴ baseline discussed in [*Why Corners Go Dark*](/articles/corner-illumination)) would predict. This is an additional, sensor-specific source of corner darkening layered on top of the optical causes.
+
+**Color crosstalk.** Light intended for one pixel spills into adjacent pixels when the incidence angle exceeds the microlens design range, degrading both color accuracy and spatial resolution [^5].
+
+**Color cast in corners.** If the sensor's microlens offset pattern does not match the lens's CRA distribution, the red, green, and blue color channels exhibit different falloff rates. The result is a visible color shift in the corners — typically a magenta or cyan tint — that cannot be corrected by adjusting overall exposure.
+
+### The classic example: Rangefinder wides on digital bodies
+
+A well-known illustration of CRA mismatch is the behavior of rangefinder-type wide-angle lenses — such as the Leica Elmarit-M 28 mm or the Zeiss Biogon 21 mm — on digital bodies [^7]. These designs were conceived for film and place the rear optical group close to the image plane, producing steep corner CRAs. On digital sensors optimized for the more moderate CRA profiles of SLR-type retrofocus wide-angles, the result is visible corner color casts — a direct consequence of the mismatch between lens and sensor.
+
+## CRA Matching and Microlens Offset Optimization
+
+Sensor manufacturers address the CRA challenge by shifting the positions of the microlenses progressively outward toward the sensor edges [^5] [^8]. At the center, the microlens sits directly above the photodiode. Toward the corners, each microlens is offset slightly inward (toward the optical axis) to catch the increasingly oblique chief ray and redirect it onto the photodiode below.
+
+This is a **joint optimization** between the lens and the sensor. The microlens offset pattern is designed around an expected CRA profile — a curve showing how the CRA increases from center to corner. When the lens matches this profile, light is efficiently collected across the frame. When it produces a significantly different CRA distribution, the mismatch produces the artifacts described above.
+
+The critical implication: the same lens can behave differently on two different sensors, and the same sensor can behave differently with two different lenses. The visible severity of corner color cast is a property of the **lens-sensor system**, not a fixed characteristic of either component alone [^8].
+
+## Where This Leads
+
+The CRA challenge motivates two further topics in this series. The design changes enabled by mirrorless camera mounts — shorter flange distances and wider mount throats — give designers more control over exit-pupil placement and CRA distribution ([*Mirrorless vs. SLR Lens Design*](/articles/mirrorless-lens-design)). And the theoretical limiting case of CRA control is **telecentricity** — the condition where the exit pupil is at infinity and the CRA is zero everywhere across the sensor ([*Telecentricity Explained*](/articles/telecentricity)).
+
+> **Key Takeaways**
+>
+> 1. The **exit pupil** is the apparent aperture as seen from the sensor side. Its diameter and distance from the sensor determine the geometry of every image-forming light cone.
+> 2. The **chief-ray angle (CRA)** increases toward the sensor corners. Digital sensors are sensitive to CRA because their microlenses are optimized for a limited range of incidence angles.
+> 3. CRA compatibility is a **joint lens-sensor property** — the same lens can behave differently on different sensors, and sensor manufacturers tune their microlens offsets to an expected CRA profile.
+
+*For the graduate-level mathematical treatment, see Sections 4.1–4.3 and 6 of [The Aperture Stop in Practice](/articles/aperture-stop-in-practice).*
+
+---
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series. · Previous: [The Entrance Pupil as Projection Center](/articles/entrance-pupil-projection-center) · Next: [Why Corners Go Dark](/articles/corner-illumination)*
+
+[^1]: W. J. Smith, *Modern Optical Engineering*, 4th ed. New York, NY, USA: McGraw-Hill, 2008, chs. 6, 8.
+
+[^2]: R. Kingslake and R. B. Johnson, *Lens Design Fundamentals*, 2nd ed. Burlington, MA, USA: Academic Press (Elsevier), 2010.
+
+[^3]: S. Ray, *Applied Photographic Optics*, 3rd ed. Oxford, UK: Focal Press (Elsevier), 2002.
+
+[^4]: W. T. Welford, *Aberrations of Optical Systems*. Bristol, UK: Adam Hilger (IOP Publishing), 1986, ch. 9.
+
+[^5]: G. Agranov, V. Berezin, and R. H. Tsai, "Crosstalk and microlens study in a color CMOS image sensor," *IEEE Trans. Electron Devices*, vol. 50, no. 1, pp. 4–11, Jan. 2003.
+
+[^6]: P. B. Catrysse and B. A. Wandell, "Optical efficiency of image sensor pixels," *J. Opt. Soc. Am. A*, vol. 19, no. 8, pp. 1610–1620, Aug. 2002.
+
+[^7]: H. H. Nasse, "Distagon, Biogon and Hologon," Carl Zeiss AG Camera Lens Division, tech. article, Dec. 2011. [Online]. Available: https://lenspire.zeiss.com/photo/app/uploads/2018/02/en_CLB41_Nasse_LensNames_Distagon.pdf.
+
+[^8]: STMicroelectronics, "Lens CRA matching recommendations for optimal colorization," Application Note AN6472, Rev. 1, Mar. 2026. [Online]. Available: https://www.st.com/resource/en/application_note/an6472-lens-cra-matching-recommendations-for-optimal-colorization-stmicroelectronics.pdf.

--- a/src/content/pupils/MirrorlessDesign.md
+++ b/src/content/pupils/MirrorlessDesign.md
@@ -1,0 +1,111 @@
+---
+slug: mirrorless-lens-design
+title: Mirrorless vs. SLR Lens Design — How Mount Geometry Shapes Image Quality
+summary: How removing the SLR mirror constraint expands the optical designer's envelope for wide-angle and fast lenses — and what mount geometry does not guarantee.
+tag: guide
+series: pupil-geometry
+seriesOrder: 6
+toc: true
+---
+
+# Mirrorless vs. SLR Lens Design — How Mount Geometry Shapes Image Quality
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series.*
+
+---
+
+## The Mirror-Box Constraint
+
+For decades, SLR camera design was defined by a single mechanical requirement: a swinging reflex mirror between the rear of the lens and the film (or sensor) plane. This mirror had to flip up and out of the light path during exposure, and it needed clearance room to swing without hitting the rear of the lens.
+
+The practical consequence was a minimum **flange distance** — the gap between the lens mount and the image plane — that had to accommodate the mirror mechanism [^1] [^2]:
+
+| Mount | Flange Distance | Mount Throat Diameter |
+|---|:-:|:-:|
+| Nikon F | 46.5 mm | 44 mm |
+| Canon EF | 44.0 mm | 54 mm |
+| Pentax K | 45.5 mm | 44 mm |
+
+This clearance requirement forced the rearmost lens element to sit far from the sensor. The designer's ability to control the geometry of the image-side light cones — particularly the **chief-ray angle** (CRA — the angle at which the central ray of each image-forming bundle strikes the sensor; see [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor)) — was constrained by the space the mirror needed.
+
+The most significant design consequence was the dominance of the **retrofocus** configuration for wide-angle lenses. A retrofocus design uses a negative front group to throw the rear focal point far enough back to clear the mirror, allowing the back focal distance to exceed the lens's focal length [^3] [^4] [^6]. This was not an optical choice made for image-quality reasons — it was a structural necessity. Retrofocus designs are more complex than symmetric wide-angle types (such as the Biogon family [^5]) and can produce steeper CRAs at the sensor corners, creating the matching challenges described in [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor).
+
+## What Mirrorless Mounts Change
+
+By removing the reflex mirror, mirrorless camera systems eliminate the clearance constraint [^1] [^2] [^7]:
+
+| Mount | Flange Distance | Mount Throat Diameter |
+|---|:-:|:-:|
+| Nikon Z | 16.0 mm | 55 mm |
+| Canon RF | 20.0 mm | 54 mm |
+| Sony E | 18.0 mm | 46 mm |
+
+Two things change: the flange distance shrinks dramatically, and in some systems the mount throat diameter increases.
+
+An important clarification: the difference in flange distance — 46.5 mm for the Nikon F-mount versus 16 mm for the Z mount, for example — does **not** translate directly into "30.5 mm of extra space for optics" [^1]. Even F-mount lenses routinely extended rear elements behind the flange plane into the mirror box. What changes is that the region between the mount plane and the sensor, which in an SLR must remain clear for mirror swing, is now available for optical elements at all times.
+
+## Design Consequences
+
+The following table summarizes how the changed geometry affects the optical designer's options. These are design inferences — they follow from first-order optical principles, not from published manufacturer CRA data [^3].
+
+| Design parameter | SLR constraint | Mirrorless freedom | Practical implication |
+|---|---|---|---|
+| Rear-element placement | Must clear mirror swing path | Can sit close to sensor | More control over exit-pupil position and CRA distribution |
+| Rear-element diameter | Limited by mount throat | Can use full throat diameter (up to 55 mm for Nikon Z) | Broader exit-pupil diameter; better CRA/vignetting balance |
+| Rear-group corrective power | Limited by distance from sensor | Can place corrective elements near image plane | Better field-curvature and astigmatism management |
+| Wide-angle architecture | Retrofocus required for mirror clearance | Retrofocus still common but not mandatory | Potential for different wide-angle design tradeoffs |
+
+**These benefits are uneven across lens categories.** The short flange distance matters far more for wide-angle and very fast lenses — where the object-space field angles are large and CRA control is the dominant design challenge — than for many telephotos, where the rear-group geometry is already favorable regardless of mount type.
+
+## What Mount Geometry Does NOT Prove
+
+The expanded design envelope of a mirrorless mount does **not** prove that any particular lens built for that mount achieves any specific optical outcome [^3]:
+
+- A mirrorless mount does not guarantee telecentricity (see [*Telecentricity Explained*](/articles/telecentricity)). Most photographic lenses — including those on mirrorless mounts — are not telecentric.
+- A mirrorless mount does not guarantee low CRA or superior corner illumination. These depend on the optical prescription.
+- Two lenses designed for the same mount can make very different tradeoffs between CRA control, aperture, size, weight, and aberration correction.
+
+The mount provides design **freedom**. The optical prescription determines the **outcome**.
+
+## Why Fast Primes and Ultra-Wides Are the Showcase Designs
+
+**Ultra-wide zooms** (e.g., 14–24 mm f/2.8 designs): at 14 mm on full frame, the half-field angle reaches approximately 57°. Controlling the CRA across such an extreme field is the dominant design pressure. The ability to place rear elements close to the sensor and to use a large mount throat is directly relevant [^1] [^3].
+
+**Fast wide primes** (e.g., 35 mm f/1.2): the large entrance-pupil diameter amplifies every off-axis aberration. Mount throat diameter constrains the maximum rear-element size, which constrains the exit-pupil diameter and the achievable CRA/vignetting balance [^1] [^3].
+
+**f/0.95 designs:** lenses at this extreme aperture would have been impractical on many SLR mounts due to rear-element constraints. The wider throat and shorter flange distance make them feasible.
+
+A compact, inexpensive 50 mm f/1.8 for a mirrorless mount, by contrast, may not differ significantly in its optical architecture from an SLR-era equivalent.
+
+> **What photographers may see in practice**
+>
+> - More design freedom for ultra-wide and very fast lenses — the categories where SLR constraints bit hardest.
+> - Potentially easier CRA management, reducing corner color casts and sensor-related falloff.
+> - Larger rear elements in some designs, enabling a better balance between corner illumination and wide-aperture performance.
+> - No automatic guarantee of better corners, lower distortion, or telecentricity for any specific lens.
+
+> **Key Takeaways**
+>
+> 1. The SLR mirror box forced a minimum flange distance that constrained rear-element placement and CRA control. Mirrorless mounts remove this constraint.
+> 2. The benefits are **uneven**: wide-angle and very fast lenses gain the most design freedom; many telephotos gain little.
+> 3. Mount geometry provides design **freedom**, not design **outcomes**. The optical prescription determines whether a specific lens exploits that freedom.
+
+*For the graduate-level treatment of design inferences from mount geometry, see Section 7 of [The Aperture Stop in Practice](/articles/aperture-stop-in-practice).*
+
+---
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series. · Previous: [Telecentricity Explained](/articles/telecentricity) · Next: [Working f-Number](/articles/working-f-number)*
+
+[^1]: Nikon Corp., "Nikon Z series: Z mount system." [Online]. Available: https://www.nikonusa.com/learn-and-explore/c/products-and-innovation/nikon-z-series-z-mount-system. [Accessed: Apr. 2026].
+
+[^2]: Canon Inc., "RF mount specifications." [Online]. Available: https://www.usa.canon.com/cameras/mirrorless-cameras. [Accessed: Apr. 2026].
+
+[^3]: W. J. Smith, *Modern Optical Engineering*, 4th ed. New York, NY, USA: McGraw-Hill, 2008, chs. 6, 8.
+
+[^4]: R. Kingslake, *A History of the Photographic Lens*. San Diego, CA, USA: Academic Press, 1989.
+
+[^5]: H. H. Nasse, "Distagon, Biogon and Hologon," Carl Zeiss AG Camera Lens Division, tech. article, Dec. 2011. [Online]. Available: https://lenspire.zeiss.com/photo/app/uploads/2018/02/en_CLB41_Nasse_LensNames_Distagon.pdf.
+
+[^6]: S. Ray, *Applied Photographic Optics*, 3rd ed. Oxford, UK: Focal Press (Elsevier), 2002.
+
+[^7]: Sony Corp., "E-mount lens specifications." [Online]. Available: https://www.sony.com/en/articles/product-specifications-702. [Accessed: Apr. 2026].

--- a/src/content/pupils/ProjectionCenter.md
+++ b/src/content/pupils/ProjectionCenter.md
@@ -24,7 +24,8 @@ The answer is the **entrance pupil** — the apparent aperture of the lens as se
 
 When the rotation axis is displaced from the entrance pupil — for example, when the camera rotates about the tripod socket, which is typically well behind the entrance pupil — near objects shift laterally relative to far objects between frames. This relative shift is **parallax**, and it is the direct cause of the stitching artifacts described above.
 
-![Two side-by-side views showing camera rotation. Left panel: rotating around the entrance pupil keeps near and far objects aligned between frames — no parallax. Right panel: rotating around the tripod socket causes the near object to shift against the far background — parallax error.](/diagrams/pupils/projection-center.svg)
+<!-- diagram temporarily hidden -->
+
 
 ## Why the Entrance Pupil? The Projection Center
 

--- a/src/content/pupils/ProjectionCenter.md
+++ b/src/content/pupils/ProjectionCenter.md
@@ -1,0 +1,96 @@
+---
+slug: entrance-pupil-projection-center
+title: The Entrance Pupil as Projection Center — Perspective, Panoramas, and the "Nodal Point" Myth
+summary: Why the entrance pupil — not the "nodal point" — is the correct rotation axis for parallax-free panoramic stitching, and how to find it empirically for any lens.
+tag: guide
+series: pupil-geometry
+seriesOrder: 2
+toc: true
+---
+
+# The Entrance Pupil as Projection Center — Perspective, Panoramas, and the "Nodal Point" Myth
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series.*
+
+---
+
+## The Problem: Why Do Panoramas Have Ghosting at the Stitch Lines?
+
+If you have ever stitched a panorama from multiple overlapping frames, you may have encountered a frustrating artifact: objects at different distances from the camera appear to shift relative to each other between frames. Near objects slide sideways against the background. The stitching software does its best, but the overlapping regions do not quite align, producing ghosted edges, doubled features, and broken lines.
+
+This happens because the camera was rotated about the wrong point. The question is: what is the *right* point?
+
+The answer is the **entrance pupil** — the apparent aperture of the lens as seen from the scene side (introduced in [*What Is the Entrance Pupil?*](/articles/entrance-pupil)). When the camera rotates about the center of the entrance pupil, near and far objects maintain the same angular relationships in every frame, and the overlapping regions register correctly [^1] [^3] [^4]. The stitch is seamless.
+
+When the rotation axis is displaced from the entrance pupil — for example, when the camera rotates about the tripod socket, which is typically well behind the entrance pupil — near objects shift laterally relative to far objects between frames. This relative shift is **parallax**, and it is the direct cause of the stitching artifacts described above.
+
+*[Diagram: Two side-by-side views of a camera on a panorama head. Left: rotation axis at entrance pupil (no parallax — near and far targets stay aligned). Right: rotation axis at tripod socket (parallax — near target shifts relative to far target).]*
+
+## Why the Entrance Pupil? The Projection Center
+
+The entrance pupil is the correct rotation point because it is the **projection center** of the lens — the point from which the lens maps angular positions in the scene to linear positions on the sensor [^1] [^2].
+
+For a rectilinear (non-fisheye) lens focused at infinity, the mapping follows:
+
+$$y' = f \tan W$$
+
+where $y'$ is the image height on the sensor, $f$ is the effective focal length, and $W$ is the semi-field angle measured from the optical axis. This is rectilinear projection: straight lines in the scene map to straight lines in the image, and the mapping is governed by the tangent of the field angle.
+
+The point from which these angular relationships are measured — the vertex of the projection — is the center of the entrance pupil. This is why the entrance pupil, rather than the front element, the rear element, or the lens's physical center, is the geometrically meaningful reference point for perspective. All angular relationships measured from the entrance pupil are faithfully preserved in the image. Measure them from any other point, and the correspondence breaks down.
+
+## Finding the Entrance Pupil for Panoramic Stitching
+
+For the minority of lenses that publish entrance-pupil position data, setup is straightforward. The Leica APO-Summicron-M 35 f/2 ASPH., for example, specifies 13.8 mm in front of the bayonet mount [^5]. Set the panorama head's adjustment rail so that the rotation axis falls at that point.
+
+For lenses that do not publish this information — which is most of them — the entrance-pupil position can be found empirically using the **two-target method**:
+
+1. Set up two vertical targets (pencils, poles, or any slender objects) at substantially different distances from the camera, aligned so they overlap in the viewfinder.
+2. With the camera on the panorama head, rotate it left and right.
+3. If the near target shifts relative to the far target as the camera rotates, the rotation axis is not at the entrance pupil. Slide the camera forward or backward on the rail and repeat.
+4. When rotation produces no relative shift between the targets, the rotation axis coincides with the entrance pupil.
+
+This procedure typically takes a few minutes and is reliable to within a millimeter or two — more than adequate for any practical panoramic stitching application.
+
+### Zoom Lenses and Wide-Angles
+
+**Zoom lenses:** The entrance-pupil position changes with focal length, because the front group's imaging geometry shifts as the zoom mechanism reconfigures the elements. The panorama-head setting must be re-adjusted for each focal length used in the stitch.
+
+**Wide-angle lenses:** The entrance pupil is often located close to the front element. For ultra-wide lenses, this may place the no-parallax point very near the front of the lens, requiring careful positioning on the rail.
+
+> **Advanced note: Residual parallax from pupil aberrations**
+>
+> The entrance pupil is the exact no-parallax point only in the paraxial (first-order) model. In real lenses, the effective pupil position, size, and shape vary slightly with field angle due to pupil aberrations [^6]. No single rotation point perfectly eliminates parallax across the entire field of view. In practice, this residual parallax is negligible for panoramic stitching — the entrance-pupil position is the correct answer to well within the accuracy of a manual rail adjustment.
+
+> **Note: The "nodal point" — a persistent misnomer**
+>
+> Photographers frequently refer to the panorama rotation point as the "nodal point." This is technically incorrect [^1] [^7]. The **nodal points** are cardinal points of the lens system defined by the property of unit angular magnification — a ray aimed at the front nodal point exits appearing to come from the rear nodal point at the same angle [^1] [^2]. They describe how the lens maps ray angles through the principal planes, and they have nothing to do with the aperture stop or the pupils.
+>
+> The conflation almost certainly originates from the simplest teaching model in optics: the single thin lens with the stop at the lens plane. In that model, the principal points, nodal points, entrance pupil, and exit pupil all collapse to a single point. Students learn this simplified picture, internalize the coincidence, and carry it into discussions of real lenses — where these quantities occupy different positions along the optical axis [^1] [^2].
+>
+> The correct term for the no-parallax rotation point is the **entrance pupil**. It defines the projection center, and the projection center is the point about which rotation preserves angular relationships across overlapping frames.
+
+> **Key Takeaways**
+>
+> 1. The **entrance pupil** is the correct rotation point for parallax-free panoramic stitching — not the "nodal point," the front element, or the tripod socket.
+> 2. The entrance pupil is the **projection center** of the lens: the point from which angular positions in the scene are mapped to positions on the sensor.
+> 3. If the lens does not publish its entrance-pupil position, the **two-target method** finds it empirically in minutes.
+
+*For the graduate-level mathematical treatment, see Sections 3.2–3.3 and the misconception discussion in Section 8 of [The Aperture Stop in Practice](/articles/aperture-stop-in-practice).*
+
+---
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series. · Previous: [What Is the Entrance Pupil?](/articles/entrance-pupil) · Next: [The Exit Pupil and Your Digital Sensor](/articles/exit-pupil-sensor)*
+
+[^1]: W. J. Smith, *Modern Optical Engineering*, 4th ed. New York, NY, USA: McGraw-Hill, 2008, chs. 6, 8.
+
+[^2]: R. Kingslake and R. B. Johnson, *Lens Design Fundamentals*, 2nd ed. Burlington, MA, USA: Academic Press (Elsevier), 2010.
+
+[^3]: R. Littlefield, "Theory of the no-parallax point in panorama photography," 2006. [Online]. Available: http://www.janrik.net/PanoPostings/NoParallaxPoint/TheoryOfTheNoParallaxPoint.pdf. [Accessed: Apr. 2026].
+
+[^4]: D. A. Kerr, "The proper pivot point for panoramic photography," tech. note, 2005.
+
+[^5]: Leica Camera AG, "APO-Summicron-M 35 f/2 ASPH. — Technical specification." [Online]. Available: https://leica-camera.com/en-US/photography/lenses/m/apo-summicron-m-35-f2-asph-black-anodized-finish/technical-specification. [Accessed: Apr. 2026].
+
+[^6]: J. Sasián, "Pupil aberrations," OPTI 518 lecture notes, College of Optical Sciences, Univ. Arizona, 2014; rev. 2021.
+
+[^7]: E. Hecht, *Optics*, 5th ed. Boston, MA, USA: Pearson, 2017, ch. 5.

--- a/src/content/pupils/ProjectionCenter.md
+++ b/src/content/pupils/ProjectionCenter.md
@@ -24,7 +24,7 @@ The answer is the **entrance pupil** — the apparent aperture of the lens as se
 
 When the rotation axis is displaced from the entrance pupil — for example, when the camera rotates about the tripod socket, which is typically well behind the entrance pupil — near objects shift laterally relative to far objects between frames. This relative shift is **parallax**, and it is the direct cause of the stitching artifacts described above.
 
-*[Diagram: Two side-by-side views of a camera on a panorama head. Left: rotation axis at entrance pupil (no parallax — near and far targets stay aligned). Right: rotation axis at tripod socket (parallax — near target shifts relative to far target).]*
+![Two side-by-side views showing camera rotation. Left panel: rotating around the entrance pupil keeps near and far objects aligned between frames — no parallax. Right panel: rotating around the tripod socket causes the near object to shift against the far background — parallax error.](/diagrams/pupils/projection-center.svg)
 
 ## Why the Entrance Pupil? The Projection Center
 

--- a/src/content/pupils/PupilGeometryIndex.md
+++ b/src/content/pupils/PupilGeometryIndex.md
@@ -1,0 +1,45 @@
+---
+slug: pupil-geometry
+title: Pupil Geometry in Photographic Lenses
+summary: A series of primers on aperture stops, entrance pupils, exit pupils, and telecentricity — from the f-number definition through sensor compatibility, corner illumination, and the mirrorless design advantage.
+tag: guide
+series: pupil-geometry
+seriesOrder: 0
+toc: true
+---
+
+# Pupil Geometry in Photographic Lenses
+
+When a photographer adjusts the aperture ring, the physical iris opens or closes. But the optical system negotiates something more subtle: two virtual images of that iris — the entrance pupil and the exit pupil — that govern every light cone passing through the lens. The entrance pupil determines the f-number, defines the perspective projection center, and sets the no-parallax rotation point for panoramic stitching. The exit pupil determines how light arrives at the sensor, controlling the chief-ray angle that digital sensors are sensitive to.
+
+Understanding the distinction between the aperture stop and the pupils — and between the entrance pupil and the exit pupil — clarifies a surprising number of photographic effects that are otherwise mysterious: why macro photographers lose exposure at close focus, why rangefinder wides show corner color casts on digital bodies, why stopping down fixes some corner shading but not all, and what "telecentric" actually means versus the marketing use of the term.
+
+This series walks through the key concepts, one article at a time.
+
+---
+
+## The Articles
+
+- **[What Is the Entrance Pupil?](/articles/entrance-pupil)** — The aperture stop, the entrance pupil, and why the f-number is defined by the image of the iris — not the physical hardware inside the lens.
+- **[The Entrance Pupil as Projection Center](/articles/entrance-pupil-projection-center)** — Perspective geometry, the no-parallax point for panoramic stitching, and the "nodal point" myth.
+- **[The Exit Pupil and Your Digital Sensor](/articles/exit-pupil-sensor)** — Chief-ray angle, microlens arrays, color cast from CRA mismatch, and why rangefinder wides can misbehave on digital bodies.
+- **[Why Corners Go Dark](/articles/corner-illumination)** — The three distinct causes of corner light falloff: natural radiometric falloff (the cos⁴ law), optical vignetting, and mechanical vignetting — and why stopping down fixes only one of them.
+- **[Telecentricity Explained](/articles/telecentricity)** — What telecentricity actually means, how it is achieved by placing the stop at a group focal point, what it costs, and why most photographic lenses are not telecentric.
+- **[Mirrorless vs. SLR Lens Design](/articles/mirrorless-lens-design)** — How removing the SLR mirror constraint expands the optical designer's envelope for wide-angle and fast lenses — and what mount geometry does not guarantee.
+- **[Working f-Number](/articles/working-f-number)** — Why macro photographers lose two stops of light at 1:1 magnification, the bellows factor, pupil magnification corrections, and the close-up diopter exception.
+
+---
+
+## The Full Monograph
+
+For the unified graduate-level treatment — first-order definitions, marginal and chief rays, working f-number derivation, panorama rotation theory, generalized illumination law, cos⁴ derivation, pupil aberration overview, telecentricity mechanisms, mirrorless design inferences, and a comprehensive misconceptions section — see the full monograph:
+
+**[The Aperture Stop in Practice: Entrance Pupil, Exit Pupil, and Telecentricity](/articles/aperture-stop-in-practice)**
+
+The monograph is the authoritative reference; the articles are standalone summaries suitable for readers who want the core idea for one topic without the full mathematical context.
+
+---
+
+## How to Read This Series
+
+Each article is self-contained. The articles build on each other loosely in order — the entrance-pupil articles establish the conceptual framework that the exit-pupil, corner-illumination, and telecentricity discussions depend on — but any article can be read independently.

--- a/src/content/pupils/Telecentricity.md
+++ b/src/content/pupils/Telecentricity.md
@@ -32,7 +32,7 @@ There are three forms:
 
 Each form is a geometric condition, not an optical quality metric.
 
-*[Diagram: Three simple side-by-side sketches. Left: object-space telecentric — chief rays parallel on the scene side, converging on the sensor side. Center: image-space telecentric — chief rays converging on the scene side, parallel on the sensor side. Right: double telecentric — chief rays parallel on both sides. Label pupil positions as "at infinity" on the relevant side.]*
+![Three side-by-side diagrams illustrating the three forms of telecentricity. Left: object-space telecentric, with chief rays parallel on the scene side and the entrance pupil at infinity. Center: image-space telecentric, with chief rays parallel on the sensor side and the exit pupil at infinity. Right: double telecentric, with chief rays parallel on both sides.](/diagrams/pupils/telecentricity.svg)
 
 **Most photographic lenses are not telecentric — and that's fine.** Strict telecentricity requires the aperture stop to sit at a specific location (a group focal point), and that placement conflicts with compactness, zoom-range flexibility, aberration correction, and the ability to focus from infinity to close range [^1] [^5]. What many modern digital-era lens designs actually pursue is **reduced CRA** — more favorable image-side chief-ray geometry than earlier film-era or SLR-era designs could achieve. This is a **design tendency on a continuum**, not a binary telecentric/non-telecentric classification. Saying a lens has "reduced CRA" or "more favorable rear-ray geometry" is accurate; saying it "is telecentric" implies a strict condition most photo lenses don't satisfy.
 

--- a/src/content/pupils/Telecentricity.md
+++ b/src/content/pupils/Telecentricity.md
@@ -1,0 +1,105 @@
+---
+slug: telecentricity
+title: Telecentricity Explained — What It Actually Means and What It Costs
+summary: What telecentricity actually means, how it is achieved by placing the stop at a group focal point, what it costs in design freedom, and why most photographic lenses are not telecentric.
+tag: guide
+series: pupil-geometry
+seriesOrder: 5
+toc: true
+---
+
+# Telecentricity Explained — What It Actually Means and What It Costs
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series.*
+
+---
+
+## Why Photographers Hear This Word
+
+"Telecentric" appears frequently in photographic optics discussions — lens reviews, mount-system debates, and marketing materials. It is almost always used loosely, as a vague synonym for "digital-friendly" or "good rear-ray geometry." But telecentricity is not a quality grade. It is a specific geometric condition with a precise definition, specific structural requirements, and real engineering costs [^1] [^2] [^3] [^4].
+
+Understanding what the word actually means — and what it does *not* mean — prevents two common errors: treating telecentricity as the secret ideal all good lenses ought to reach, and confusing it with "reduced CRA" (chief-ray angle — the angle at which the chief ray strikes the sensor), which is what most photographic discussions actually mean.
+
+## What Telecentricity Actually Means
+
+There are three forms:
+
+**Object-space telecentric.** The entrance pupil (the apparent aperture on the scene side) is located at infinity. All chief rays in object space are parallel to the optical axis.
+
+**Image-space telecentric.** The exit pupil (the apparent aperture on the sensor side) is located at infinity. All chief rays in image space are parallel to the optical axis — light arrives perpendicular to the sensor everywhere across the frame. The CRA is zero at every pixel.
+
+**Double telecentric (bi-telecentric).** Both conditions hold simultaneously.
+
+Each form is a geometric condition, not an optical quality metric.
+
+*[Diagram: Three simple side-by-side sketches. Left: object-space telecentric — chief rays parallel on the scene side, converging on the sensor side. Center: image-space telecentric — chief rays converging on the scene side, parallel on the sensor side. Right: double telecentric — chief rays parallel on both sides. Label pupil positions as "at infinity" on the relevant side.]*
+
+**Most photographic lenses are not telecentric — and that's fine.** Strict telecentricity requires the aperture stop to sit at a specific location (a group focal point), and that placement conflicts with compactness, zoom-range flexibility, aberration correction, and the ability to focus from infinity to close range [^1] [^5]. What many modern digital-era lens designs actually pursue is **reduced CRA** — more favorable image-side chief-ray geometry than earlier film-era or SLR-era designs could achieve. This is a **design tendency on a continuum**, not a binary telecentric/non-telecentric classification. Saying a lens has "reduced CRA" or "more favorable rear-ray geometry" is accurate; saying it "is telecentric" implies a strict condition most photo lenses don't satisfy.
+
+## How Telecentricity Is Achieved — The Structural Mechanism
+
+Telecentricity does not emerge spontaneously from good design. It is achieved by a specific geometric trick: placing the aperture stop where a neighboring lens group "sees" it at its own focal point, so that group images the stop to infinity [^1] [^2] [^3].
+
+More precisely:
+
+**Object-space telecentricity** requires placing the stop at the **rear focal point of the front optical group**. The front group then images the stop to infinity in object space — the entrance pupil is at infinity, and all chief rays on the scene side are parallel to the axis [^1] [^3].
+
+**Image-space telecentricity** requires the complementary arrangement: the stop sits at the **front focal point of the rear optical group**. The rear group images the stop to infinity in image space — the exit pupil is at infinity, and chief rays arrive perpendicular to the sensor [^1] [^3].
+
+**Double telecentricity** requires both conditions simultaneously, tightly constraining the power distribution, element spacing, and physical length of the system.
+
+The essential point: telecentricity is a **constraint on stop placement**, not an emergent property of a well-corrected design.
+
+## What Each Form Is Good For
+
+### Object-space telecentricity: Stable magnification
+
+When chief rays are parallel in object space, magnification is insensitive to small changes in object distance [^1] [^2] [^3]. Objects at slightly different distances within the depth of field are all imaged at the same scale. This is essential for machine-vision metrology: imagine a camera inspecting machined pins on a vibrating conveyor belt. With a non-telecentric lens, pins at slightly different distances are imaged at different magnifications, making dimensional measurements unreliable. With an object-space telecentric lens, magnification is stable.
+
+The tradeoff: the field of view is limited by the front-element diameter, because parallel chief rays cannot "look around" anything larger than the lens aperture. Object-space telecentric lenses for industrial inspection are characteristically large.
+
+### Image-space telecentricity: Zero CRA at the sensor
+
+When the exit pupil is at infinity, the CRA is zero at every point on the sensor [^1] [^3]. This directly suppresses the angular-sensitivity problems described in [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor): microlens misalignment, color crosstalk, and corner color cast all diminish when light arrives perpendicular to the sensor everywhere.
+
+An important clarification: only the **chief rays** are perpendicular to the sensor. The full cone of rays from each field point still has angular spread determined by the f-number. Telecentricity makes the *center* of each cone normal to the sensor, not every ray within it [^1]. But the chief-ray angle dominates the microlens-alignment and color-shading effects.
+
+**The connection to corner illumination.** In [*Why Corners Go Dark*](/articles/corner-illumination), one of the four cosine factors in the cos⁴ law arises from oblique incidence of the chief ray on the sensor surface. Image-space telecentricity eliminates that factor by construction. However, the other contributions — reduced projected pupil area and increased image distance — persist regardless of telecentricity, because they depend on the object-space field geometry [^1]. Telecentricity addresses the sensor-angle-sensitivity problem comprehensively, but it does not abolish radiometric falloff.
+
+### Double telecentricity: Both benefits combined
+
+Used in lithography, metrology, and specialized inspection — not in general-purpose photography. Double telecentric lenses are physically large, inherently finite-conjugate systems, and the tight stop-placement constraints limit design freedom [^3].
+
+## What Telecentricity Costs
+
+**The stop-placement constraint** conflicts with other design goals. The stop must sit at a group focal point — a very specific location. This restricts the designer's freedom to optimize the stop for astigmatism, field curvature, zoom mechanisms, or aberration balance across the field. In most photographic lenses, the optimal stop position for aberration correction is *not* at a group focal point [^1].
+
+**Object-space telecentric lenses** have a field of view limited by the front-element diameter. **Double telecentric designs** impose the tightest constraints, with coupled inter-group spacing, group focal lengths, and total system length.
+
+> **Myth vs. reality**
+>
+> - "Telecentric" does **not** mean "well-corrected" — it is a geometric condition with costs.
+> - "Telecentric" does **not** mean "distortion-free" — a telecentric lens can exhibit barrel or pincushion distortion [^1].
+> - "Reduced CRA" is **not** the same as telecentricity — most photographic lenses that reduce CRA do so partially, not by placing the exit pupil at infinity.
+
+> **Key Takeaways**
+>
+> 1. Telecentricity means the entrance pupil, exit pupil, or both are located at **infinity** — a specific geometric condition achieved by placing the stop at a group focal point.
+> 2. Most photographic lenses are **not** telecentric. What they pursue is **reduced CRA** — a continuum of improvement, not a binary switch.
+> 3. Telecentricity has real **costs**: stop-placement constraints, size limitations, and conflicts with other design goals. It is a tradeoff, not a free upgrade.
+
+*For the graduate-level mathematical treatment, including the thin-lens derivation of the structural mechanism, see Section 6 of [The Aperture Stop in Practice](/articles/aperture-stop-in-practice). The distortion-independence discussion appears in Section 8.*
+
+---
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series. · Previous: [Why Corners Go Dark](/articles/corner-illumination) · Next: [Mirrorless vs. SLR Lens Design](/articles/mirrorless-lens-design)*
+
+[^1]: W. J. Smith, *Modern Optical Engineering*, 4th ed. New York, NY, USA: McGraw-Hill, 2008, chs. 6, 8.
+
+[^2]: J. Sasián, *Introduction to Lens Design*. Cambridge, UK: Cambridge Univ. Press, 2019.
+
+[^3]: Edmund Optics, "Telecentric design topics," *Imaging Resource Guide*, sec. 4.4. [Online]. Available: https://www.edmundoptics.com/knowledge-center/application-notes/imaging/telecentric-design-topics/. [Accessed: Apr. 2026].
+
+[^4]: J. E. Greivenkamp, "Stops and pupils," OPTI 502 course notes, College of Optical Sciences, Univ. Arizona, 2019.
+
+[^5]: S. Ray, *Applied Photographic Optics*, 3rd ed. Oxford, UK: Focal Press (Elsevier), 2002.

--- a/src/content/pupils/WorkingFNumber.md
+++ b/src/content/pupils/WorkingFNumber.md
@@ -28,7 +28,7 @@ The f-number engraved on a lens barrel is the **infinity-conjugate f-number** �
 
 As the lens focuses closer, the image conjugate lengthens: the image forms farther from the exit pupil (the apparent aperture on the sensor side; see [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor)). The exit pupil subtends a smaller angle as seen from the image plane, so less light per unit area reaches the sensor.
 
-*[Diagram: Two side-by-side cross-sections. Left: lens focused at infinity — exit pupil subtends a wide angle from the image plane, labeled $N$. Right: lens extended for close focus — image plane farther away, exit pupil subtends a narrower angle, labeled $N_{\text{eff}} > N$. Show the longer image conjugate explicitly.]*
+![Two side-by-side cross-sections comparing f-number at infinity focus versus close focus. Left: at infinity the exit pupil subtends a wide angle from the sensor, labeled N. Right: with the lens extended for close focus the sensor is farther from the exit pupil, the angle narrows, and the effective f-number N_eff is larger than N.](/diagrams/pupils/working-fnumber.svg)
 
 For a conventional lens — one that focuses by changing the overall lens-to-sensor distance without altering its internal optics — the relationship is [^1] [^2]:
 

--- a/src/content/pupils/WorkingFNumber.md
+++ b/src/content/pupils/WorkingFNumber.md
@@ -1,0 +1,112 @@
+---
+slug: working-f-number
+title: Working f-Number — Why Macro Photographers Lose Light
+summary: Why macro photographers lose two stops of light at 1:1 magnification, the bellows factor formula, pupil magnification corrections for telephoto macros, and the close-up diopter exception.
+tag: guide
+series: pupil-geometry
+seriesOrder: 7
+toc: true
+---
+
+# Working f-Number — Why Macro Photographers Lose Light
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series.*
+
+---
+
+## The Observation: Exposure Loss at Close Focus
+
+A lens marked f/2.8 delivers f/2.8 when focused at infinity. Move to 1:1 macro magnification — life-size reproduction — and the same iris setting delivers the light equivalent of f/5.6. That is a two-stop loss, enough to turn a well-exposed ambient shot into an underexposed one.
+
+Every macro photographer has experienced this. TTL (through-the-lens) metering compensates automatically, so in practice the camera adjusts and the photographer may not even notice. But the effect becomes critical for manual flash exposure (where the photographer calculates from the guide number and the marked f-number), for extension-tube calculations, and any situation where the actual light-delivery performance of the lens at close focus matters.
+
+Understanding *why* the exposure changes — even though the physical iris has not moved — requires understanding the relationship between magnification, pupil geometry, and the effective f-number.
+
+## The Simple Explanation: The Image Moves Farther from the Lens
+
+The f-number engraved on a lens barrel is the **infinity-conjugate f-number** — valid when the lens is focused at infinity. At infinity focus, the image forms one focal length behind the rear principal plane.
+
+As the lens focuses closer, the image conjugate lengthens: the image forms farther from the exit pupil (the apparent aperture on the sensor side; see [*The Exit Pupil and Your Digital Sensor*](/articles/exit-pupil-sensor)). The exit pupil subtends a smaller angle as seen from the image plane, so less light per unit area reaches the sensor.
+
+*[Diagram: Two side-by-side cross-sections. Left: lens focused at infinity — exit pupil subtends a wide angle from the image plane, labeled $N$. Right: lens extended for close focus — image plane farther away, exit pupil subtends a narrower angle, labeled $N_{\text{eff}} > N$. Show the longer image conjugate explicitly.]*
+
+For a conventional lens — one that focuses by changing the overall lens-to-sensor distance without altering its internal optics — the relationship is [^1] [^2]:
+
+$$N_{\text{eff}} = N(1 + m)$$
+
+where $N$ is the marked f-number and $m$ is the image magnification (image size divided by object size, positive by convention). This is the **bellows factor**.
+
+At 1:1 ($m = 1$), the effective f-number doubles: $N_{\text{eff}} = 2N$. A lens marked f/2.8 behaves as f/5.6 — exactly two stops lost. At 2:1 ($m = 2$), it triples: f/2.8 becomes f/8.4, over three stops.
+
+## The Refinement: Pupil Magnification
+
+The simple $(1 + m)$ rule assumes the entrance and exit pupils are the same size — that the **pupil magnification** $m_p = 1$. For many lenses, this is not the case. When $m_p \neq 1$, the generalized expression is [^1] [^2]:
+
+$$N_{\text{eff}} = N\left(1 + \frac{m}{m_p}\right)$$
+
+**Telephoto macro lenses** ($m_p < 1$, exit pupil smaller than entrance pupil): dividing $m$ by a number less than 1 increases the correction term. The exposure penalty is **worse** than $(1 + m)$ predicts.
+
+**Retrofocus designs** ($m_p > 1$, exit pupil larger than entrance pupil): the correction term is reduced, and the penalty is **less** than $(1 + m)$.
+
+### A worked example
+
+A 180 mm macro lens with $m_p = 0.7$ at 1:1:
+
+$$N_{\text{eff}} = N\left(1 + \frac{1}{0.7}\right) = N \times 2.43$$
+
+Instead of two stops lost ($2N$), this lens loses about **2.6 stops** ($2.43N$). The difference — about two-thirds of a stop — matters for precise manual flash work.
+
+### Effective f-number multiplier at various magnifications
+
+| Magnification ($m$) | $m_p = 1.0$ | $m_p = 0.7$ | $m_p = 1.5$ |
+|:-:|:-:|:-:|:-:|
+| 0.1 (1:10) | 1.10× | 1.14× | 1.07× |
+| 0.25 (1:4) | 1.25× | 1.36× | 1.17× |
+| 0.5 (1:2) | 1.50× | 1.71× | 1.33× |
+| 1.0 (1:1) | 2.00× | 2.43× | 1.67× |
+| 2.0 (2:1) | 3.00× | 3.86× | 2.33× |
+
+## Practical Guidance
+
+**TTL metering handles this automatically** for ambient-light exposure. The meter reads the light that actually reaches the sensor, incorporating all bellows-factor and pupil-magnification effects.
+
+**For manual flash work**, use the generalized formula if you know $m_p$. If you don't, the simple $(1 + m)$ rule is a reasonable approximation for most standard macro lenses, but expect potential error of up to a stop for strongly telephoto or retrofocus designs at high magnification.
+
+**Extension tubes** add to the image conjugate and increase the effective f-number [^4]. Each tube contributes additional lens-to-sensor distance. The bellows factor applies to the total extension.
+
+> **A caution about internally focusing lenses**
+>
+> The formulas above apply to conventional lenses that focus by extending the barrel. Many modern lenses use **internal focusing (IF)**, moving internal groups while the barrel length stays fixed [^3]. IF lenses change their effective focal length and pupil geometry as they focus, so the relationship between magnification and exposure loss becomes design-specific — it cannot be predicted from the infinity f-number and magnification alone. The camera's TTL meter still accounts for the actual light, but analytical exposure calculations may not match the simple bellows factor. For the full treatment of how IF architectures alter pupil and conjugate geometry, see the [*Internal Focusing in Photographic Lens Design*](/articles/internal-focusing-monograph) monograph on OpticalBench.net.
+
+> **Sidebar: Close-up diopter lenses — magnification without bellows-factor cost**
+>
+> Close-up diopter lenses (supplementary positive lenses attached to the front of the main lens) offer an instructive contrast to extension tubes. A diopter changes the object conjugate — allowing the lens to focus on closer objects — without extending the image conjugate. The lens-to-sensor distance remains unchanged, so the exit pupil subtends the same angle from the sensor as before. The magnification increase comes without the corresponding bellows-factor exposure penalty. This is one reason close-up diopters remain popular for field macro work despite their optical compromises. The formal analogy between a supplementary diopter and the front-cell focusing mechanism is developed in the *Front-Cell Focusing* monograph on OpticalBench.net.
+
+> **Rules of Thumb**
+>
+> - At **1:4 magnification**: expect a modest light loss (roughly ⅓ stop if $m_p \approx 1$).
+> - At **1:2 magnification**: expect about 1 stop of loss.
+> - At **1:1 magnification**: expect roughly **2 stops** if $m_p \approx 1$. Telephoto macros ($m_p < 1$) lose more.
+> - **TTL metering** compensates automatically. These calculations matter mainly for manual flash.
+
+> **Key Takeaways**
+>
+> 1. The marked f-number is valid only at infinity focus. At closer distances, the effective f-number increases because the image conjugate lengthens: $N_{\text{eff}} = N(1 + m)$.
+> 2. When $m_p \neq 1$, the generalized formula $N_{\text{eff}} = N(1 + m/m_p)$ accounts for the actual exit-pupil geometry. Telephoto macros ($m_p < 1$) lose more light than the simple rule predicts.
+> 3. **Close-up diopter lenses** gain magnification without extending the image conjugate, avoiding the bellows-factor penalty entirely.
+
+*For the graduate-level mathematical treatment, see Sections 3.4 and 4.2 of [The Aperture Stop in Practice](/articles/aperture-stop-in-practice).*
+
+---
+
+*Part of the [Pupil Geometry in Photographic Lenses](/articles/pupil-geometry) series. · Previous: [Mirrorless vs. SLR Lens Design](/articles/mirrorless-lens-design)*
+
+*This is the final article in this series. For the graduate-level treatment of all topics covered here, see [The Aperture Stop in Practice](/articles/aperture-stop-in-practice).*
+
+[^1]: W. J. Smith, *Modern Optical Engineering*, 4th ed. New York, NY, USA: McGraw-Hill, 2008, chs. 6, 8.
+
+[^2]: W. T. Welford, *Aberrations of Optical Systems*. Bristol, UK: Adam Hilger (IOP Publishing), 1986, ch. 9.
+
+[^3]: S. Ray, *Applied Photographic Optics*, 3rd ed. Oxford, UK: Focal Press (Elsevier), 2002.
+
+[^4]: L. Lefkowitz, *The Manual of Close-Up Photography*. Garden City, NY, USA: Amphoto, 1979.

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -212,6 +212,23 @@ function useMarkdownComponents(t: Theme, isStartHere: boolean) {
         </td>
       ),
       hr: () => <hr style={{ border: "none", borderTop: `1px solid ${t.descBorder}`, margin: "18px 0" }} />,
+      img: ({ src, alt }: { src?: string; alt?: string }) => (
+        <figure style={{ margin: "24px 0", textAlign: "center" }}>
+          <img
+            src={src}
+            alt={alt ?? ""}
+            style={{
+              maxWidth: "100%",
+              height: "auto",
+              borderRadius: 6,
+              border: `1px solid ${t.descTableBorder}`,
+            }}
+          />
+          {alt && (
+            <figcaption style={{ marginTop: 6, fontSize: 11, color: t.muted, fontStyle: "italic" }}>{alt}</figcaption>
+          )}
+        </figure>
+      ),
     }),
     [t, isStartHere],
   );

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -20,6 +20,10 @@ import { SITE_NAME, SITE_URL } from "../utils/lensMetadata.js";
 import { articleJsonLd, breadcrumbJsonLd } from "../utils/structuredData.js";
 import { usePageThemeToggle } from "../utils/usePageThemeToggle.js";
 import { ARTICLE_CONTENT, ARTICLE_SERIES } from "../utils/homepageContent.js";
+import EntrancePupilDiagram from "../components/diagram/EntrancePupilDiagram.js";
+import ExitPupilDiagram from "../components/diagram/ExitPupilDiagram.js";
+import TelecentricityDiagram from "../components/diagram/TelecentricityDiagram.js";
+import WorkingFNumberDiagram from "../components/diagram/WorkingFNumberDiagram.js";
 import type { Theme } from "../types/theme.js";
 
 const PAGE_BASE_STYLE = {
@@ -33,7 +37,7 @@ const PAGE_BASE_STYLE = {
 const NAV_STYLE: CSSProperties = { marginTop: "1.5rem", marginBottom: "1.5rem", fontSize: "0.8rem" };
 
 /** Theme-aware markdown components — same pattern as DescriptionPanel */
-function useMarkdownComponents(t: Theme, isStartHere: boolean) {
+function useMarkdownComponents(t: Theme, isStartHere: boolean, isDark: boolean) {
   return useMemo(
     () => ({
       h1: ({ children, id }: { children?: ReactNode; id?: string }) => (
@@ -212,25 +216,75 @@ function useMarkdownComponents(t: Theme, isStartHere: boolean) {
         </td>
       ),
       hr: () => <hr style={{ border: "none", borderTop: `1px solid ${t.descBorder}`, margin: "18px 0" }} />,
-      img: ({ src, alt }: { src?: string; alt?: string }) => (
-        <figure style={{ margin: "24px 0", textAlign: "center" }}>
-          <img
-            src={src}
-            alt={alt ?? ""}
-            style={{
-              maxWidth: "100%",
-              height: "auto",
-              borderRadius: 6,
-              border: `1px solid ${t.descTableBorder}`,
-            }}
-          />
-          {alt && (
-            <figcaption style={{ marginTop: 6, fontSize: 11, color: t.muted, fontStyle: "italic" }}>{alt}</figcaption>
-          )}
-        </figure>
-      ),
+      img: ({ src, alt }: { src?: string; alt?: string }) => {
+        if (src?.includes("entrance-pupil")) {
+          return (
+            <figure style={{ margin: "24px 0", textAlign: "center" }}>
+              <EntrancePupilDiagram isDark={isDark} />
+              {alt && (
+                <figcaption style={{ marginTop: 6, fontSize: 11, color: t.muted, fontStyle: "italic" }}>
+                  {alt}
+                </figcaption>
+              )}
+            </figure>
+          );
+        }
+        if (src?.includes("exit-pupil")) {
+          return (
+            <figure style={{ margin: "24px 0", textAlign: "center" }}>
+              <ExitPupilDiagram isDark={isDark} />
+              {alt && (
+                <figcaption style={{ marginTop: 6, fontSize: 11, color: t.muted, fontStyle: "italic" }}>
+                  {alt}
+                </figcaption>
+              )}
+            </figure>
+          );
+        }
+        if (src?.includes("telecentricity")) {
+          return (
+            <figure style={{ margin: "24px 0", textAlign: "center" }}>
+              <TelecentricityDiagram isDark={isDark} />
+              {alt && (
+                <figcaption style={{ marginTop: 6, fontSize: 11, color: t.muted, fontStyle: "italic" }}>
+                  {alt}
+                </figcaption>
+              )}
+            </figure>
+          );
+        }
+        if (src?.includes("working-fnumber")) {
+          return (
+            <figure style={{ margin: "24px 0", textAlign: "center" }}>
+              <WorkingFNumberDiagram isDark={isDark} />
+              {alt && (
+                <figcaption style={{ marginTop: 6, fontSize: 11, color: t.muted, fontStyle: "italic" }}>
+                  {alt}
+                </figcaption>
+              )}
+            </figure>
+          );
+        }
+        return (
+          <figure style={{ margin: "24px 0", textAlign: "center" }}>
+            <img
+              src={src}
+              alt={alt ?? ""}
+              style={{
+                maxWidth: "100%",
+                height: "auto",
+                borderRadius: 6,
+                border: `1px solid ${t.descTableBorder}`,
+              }}
+            />
+            {alt && (
+              <figcaption style={{ marginTop: 6, fontSize: 11, color: t.muted, fontStyle: "italic" }}>{alt}</figcaption>
+            )}
+          </figure>
+        );
+      },
     }),
-    [t, isStartHere],
+    [t, isStartHere, isDark],
   );
 }
 
@@ -238,8 +292,8 @@ export default function ArticlePage() {
   const { slug } = useParams<{ slug: string }>();
   const { state: locationState } = useLocation();
   const fromStartHere = (locationState as { fromStartHere?: boolean } | null)?.fromStartHere === true;
-  const { theme: t, themeMode, highContrast, toggleTheme, toggleHC } = usePageThemeToggle();
-  const components = useMarkdownComponents(t, slug === "start-here");
+  const { theme: t, themeMode, dark, highContrast, toggleTheme, toggleHC } = usePageThemeToggle();
+  const components = useMarkdownComponents(t, slug === "start-here", dark);
 
   useEffect(() => {
     window.scrollTo({ top: 0, left: 0 });

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -22,6 +22,11 @@ export const CHANGELOG: ChangelogEntry[] = [
   // ── 2026-04-21 ──────────────────────────────────────────────────────────
   {
     date: "2026-04-21",
+    type: "article",
+    summary: "Added Pupil Geometry article series covering entrance pupil, exit pupil, telecentricity, and more",
+  },
+  {
+    date: "2026-04-21",
     type: "improvement",
     summary:
       "Improved element outline rendering, added a 10% boundary-gap clearance margin, and audited production semi-diameters",

--- a/src/utils/homepageContent.ts
+++ b/src/utils/homepageContent.ts
@@ -95,7 +95,7 @@ export function stripFrontmatter(raw: string): string {
   return raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n*/, "");
 }
 
-const _mdModules = import.meta.glob<string>("../content/*.md", {
+const _mdModules = import.meta.glob<string>("../content/**/*.md", {
   eager: true,
   query: "?raw",
   import: "default",

--- a/src/utils/usePageThemeToggle.ts
+++ b/src/utils/usePageThemeToggle.ts
@@ -27,6 +27,7 @@ import type { Theme } from "../types/theme.js";
 interface PageThemeToggle {
   theme: Theme;
   themeMode: ThemeMode;
+  dark: boolean;
   highContrast: boolean;
   toggleTheme: () => void;
   toggleHC: () => void;
@@ -80,7 +81,14 @@ export function usePageThemeToggle(): PageThemeToggle {
   }, [themeMode, persist]);
 
   const resolvedDark = themeMode === "auto" ? systemDark : themeMode === "dark";
-  return { theme: resolveTheme(resolvedDark, highContrast), themeMode, highContrast, toggleTheme, toggleHC };
+  return {
+    theme: resolveTheme(resolvedDark, highContrast),
+    themeMode,
+    dark: resolvedDark,
+    highContrast,
+    toggleTheme,
+    toggleHC,
+  };
 }
 
 export type { ThemeMode } from "./themePreferences.js";


### PR DESCRIPTION
## Summary

- Adds the full **Pupil Geometry in Photographic Lenses** article series: Entrance Pupil, Exit Pupil & Digital Sensor, Entrance Pupil as Projection Center, Aperture Stop, Corner Illumination, Mirrorless vs SLR Design, Telecentricity, Working F-Number — with linked footnote citations throughout
- Adds inline SVG diagrams for four articles (entrance pupil, exit pupil, telecentricity, working f-number) that switch between dark and light palettes in sync with the app's theme toggle
- Geometry improvements to diagrams: EP size contrast enlarged; telecentricity middle-panel rays corrected; legend respaced; working f-number left-panel elements shifted closer to sensor
- Adds Pupil Geometry series entry to homepage changelog
- Temporarily hides the projection-center diagram (placeholder pending revision)

## Technical notes

- `usePageThemeToggle` now exposes `dark: boolean` (the resolved dark/light state)
- `ArticlePage` img renderer detects diagram srcs by path substring and renders the React component in place of a static `<img>`
- Marker IDs are prefixed per diagram (`xp-`, `tc-`, `wfn-`) to avoid collisions when multiple diagrams appear on the same page

## Test plan

- [ ] Toggle dark/light/auto theme — all four diagrams update immediately
- [ ] Verify diagrams render correctly in both dark and light modes
- [ ] Confirm projection-center article loads without diagram (no broken image)
- [ ] Confirm changelog entry appears on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)