### PR TITLE
[codex] Add fast RF primes and Nokton lens

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `92` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
+- `95` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Nikon, Zeiss, Voigtlander, Canon, Ricoh, and Vivitar
 - Lens pages pair interactive diagrams with long-form optical analysis markdown
 

--- a/src/lens-data/CanonRF50mmf12L.analysis.md
+++ b/src/lens-data/CanonRF50mmf12L.analysis.md
@@ -1,0 +1,361 @@
+# Canon RF 50mm f/1.2 L USM — Optical Design Analysis
+
+## Patent & Production Lens Identification
+
+**Patent:** US 2019/0265441 A1 — "Optical System and Image Pickup Apparatus"
+**Inventor:** Masato Katayose (Canon Kabushiki Kaisha)
+**Published:** August 29, 2019
+**Priority:** JP 2018-032883, February 27, 2018
+**Production example:** Example 2 (Numerical Data 2)
+
+Example 2 was identified as the production design on the basis of three independent concordances with Canon's published specifications. The patent states a maximum magnification of −0.19 at closest focus, which matches Canon's specified 0.19× exactly; no other example in the patent achieves this value. The patent's 15-element / 9-group construction, 2ω = 45.90° field angle, and three aspherical surfaces likewise correspond to Canon's published data of 15 elements in 9 groups, 46° diagonal field of view, and three aspherical elements (two ground aspherics and one glass-molded aspherical). The patent focal length of 51.10 mm and f/1.25 aperture represent the unscaled design prescription — the production lens is marketed at 50 mm and f/1.2, consistent with the routine rounding conventions used in consumer lens specifications. (The f/1.25 to f/1.2 difference is less than 1/6 stop.)
+
+A note on aspherical element counts: Canon's own product page specifies "Three Aspherical Elements and One UD Element," and DXoMark's review (based on Canon press materials) further identifies them as "2 large-diameter ground aspherical lens elements, and 1 glass-molded aspherical lens element." Some third-party retailers simplify this to "one aspherical element" in abbreviated spec sheets; the Canon first-party specification of three aspherical elements is authoritative and matches the patent.
+
+The patent's Example 2 surface data contains OCR transcription errors in the published text at surfaces 14–18, where the radii of curvature were corrupted by cross-contamination with Example 3. The correct values were recovered by rasterizing the patent PDF at 400 DPI and reading the prescription table directly from the image. Five radii were corrected: surface 14 (251.143, not −73.147), surface 15 (87.566, not 307.461), surface 16 (−43.447, not −33.624), surface 17 (105.692, not 109.612), and surface 18 (161.695, not 244.351). The corrected prescription reproduces all patent-stated parameters: EFL = 51.10 mm, BFD = 14.60 mm, total track = 111.01 mm, and all 15 element focal lengths, all group focal lengths, and all nine conditional expression values from Table 1.
+
+
+## Optical Layout
+
+The lens consists of 15 glass elements arranged in 9 air-separated groups, organized into two functional regions divided by the aperture stop (SP):
+
+- **Front Lens Group (LF):** Surfaces 1–10, 6 elements (G1–G6) in 4 groups — positive overall power (f_LF = 198.77 mm)
+- **Aperture Stop (SP):** Surface 11
+- **Rear Lens Group (LR):** Surfaces 12–25, 9 elements (G7–G15) in 5 groups — positive overall power (f_LR = 44.87 mm)
+
+The system is further divided into two mechanically distinct lens units for focusing:
+
+- **Focus Unit (L1):** Surfaces 1–19, elements G1–G11 — moves toward the object during close-focus (f_L1 = 61.31 mm)
+- **Stationary Unit (L2):** Surfaces 20–25, elements G12–G15 — fixed relative to the image plane (f_L2 = 586.4 mm)
+
+This is a front-group extension focus architecture: the focus unit L1 contains the entire front group, the aperture stop, and the first five elements of the rear group. It translates as a rigid block toward the object during close-focus. Only the final four elements (two cemented doublets, unit L2) remain stationary relative to the image plane. A single air gap — d19, between G11 and G12 — changes during focusing, while the BFD (d25) remains constant. Despite having only one variable gap, this is not unit focus in the conventional sense: unit focus implies the entire lens moves with only the back focal distance changing. Here, a subunit (L1) extends while L2 and the image plane relationship is fixed. The extreme focal length ratio f1/f2 = 0.105 ensures that focus-induced aberration variations remain small, since the stationary unit contributes only weak positive power and serves primarily as a field-flattening corrector.
+
+
+## Verified Design Parameters
+
+| Parameter | Computed | Patent |
+|-----------|----------|--------|
+| EFL | 51.100 mm | 51.10 mm |
+| F-number | 1.25 | 1.25 |
+| Half-field angle | 22.95° | 22.95° |
+| Image height | 21.64 mm | 21.64 mm |
+| Total track | 111.01 mm | 111.01 mm |
+| Back focal distance | 14.60 mm | 14.60 mm |
+| Front group (LF) focal length | 198.77 mm | 198.77 mm |
+| Rear group (LR) focal length | 44.87 mm | 44.87 mm |
+| Petzval sum | 0.00164 mm⁻¹ | — |
+| Petzval radius | −608 mm | — |
+
+
+## Element-by-Element Analysis
+
+### Front Lens Group (LF): Elements G1–G6
+
+The front group's primary responsibilities are to converge the incoming marginal ray bundle (reducing the beam diameter that must pass through the aperture stop) while introducing minimal net aberration. With a combined focal length of 198.77 mm — nearly 4× the system EFL — the front group provides gentle convergence distributed across six elements, which is essential for controlling spherical aberration at f/1.2. The average refractive index of the positive elements in this group is exceptionally high (N_pave = 1.920), enabling strong convergence with moderate surface curvatures.
+
+**G1 — Biconvex Positive, aspherical front surface**
+- Glass: S-LAH65V (OHARA), nd = 1.80400, νd = 46.58
+- Focal length: +47.21 mm
+- Radii: R1 = +80.110 mm (aspherical), R2 = −68.243 mm
+- Center thickness: 9.67 mm
+- Cemented with G2 (Doublet D1)
+
+G1 is the most critical element in the design. As the positive lens "Lp" closest to the object, it carries the patent's primary conditional expression constraint: fLp/Dps = 1.240, meaning its focal length is 1.24× the distance from its front surface to the stop. This relationship ensures that the axial marginal ray is sufficiently converged by the time it reaches the stop, keeping the stop diameter manageable without introducing excessive spherical aberration. The front surface is one of two large-diameter ground aspherical surfaces. At the verified semi-diameter of 25.5 mm, the aspherical departure reaches −758 µm, monotonically increasing in magnitude from center to rim. This profile progressively reduces the convex curvature toward the edge, which is the classic correction for undercorrected spherical aberration at f/1.2 — the outer zones of the aperture are made less convergent to bring marginal rays closer to the paraxial focus. The biconvex form with relatively similar front and rear curvatures (R1/|R2| ≈ 1.17) limits the practical semi-diameter to approximately 25.5 mm due to edge thickness constraints, despite the 77 mm filter thread allowing a larger physical barrel diameter. The choice of S-LAH65V (a lanthanum-heavy crown with nd = 1.804) allows the element to achieve strong refraction while maintaining a moderate Abbe number (νd = 46.6), providing a favorable balance between power contribution and chromatic aberration.
+
+**G2 — Biconcave Negative**
+- Glass: S-TIM25 (OHARA), nd = 1.68893, νd = 31.07
+- Focal length: −43.00 mm
+- Radii: R1 = −68.243 mm, R2 = +52.862 mm
+- Center thickness: 1.64 mm
+- Cemented with G1 (Doublet D1)
+
+G2 forms the negative component of the front cemented doublet. Its lower refractive index (1.689 vs. 1.804) and high dispersion (νd = 31.1) create a classic achromatic correction at the cemented junction: the index difference at the junction surface generates negative chromatic contribution that partially offsets the positive chromatic aberration from G1's front surface. The combined doublet D1 is very weakly negative (f_D1 ≈ −1810 mm), meaning the pair functions nearly as a thick, aberration-corrected window that introduces almost no net refraction — all the convergence from G1 is essentially undone by G2. This deliberate power balance prioritizes aberration correction over convergence at the very front of the lens.
+
+**G3 — Positive Meniscus**
+- Glass: S-NPH7 (OHARA), nd = 2.00100, νd = 29.13
+- Focal length: +42.80 mm
+- Radii: R1 = +42.184 mm, R2 = +2510.576 mm (near-plano rear)
+- Center thickness: 7.47 mm
+
+G3 is optically the most remarkable element in the design. Its glass — S-NPH7 — is an ultra-high-index niobium phosphate heavy flint with nd = 2.001, one of the highest commercially available refractive indices. Both radii are positive (meniscus form, concave toward the image), but the rear surface is essentially flat (R2 ≈ 2511 mm), so the element functions as a near-plano-convex with all power concentrated at the front surface. The extremely high refractive index allows a relatively gentle curvature (R1 = 42.2 mm) to produce substantial power (f = +42.8 mm). This is the primary converging element of the front group. The high refractive index means that for a given surface power φ = (n−1)/R, the factor (n−1) = 1.001 is very large, so R can be proportionally larger, which reduces higher-order aberrations. The tradeoff is severe chromatic aberration (νd = 29.1 is very dispersive), which must be compensated elsewhere. The strong front curvature constrains the practical SD to approximately 23 mm due to edge thickness limits: at larger apertures, the front surface sag exceeds the center thickness.
+
+**G4 — Negative Meniscus**
+- Glass: S-TIL27 (OHARA), nd = 1.65412, νd = 39.68
+- Focal length: −50.05 mm
+- Radii: R1 = +99.979 mm, R2 = +24.508 mm (both positive, R1 > R2)
+- Center thickness: 1.60 mm
+
+G4 is a steeply curved negative meniscus that serves two purposes. First, it partially corrects the spherical aberration generated by G3's strong positive surface. Second, its moderate-dispersion glass provides some chromatic compensation against G3. The meniscus form (both radii positive, concave toward the image) is important: it bends the already-converging rays further while introducing the opposite sign of spherical aberration compared to G3's convex surface. The large radius difference (R1/R2 ≈ 4.1) creates strong negative power despite the meniscus shape. The rear surface (R2 = +24.508 mm) is very steeply curved, and the sag of this surface into the following 7.45 mm air gap is the binding cross-gap constraint in the front group, limiting the SD in this region to approximately 16.5 mm.
+
+**G5 — Biconcave Negative (Ln)**
+- Glass: S-TIM22 (OHARA), nd = 1.66565, νd = 35.64
+- Focal length: −38.82 mm
+- Radii: R1 = −101.919 mm, R2 = +34.799 mm
+- Center thickness: 1.34 mm
+- Cemented with G6 (Doublet D2)
+
+G5 is the negative lens "Ln" identified in the patent's conditional expressions — the most image-side negative element in the front group. Its role is to correct residual spherical aberration from the upstream positive elements (particularly G3) just before the beam enters the stop region. The patent constrains fLn/Dns = −4.156, ensuring that G5's focal length is appropriately balanced against its distance from the stop: too weak and spherical aberration goes uncorrected; too strong and the correction overshoots. The biconcave form generates strong negative power efficiently.
+
+**G6 — Positive Meniscus**
+- Glass: S-LAH79 (OHARA), nd = 1.95375, νd = 32.32
+- Focal length: +38.91 mm
+- Radii: R1 = +34.799 mm, R2 = +516.053 mm
+- Center thickness: 5.56 mm
+- Cemented with G5 (Doublet D2)
+
+G6, cemented to G5, uses another ultra-high-index glass (nd = 1.954). Both radii are positive with a near-plano rear surface (R2 ≈ 516 mm), giving a positive meniscus form. Like the G1+G2 doublet, the G5+G6 pair is nearly afocal (f_D2 ≈ −17,500 mm), indicating that this cemented doublet is designed primarily for aberration correction rather than net power contribution. The pairing of a negative element (G5, moderate index, moderate dispersion) with a positive element (G6, very high index, moderate dispersion) at a shared junction surface creates a Petzval-sum-reducing couplet — the negative element contributes negative Petzval while the positive element, with its much higher refractive index, contributes less positive Petzval per unit of power than a lower-index alternative would.
+
+
+### Aperture Stop
+
+The aperture stop is located at surface 11, between the front and rear groups. Its position — 38.07 mm from G1's front surface and 58.34 mm from the last surface of the rear group — places it at Dps/Dsr = 0.653, which the patent constrains to the range 0.35–0.85. This relatively forward stop position (closer to the front than the rear of the lens) is characteristic of double-Gauss derivatives and helps to maintain symmetry of aberration contributions about the stop, reducing odd-order aberrations like coma and distortion. The production lens uses a 10-blade diaphragm.
+
+
+### Rear Lens Group (LR): Elements G7–G15
+
+The rear group carries the bulk of the system's refractive power (f_LR = 44.87 mm, less than the system EFL of 51.1 mm). It consists of nine elements in five groups: four cemented doublets and one singlet. Its primary responsibilities are: final image formation, field curvature correction, chromatic aberration balancing, and maintaining telecentricity for the digital sensor.
+
+**G7 — Positive Meniscus (UD element)**
+- Glass: S-FPL51 (OHARA), nd = 1.49700, νd = 81.54
+- Focal length: +42.76 mm
+- Radii: R1 = −1398.232 mm (near-plano), R2 = −20.985 mm
+- Center thickness: 10.02 mm
+- Cemented with G8 (Doublet D3)
+
+G7 is the most distinctive element in the rear group — it uses S-FPL51 fluorophosphate glass with an exceptionally high Abbe number of 81.54, identifying it as the **UD (Ultra-low Dispersion) element** specified by Canon in the production lens. This glass belongs to the fluoride-phosphate family developed specifically for apochromatic correction. Despite its low refractive index (1.497), the meniscus form generates substantial positive power (f = +42.76 mm). Both surfaces have negative radii, forming a meniscus concave toward the object. The front surface is nearly flat (R1 = −1398 mm, contributing negligible power), while the steeply curved rear surface (R2 = −20.985 mm) is the primary power source. The positive refraction occurs because light exits the dense glass (n = 1.497) through a surface whose center of curvature lies to the left: this geometry bends the exiting rays toward the optical axis, producing convergence (surface power φ = (1.0 − 1.497)/(−20.985) = +0.0237 mm⁻¹). The 10.02 mm center thickness — the thickest element in the entire lens — is a consequence of the meniscus geometry: the element must maintain adequate edge thickness despite the steep rear curvature.
+
+The pairing of G7 (high νd, positive power) with G8 (low νd, negative power) in cemented doublet D3 creates a powerful chromatic corrector. Unlike the weakly powered front-group doublets, D3 has significant net negative power (f_D3 = −67.4 mm), contributing negative Petzval curvature that helps flatten the field.
+
+**G8 — Biconcave Negative**
+- Glass: S-NBH55 (OHARA), nd = 1.73800, νd = 32.26
+- Focal length: −26.19 mm
+- Radii: R1 = −20.985 mm (junction), R2 = +251.143 mm
+- Center thickness: 1.29 mm
+- Cemented with G7 (Doublet D3)
+
+G8 is the strongest negative element in the entire system (f = −26.19 mm). Nearly all of its power originates from the steeply curved junction surface (R = −20.985 mm), while the rear surface (R = +251.143 mm) contributes only moderate additional refraction. Its high-dispersion niobium flint glass (νd = 32.26) provides aggressive chromatic compensation against G7's low-dispersion positive contribution. The cemented junction between G7 and G8 — where light transitions from nd = 1.497 to nd = 1.738, a Δnd of 0.241 — is the site of the most powerful chromatic correction in the lens. This large index step at the junction generates substantial negative longitudinal chromatic aberration that offsets the accumulated positive chromatic aberration from the front group's high-index positive elements.
+
+**G9 — Biconvex Positive**
+- Glass: S-LAL14 (OHARA), nd = 1.76385, νd = 48.51
+- Focal length: +38.96 mm
+- Radii: R1 = +87.566 mm (corrected), R2 = −43.447 mm (corrected)
+- Center thickness: 7.29 mm
+- Cemented with G10 (Doublet D4)
+
+**G10 — Biconcave Negative**
+- Glass: S-TIM22 (OHARA), nd = 1.66565, νd = 35.64
+- Focal length: −46.10 mm
+- Radii: R1 = −43.447 mm (corrected), R2 = +105.692 mm (corrected)
+- Center thickness: 1.28 mm
+- Cemented with G9 (Doublet D4)
+
+Doublet D4 (G9+G10) has moderate positive power (f_D4 = +204.8 mm). G9 uses a lanthanum crown glass with good Abbe number (νd = 48.5), providing positive power with relatively low chromatic contribution. G10, using the same S-TIM22 glass as G5, provides the negative chromatic correction. This doublet helps correct residual lateral chromatic aberration and contributes to the overall power balance of the rear group.
+
+**G11 — Biconvex Positive, aspherical front surface**
+- Glass: S-LAH89 (OHARA), nd = 1.88300, νd = 40.80
+- Focal length: +38.77 mm
+- Radii: R1 = +161.695 mm (aspherical, corrected), R2 = −42.423 mm
+- Center thickness: 7.96 mm
+
+G11 is the last element of the focus unit (L1) and carries the second ground aspherical surface. Its front surface (surface 18*) has a departure of approximately −391 µm at the verified 21.5 mm semi-diameter, progressively reducing the surface's convex curvature outward. This asphere is positioned in the converging beam after the stop, where it corrects residual higher-order spherical aberration and reduces the sensitivity of off-axis performance to focus position. The high-index S-LAH89 glass (nd = 1.883) allows the biconvex element to generate strong positive power while maintaining manageable surface curvatures.
+
+The air gap immediately after G11 (surface 19, d = 1.95 mm at infinity, expanding to 16.11 mm at closest focus) is the sole variable spacing in the system. This gap defines the focus interface between the moving unit L1 and the stationary unit L2; the BFD after L2 remains constant at 14.60 mm.
+
+**G12 — Biconvex Positive**
+- Glass: S-LAH89 (OHARA), nd = 1.88300, νd = 40.80
+- Focal length: +33.67 mm
+- Radii: R1 = +54.474 mm, R2 = −60.531 mm
+- Center thickness: 8.77 mm
+- Cemented with G13 (Doublet D5)
+
+**G13 — Biconcave Negative**
+- Glass: S-TIM1 (OHARA), nd = 1.59551, νd = 39.24
+- Focal length: −40.55 mm
+- Radii: R1 = −60.531 mm, R2 = +40.560 mm
+- Center thickness: 1.54 mm
+- Cemented with G12 (Doublet D5)
+
+Doublet D5 (G12+G13) is the first element group of the stationary unit L2. Its moderate positive power (f_D5 = +136.6 mm) provides final convergence adjustments. The 7.14 mm air gap following D5 allows the ray bundle to spread slightly before entering the final doublet, which is important for the field-flattening function of D6.
+
+**G14 — Biconcave Negative**
+- Glass: S-TIM35 (OHARA), nd = 1.67300, νd = 38.15
+- Focal length: −55.64 mm
+- Radii: R1 = −58.170 mm, R2 = +105.985 mm
+- Center thickness: 1.21 mm
+- Cemented with G15 (Doublet D6)
+
+**G15 — Biconvex Positive, aspherical rear surface**
+- Glass: S-LAH65V / L-LAH65V (OHARA), nd = 1.80400, νd = 46.58
+- Focal length: +89.08 mm
+- Radii: R1 = +105.985 mm, R2 = −216.191 mm (aspherical)
+- Center thickness: 5.08 mm
+- Cemented with G14 (Doublet D6)
+
+Doublet D6 (G14+G15) is the final optical group before the image plane, and it carries the third aspherical surface on G15's rear face. This doublet has moderate negative power (f_D6 = −154.7 mm), functioning as a field-flattening element that reduces Petzval curvature. The aspherical departure on surface 25* is positive — approximately +293 µm at the verified 16.5 mm semi-diameter — meaning the surface becomes less concave toward the rim. This rear-most asphere primarily corrects field-dependent astigmatism and field curvature at the image periphery. Given its position close to the image plane where chief ray heights are large and marginal ray heights are small, it preferentially affects off-axis rather than on-axis performance.
+
+G15 uses the same S-LAH65V glass as the front element G1, creating a bookend symmetry in the glass selection. The production lens likely manufactures this final aspherical surface by glass molding (GMo) rather than grinding, consistent with Canon's stated specification of "two ground aspherical elements and one glass-molded aspherical element" — the two large-diameter aspherics on G1 and G11 would require grinding, while the smaller rear element G15 is suitable for precision glass molding. (OHARA produces S-LAH65V in both conventional and PGM-compatible variants, the latter designated L-LAH65V, confirming the glass is available for molding.)
+
+
+## Aspherical Surfaces
+
+The design employs three aspherical surfaces on three separate elements, all with conic constant K = 0 (spherical base curve) and even-order polynomial deformations through A12:
+
+| Surface | Element | R (mm) | Position | Manufacturing | Departure at SD |
+|---------|---------|--------|----------|---------------|-----------------|
+| 1* | G1 (front) | +80.110 | Front of lens | Ground | −758 µm at 25.5 mm |
+| 18* | G11 (front) | +161.695 | After stop | Ground | −391 µm at 21.5 mm |
+| 25* | G15 (rear) | −216.191 | Last surface | Glass-molded | +293 µm at 16.5 mm |
+
+The aspherical surfaces are strategically distributed through the system to address different aberrations. Surface 1* operates at the largest beam diameter and targets zonal and marginal spherical aberration — the dominant aberration in any f/1.2 design. Its departure increases monotonically in magnitude from center to rim, progressively flattening the convex surface to reduce the convergence of marginal rays. Surface 18* sits in the converging beam after the stop, where it corrects residual higher-order spherical aberration and helps maintain correction across the focus range. Surface 25*, near the image plane, primarily addresses field-dependent aberrations (astigmatism and field curvature) without significantly affecting on-axis performance.
+
+All three surfaces use a purely polynomial aspherical profile with no conic term (K = 0). Coefficients extend to A12 (12th order), indicating that correction of very high-order zonal aberrations is necessary at f/1.2.
+
+### Surface 1* — Aspherical Coefficients
+| Coefficient | Value |
+|-------------|-------|
+| K | 0 |
+| A4 | −1.44652 × 10⁻⁶ |
+| A6 | −1.02693 × 10⁻⁹ |
+| A8 | +1.91678 × 10⁻¹² |
+| A10 | −3.07794 × 10⁻¹⁵ |
+| A12 | +2.00476 × 10⁻¹⁸ |
+
+### Surface 18* — Aspherical Coefficients
+| Coefficient | Value |
+|-------------|-------|
+| K | 0 |
+| A4 | −2.17027 × 10⁻⁶ |
+| A6 | +4.00496 × 10⁻⁹ |
+| A8 | −1.90948 × 10⁻¹¹ |
+| A10 | +4.86536 × 10⁻¹⁴ |
+| A12 | −4.89586 × 10⁻¹⁷ |
+
+### Surface 25* — Aspherical Coefficients
+| Coefficient | Value |
+|-------------|-------|
+| K | 0 |
+| A4 | +3.50064 × 10⁻⁶ |
+| A6 | −5.98670 × 10⁻¹⁰ |
+| A8 | +1.34319 × 10⁻¹¹ |
+| A10 | −2.56798 × 10⁻¹⁴ |
+| A12 | +2.59930 × 10⁻¹⁷ |
+
+
+## Glass Selection Strategy
+
+The glass selection reveals a deliberate multi-tier strategy:
+
+**Ultra-high-index positives (nd > 1.88):** G3 (2.001), G6 (1.954), G11 (1.883), G12 (1.883). These elements carry the bulk of the system's positive refractive power. The extremely high indices allow strong convergence with gentle curvatures, minimizing higher-order aberrations. The tradeoff — moderate to high dispersion — is compensated by paired negative elements.
+
+**Moderate-index lanthanum crowns (nd 1.76–1.80):** G1 (1.804), G9 (1.764), G15 (1.804). These serve as positive elements where the dispersion constraint is tighter — particularly at the system's entrance (G1) and exit (G15), where chromatic errors are hardest to correct downstream.
+
+**UD (fluorophosphate) glass:** G7 (1.497, νd = 81.5). This single element carries the system's apochromatic correction. Its exceptionally low dispersion, paired with the high-dispersion G8 in cemented doublet D3, provides the primary mechanism for controlling secondary chromatic aberration (the residual g-line/d-line focus shift that simple achromatic doublets cannot correct).
+
+**Flint glasses for chromatic compensation (nd 1.59–1.74, νd 31–39):** G2, G4, G5, G8, G10, G13, G14. These moderate-to-high-dispersion elements serve as chromatic compensators paired with the high-index positives. The diversity of flint types (titanium flints, niobium flints, standard flints) reflects careful optimization of partial dispersion matching across the spectrum.
+
+The average positive-element index in the front group (N_pave = 1.920) is exceptionally high, enabling the 15-element design to achieve f/1.2 in a total track of only 111 mm — roughly 2.2× the focal length.
+
+
+## Petzval Sum and Field Curvature
+
+The computed Petzval sum is +0.00164 mm⁻¹, corresponding to a Petzval radius of −608 mm. For a full-frame sensor with 21.64 mm image height, the predicted sagittal field curvature at the edge is approximately −0.38 mm. This remarkably low Petzval sum for an f/1.2 design reflects the systematic use of negative-power elements (particularly doublets D3 and D6) to counterbalance the Petzval contributions of the many positive elements. The near-zero Petzval sum is essential at f/1.2, where the shallow depth of field makes even small field curvature visible as corner softness.
+
+
+## Focusing Mechanism
+
+The lens employs a **front-group extension focus** system (Claim 8 of the patent): focusing from infinity to the closest distance (0.40 m, magnification −0.19) is accomplished by translating lens unit L1 (elements G1–G11, including the aperture stop) as a rigid block toward the object. Lens unit L2 (elements G12–G15) remains stationary relative to the sensor. Only the air gap d19 — between the last element of L1 (G11) and the first element of L2 (G12) — changes during focusing. The BFD (d25 = 14.60 mm) remains constant because L2 does not move.
+
+This focus architecture has a single variable gap but is distinct from unit focus: in unit focus, the entire lens translates and only the BFD changes; here, a subunit extends while the rear group and BFD are fixed. It is also distinct from classical inner focus, where the moving group is flanked on both sides by stationary groups, typically producing two variable gaps. The patent distinguishes this architecture (Claim 8, Examples 1–3) from the floating-focus variant in Example 4, where both L1 and L2 move independently along different loci with two variable gaps (d19 and d25).
+
+| Parameter | Infinity | Closest Focus |
+|-----------|----------|---------------|
+| d19 (air gap after G11) | 1.95 mm | 16.11 mm |
+| d25 (BFD, constant) | 14.60 mm | 14.60 mm |
+| Focus extension | — | 14.16 mm |
+
+The 14.16 mm extension corresponds to roughly 0.28× the system EFL. Because the aperture stop moves with the focus unit, the entrance pupil position shifts during focusing, but the f-number remains nominally constant. The front-group extension approach — rather than the more common internal-focus or rear-focus designs — was chosen because it minimizes variations in spherical aberration during focusing. This is critical at f/1.2, where even small spherical aberration changes produce visible shifts in focus quality. The patent notes (¶0062) that this architecture "satisfactorily reduces" focus-induced aberration variations while simultaneously reducing the effective front lens diameter compared to unit-focusing alternatives.
+
+The focus is driven by a ring-type Ultrasonic Motor (USM) with Canon's optimized focusing algorithms and a high-speed CPU. The focus limiter switch (0.8 m – ∞) allows photographers to restrict the focus range for faster acquisition in situations where close-focus capability is unnecessary.
+
+
+## Aberration Correction Philosophy
+
+The design embodies a distinctive approach to aberration correction at extreme apertures:
+
+**Spherical aberration** is the dominant challenge at f/1.2. The strategy combines three complementary mechanisms: ultra-high-index glasses in the positive elements reduce surface curvatures and hence the magnitude of the generated aberration; negative elements (particularly G4, G5, G8) positioned at strategic locations introduce compensating opposite-sign spherical aberration; and two ground aspherical surfaces (on G1 and G11) provide the fine-tuning of zonal balance that spherical surfaces alone cannot achieve.
+
+**Chromatic aberration** is controlled through an unusually sophisticated glass palette. The system-level approach uses the UD element (G7) paired with the high-dispersion G8 at the cemented junction of doublet D3 as the primary chromatic corrector, supplemented by five additional achromatic-style pairings distributed through both groups. The patent's aberration diagrams show lateral chromatic aberration controlled to within ±0.050 mm across the field — a remarkable achievement for f/1.2.
+
+**Field curvature** is addressed through the very low Petzval sum (0.00164 mm⁻¹), achieved by the systematic use of high-index positive elements (which contribute less Petzval per unit of power) and strong negative elements (particularly in doublets D3 and D6). The rear aspherical surface (25*) provides additional field-dependent correction.
+
+**Coma and astigmatism** benefit from the quasi-symmetric arrangement of elements about the aperture stop. The front group's gentle convergence and the stop's moderately forward position create partial symmetry that inherently reduces odd-order aberrations. The patent's aberration diagrams show well-controlled astigmatism at ω = 22.95°.
+
+**Flare and ghosting** are addressed in the production lens through Canon's Air Sphere Coating (ASC), applied to one surface. ASC uses a vapor-deposited layer containing microscopic air spheres that create a very low effective refractive index at the glass-air boundary, suppressing reflections more effectively than conventional multi-layer coatings, particularly at high angles of incidence. This is especially important in a 15-element design where the 18 air-glass surfaces can produce significant ghosting in backlit conditions.
+
+
+## Cemented Doublet Summary
+
+| Doublet | Elements | Group FL (mm) | Primary Function |
+|---------|----------|---------------|------------------|
+| D1 | G1 + G2 | −1810 | Near-afocal front corrector (spherical + axial chromatic) |
+| D2 | G5 + G6 | −17,499 | Near-afocal pre-stop corrector (spherical + Petzval) |
+| D3 | G7 + G8 | −67.4 | Primary chromatic corrector (UD glass); Petzval flattener |
+| D4 | G9 + G10 | +204.8 | Moderate positive power; residual chromatic + astigmatism |
+| D5 | G12 + G13 | +136.6 | Stationary positive group; final convergence |
+| D6 | G14 + G15 | −154.7 | Field flattener; rear aspherical corrector |
+
+The six cemented doublets account for 12 of the 15 elements. Only G3, G4, and G11 are standalone singlets — and all three are in the converging beam path where their singular surfaces serve specific aberration-control roles that would be compromised by cementing.
+
+
+## Correspondence to Production Specifications
+
+| Specification | Patent Example 2 | Canon RF 50mm f/1.2 L USM |
+|---------------|-------------------|---------------------------|
+| Focal length | 51.10 mm | 50 mm |
+| Maximum aperture | f/1.25 | f/1.2 |
+| Elements / Groups | 15 / 9 | 15 / 9 |
+| Aspherical elements | 3 (surfaces 1*, 18*, 25*) | 3 (2 ground + 1 GMo) |
+| UD elements | 1 (G7, S-FPL51) | 1 |
+| Diagonal field | 45.90° | 46° |
+| Closest focus | 0.40 m (implied by m = −0.19) | 0.40 m |
+| Max magnification | −0.19 | 0.19× |
+| Total track | 111.01 mm | 108 mm (barrel length, excl. mount protrusion) |
+| BFD | 14.60 mm | 14.6 mm (rear element recessed ~5.4 mm behind flange) |
+| Aperture blades | — | 10 |
+| Filter diameter | — | 77 mm |
+| Coatings | — | ASC (Air Sphere Coating) on one surface; fluorine front/rear |
+
+The BFD of 14.60 mm in the patent is the air-equivalent distance from the last lens surface to the paraxial image plane. Since this is shorter than the Canon RF mount's 20 mm flange-to-sensor distance, the last lens surface (surface 25*) is recessed approximately 5.4 mm behind the flange face, extending into the camera body. This is a common and deliberate feature of RF-mount lens designs, which exploit the short 20 mm flange distance to position rear elements closer to the sensor for improved corner illumination and reduced field curvature.
+
+
+## Appendix: Corrected Surface Prescription (Example 2)
+
+The following prescription reflects the verified values after OCR correction. Surfaces marked with asterisks (*) are aspherical. Surfaces highlighted in bold italics had OCR errors that were corrected from the rasterized patent PDF.
+
+| Surface | R (mm) | d (mm) | nd | νd | Element |
+|---------|--------|--------|-------|-------|---------|
+| 1* | 80.110 | 9.67 | 1.80400 | 46.58 | G1 |
+| 2 | −68.243 | 1.64 | 1.68893 | 31.07 | G2 |
+| 3 | 52.862 | 0.20 | 1.0 | — | air |
+| 4 | 42.184 | 7.47 | 2.00100 | 29.13 | G3 |
+| 5 | 2510.576 | 0.70 | 1.0 | — | air |
+| 6 | 99.979 | 1.60 | 1.65412 | 39.68 | G4 |
+| 7 | 24.508 | 7.45 | 1.0 | — | air |
+| 8 | −101.919 | 1.34 | 1.66565 | 35.64 | G5 |
+| 9 | 34.799 | 5.56 | 1.95375 | 32.32 | G6 |
+| 10 | 516.053 | 2.44 | 1.0 | — | air |
+| STO | ∞ | 2.58 | 1.0 | — | stop |
+| 12 | −1398.232 | 10.02 | 1.49700 | 81.54 | G7 (UD) |
+| 13 | −20.985 | 1.29 | 1.73800 | 32.26 | G8 |
+| **14** | **251.143** | 0.44 | 1.0 | — | air |
+| **15** | **87.566** | 7.29 | 1.76385 | 48.51 | G9 |
+| **16** | **−43.447** | 1.28 | 1.66565 | 35.64 | G10 |
+| **17** | **105.692** | 1.79 | 1.0 | — | air |
+| **18*** | **161.695** | 7.96 | 1.88300 | 40.80 | G11 |
+| 19 | −42.423 | 1.95 (var) | 1.0 | — | air |
+| 20 | 54.474 | 8.77 | 1.88300 | 40.80 | G12 |
+| 21 | −60.531 | 1.54 | 1.59551 | 39.24 | G13 |
+| 22 | 40.560 | 7.14 | 1.0 | — | air |
+| 23 | −58.170 | 1.21 | 1.67300 | 38.15 | G14 |
+| 24 | 105.985 | 5.08 | 1.80400 | 46.58 | G15 |
+| 25* | −216.191 | 14.60 | 1.0 | — | air (BFD) |

--- a/src/lens-data/CanonRF50mmf12L.data.ts
+++ b/src/lens-data/CanonRF50mmf12L.data.ts
@@ -1,0 +1,384 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — Canon RF 50mm f/1.2 L USM                   ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2019/0265441 A1 Example 2 (Katayose / Canon).    ║
+ * ║  Large-aperture 50mm prime for Canon RF mount (mirrorless).        ║
+ * ║  15 elements / 9 groups, 3 aspherical surfaces, 1 UD element.     ║
+ * ║  Focus: front-group extension (L1 translates toward object;       ║
+ * ║    L2 stationary). Single variable gap (d19); BFD constant.       ║
+ * ║    Not unit focus (only a subunit moves, not the entire lens).    ║
+ * ║                                                                    ║
+ * ║  NOTE ON PRESCRIPTION:                                             ║
+ * ║    Patent text for Example 2 contains OCR-corrupted radii at      ║
+ * ║    surfaces 14–18. Corrected values recovered from rasterized     ║
+ * ║    patent PDF at 400 DPI. Corrected prescription reproduces all   ║
+ * ║    patent-stated parameters: EFL = 51.10 mm, BFD = 14.60 mm,     ║
+ * ║    total track = 111.01 mm, all element/group focal lengths,      ║
+ * ║    and all Table 1 conditional expressions.                        ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Estimated via combined marginal + chief ray trace at            ║
+ * ║    offAxisFieldFrac = 0.60 with ~8–10% mechanical clearance.      ║
+ * ║    Front element SD constrained by edge thickness (biconvex       ║
+ * ║    R1=80.1/R2=−68.2 limits practical SD to ~25.5 mm despite      ║
+ * ║    77 mm filter thread). Gap 7 (d=7.45 mm between G4 and G5)     ║
+ * ║    is the binding cross-gap constraint, limiting the G4 rear      ║
+ * ║    boundary to ~15.4 mm while G5 keeps the larger clear aperture. ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "canon-rf-50-f12-l",
+  maker: "Canon",
+  name: "CANON RF 50mm f/1.2 L USM",
+  subtitle: "US 2019/0265441 A1 EXAMPLE 2 — CANON / KATAYOSE",
+  specs: [
+    "15 ELEMENTS / 9 GROUPS",
+    "f ≈ 51.1 mm (marketed 50 mm)",
+    "F/1.25 (marketed F/1.2)",
+    "2ω ≈ 45.9°",
+    "3 ASPHERICAL SURFACES",
+    "1 UD ELEMENT (S-FPL51)",
+  ],
+
+  /* ── Metadata ── */
+  focalLengthMarketing: 50,
+  focalLengthDesign: 51.1,
+  apertureMarketing: 1.2,
+  apertureDesign: 1.25,
+  patentYear: 2019,
+  elementCount: 15,
+  groupCount: 9,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "G1",
+      label: "Element 1",
+      type: "Biconvex Positive (1× Asph)",
+      nd: 1.804,
+      vd: 46.58,
+      fl: 47.21,
+      glass: "S-LAH65V (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Front positive element (Lp); primary beam convergence. Ground aspherical front surface for zonal spherical aberration correction at f/1.2.",
+      cemented: "D1",
+    },
+    {
+      id: 2,
+      name: "G2",
+      label: "Element 2",
+      type: "Biconcave Negative",
+      nd: 1.68893,
+      vd: 31.07,
+      fl: -43.0,
+      glass: "S-TIM25 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Negative component of front doublet D1; chromatic correction against G1. Doublet D1 is near-afocal (f ≈ −1810 mm).",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "G3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 2.001,
+      vd: 29.13,
+      fl: 42.8,
+      glass: "S-NPH7 (OHARA)",
+      apd: "inferred",
+      apdNote: "Ultra-high-index niobium phosphate (nd = 2.001); expected positive dPgF anomaly",
+      role: "Primary converging element; ultra-high refractive index enables strong power with moderate curvature. Near-plano rear surface (R₂ ≈ 2511 mm).",
+    },
+    {
+      id: 4,
+      name: "G4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.65412,
+      vd: 39.68,
+      fl: -50.05,
+      glass: "S-TIL27 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Spherical aberration corrector for G3; steep meniscus form (concave toward image).",
+    },
+    {
+      id: 5,
+      name: "G5",
+      label: "Element 5",
+      type: "Biconcave Negative",
+      nd: 1.66565,
+      vd: 35.64,
+      fl: -38.82,
+      glass: "S-TIM22 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Negative lens Ln (patent conditional expr.); final spherical aberration correction before stop. fLn/Dns = −4.156.",
+      cemented: "D2",
+    },
+    {
+      id: 6,
+      name: "G6",
+      label: "Element 6",
+      type: "Positive Meniscus",
+      nd: 1.95375,
+      vd: 32.32,
+      fl: 38.91,
+      glass: "S-LAH79 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Ultra-high-index positive in near-afocal doublet D2 (f ≈ −17,500 mm); Petzval-reducing pair with G5. Near-plano rear (R₂ ≈ 516 mm).",
+      cemented: "D2",
+    },
+    {
+      id: 7,
+      name: "G7",
+      label: "Element 7",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.54,
+      fl: 42.76,
+      glass: "S-FPL51 (OHARA)",
+      apd: "inferred",
+      apdNote: "Fluorophosphate UD glass; strongly anomalous positive dPgF for secondary chromatic correction",
+      role: "UD (Ultra-low Dispersion) element; primary apochromatic corrector. Nearly plano-concave meniscus (R₁ ≈ −1398 mm). Thickest element (ct = 10.02 mm).",
+      cemented: "D3",
+    },
+    {
+      id: 8,
+      name: "G8",
+      label: "Element 8",
+      type: "Biconcave Negative",
+      nd: 1.738,
+      vd: 32.26,
+      fl: -26.19,
+      glass: "S-NBH55 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Strongest negative element (f = −26.2 mm); paired with G7 in doublet D3 (f = −67.4 mm) for aggressive chromatic correction. Junction Δnd = 0.241.",
+      cemented: "D3",
+    },
+    {
+      id: 9,
+      name: "G9",
+      label: "Element 9",
+      type: "Biconvex Positive",
+      nd: 1.76385,
+      vd: 48.51,
+      fl: 38.96,
+      glass: "S-LAL14 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Moderate positive power; residual chromatic and astigmatism correction. Lanthanum crown for favorable dispersion balance.",
+      cemented: "D4",
+    },
+    {
+      id: 10,
+      name: "G10",
+      label: "Element 10",
+      type: "Biconcave Negative",
+      nd: 1.66565,
+      vd: 35.64,
+      fl: -46.1,
+      glass: "S-TIM22 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Negative component of doublet D4 (f = +204.8 mm); lateral chromatic compensation.",
+      cemented: "D4",
+    },
+    {
+      id: 11,
+      name: "G11",
+      label: "Element 11",
+      type: "Biconvex Positive (1× Asph)",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 38.77,
+      glass: "S-LAH89 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Last element of focus unit L1; second ground aspherical surface (S18*) for residual higher-order spherical aberration. High-index biconvex.",
+    },
+    {
+      id: 12,
+      name: "G12",
+      label: "Element 12",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 33.67,
+      glass: "S-LAH89 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "First element of stationary unit L2; final convergence. Same glass as G11.",
+      cemented: "D5",
+    },
+    {
+      id: 13,
+      name: "G13",
+      label: "Element 13",
+      type: "Biconcave Negative",
+      nd: 1.59551,
+      vd: 39.24,
+      fl: -40.55,
+      glass: "S-TIM1 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Negative component of doublet D5 (f = +136.6 mm).",
+      cemented: "D5",
+    },
+    {
+      id: 14,
+      name: "G14",
+      label: "Element 14",
+      type: "Biconcave Negative",
+      nd: 1.673,
+      vd: 38.15,
+      fl: -55.64,
+      glass: "S-TIM35 (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Negative component of rear field-flattening doublet D6 (f = −154.7 mm); Petzval curvature reduction.",
+      cemented: "D6",
+    },
+    {
+      id: 15,
+      name: "G15",
+      label: "Element 15",
+      type: "Biconvex Positive (1× Asph)",
+      nd: 1.804,
+      vd: 46.58,
+      fl: 89.08,
+      glass: "S-LAH65V / L-LAH65V (OHARA)",
+      apd: false,
+      apdNote: "",
+      role: "Final element; glass-molded aspherical rear surface (S25*) for field-dependent astigmatism/curvature correction. Same glass family as G1.",
+      cemented: "D6",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Front Lens Group (LF): G1–G6 ──
+    // Cemented doublet D1: G1 + G2
+    { label: "1A", R: 80.11, d: 9.67, nd: 1.804, elemId: 1, sd: 25.5 }, // G1 front (asph)
+    { label: "2", R: -68.243, d: 1.64, nd: 1.68893, elemId: 2, sd: 25.0 }, // G1→G2 junction
+    { label: "3", R: 52.862, d: 0.2, nd: 1.0, elemId: 0, sd: 23.0 }, // G2 rear → air
+
+    // Singlet G3
+    { label: "4", R: 42.184, d: 7.47, nd: 2.001, elemId: 3, sd: 23.0 }, // G3 front
+    { label: "5", R: 2510.576, d: 0.7, nd: 1.0, elemId: 0, sd: 22.0 }, // G3 rear → air
+
+    // Singlet G4
+    { label: "6", R: 99.979, d: 1.6, nd: 1.65412, elemId: 4, sd: 19.0 }, // G4 front
+    { label: "7", R: 24.508, d: 7.45, nd: 1.0, elemId: 0, sd: 15.4 }, // G4 rear → air
+
+    // Cemented doublet D2: G5 + G6
+    { label: "8", R: -101.919, d: 1.34, nd: 1.66565, elemId: 5, sd: 16.5 }, // G5 front
+    { label: "9", R: 34.799, d: 5.56, nd: 1.95375, elemId: 6, sd: 16.5 }, // G5→G6 junction
+    { label: "10", R: 516.053, d: 2.44, nd: 1.0, elemId: 0, sd: 16.0 }, // G6 rear → air
+
+    // ── Aperture Stop ──
+    { label: "STO", R: 1e15, d: 2.58, nd: 1.0, elemId: 0, sd: 15.5 },
+
+    // ── Rear Lens Group (LR): G7–G15 ──
+    // Cemented doublet D3: G7 (UD) + G8
+    { label: "12", R: -1398.232, d: 10.02, nd: 1.497, elemId: 7, sd: 16.0 }, // G7 front
+    { label: "13", R: -20.985, d: 1.29, nd: 1.738, elemId: 8, sd: 18.0 }, // G7→G8 junction
+    { label: "14", R: 251.143, d: 0.44, nd: 1.0, elemId: 0, sd: 18.0 }, // G8 rear → air
+
+    // Cemented doublet D4: G9 + G10
+    { label: "15", R: 87.566, d: 7.29, nd: 1.76385, elemId: 9, sd: 19.0 }, // G9 front
+    { label: "16", R: -43.447, d: 1.28, nd: 1.66565, elemId: 10, sd: 20.5 }, // G9→G10 junction
+    { label: "17", R: 105.692, d: 1.79, nd: 1.0, elemId: 0, sd: 20.5 }, // G10 rear → air
+
+    // Singlet G11
+    { label: "18A", R: 161.695, d: 7.96, nd: 1.883, elemId: 11, sd: 21.5 }, // G11 front (asph)
+    { label: "19", R: -42.423, d: 1.95, nd: 1.0, elemId: 0, sd: 23.0 }, // G11 rear → air (VARIABLE)
+
+    // Cemented doublet D5: G12 + G13 (stationary unit L2)
+    { label: "20", R: 54.474, d: 8.77, nd: 1.883, elemId: 12, sd: 22.5 }, // G12 front
+    { label: "21", R: -60.531, d: 1.54, nd: 1.59551, elemId: 13, sd: 20.0 }, // G12→G13 junction
+    { label: "22", R: 40.56, d: 7.14, nd: 1.0, elemId: 0, sd: 19.5 }, // G13 rear → air
+
+    // Cemented doublet D6: G14 + G15
+    { label: "23", R: -58.17, d: 1.21, nd: 1.673, elemId: 14, sd: 17.0 }, // G14 front
+    { label: "24", R: 105.985, d: 5.08, nd: 1.804, elemId: 15, sd: 17.0 }, // G14→G15 junction
+    { label: "25A", R: -216.191, d: 14.6, nd: 1.0, elemId: 0, sd: 16.5 }, // G15 rear (asph) → air (BFD)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "1A": {
+      K: 0,
+      A4: -1.44652e-6,
+      A6: -1.02693e-9,
+      A8: 1.91678e-12,
+      A10: -3.07794e-15,
+      A12: 2.00476e-18,
+      A14: 0,
+    },
+    "18A": {
+      K: 0,
+      A4: -2.17027e-6,
+      A6: 4.00496e-9,
+      A8: -1.90948e-11,
+      A10: 4.86536e-14,
+      A12: -4.89586e-17,
+      A14: 0,
+    },
+    "25A": {
+      K: 0,
+      A4: 3.50064e-6,
+      A6: -5.9867e-10,
+      A8: 1.34319e-11,
+      A10: -2.56798e-14,
+      A12: 2.5993e-17,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings ── */
+  var: {
+    "19": [1.95, 16.11],
+  },
+  varLabels: [["19", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT (LF)", fromSurface: "1A", toSurface: "10" },
+    { text: "REAR (LR)", fromSurface: "12", toSurface: "25A" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "1A", toSurface: "3" },
+    { text: "D2", fromSurface: "8", toSurface: "10" },
+    { text: "D3", fromSurface: "12", toSurface: "14" },
+    { text: "D4", fromSurface: "15", toSurface: "17" },
+    { text: "D5", fromSurface: "20", toSurface: "22" },
+    { text: "D6", fromSurface: "23", toSurface: "25A" },
+  ],
+
+  /* ── Focus ── */
+  closeFocusM: 0.4,
+  focusDescription:
+    "Front-group extension focus: L1 (G1–G11 + stop) translates toward object; L2 (G12–G15) stationary. Single variable gap (d19); BFD constant. Ring-type USM.",
+
+  /* ── Aperture ── */
+  nominalFno: 1.2,
+  fstopSeries: [1.2, 1.4, 1.8, 2, 2.5, 2.8, 4, 5.6, 8, 11, 16],
+  apertureBlades: 10,
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.38,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/CanonRF85mmf12L.analysis.md
+++ b/src/lens-data/CanonRF85mmf12L.analysis.md
@@ -1,0 +1,308 @@
+# Canon RF 85mm f/1.2L USM — Optical Analysis
+
+**Patent:** US 2020/0012073 A1, Example 1 (First Numerical Embodiment)
+**Inventor:** Satoshi Maetaki (Canon Kabushiki Kaisha)
+**Published:** January 9, 2020 · **Priority:** JP 2018-127359, July 4, 2018
+
+---
+
+## 1. Overview
+
+The Canon RF 85mm f/1.2L USM is a large-aperture short-telephoto prime designed for Canon's RF mirrorless mount. It represents a significant advance over its EF-mount predecessor (EF 85mm f/1.2L II USM, 8 elements / 7 groups) with a substantially more complex optical formula: 13 elements in 9 groups in production, employing Canon's proprietary Blue Spectrum Refractive (BR) optics, one aspherical element, and one Ultra-low Dispersion (UD) glass element. The design achieves sharp performance at f/1.2 — a feat the older EF version could not match until stopped down to f/2.8 or beyond.
+
+The First Numerical Embodiment of US 2020/0012073 A1 presents a 14-element, 3-unit design with a computed effective focal length of 86.53 mm and a maximum aperture of f/1.24. These values closely approximate the production lens (85 mm, f/1.2). The additional element relative to production likely reflects design-space exploration in the patent filing; Canon's marketing counts the BR optics element within its 13-element total, and the production configuration may differ slightly in the rear group.
+
+### Design-patent concordance
+
+| Parameter | Patent (Ex. 1) | Production (Canon) |
+|---|---|---|
+| Focal length | 86.53 mm | 85 mm |
+| Maximum aperture | f/1.24 | f/1.2 |
+| Elements / groups | 14 / 9 | 13 / 9 |
+| Aspherical surfaces | 1 (surface 8) | 1 element |
+| BR optics element | Lens 9 (nd = 1.60401) | 1 BR element |
+| UD element | Lens 4 (nd = 1.49700) | 1 UD element |
+| Half-field angle | 14.04° | 14° (diagonal 28°30′) |
+| Close focus | 0.85 m | 0.85 m |
+| Filter thread | — | 82 mm |
+| Overall length | 134.49 mm | 117.3 mm (optical) |
+| Image circle | 43.28 mm (2 × 21.64) | 43.2 mm (full-frame) |
+
+The overall length discrepancy (134.49 vs. 117.3 mm) reflects Canon's measurement convention — the marketed figure likely excludes the lens mount flange depth and measures the mechanical housing, whereas the patent's 134.49 mm is the total optical track from the first surface vertex to the image plane.
+
+The patent's effective ray diameter at surface 1 (70.20 mm) is consistent with the production lens's 82 mm filter thread, which typically allows for a clear aperture of approximately 70–72 mm after accounting for the filter mount and barrel wall thickness.
+
+It is worth noting that the patent's sixth example (Example 6) has 13 elements in 2 lens units with 2 aspherical surfaces — matching the production element count but not the aspherical count. No single patent example is an exact match to every production specification; Example 1 provides the most detailed prescription for the 3-unit, single-asphere configuration that represents the core design philosophy of the RF 85mm f/1.2L USM.
+
+---
+
+## 2. Optical Layout — Three Lens Units, Nine Groups
+
+The patent organizes the 14 elements into three lens units defined by their focusing behavior:
+
+**Unit L1** (positive, f₁ = 452.3 mm, f₁/f = 5.2): A cemented doublet of two elements forming a weakly positive front group. L1 is fixed during focusing.
+
+**Unit L2** (positive, f₂ = 93.1 mm): The workhorse of the design, containing 8 elements in 5 air-separated groups. L2 carries the aperture stop, the aspherical surface, the BR optics element, and the UD glass element. L2 is the sole focusing group, translating bodily toward the object during close-focus.
+
+**Unit L3** (positive, f₃ = 845.7 mm): A weakly positive rear group of 4 elements in 3 air-separated groups. L3 is fixed during focusing and serves primarily to control the exit ray angle for compatibility with digital sensor microlens arrays.
+
+The nine air-separated groups, from front to rear, are:
+
+| Group | Elements | Type | Unit |
+|---|---|---|---|
+| G1 | L1 + L2 | Cemented doublet | L1 |
+| G2 | L3 (Lp1) | Singlet — positive meniscus | L2 |
+| G3 | L4 | Singlet — positive meniscus (UD) | L2 |
+| G4 | L5 | Singlet — negative meniscus (asph.) | L2 |
+| — | STO | Aperture stop | L2 |
+| G5 | L6 + L7 (DL1) | Cemented doublet | L2 |
+| G6 | L8 + L9 + L10 (DL2) | Cemented triplet (BR) | L2 |
+| G7 | L11 + L12 | Cemented doublet | L3 |
+| G8 | L13 | Singlet — biconcave | L3 |
+| G9 | L14 | Singlet — biconvex | L3 |
+
+---
+
+## 3. The Aspherical Surface — Surface 8
+
+Only one surface in the design is aspherical: the front surface of Lens 5 (surface 8 in the patent numbering). This is a concave meniscus element located immediately before the aperture stop, placing it at the ideal position to control spherical aberration — the marginal ray height is still substantial (effective ray diameter 41.24 mm per the patent) but the beam is converging, making aspherical correction highly efficient.
+
+### Aspherical coefficients
+
+The surface uses the standard even-polynomial sag equation with a spherical base (K = 0):
+
+$$Z(h) = \frac{h^2/R}{1 + \sqrt{1 - (h/R)^2}} + B \cdot h^4 + C \cdot h^6 + D \cdot h^8$$
+
+| Coefficient | Value |
+|---|---|
+| R | 75.484 mm |
+| K | 0.0 (spherical base) |
+| B (4th order) | −2.2875 × 10⁻⁶ |
+| C (6th order) | −2.1286 × 10⁻¹⁰ |
+| D (8th order) | +2.6709 × 10⁻¹³ |
+| E (10th order) | 0.0 |
+
+### Aspherical departure from the base sphere
+
+| Height h (mm) | Sphere sag (mm) | Aspherical sag (mm) | Departure (μm) |
+|---|---|---|---|
+| 5.0 | 0.1658 | 0.1643 | −1.4 |
+| 10.0 | 0.6653 | 0.6423 | −23.1 |
+| 15.0 | 1.5054 | 1.3878 | −117.5 |
+| 20.0 | 2.6978 | 2.3250 | −372.8 |
+
+The aspherical departure is uniformly negative, meaning the surface is *flatter* than the base sphere at all zones. At the edge of the clear aperture (~20 mm semi-diameter), the departure reaches nearly 0.37 mm — a substantial correction. The dominant 4th-order term (B < 0) is the primary spherical aberration corrector, while the 8th-order term (D > 0) provides a small restorative kick at high zones, preventing over-correction at the rim. The 6th-order term (C < 0) is comparatively weak, acting as a smooth bridge between the two.
+
+This aspherical element is large-diameter (effective ray diameter ~41 mm) and made from high-index glass (nd = 1.85478), which presents significant manufacturing challenges. Canon markets this as a "large diameter aspherical element" and it is likely produced by precision glass molding (PGM) given the glass type and the scale involved.
+
+### Role in aberration control
+
+Surface 8 is positioned just before the stop, where marginal ray heights are still high but the chief ray is crossing toward zero. This placement means the aspherical correction predominantly affects spherical aberration (which depends on marginal ray height to the fourth power) with minimal impact on field-dependent aberrations like coma and astigmatism. For an f/1.2 lens where third-order spherical aberration is the dominant challenge, this is optimal.
+
+---
+
+## 4. Glass Identification and Material Analysis
+
+The design uses 10 distinct glass types across 14 elements. Glass identification proceeds from the six-digit code (nd × 1000 / νd × 10) cross-referenced against catalog data. Canon does not publish its glass sourcing, so matches are given at the family level.
+
+### Complete glass table
+
+| Element | nd | νd | Code | Probable glass family | Notes |
+|---|---|---|---|---|---|
+| L1 | 1.61800 | 63.4 | 618/634 | S-PHM52 (OHARA) or equiv. | Phosphate crown |
+| L2 | 1.72047 | 34.7 | 720/347 | S-LAF2 or S-NBF1 (OHARA) | Lanthanum flint |
+| L3 (Lp1) | 1.92286 | 20.9 | 923/209 | S-NPH2 (OHARA) | Ultra-high-index dense flint |
+| L4 | 1.49700 | 81.5 | 497/815 | S-FPL51 (OHARA) | UD glass (fluorophosphate crown) |
+| L5 | 1.85478 | 24.8 | 855/248 | E-FDS2 (HIKARI) or FDS18 (HOYA) | High-index flint (aspherical) |
+| L6 | 1.85478 | 24.8 | 855/248 | Same as L5 | High-index flint |
+| L7 | 1.88300 | 40.8 | 883/408 | S-LAH58 (OHARA) | Lanthanum heavy flint |
+| L8 | 1.54072 | 47.2 | 541/472 | No catalog match; likely custom | BR carrier glass (object-side) |
+| L9 (Lp2) | 1.60401 | 20.8 | 604/208 | **BR optics** (organic material) | Canon proprietary |
+| L10 | 1.95375 | 32.3 | 954/323 | S-LAH79 (OHARA) | Ultra-high-index lanthanum |
+| L11 | 1.95375 | 32.3 | 954/323 | S-LAH79 (OHARA) | Same as L10 |
+| L12 | 1.62004 | 36.3 | 620/363 | S-TIM22 (OHARA) — exact match | Titanium flint |
+| L13 | 1.68893 | 31.1 | 689/311 | S-TIM27 (OHARA) | Titanium flint |
+| L14 | 1.90043 | 37.4 | 900/374 | S-LAH64 (OHARA) | Lanthanum heavy flint |
+
+### Key material observations
+
+**Ultra-high-index glasses (nd > 1.9):** Four elements (L3, L10, L11, L14) employ glasses with nd exceeding 1.90 — an exceptionally aggressive choice that allows strong positive refractive power without proportionally large Petzval sum contributions. The verified Petzval sum for the entire system is 0.00107 mm⁻¹, yielding a Petzval radius of 934 mm — remarkably flat for a lens of this speed.
+
+**UD glass (L4):** Lens 4 (nd = 1.49700, νd = 81.5) is the Ultra-low Dispersion element marketed by Canon. This glass is essentially equivalent to OHARA S-FPL51, a fluorophosphate crown with dispersion properties approaching fluorite (CaF₂). Positioned in Group G3 as a strongly positive meniscus (fl = +97.8 mm), it provides primary chromatic correction in the front half of L2.
+
+**BR optics (L9):** Lens 9 (nd = 1.60401, νd = 20.8) is the Blue Spectrum Refractive optics element — Canon's proprietary organic optical material. Two distinctive features identify it unambiguously: its very high anomalous partial dispersion (ΔθgF = 0.092, nearly an order of magnitude above the Lp1 element), and its refractive index / Abbe number combination, which falls well outside the standard glass map. No conventional optical glass matches nd = 1.604 with νd = 20.8. The material is sandwiched between Lens 8 (nd = 1.54072) and Lens 10 (nd = 1.95375) to form a cemented triplet (Group G6 / DL2).
+
+---
+
+## 5. Blue Spectrum Refractive (BR) Optics — Lens 9
+
+Canon's BR optics technology, first deployed in the EF 35mm f/1.4L II USM (2015), uses a specially engineered organic polymer whose molecular structure produces anomalous dispersion characteristics exceeding those of fluorite or Super UD glass. The key property is an extremely strong ability to refract blue light (short wavelengths around 435–486 nm) relative to longer wavelengths, quantified by the anomalous partial dispersion ΔθgF.
+
+### Physical construction
+
+In this design, the BR element (Lens 9) is just 1.00 mm thick at center, sandwiched between two conventional glass elements in the cemented triplet DL2:
+
+- **L8** (nd = 1.54072, νd = 47.2) — the convex glass carrier on the object side
+- **L9** (nd = 1.60401, νd = 20.8, ΔθgF = 0.092) — the BR organic element
+- **L10** (nd = 1.95375, νd = 32.3) — the concave glass carrier on the image side
+
+The junction surfaces are R₈₋₉ = 58.169 mm and R₉₋₁₀ = 77.751 mm, giving Lens 9 a weakly positive meniscus shape (fl = +375.2 mm). The extremely long focal length means Lens 9 contributes minimal refractive power but exerts strong chromatic influence through its anomalous dispersion.
+
+### Chromatic correction strategy
+
+The patent's core invention places two positive lenses with anomalous partial dispersion symmetrically about the aperture stop:
+
+**Lp1 (Lens 3)** — before the stop, nd = 1.92286, νd = 20.9, ΔθgF = 0.008. This ultra-high-index dense flint has only modestly anomalous dispersion. Positioned where marginal ray heights are high and chief ray heights are moderate, it contributes significant primary chromatic aberration through its very high dispersion (low νd), which is compensated by the negative elements in the system. Its placement in the design is specifically motivated by its anomalous partial dispersion — even a modest ΔθgF of 0.008, acting on a positive element at high marginal ray height, meaningfully reduces the on-axis secondary spectrum.
+
+**Lp2 (Lens 9 / BR)** — after the stop, nd = 1.60401, νd = 20.8, ΔθgF = 0.092. The BR element has dramatically higher anomalous dispersion — over 11× that of Lp1. Positioned where chief ray heights are growing (light is diverging toward the image), it primarily addresses lateral chromatic aberration (chromatic aberration of magnification) at the secondary spectrum level. Its νd is similar to Lp1's, but its anomalous dispersion is far stronger, enabling correction of the g-line and F-line residuals that conventional achromatization leaves behind.
+
+The patent explains that Lp1 alone would overcorrect lateral chromatic aberration because its strong positive power at a high marginal ray position creates an imbalance. Lp2, placed symmetrically after the stop, cancels the excess lateral correction while preserving the longitudinal correction. The ratio DL1/DL2 = 1.61 quantifies this near-symmetry (a value of 1.0 would indicate perfect mirror-image placement about the stop).
+
+---
+
+## 6. Element-by-Element Functional Analysis
+
+### Front Group — Unit L1 (fixed)
+
+**Lens 1** — Biconvex positive (fl = +80.5 mm), nd = 1.618, νd = 63.4.
+The first element is a moderately positive biconvex crown serving as the front collecting element. Its phosphate crown glass provides low dispersion and moderate refractive index, keeping primary chromatic aberration under control at the enormous entrance pupil (~70 mm effective ray diameter). It is cemented to Lens 2.
+
+**Lens 2** — Biconcave negative (fl = −88.7 mm), nd = 1.720, νd = 34.7.
+The rear element of the front cemented doublet, a lanthanum flint with higher dispersion. Together with L1, this forms a weakly positive doublet (combined focal length = 452.3 mm, f₁/f = 5.2). The cemented interface corrects primary axial color introduced by L1, while the weak combined power means L1 contributes only modestly to the Petzval sum. The group's primary role is to gently pre-converge the beam entering the much more powerful L2 unit.
+
+### Focusing Group — Unit L2 (movable)
+
+**Lens 3 (Lp1)** — Positive meniscus (fl = +134.4 mm), nd = 1.923, νd = 20.9.
+The first positive lens with anomalous partial dispersion (ΔθgF₁ = 0.008). This ultra-high-index dense flint (probably S-NPH2) is powerfully refracting in a meniscus form that minimizes surface aberrations. As a positive element with very high dispersion (νd = 20.9), L3 contributes significantly to primary longitudinal chromatic aberration — its strong wavelength-dependent power is then compensated by the negative flint elements (L5, L6) through conventional achromatization. However, L3's position in the design is driven primarily by its anomalous partial dispersion: even after the system's primary crown-flint chromatic balance is established, a secondary spectrum residual persists, and L3's modest ΔθgF = 0.008 provides a small but meaningful correction to this residual at the on-axis level. Its very high refractive index (1.923) keeps the Petzval contribution manageable despite the strong positive power.
+
+**Lens 4 (UD)** — Positive meniscus (fl = +97.8 mm), nd = 1.497, νd = 81.5.
+The UD (Ultra-low Dispersion) element, equivalent to S-FPL51 fluorophosphate. This is the strongest positive power contributor in the front half of L2 (fl = +97.8 mm), and its extremely low dispersion (νd = 81.5) means it introduces very little primary chromatic aberration per unit of refractive power — a highly efficient "crown" element. S-FPL51-class glasses also possess significant anomalous partial dispersion, making L4 a contributor to secondary spectrum correction alongside Lp1 and the BR element. The thick meniscus form (11.43 mm center thickness) also helps control spherical aberration and coma.
+
+**Lens 5 (Aspherical)** — Negative meniscus (fl = −52.5 mm), nd = 1.855, νd = 24.8.
+The sole aspherical element, a strongly negative meniscus positioned immediately before the aperture stop. Its aspherical front surface (surface 8) corrects the dominant higher-order spherical aberration that would otherwise overwhelm the image at f/1.2. The negative power also contributes to the telephoto ratio, helps flatten the Petzval field, and provides chromatic balancing against the preceding positive elements. Made from high-index flint glass to allow the aspherical correction without excessive curvature.
+
+**Aperture Stop (STO)** — Located between surfaces 9 and 11 (d = 10.68 + 4.51 = 15.19 mm from L5 rear to L6 front). The 9-blade diaphragm sits in this air gap.
+
+**Lens 6 + Lens 7 (Doublet DL1)** — Combined fl = +223.8 mm.
+L6 is a strongly negative biconcave flint (fl = −27.9 mm, nd = 1.855, νd = 24.8), cemented to L7, a strongly positive biconvex element (fl = +26.6 mm, nd = 1.883, νd = 40.8). This is a classic achromatic doublet positioned just after the stop, where it corrects axial color and spherical aberration in the diverging beam. The combined group is weakly positive, maintaining beam convergence toward the image.
+
+**Lens 8 + Lens 9 + Lens 10 (Triplet DL2 / BR triplet)** — Combined fl = +137.9 mm.
+The BR optics assembly. L8 is a weakly negative biconcave carrier (fl = −48.6 mm, nd = 1.541), L9 is the BR organic element (fl = +375.2 mm, nd = 1.604), and L10 is a strongly positive biconvex element (fl = +41.7 mm, nd = 1.954). The triplet as a whole is moderately positive, providing the secondary chromatic correction (secondary spectrum reduction) that is the patent's central innovation. The BR element's extreme anomalous dispersion (ΔθgF = 0.092) cancels the lateral chromatic overcorrection from Lp1 in the front group.
+
+### Rear Group — Unit L3 (fixed)
+
+**Lens 11 + Lens 12 (Doublet)** — Combined fl = +188.4 mm.
+L11 is a strongly positive biconvex element (fl = +41.4 mm, nd = 1.954, νd = 32.3), cemented to L12, a negative biconcave element (fl = −51.6 mm, nd = 1.620, νd = 36.3). This achromatic doublet in the rear group helps control chromatic aberration in the strongly converging beam approaching the image plane. The ultra-high-index glass of L11 keeps the Petzval contribution small.
+
+**Lens 13** — Biconcave negative (fl = −61.9 mm), nd = 1.689, νd = 31.1.
+A weakly negative singlet that provides field curvature correction and helps control astigmatism in the outer field zones. Its titanium flint glass (S-TIM27) balances the chromatic residuals from the preceding doublet.
+
+**Lens 14** — Biconvex positive (fl = +86.3 mm), nd = 1.900, νd = 37.4.
+The final element, a strongly positive biconvex in ultra-high-index lanthanum glass. This element serves two purposes: it provides positive power to reduce the convergence angle of the exit rays (bringing them closer to perpendicular incidence on the sensor for better microlens compatibility), and it contributes final chromatic balancing. Its focal length (+86.3 mm) is almost identical to the system focal length, and its strong convergence helps place the exit pupil 38 mm in front of the image plane — far enough that ray angles at the sensor remain moderate across the field.
+
+---
+
+## 7. Focusing Mechanism
+
+### Unit focus of L2
+
+The entire L2 group (8 elements, Groups G2–G6) translates bodily toward the object when focusing from infinity to close distance. This is an internal focusing design: L1 and L3 remain stationary, the front element does not rotate or extend, and the overall physical length of the lens housing is constant.
+
+The two variable air gaps are:
+
+| Gap | Surface | Infinity | Close (0.85 m) | Change |
+|---|---|---|---|---|
+| L1 → L2 | d₃ | 14.36 mm | 1.61 mm | −12.75 mm |
+| L2 → L3 | d₁₇ | 1.64 mm | 14.39 mm | +12.75 mm |
+
+The L2 shift of 12.75 mm is substantial — nearly the entire available gap between L1 and L2 is consumed at minimum focus distance. The conservation rule (Δd₃ + Δd₁₇ = 0) confirms that the total track remains constant at 134.49 mm, consistent with an internally focusing design where the sensor-to-front-vertex distance does not change.
+
+### Why L2 focus works
+
+The patent designates L2 as a positive group with f₂ = 93.1 mm, close to the system focal length (f₂/f = 1.08). When L2 moves forward, the effective object distance for L2 decreases while the effective throw to the image (through L3) increases, refocusing the system onto progressively closer objects. The ratio f₂/f ≈ 1 means the focus sensitivity is high (small L2 movements produce large changes in object distance), but the 0.85 m minimum focus distance still requires a 12.75 mm stroke — a consequence of the long focal length and only moderate f₂/f ratio.
+
+Because all of the chromatic correction elements (Lp1/BR/UD) move together with the stop, focus breathing effects on chromatic performance are minimized. The patent specifically notes this advantage in paragraphs [0036] and [0041]: chromatic aberration fluctuation during focusing is reduced because the chromatic-correcting elements maintain their fixed relationship to the aperture stop.
+
+---
+
+## 8. Computed Optical Parameters
+
+All values independently verified by paraxial ray trace (ABCD matrix / y-nu method).
+
+### System parameters
+
+| Parameter | Value |
+|---|---|
+| Effective focal length | 86.53 mm |
+| F-number (design) | f/1.24 |
+| Half-field angle (ω) | 14.04° |
+| Image height | 21.64 mm (full-frame 43.28 mm diagonal) |
+| Overall optical length | 134.49 mm |
+| Back focal distance | 14.91 mm |
+| Entrance pupil position | 113.67 mm behind front surface |
+| Exit pupil position | −38.04 mm (38 mm in front of image plane) |
+| Petzval sum | 0.00107 mm⁻¹ |
+| Petzval radius | 934 mm |
+
+### Unit focal lengths
+
+| Unit | Focal length (mm) | Power contribution |
+|---|---|---|
+| L1 | +452.3 | Weak positive collector |
+| L2 | +93.1 | Primary power; focusing |
+| L3 | +845.7 | Weak positive; exit pupil control |
+
+### Element focal lengths (thick-lens, standalone in air)
+
+| Element | Shape | fl (mm) | Glass (nd/νd) | Role |
+|---|---|---|---|---|
+| L1 | Biconvex (+) | +80.5 | 1.618/63.4 | Front crown |
+| L2 | Biconcave (−) | −88.7 | 1.720/34.7 | Front flint |
+| L3 (Lp1) | Pos. meniscus (+) | +134.4 | 1.923/20.9 | APD corrector (axial CA) |
+| L4 (UD) | Pos. meniscus (+) | +97.8 | 1.497/81.5 | UD glass (low-dispersion positive) |
+| L5 (asph.) | Neg. meniscus (−) | −52.5 | 1.855/24.8 | Spherical aberration corrector |
+| L6 | Biconcave (−) | −27.9 | 1.855/24.8 | DL1 flint component |
+| L7 | Biconvex (+) | +26.6 | 1.883/40.8 | DL1 crown component |
+| L8 | Biconcave (−) | −48.6 | 1.541/47.2 | BR carrier (object side) |
+| L9 (BR) | Pos. meniscus (+) | +375.2 | 1.604/20.8 | BR optics (lateral CA) |
+| L10 | Biconvex (+) | +41.7 | 1.954/32.3 | BR carrier + positive power |
+| L11 | Biconvex (+) | +41.4 | 1.954/32.3 | Rear doublet crown |
+| L12 | Biconcave (−) | −51.6 | 1.620/36.3 | Rear doublet flint |
+| L13 | Biconcave (−) | −61.9 | 1.689/31.1 | Field flattener |
+| L14 | Biconvex (+) | +86.3 | 1.900/37.4 | Exit angle control |
+
+---
+
+## 9. Design Philosophy — Summary
+
+The Canon RF 85mm f/1.2L USM exemplifies several trends in modern high-performance lens design:
+
+**Ultra-high-index glass usage:** Four elements exceed nd = 1.90, allowing the design to distribute positive power across many surfaces while keeping the Petzval sum remarkably low (R_P = 934 mm). Without these materials, an f/1.2 design at 85 mm would suffer from pronounced field curvature.
+
+**BR optics for secondary spectrum:** The organic BR element addresses a limitation that even fluorite and Super UD glass cannot fully solve: the secondary spectrum of the g-line and F-line in the lateral (magnification) direction. By placing the BR element after the stop — symmetrically opposite the Lp1 element before the stop — the design achieves simultaneous correction of both longitudinal and lateral secondary chromatic aberration.
+
+**Single aspherical surface efficiency:** Rather than using multiple aspherical surfaces, the design achieves spherical aberration control with a single well-placed aspherical surface on a high-index substrate, immediately before the stop. The 0.37 mm departure at the rim indicates a heavily worked asphere, but the K = 0 (spherical) conic base with only three non-zero polynomial terms suggests the manufacturing challenge is primarily in the departure magnitude rather than in surface complexity.
+
+**Internal focusing with chromatic stability:** By placing all chromatic correction elements within the moving L2 group, the design ensures that chromatic performance is invariant across the focus range — a critical advantage for a portrait lens that must maintain consistent color rendition from infinity to minimum focus distance.
+
+**No optical image stabilization:** Unlike many modern RF-mount lenses, the RF 85mm f/1.2L USM omits in-lens optical stabilization. This is a deliberate trade-off: the large, fast optical formula leaves little room for a stabilization group without compromising image quality or increasing size further. Users rely on in-body image stabilization (IBIS) available in newer EOS R bodies.
+
+### Patent conditional expression validation
+
+The patent defines 18 conditional expressions that bound the design space. Example 1 satisfies all of them, with key values confirming the design intent:
+
+| Expression | Meaning | Value | Bounds |
+|---|---|---|---|
+| (1) ΔθgF1 | Lp1 anomalous dispersion | 0.01 | 0.005–0.40 |
+| (2) ΔθgF2 | Lp2 anomalous dispersion | 0.09 | 0.005–0.40 |
+| (3) DL1/DL2 | Symmetry about stop | 1.61 | 0.50–3.00 |
+| (4) nd1 | Lp1 refractive index | 1.9229 | 1.80–2.40 |
+| (13) fp1/f2 | Lp1 power relative to L2 | 1.44 | 0.50–5.00 |
+| (14) fp2/f2 | Lp2 power relative to L2 | 4.03 | 0.50–10.0 |
+| (15) f1/f | L1 power relative to system | 5.23 | 1.50–45.0 |
+| (16) f2/f | L2 power relative to system | 1.08 | 0.50–1.50 |
+| (18) Fno | Aperture ratio | 1.24 | 0.50–2.50 |
+
+---
+
+*Analysis verified by independent paraxial ray trace. All focal lengths, unit powers, Petzval sum, and variable-gap values confirmed to within rounding tolerance of the patent prescription.*

--- a/src/lens-data/CanonRF85mmf12L.data.ts
+++ b/src/lens-data/CanonRF85mmf12L.data.ts
@@ -1,0 +1,337 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — CANON RF 85mm f/1.2L USM                    ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 2020/0012073 A1, Example 1 (Maetaki / Canon).    ║
+ * ║  Large-aperture medium telephoto, 3-unit internal-focus design.    ║
+ * ║  14 elements / 9 groups, 1 aspherical surface.                    ║
+ * ║  Focus: Internal focus — L2 (8 elements) translates bodily        ║
+ * ║         toward object from infinity to close focus.               ║
+ * ║  Variable gaps: d3 (L1→L2), d17 (L2→L3). Track conserved.        ║
+ * ║                                                                    ║
+ * ║  NOTE: Patent Example 1 has 14 elements; production lens has 13.  ║
+ * ║  The patent prescription models the core design philosophy with   ║
+ * ║  f = 86.53 mm (production 85 mm) and Fno = 1.24 (production 1.2).║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Derived from patent "Effective Ray Diameter" / 2. Surface 20  ║
+ * ║    is slightly reduced from the tabulated 18.2 mm to preserve     ║
+ * ║    visible clearance across the tight L12→L13 air gap.             ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "canon-rf-85f12l",
+  maker: "Canon",
+  name: "CANON RF 85mm f/1.2L USM",
+  subtitle: "US 2020/0012073 A1 EXAMPLE 1 — CANON / MAETAKI",
+  specs: [
+    "14 ELEMENTS / 9 GROUPS",
+    "f ≈ 86.5 mm",
+    "F/1.24",
+    "2ω ≈ 28.1°",
+    "1 ASPHERICAL SURFACE",
+    "BR OPTICS (CANON PROPRIETARY)",
+  ],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: 85,
+  focalLengthDesign: 86.53,
+  apertureMarketing: 1.2,
+  apertureDesign: 1.24,
+  patentYear: 2020,
+  elementCount: 13, // production count; patent Example 1 has 14
+  groupCount: 9,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.618,
+      vd: 63.4,
+      fl: 80.5,
+      glass: "S-PHM52 (OHARA)",
+      apd: false,
+      role: "Front crown — collector element",
+      cemented: "D1",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconcave Negative",
+      nd: 1.72047,
+      vd: 34.7,
+      fl: -88.7,
+      glass: "S-NBF1 or S-LAF2 (OHARA)",
+      apd: false,
+      role: "Front flint — primary color correction with L1",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3 (Lp1)",
+      type: "Positive Meniscus",
+      nd: 1.92286,
+      vd: 20.9,
+      fl: 134.4,
+      glass: "S-NPH2 (OHARA)",
+      apd: "patent",
+      apdNote:
+        "ΔθgF₁ = 0.008 — ultra-high-index dense flint with anomalous partial dispersion for axial secondary spectrum correction",
+      role: "First APD positive lens — on-axis chromatic correction",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4 (UD)",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.5,
+      fl: 97.8,
+      glass: "S-FPL51 (OHARA)",
+      apd: "inferred",
+      apdNote: "UD glass — fluorophosphate crown with inherent anomalous partial dispersion",
+      role: "Ultra-low Dispersion positive element — primary chromatic correction",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.85478,
+      vd: 24.8,
+      fl: -52.5,
+      glass: "855/248 — high-index dense flint",
+      apd: false,
+      role: "Aspherical element — spherical aberration correction at f/1.2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.85478,
+      vd: 24.8,
+      fl: -27.9,
+      glass: "855/248 — high-index dense flint",
+      apd: false,
+      role: "DL1 flint — axial color and SA correction after stop",
+      cemented: "DL1",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.883,
+      vd: 40.8,
+      fl: 26.6,
+      glass: "S-LAH58 (OHARA)",
+      apd: false,
+      role: "DL1 crown — achromatic partner to L6",
+      cemented: "DL1",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconcave Negative",
+      nd: 1.54072,
+      vd: 47.2,
+      fl: -48.6,
+      glass: "541/472 — likely custom BR carrier",
+      apd: false,
+      role: "BR triplet carrier (object side) — diverging element",
+      cemented: "DL2",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9 (Lp2 / BR)",
+      type: "Positive Meniscus",
+      nd: 1.60401,
+      vd: 20.8,
+      fl: 375.2,
+      glass: "BR optics (Canon proprietary organic)",
+      apd: "patent",
+      apdNote: "ΔθgF₂ = 0.092 — Blue Spectrum Refractive element for lateral secondary spectrum correction",
+      role: "Second APD positive lens — lateral chromatic aberration of magnification cancellation",
+      cemented: "DL2",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.95375,
+      vd: 32.3,
+      fl: 41.7,
+      glass: "S-LAH79 (OHARA)",
+      apd: false,
+      role: "BR triplet carrier (image side) — primary positive power",
+      cemented: "DL2",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Biconvex Positive",
+      nd: 1.95375,
+      vd: 32.3,
+      fl: 41.4,
+      glass: "S-LAH79 (OHARA)",
+      apd: false,
+      role: "Rear doublet crown — exit beam convergence",
+      cemented: "D2",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Biconcave Negative",
+      nd: 1.62004,
+      vd: 36.3,
+      fl: -51.6,
+      glass: "S-TIM22 (OHARA)",
+      apd: false,
+      role: "Rear doublet flint — chromatic balancing",
+      cemented: "D2",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Biconcave Negative",
+      nd: 1.68893,
+      vd: 31.1,
+      fl: -61.9,
+      glass: "S-TIM27 (OHARA)",
+      apd: false,
+      role: "Field flattener — astigmatism and field curvature control",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Biconvex Positive",
+      nd: 1.90043,
+      vd: 37.4,
+      fl: 86.3,
+      glass: "S-LAH64 (OHARA)",
+      apd: false,
+      role: "Exit element — ray angle telecentric correction for sensor compatibility",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Unit L1 (fixed) — cemented doublet ──
+    { label: "1", R: 71.655, d: 15.57, nd: 1.618, elemId: 1, sd: 35.1 }, // L1 front
+    { label: "2", R: -149.456, d: 3.0, nd: 1.72047, elemId: 2, sd: 35.1 }, // L1→L2 junction
+    { label: "3", R: 112.469, d: 14.36, nd: 1.0, elemId: 0, sd: 32.32 }, // L2 rear → air (VARIABLE: L1→L2 gap)
+
+    // ── Unit L2 (focus group) ──
+    // G2: L3 (Lp1 — APD positive meniscus)
+    { label: "4", R: 67.332, d: 5.75, nd: 1.92286, elemId: 3, sd: 30.76 }, // L3 front
+    { label: "5", R: 141.236, d: 0.3, nd: 1.0, elemId: 0, sd: 30.3 }, // L3 rear → air
+
+    // G3: L4 (UD glass)
+    { label: "6", R: 39.868, d: 11.43, nd: 1.497, elemId: 4, sd: 27.5 }, // L4 front
+    { label: "7", R: 200.86, d: 6.51, nd: 1.0, elemId: 0, sd: 26.36 }, // L4 rear → air
+
+    // G4: L5 (aspherical negative meniscus)
+    { label: "8A", R: 75.484, d: 2.5, nd: 1.85478, elemId: 5, sd: 20.62 }, // L5 front (aspherical)
+    { label: "9", R: 27.701, d: 10.68, nd: 1.0, elemId: 0, sd: 17.58 }, // L5 rear → air
+
+    // Aperture stop
+    { label: "STO", R: 1e15, d: 4.51, nd: 1.0, elemId: 0, sd: 16.55 },
+
+    // G5: DL1 — cemented doublet (L6 + L7)
+    { label: "11", R: -85.831, d: 1.5, nd: 1.85478, elemId: 6, sd: 15.84 }, // L6 front
+    { label: "12", R: 33.313, d: 9.5, nd: 1.883, elemId: 7, sd: 15.6 }, // L6→L7 junction
+    { label: "13", R: -68.563, d: 2.28, nd: 1.0, elemId: 0, sd: 15.44 }, // L7 rear → air
+
+    // G6: DL2 — cemented triplet (L8 + L9 BR + L10)
+    { label: "14", R: -48.43, d: 1.7, nd: 1.54072, elemId: 8, sd: 14.93 }, // L8 front
+    { label: "15", R: 58.169, d: 1.0, nd: 1.60401, elemId: 9, sd: 17.0 }, // L8→L9 junction (BR)
+    { label: "16", R: 77.751, d: 6.95, nd: 1.95375, elemId: 10, sd: 17.11 }, // L9→L10 junction
+    { label: "17", R: -77.751, d: 1.64, nd: 1.0, elemId: 0, sd: 17.7 }, // L10 rear → air (VARIABLE: L2→L3 gap)
+
+    // ── Unit L3 (fixed) ──
+    // G7: Cemented doublet (L11 + L12)
+    { label: "18", R: 204.839, d: 7.0, nd: 1.95375, elemId: 11, sd: 18.43 }, // L11 front
+    { label: "19", R: -48.06, d: 2.2, nd: 1.62004, elemId: 12, sd: 18.52 }, // L11→L12 junction
+    { label: "20", R: 97.164, d: 5.4, nd: 1.0, elemId: 0, sd: 17.9 }, // L12 rear → air
+
+    // G8: L13 (biconcave singlet)
+    { label: "21", R: -52.101, d: 1.65, nd: 1.68893, elemId: 13, sd: 18.22 }, // L13 front
+    { label: "22", R: 237.864, d: 0.15, nd: 1.0, elemId: 0, sd: 19.25 }, // L13 rear → air
+
+    // G9: L14 (biconvex singlet)
+    { label: "23", R: 97.826, d: 4.0, nd: 1.90043, elemId: 14, sd: 19.78 }, // L14 front
+    { label: "24", R: -370.202, d: 14.91, nd: 1.0, elemId: 0, sd: 19.9 }, // L14 rear → BFD
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {
+    "8A": {
+      K: 0,
+      A4: -2.2875e-6,
+      A6: -2.1286e-10,
+      A8: 2.6709e-13,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings (internal focus) ──
+   *  L2 translates bodily toward object for close focus.
+   *  d3 (L1→L2 gap) decreases; d17 (L2→L3 gap) increases.
+   *  Total track conserved: d3 + d17 = 16.00 mm at all focus positions.
+   *  Close-focus gaps computed via paraxial ray trace for MFD = 0.85 m.
+   */
+  var: {
+    "3": [14.36, 1.61], // L1→L2 gap: [infinity, close 0.85 m]
+    "17": [1.64, 14.39], // L2→L3 gap: [infinity, close 0.85 m]
+  },
+  varLabels: [
+    ["3", "D3"],
+    ["17", "D17"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "L1 (FIXED)", fromSurface: "1", toSurface: "3" },
+    { text: "L2 (FOCUS)", fromSurface: "4", toSurface: "17" },
+    { text: "L3 (FIXED)", fromSurface: "18", toSurface: "24" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "DL1", fromSurface: "11", toSurface: "13" },
+    { text: "DL2", fromSurface: "14", toSurface: "17" },
+    { text: "D2", fromSurface: "18", toSurface: "20" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.85,
+  focusDescription: "Internal focus: L2 (8 elements, Groups G2–G6) translates toward object. L1 and L3 fixed.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 1.2,
+  fstopSeries: [1.2, 1.4, 2, 2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.42,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/VoigtlanderNokton35mmf12.analysis.md
+++ b/src/lens-data/VoigtlanderNokton35mmf12.analysis.md
@@ -1,0 +1,315 @@
+# Voigtländer NOKTON 35mm f/1.2 Aspherical — Optical Analysis
+
+**Patent:** JP 2004-101880A, Example 2 (Table 3 / Table 4)
+**Inventor:** Yoshitoshi Hoda (蓬田 祥寿)
+**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nagano Prefecture, Japan
+**Filed:** September 10, 2002 (Heisei 14)
+**Published:** April 2, 2004 (Heisei 16)
+
+---
+
+## 1. Introduction and Production Context
+
+The Voigtländer NOKTON 35mm f/1.2 Aspherical is a landmark lens in the Leica M-mount ecosystem. At its introduction, it was the fastest 35mm lens produced for the M system — a distinction it held for over fifteen years until Chinese manufacturers entered the ultra-fast segment. Designed by Yoshitoshi Hoda at Cosina's optical division in Nakano, Nagano Prefecture, the lens was introduced circa 2004 and underwent four major production iterations:
+
+**Version I (c. 2004–2010):** 10 elements in 7 groups, 490 g, MFD 0.7 m. This original production lens is covered by the patent under review. Cosina discontinued it around 2010, stating publicly that the required optical glass had become too difficult and expensive to procure. This remark is consistent with the design's heavy reliance on S-LAH65 (nd = 1.80420), an expensive high-index lanthanum glass appearing in three separate elements, and S-LAH63 (nd = 1.80610) in two aspherical elements requiring precision molding of high-index glass — a manufacturing process that is both technically demanding and costly.
+
+**Version II (2011–c. 2019):** 10 elements in 7 groups, 471 g, MFD 0.5 m. Cosina described this as "the same formula with improved glass" — likely referring to updated melt batches, revised coatings, and possibly substitute catalog designations for glasses whose original production had been curtailed. The 19 g weight reduction and shorter barrel suggest modest mechanical redesign while preserving the optical prescription.
+
+**Version III (2020–2024):** 9 elements in 7 groups, 332 g, MFD 0.5 m, four aspherical surfaces. A completely new optical design — not covered by this patent — achieving 30% weight reduction by eliminating one element and adding a fourth aspherical surface.
+
+**Version IV (2025–):** 9 elements in 7 groups, 300 g. Shares the Version III optical design with further mechanical refinement and weight savings.
+
+The patent JP 2004-101880A presents two numerical examples. **Example 2** is analyzed here as the prescription believed to correspond to the production Version I/II lens, based on its matching element count (10/7), aspherical surface count (3 surfaces across 2 elements), and consistent use of the same high-index lanthanum glass types cited in Cosina's production descriptions.
+
+
+## 2. Design Overview
+
+The Nokton 35mm f/1.2 Aspherical is a modified double-Gauss design adapted for wide-angle use. The lens comprises 10 elements arranged in 7 groups, divided into two main groups around a central aperture stop:
+
+**Front Group G21 (5 elements, 3 groups):** A negative meniscus singlet followed by two cemented doublets, arranged with their convex faces pointing inward toward each other. This front group has a focal length of approximately +60.0 mm and provides the overall positive convergence needed to collect the wide f/1.2 cone of light.
+
+**Rear Group G22 (5 elements, 4 groups):** A negative meniscus singlet (aspherical), a cemented doublet, a biconvex positive singlet (double aspherical), and a biconcave negative singlet. This group has a focal length of approximately +52.3 mm and is responsible for final correction of the aberrations introduced by the front group's extreme speed.
+
+### Key Design Parameters
+
+| Parameter | Value |
+|---|---|
+| Focal length (design) | 35.808 mm |
+| Focal length (marketed) | 35 mm |
+| Maximum aperture (design) | f/1.24 |
+| Maximum aperture (marketed) | f/1.2 |
+| Half-field angle (ω) | 31.8° |
+| Full field of view (2ω) | 63.6° |
+| Elements / Groups | 10 / 7 |
+| Aspherical surfaces | 3 (on 2 elements) |
+| Entrance pupil diameter | 28.88 mm |
+| BFL | 23.51 mm |
+| Total track (S1 to image) | 89.16 mm |
+| Total track / EFL ratio | 2.49 |
+| Petzval sum | +0.00374 mm⁻¹ |
+| Petzval radius | 267.8 mm |
+| Mount | Leica M (flange 27.80 mm) |
+
+
+## 3. Optical Prescription (Example 2, Table 3)
+
+The complete surface prescription is reproduced below. Surfaces marked with an asterisk (*) are aspherical. Surface 9 is the aperture stop (絞り). All refractive indices and Abbe numbers are at the d-line (587.6 nm).
+
+| Surface | R (mm) | d (mm) | nd | νd | Element |
+|---------|--------|--------|------|------|---------|
+| 1 | +200.000 | 1.60 | 1.48749 | 70.4 | L1 front |
+| 2 | +41.361 | 9.55 | air | — | L1 rear |
+| 3 | −29.539 | 1.50 | 1.56732 | 42.8 | L2a front |
+| 4 | +233.985 | 6.67 | 1.80420 | 46.5 | L2a–L2b junction |
+| 5 | −41.350 | 0.15 | air | — | L2b rear |
+| 6 | +28.934 | 13.10 | 1.80420 | 46.5 | L3a front |
+| 7 | −47.262 | 2.80 | 1.64769 | 33.8 | L3a–L3b junction |
+| 8 | +40.326 | 4.04 | air | — | L3b rear |
+| 9 (STO) | ∞ | 3.51 | air | — | Aperture stop |
+| 10* | −200.000 | 1.70 | 1.80610 | 40.7 | L4 front |
+| 11 | −254.022 | 2.86 | air | — | L4 rear |
+| 12 | −30.236 | 1.40 | 1.80518 | 25.5 | L5a front |
+| 13 | +46.963 | 8.51 | 1.80420 | 46.5 | L5a–L5b junction |
+| 14 | −27.172 | 0.15 | air | — | L5b rear |
+| 15* | +81.004 | 6.41 | 1.80610 | 40.7 | L6 front |
+| 16* | −31.428 | 0.20 | air | — | L6 rear |
+| 17 | −75.075 | 1.50 | 1.54814 | 45.8 | L7 front |
+| 18 | +30.000 | (BFL) | air | — | L7 rear |
+
+**Computed BFL:** 23.51 mm (image plane distance from surface 18).
+
+
+## 4. Element-by-Element Analysis
+
+### L1 — Negative Meniscus (Front Element)
+
+**Glass:** nd = 1.48749, νd = 70.4 — identified as **OHARA S-FSL5** (fluorine-crown), alternatively HOYA FC5 or Schott N-FK5.
+
+**Shape:** Both radii positive (R₁ = +200.000, R₂ = +41.361), making this a negative meniscus with its convex side toward the object. The front radius is nearly five times the rear, giving a gently curved front face and a strongly curved rear concavity.
+
+**Focal length:** −107.3 mm (thick-lens, in-air).
+
+**Role:** This is a classic wide-angle front element serving as a negative field-flattening lens. Its low refractive index (the lowest in the system) and high Abbe number mean it introduces minimal chromatic aberration despite its significant refractive power — a useful property for a large-diameter element operating at the system's widest ray heights. By diverging the incoming ray bundle before it enters the cemented doublets, L1 enlarges the effective field that the rear groups can accept. The meniscus shape controls astigmatism by bending the field in the direction opposite to the Petzval curvature contributed by the strong positive elements deeper in the system. This element is relatively thin (1.60 mm center thickness) and large in diameter — it defines the physical aperture of the lens barrel and contributes to the lens's characteristic 52 mm filter thread.
+
+The choice of a low-index fluorine-crown is noteworthy: it minimizes Petzval contribution (surface power is proportional to Δn, which is small here) while its high Abbe number ensures that this large-diameter element introduces minimal chromatic aberration despite its significant refractive power. The Petzval contributions from L1's two surfaces partially cancel each other but leave a net negative residual (−0.006 mm⁻¹), helping to flatten the inherently positive Petzval sum of the system.
+
+
+### L2a + L2b — Cemented Doublet 22
+
+**L2a glass:** nd = 1.56732, νd = 42.8 — **OHARA S-BAM4** (barium light flint).
+**L2b glass:** nd = 1.80420, νd = 46.5 — **OHARA S-LAH65** (high-index lanthanum glass).
+
+**Shape:** L2a is biconcave (R₃ = −29.539, R₄ = +233.985); L2b is biconvex (R₄ = +233.985, R₅ = −41.350). The junction surface at R₄ = +233.985 mm is nearly flat — the two elements meet at a very gently curved interface.
+
+**Individual focal lengths:** L2a ≈ −46.1 mm (negative), L2b ≈ +44.2 mm (positive).
+**Doublet focal length:** +340.4 mm (weakly positive overall).
+
+**Role:** This doublet is the first chromatic corrector in the system. The combination of a barium flint negative element with a high-index lanthanum positive element creates an achromatic pair. However, the V-number difference between L2a and L2b is small (Δν = 3.7) while the refractive index difference is substantial (Δnd = 0.237). This pairing prioritizes monochromatic correction — spherical aberration and coma — over chromatic correction. The junction surface itself is nearly flat (R₄ = +234 mm, φ ≈ 0.001 mm⁻¹), so the large index step across it contributes negligible surface power; the doublet's corrective work is instead carried by its strongly curved outer surfaces (R₃ = −29.5 and R₅ = −41.4), where the individual element powers are large and opposite in sign (L2a ≈ −46 mm, L2b ≈ +44 mm) while the net doublet power is weak (+340 mm). This "nearly-zero net power with large constituent powers" configuration is efficient for higher-order aberration correction at f/1.2.
+
+The patent explicitly requires that the positive elements in all cemented doublets have nd > 1.7 to control astigmatism and field curvature. L2b, with nd = 1.80420, satisfies this condition.
+
+
+### L3a + L3b — Cemented Doublet 23
+
+**L3a glass:** nd = 1.80420, νd = 46.5 — **OHARA S-LAH65** (high-index lanthanum glass).
+**L3b glass:** nd = 1.64769, νd = 33.8 — **OHARA S-TIF1** (titanium flint).
+
+**Shape:** L3a is biconvex (R₆ = +28.934, R₇ = −47.262); L3b is biconcave (R₇ = −47.262, R₈ = +40.326).
+
+**Individual focal lengths:** L3a ≈ +24.2 mm (strong positive — the strongest individual element in the front group), L3b ≈ −33.2 mm (strong negative).
+**Doublet focal length:** +54.2 mm (net positive).
+
+**Role:** This is the principal power-generating doublet, positioned immediately before the stop. The thick L3a element (13.10 mm center thickness — the thickest in the system) carries the highest surface powers in the front group, with its front surface contributing the largest single Petzval increment (+0.0154 mm⁻¹). The high refractive index of S-LAH65 is essential here: it provides strong convergence while keeping the Petzval contribution manageable (since Petzval contribution scales as φ/(n·n'), the high index in the denominator partially offsets the high surface power in the numerator). The substantial 13.1 mm center thickness is physically necessary: at f = +24.2 mm the constituent surface powers are very high, and the thick-lens correction term (−d·φ₁·φ₂/n) is significant, contributing roughly 7 mm of additional focal length beyond the thin-lens estimate.
+
+The Abbe number difference within this doublet is more substantial (Δν = 12.7), making it the primary chromatic corrector in the front group. The titanium flint L3b is paired against the high-index lanthanum L3a in a traditional achromatic arrangement. The doublet's front convex surface (L3a, R₆ = +28.934) and the first doublet's rear convex surface (L2b, R₅ = −41.350) face each other across a tiny 0.15 mm air gap — a classic double-Gauss "waist" configuration that enables high-order aberration balancing.
+
+
+### Aperture Stop (S₂)
+
+The stop is placed in the 4.04 + 3.51 = 7.55 mm air space between the rear of doublet 23 (surface 8) and the front of element L4 (surface 10). The stop's position between the two main groups is characteristic of double-Gauss designs. At f/1.24, the stop semi-diameter is approximately 12.9 mm, yielding an entrance pupil diameter of approximately 28.9 mm.
+
+
+### L4 — Negative Meniscus (Aspherical)
+
+**Glass:** nd = 1.80610, νd = 40.7 — **OHARA S-LAH63** (high-index lanthanum glass).
+
+**Shape:** Both radii negative (R₁₀ = −200.000, R₁₁ = −254.022), forming a negative meniscus with its concave side facing the object. The two surfaces have similar magnitudes of curvature, making this a very weakly powered element.
+
+**Focal length:** −1183.3 mm (thick-lens, in-air). This is the weakest-powered element in the entire system by far.
+
+**Aspherical surface:** Surface 10 (front, concave to object) carries aspherical correction with K = 0 (spherical base curve) and a dominant negative A4 coefficient of −3.465 × 10⁻⁵. The aspherical departure is substantial — at h = 10 mm, the surface departs from its base sphere by −0.407 mm, increasing to −0.900 mm at h = 12 mm. This strongly negative departure deepens the concavity of the surface at the margin relative to the paraxial zone.
+
+**Role:** Despite its negligible base power, L4 is one of the most optically important elements in the system. Its aspherical surface acts as a "correction plate" positioned immediately behind the stop, where it intercepts the full marginal ray bundle while the chief ray passes near the axis. This placement makes it highly effective for correcting spherical aberration without introducing significant field-dependent aberrations (since the chief ray height is near zero at the stop, aspherical departures here do not generate coma or astigmatism). The negative A4 coefficient deepens the concavity at the aperture margins, adding local negative refractive power that grows with ray height. The resulting wavefront contribution has the sign Δn × A4 < 0 (since Δn = +0.806 and A4 < 0), which provides an overcorrecting spherical aberration contribution that counteracts the undercorrection from the strong positive elements elsewhere in the system. The high refractive index of S-LAH63 (nd = 1.806) amplifies the aspherical effect per unit of surface departure.
+
+The patent text specifically identifies this surface as bearing aspherical correction: "メニスカス負レンズ24は、物体側を向いた凹面が非球面に形成されている" (the concave surface of meniscus negative lens 24 facing the object side is formed as an aspherical surface).
+
+
+### L5a + L5b — Cemented Doublet 25
+
+**L5a glass:** nd = 1.80518, νd = 25.5 — **OHARA S-TIH14** (titanium flint, high-dispersion).
+**L5b glass:** nd = 1.80420, νd = 46.5 — **OHARA S-LAH65** (high-index lanthanum glass).
+
+**Shape:** L5a is biconcave (R₁₂ = −30.236, R₁₃ = +46.963); L5b is biconvex (R₁₃ = +46.963, R₁₄ = −27.172).
+
+**Individual focal lengths:** L5a ≈ −22.7 mm (strong negative), L5b ≈ +22.6 mm (strong positive).
+**Doublet focal length:** +137.4 mm (weakly positive).
+
+**Role:** This doublet is the principal chromatic corrector for the rear group. With a V-number difference of Δν = 21.0 — the largest in the system — it carries the heaviest burden for axial chromatic aberration correction. The refractive indices are nearly identical (Δnd ≈ 0.001), which is the hallmark of a "new achromat" design: the chromatic correction arises almost entirely from the dispersion difference rather than from an index step, minimizing the monochromatic aberration penalty. The individual element focal lengths are nearly equal in magnitude and opposite in sign (−22.7 vs. +22.6), producing a nearly afocal pair that nonetheless generates strong chromatic correction through the large Abbe number difference.
+
+The combination of S-TIH14 (a very high-dispersion titanium flint, νd = 25.5) with S-LAH65 (a high-index lanthanum glass, νd = 46.5) provides efficient chromatic correction per unit of doublet power. The L5b element is thick (8.51 mm center thickness), which separates the front and rear surface powers sufficiently to generate a "thick-lens" achromatic effect — the correction of longitudinal chromatic aberration becomes somewhat independent of the exact surface radii, making the design more tolerant of manufacturing errors.
+
+
+### L6 — Biconvex Positive (Double Aspherical)
+
+**Glass:** nd = 1.80610, νd = 40.7 — **OHARA S-LAH63** (high-index lanthanum glass).
+
+**Shape:** Biconvex (R₁₅ = +81.004, R₁₆ = −31.428). The rear surface has approximately 2.6× the curvature of the front surface, making this an asymmetric biconvex element with most of the bending power concentrated on the rear surface.
+
+**Focal length:** +28.8 mm (thick-lens, in-air). This is one of the three strongest positive elements in the system, alongside L3a (+24.2 mm) and L5b (+22.6 mm).
+
+**Aspherical surfaces:** Both surfaces carry aspherical correction:
+
+**Surface 15 (front):** K = 0, A4 = +3.638 × 10⁻⁶. The aspherical departure is mild — only +0.026 mm at h = 10 mm. The positive A4 slightly steepens the front convex surface at the margins, locally increasing the convergent power. The wavefront product Δn × A4 > 0 (since Δn = +0.806 entering glass), so this surface makes a mild undercorrecting contribution to spherical aberration — a deliberate addition that provides a degree of freedom for balancing the overcorrection from S10 and S16.
+
+**Surface 16 (rear):** K = 0, A4 = +1.179 × 10⁻⁵. The departure is more significant: +0.097 mm at h = 10 mm, rising to +0.193 mm at h = 12 mm. The positive A4 partially flattens the strongly concave rear surface at the margins, locally reducing the convergent power. Because light exits the glass here (Δn = −0.806), the wavefront product Δn × A4 < 0, making this surface an overcorrecting SA contributor — working in the same direction as S10 to counteract the system's undercorrection.
+
+**Role:** L6 is the primary convergent element of the rear group, providing the bulk of the power needed to bring the ray bundle to focus. Its double aspherical surfaces are the most technically demanding manufacturing feature in the lens — precision molding or grinding of aspherical surfaces in high-index glass (nd = 1.806) requires exceptional tooling accuracy. This is very likely the element whose manufacture Cosina cited as "too difficult and expensive" when discontinuing Version I. The combined effect of the two aspherical surfaces on L6, working in concert with the aspherical S10 on L4, enables correction of spherical aberration across the full f/1.2 aperture while simultaneously managing coma and astigmatism in the off-axis field.
+
+The large rear surface curvature (R₁₆ = −31.428 mm) generates the single largest positive Petzval contribution of any surface in the rear group (+0.0142 mm⁻¹), which is partially compensated by L7's negative contributions.
+
+
+### L7 — Biconcave Negative (Rear Element)
+
+**Glass:** nd = 1.54814, νd = 45.8 — **OHARA S-TIL2** (light titanium flint).
+
+**Shape:** Biconcave (R₁₇ = −75.075, R₁₈ = +30.000). The rear surface has 2.5× the curvature of the front, making this a strongly asymmetric negative element with most of its divergent power on the exit face.
+
+**Focal length:** −38.9 mm (thick-lens, in-air). This is the third-strongest negative element in the system, after L5a (−22.7 mm) and L3b (−33.2 mm).
+
+**Role:** L7 is the field-flattening and exit-pupil-shaping element. Its strong negative power counteracts the Petzval curvature of L6, contributing the system's largest single negative Petzval increment (−0.0118 mm⁻¹ from surface 18 alone). The relatively low refractive index (nd = 1.548, the second-lowest in the system) is intentional: it maximizes the Petzval correction per unit of element power, since the Petzval contribution goes as φ/(n·n'), and low n in the denominator amplifies the correcting effect.
+
+The rear surface (R₁₈ = +30.000 mm) faces the image plane and defines the exit pupil characteristics of the system. This surface's curvature creates significant telecentric departure — the chief ray exits at a non-zero angle to the optical axis, which can interact with digital sensor cover glass and microlens arrays. This is a known characteristic of Leica M-mount wide-angle lenses and one reason why digital Leica cameras incorporate software corrections for oblique incidence.
+
+
+## 5. Glass Selection Strategy
+
+The design uses 7 distinct glass types across 10 elements, with three types appearing in multiple elements:
+
+| Glass (OHARA) | Code | nd | νd | Elements | Count |
+|---|---|---|---|---|---|
+| S-FSL5 | 1487/704 | 1.48749 | 70.4 | L1 | 1 |
+| S-BAM4 | 1567/428 | 1.56732 | 42.8 | L2a | 1 |
+| **S-LAH65** | **1804/465** | **1.80420** | **46.5** | **L2b, L3a, L5b** | **3** |
+| S-TIF1 | 1648/338 | 1.64769 | 33.8 | L3b | 1 |
+| **S-LAH63** | **1806/407** | **1.80610** | **40.7** | **L4, L6** | **2** |
+| S-TIH14 | 1805/255 | 1.80518 | 25.5 | L5a | 1 |
+| S-TIL2 | 1548/458 | 1.54814 | 45.8 | L7 | 1 |
+
+The dominant materials are two high-index lanthanum glasses: S-LAH65 (3 elements) and S-LAH63 (2 elements). Together, these account for half the elements in the system. Six of the ten elements have nd > 1.7, and the three highest-index glasses (S-LAH65, S-LAH63, S-TIH14) all exceed nd = 1.80 — placing them among the most expensive and challenging optical glasses to manufacture.
+
+The patent explicitly requires all positive elements in cemented doublets to have nd > 1.7, and all three (L2b, L3a, L5b) satisfy this with nd = 1.80420. This condition is the key to controlling field curvature at f/1.2: high refractive index in the positive elements reduces the Petzval sum per unit of convergent power, keeping the net field curvature manageable despite the system's very large total power (φ = 0.0279 mm⁻¹).
+
+**Note on glass procurement:** The S-LAH65 glass type is particularly significant in the production history. It appears in three elements and is a high-index lanthanum glass requiring rare-earth raw materials. OHARA's "S-" prefix designates their eco-friendly (lead-free) product line. The Version I lens, produced from approximately 2004–2010, may have originally been designed around pre-S-prefix OHARA glasses (LAH65 vs. S-LAH65), and the transition between conventional and eco-friendly formulations may have been part of the supply-chain difficulty Cosina cited when discontinuing Version I. When Version II was described as having the "same formula with improved glass," it likely refers in part to the migration to the S-prefix eco-friendly equivalents.
+
+**Confidence assessment:** All ten glass identifications are exact matches to OHARA catalog values (zero residual in nd, ≤ 0.04 in νd). Cosina is known to source glass primarily from OHARA and HOYA. Equivalent identifications exist in the HOYA catalog for all ten types (FC5, BAF3, TAFD5, NBFD3, TAFD5H, TAFD30, FD2). The exact supplier cannot be determined from patent data alone.
+
+
+## 6. Aspherical Surface Details
+
+All three aspherical surfaces use K = 0 (spherical base curves) with polynomial deformation coefficients A through D (4th through 10th order). The patent's aspherical sag equation is:
+
+$$Z(h) = \frac{ch^2}{1 + \sqrt{1 - (1+K)c^2h^2}} + Ah^4 + Bh^6 + Ch^8 + Dh^{10}$$
+
+where c = 1/R, K is the conic constant, and A, B, C, D are the 4th through 10th order aspherical coefficients.
+
+### Surface 10 (L4 front — concave to object)
+
+| Coefficient | Value |
+|---|---|
+| K | 0.000 |
+| A (A4) | −3.46513 × 10⁻⁵ |
+| B (A6) | −5.82425 × 10⁻⁸ |
+| C (A8) | −3.01558 × 10⁻¹¹ |
+| D (A10) | +7.98551 × 10⁻¹⁴ |
+
+This surface has the strongest aspherical departure in the system. At h = 10 mm, the surface departs −0.407 mm from the base sphere (deeper concavity at the margins). The A4 and A6 coefficients are both negative, meaning the aspherical correction builds monotonically through 6th order before the small positive D term provides a mild 10th-order correction at the extreme aperture. Because light enters glass at this surface (Δn = +0.806) and A4 < 0, the wavefront product Δn × A4 is negative — an overcorrecting SA contribution that helps balance the system's net undercorrection from its strong positive elements.
+
+### Surface 15 (L6 front — convex to object)
+
+| Coefficient | Value |
+|---|---|
+| K | 0.000 |
+| A (A4) | +3.63823 × 10⁻⁶ |
+| B (A6) | −2.57284 × 10⁻⁸ |
+| C (A8) | +2.13341 × 10⁻¹⁰ |
+| D (A10) | −5.87072 × 10⁻¹³ |
+
+This surface has mild aspherical departure (+0.026 mm at h = 10 mm). The sign-alternating coefficients (positive A4, negative A6, positive A8, negative A10) indicate an oscillatory correction profile — the surface alternately adds and subtracts wavefront deviation at increasing aperture zones. This pattern is characteristic of a surface tuned for higher-order aberration balancing, where the sign alternation provides zone-by-zone control. The leading A4 term makes a mild undercorrecting SA contribution (Δn × A4 > 0), providing a deliberate degree of freedom for the optimizer to balance the strong overcorrection from S10 and S16.
+
+### Surface 16 (L6 rear — concave to object)
+
+| Coefficient | Value |
+|---|---|
+| K | 0.000 |
+| A (A4) | +1.17867 × 10⁻⁵ |
+| B (A6) | −3.91138 × 10⁻⁸ |
+| C (A8) | +2.32768 × 10⁻¹⁰ |
+| D (A10) | −5.55678 × 10⁻¹³ |
+
+Moderate departure (+0.097 mm at h = 10 mm). The coefficient sign pattern is identical to surface 15 — sign-alternating — but with roughly 3× the A4 magnitude. On this strongly curved concave surface (R = −31.428 mm), the positive A4 partially flattens the surface at the margins, locally reducing the convergent power. Because light exits the glass here (Δn = −0.806), the wavefront product Δn × A4 < 0, making this an overcorrecting SA contributor — the same sign as S10. Together, S10 and S16 provide the system's net overcorrecting aspherical SA correction, while S15's mild undercorrecting contribution serves as a balancing term, giving the designer three independent degrees of freedom for zonal SA optimization across the full f/1.2 aperture.
+
+
+## 7. Aberration Correction Strategy
+
+### Spherical Aberration
+
+At f/1.2, spherical aberration is the dominant challenge. The design addresses it through three mechanisms: the three cemented doublets provide bulk aberration correction through their high-index positive elements and strong constituent powers; the three aspherical surfaces provide zone-specific correction across the aperture (two overcorrecting contributors on S10 and S16, balanced by a mild undercorrecting contributor on S15); and the near-symmetric double-Gauss layout inherently cancels odd-order coma and distortion to first order.
+
+### Chromatic Aberration
+
+The three cemented doublets divide chromatic correction across the system. Doublet 25 (rear group) carries the heaviest chromatic burden with Δν = 21.0. Doublet 23 (front group, Δν = 12.7) provides secondary chromatic correction. Doublet 22 (Δν = 3.7) contributes primarily monochromatic correction with only modest chromatic contribution. The patent's aberration curves for Example 2 show well-corrected axial chromatic aberration between the d and g lines, with residual secondary spectrum typical of designs not employing anomalous-dispersion glasses.
+
+### Field Curvature and Petzval Sum
+
+The computed Petzval sum is +0.00374 mm⁻¹, corresponding to a Petzval radius of 267.8 mm and a Petzval ratio (R_P/f) of 7.48. At the corner of the 35mm format (half-diagonal 21.6 mm), the Petzval sag is h²/(2R_P) ≈ 0.87 mm — moderate field curvature that places the sagittal image surface roughly 0.9 mm inside the flat focal plane at the extreme corner. This is well-corrected for a lens of this speed and is small enough that the sagittal and tangential image surfaces remain close to the flat focal plane across most of the field, as confirmed by the patent's astigmatism curves.
+
+The Petzval correction is achieved primarily through the index-matching strategy: using high-index glass (nd > 1.8) in the positive elements forces the Petzval contributions of positive and negative surface powers to partially cancel within each element.
+
+### Distortion
+
+The near-symmetric double-Gauss configuration inherently suppresses odd-order distortion. The patent's distortion curve for Example 2 shows less than ±2.5% distortion across the field — though reviewers of the production Version III (a different design) have noted "moustache distortion," this may not apply to the Version I/II covered here.
+
+
+## 8. Focus Mechanism
+
+The Voigtländer Nokton 35mm f/1.2 Aspherical (Versions I and II) uses **unit focusing** — the entire optical assembly moves forward as a rigid body during focus. This is standard for Leica M-mount rangefinder lenses, where the focusing helicoid translates the whole lens group relative to the camera body's flange. The patent prescription does not include variable air-spacing tables for different object distances, which is consistent with unit focusing (only the back focal distance changes).
+
+For the Version I production lens, the rangefinder-coupled focus range extends from infinity to 0.7 m. Version II extended this to 0.5 m by scale focus (below 0.7 m, focusing is by lens scale markings only, not rangefinder-coupled). This represents a focus extension of approximately 1.93 mm at 0.7 m and 2.76 mm at 0.5 m (based on the thin-lens approximation Δd ≈ f²/(s − f)).
+
+The absence of floating elements or internal focusing groups means that off-axis performance at close focus distances is not independently optimized. This is a known compromise of the unit-focus approach: field curvature and coma performance degrade at close distances compared to designs with floating elements (such as the Leica Summilux-M 35mm f/1.4 ASPH FLE, which uses a floating rear group for close-distance correction).
+
+
+## 9. Comparison Between Patent Examples
+
+The patent presents two examples with identical specifications (f = 35.8 mm, Fno = 1.24, ω = 31.8°) but different prescriptions:
+
+| Feature | Example 1 | Example 2 |
+|---|---|---|
+| Front element shape | Biconcave (R₁ = −52.773) | Negative meniscus (R₁ = +200.000) |
+| f/f₁ ratio | 0.97 | 0.60 |
+| Front group power | Stronger (f₁ ≈ 36.9 mm) | Weaker (f₁ ≈ 60.0 mm) |
+| Aspherical surfaces | 3 (S11, S15, S16) | 3 (S10, S15, S16) |
+| L7 glass | nd = 1.51680, νd = 64.2 | nd = 1.54814, νd = 45.8 |
+| Last radius | R₁₈ = +30.000 | R₁₈ = +30.000 |
+
+Example 1 uses a biconcave front element and a stronger front group (f/f₁ = 0.97), which places nearly equal power before and after the stop. Example 2 adopts a weaker front group (f/f₁ = 0.60) with a negative meniscus front element, distributing more power to the rear group. The weaker front group in Example 2 reduces the lens diameter requirement and eases coma correction at the cost of a somewhat larger rear group — a trade-off the patent text explicitly discusses as favorable for production.
+
+
+## 10. Production Significance
+
+The Nokton 35mm f/1.2 Aspherical represented a milestone in rangefinder lens design when introduced. No other 35mm lens for the Leica M system had achieved f/1.2, and the design achieved this while maintaining a 52 mm filter thread — large by M-mount standards but remarkably compact given the 28.9 mm entrance pupil diameter.
+
+The design's heavy reliance on expensive lanthanum glasses (5 of 10 elements use glasses with nd > 1.80) and its two precision-molded aspherical elements in high-index S-LAH63 glass made it one of the most manufacturing-intensive Cosina designs. When rare-earth material costs and specialty glass availability created supply-chain pressure in the late 2000s, Cosina chose to reformulate rather than pass the full cost increase to consumers — a decision that led to the Version II "improved glass" revision and eventually the completely redesigned Version III.
+
+The lens's optical signature — characterized by high central sharpness at f/1.2 with gentle field curvature falloff, low focus shift, and smooth bokeh from its 12-blade diaphragm — has made it a sought-after optic among rangefinder photographers, with used Version I examples commanding premium prices well above their original retail.

--- a/src/lens-data/VoigtlanderNokton35mmf12.data.ts
+++ b/src/lens-data/VoigtlanderNokton35mmf12.data.ts
@@ -1,0 +1,259 @@
+import type { LensDataInput } from "../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — VOIGTLÄNDER NOKTON 35mm f/1.2 Aspherical             ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: JP 2004-101880A Example 2 (Cosina / Yoshitoshi Hoda) ║
+ * ║  Modified double-Gauss for Leica M mount, f/1.2 wide-angle.       ║
+ * ║  10 elements / 7 groups, 3 aspherical surfaces (on 2 elements).   ║
+ * ║  Focus: unit focus (entire lens translates).                       ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list SDs. Estimated from combined marginal +    ║
+ * ║    chief ray envelope (60% field) with ~8% clearance. Front        ║
+ * ║    elements capped at ~23 mm (52 mm filter thread). Validated:     ║
+ * ║    edge thickness ≥ 0.5 mm, cross-gap sag ≤ 90%, sd/|R| < 0.90.  ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "voigtlander-nokton-35-f12",
+  maker: "Voigtländer",
+  name: "VOIGTLÄNDER NOKTON 35mm f/1.2 Aspherical",
+  subtitle: "JP 2004-101880A Example 2 — Cosina / Hoda",
+  specs: ["10 ELEMENTS / 7 GROUPS", "f ≈ 35.8 mm", "F/1.24", "2ω ≈ 63.6°", "3 ASPHERICAL SURFACES"],
+
+  /* ── Explicit metadata fields ── */
+  focalLengthMarketing: 35,
+  focalLengthDesign: 35.808,
+  apertureMarketing: 1.2,
+  apertureDesign: 1.24,
+  patentYear: 2004,
+  elementCount: 10,
+  groupCount: 7,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.48749,
+      vd: 70.4,
+      fl: -107.3,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      role: "Negative field-flattening front element; low-index fluorine-crown minimizes Petzval contribution and chromatic aberration at the widest ray heights.",
+    },
+    {
+      id: 2,
+      name: "L2a",
+      label: "Element 2",
+      type: "Biconcave Negative",
+      nd: 1.56732,
+      vd: 42.8,
+      fl: -46.1,
+      glass: "S-BAM4 (OHARA)",
+      apd: false,
+      role: "Negative element of cemented doublet D22; barium light flint paired against high-index positive for monochromatic correction.",
+      cemented: "D22",
+    },
+    {
+      id: 3,
+      name: "L2b",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.8042,
+      vd: 46.5,
+      fl: 44.2,
+      glass: "S-LAH65 (OHARA)",
+      apd: false,
+      role: "Positive element of D22; high-index lanthanum glass (nd > 1.7 per patent requirement) provides convergence with controlled Petzval contribution.",
+      cemented: "D22",
+    },
+    {
+      id: 4,
+      name: "L3a",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.8042,
+      vd: 46.5,
+      fl: 24.2,
+      glass: "S-LAH65 (OHARA)",
+      apd: false,
+      role: "Principal power element of front group; thickest element (13.1 mm CT) carries the highest surface powers. Strongest positive element in G21.",
+      cemented: "D23",
+    },
+    {
+      id: 5,
+      name: "L3b",
+      label: "Element 5",
+      type: "Biconcave Negative",
+      nd: 1.64769,
+      vd: 33.8,
+      fl: -33.2,
+      glass: "S-TIF1 (OHARA)",
+      apd: false,
+      role: "Primary chromatic corrector in front group (Δν = 12.7); titanium flint paired with S-LAH65.",
+      cemented: "D23",
+    },
+    {
+      id: 6,
+      name: "L4",
+      label: "Element 6",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.8061,
+      vd: 40.7,
+      fl: -1183.3,
+      glass: "S-LAH63 (OHARA)",
+      apd: false,
+      role: "Aspherical correction plate immediately behind stop; near-zero base power but strong negative A4 departure provides overcorrecting SA contribution at the full f/1.2 aperture.",
+    },
+    {
+      id: 7,
+      name: "L5a",
+      label: "Element 7",
+      type: "Biconcave Negative",
+      nd: 1.80518,
+      vd: 25.5,
+      fl: -22.7,
+      glass: "S-TIH14 (OHARA)",
+      apd: false,
+      role: "High-dispersion negative element of rear chromatic doublet D25; largest Δν in system (21.0) carries heaviest axial chromatic correction burden.",
+      cemented: "D25",
+    },
+    {
+      id: 8,
+      name: "L5b",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.8042,
+      vd: 46.5,
+      fl: 22.6,
+      glass: "S-LAH65 (OHARA)",
+      apd: false,
+      role: "Positive element of D25; near-identical nd to L5a (Δnd ≈ 0.001) — 'new achromat' design where chromatic correction arises from dispersion difference, minimizing monochromatic penalty.",
+      cemented: "D25",
+    },
+    {
+      id: 9,
+      name: "L6",
+      label: "Element 9",
+      type: "Biconvex Positive (2× Asph)",
+      nd: 1.8061,
+      vd: 40.7,
+      fl: 28.8,
+      glass: "S-LAH63 (OHARA)",
+      apd: false,
+      role: "Double-aspherical power element in rear group. Front asph provides mild undercorrecting SA balance; rear asph provides overcorrecting SA. Precision-molded high-index aspheres — cited by Cosina as factor in Version I discontinuation.",
+    },
+    {
+      id: 10,
+      name: "L7",
+      label: "Element 10",
+      type: "Biconcave Negative",
+      nd: 1.54814,
+      vd: 45.8,
+      fl: -38.9,
+      glass: "S-TIL2 (OHARA)",
+      apd: false,
+      role: "Rear field-flattener and exit-pupil shaper; low nd amplifies Petzval correction per unit power. Strong rear curvature (R = +30 mm) shapes exit pupil for M-mount rangefinder compatibility.",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    { label: "1", R: 200.0, d: 1.6, nd: 1.48749, elemId: 1, sd: 23.0 }, // L1 front
+    { label: "2", R: 41.361, d: 9.55, nd: 1.0, elemId: 0, sd: 18.0 }, // L1 rear → air
+    { label: "3", R: -29.539, d: 1.5, nd: 1.56732, elemId: 2, sd: 16.0 }, // L2a front
+    { label: "4", R: 233.985, d: 6.67, nd: 1.8042, elemId: 3, sd: 16.0 }, // L2a–L2b junction
+    { label: "5", R: -41.35, d: 0.15, nd: 1.0, elemId: 0, sd: 16.0 }, // L2b rear → air
+    { label: "6", R: 28.934, d: 13.1, nd: 1.8042, elemId: 4, sd: 16.0 }, // L3a front
+    { label: "7", R: -47.262, d: 2.8, nd: 1.64769, elemId: 5, sd: 15.0 }, // L3a–L3b junction
+    { label: "8", R: 40.326, d: 4.04, nd: 1.0, elemId: 0, sd: 14.0 }, // L3b rear → air
+    { label: "STO", R: 1e15, d: 3.51, nd: 1.0, elemId: 0, sd: 12.9 }, // Aperture stop
+    { label: "10A", R: -200.0, d: 1.7, nd: 1.8061, elemId: 6, sd: 13.0 }, // L4 front (asph)
+    { label: "11", R: -254.022, d: 2.86, nd: 1.0, elemId: 0, sd: 12.9 }, // L4 rear → air
+    { label: "12", R: -30.236, d: 1.4, nd: 1.80518, elemId: 7, sd: 13.5 }, // L5a front
+    { label: "13", R: 46.963, d: 8.51, nd: 1.8042, elemId: 8, sd: 13.5 }, // L5a–L5b junction
+    { label: "14", R: -27.172, d: 0.15, nd: 1.0, elemId: 0, sd: 14.5 }, // L5b rear → air
+    { label: "15A", R: 81.004, d: 6.41, nd: 1.8061, elemId: 9, sd: 15.0 }, // L6 front (asph)
+    { label: "16A", R: -31.428, d: 0.2, nd: 1.0, elemId: 0, sd: 15.5 }, // L6 rear (asph) → air
+    { label: "17", R: -75.075, d: 1.5, nd: 1.54814, elemId: 10, sd: 15.5 }, // L7 front
+    { label: "18", R: 30.0, d: 23.51, nd: 1.0, elemId: 0, sd: 15.5 }, // L7 rear → image (BFL)
+  ],
+
+  /* ── Aspherical coefficients ──
+   *  Patent convention: K = 0 (spherical base curves), A/B/C/D = 4th–10th order.
+   *  Patent states K = 0 means "基準球面" (base sphere), consistent with standard K convention.
+   */
+  asph: {
+    "10A": {
+      K: 0,
+      A4: -3.46513e-5,
+      A6: -5.82425e-8,
+      A8: -3.01558e-11,
+      A10: 7.98551e-14,
+      A12: 0,
+      A14: 0,
+    },
+    "15A": {
+      K: 0,
+      A4: 3.63823e-6,
+      A6: -2.57284e-8,
+      A8: 2.13341e-10,
+      A10: -5.87072e-13,
+      A12: 0,
+      A14: 0,
+    },
+    "16A": {
+      K: 0,
+      A4: 1.17867e-5,
+      A6: -3.91138e-8,
+      A8: 2.32768e-10,
+      A10: -5.55678e-13,
+      A12: 0,
+      A14: 0,
+    },
+  },
+
+  /* ── Variable air spacings ──
+   *  Unit focus: only BFD changes as entire lens translates.
+   *  At 0.7 m close focus: Δd ≈ f²/(s−f) ≈ 1.93 mm extension.
+   */
+  var: {
+    "18": [23.51, 25.44],
+  },
+
+  varLabels: [["18", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G21 (Front)", fromSurface: "1", toSurface: "8" },
+    { text: "G22 (Rear)", fromSurface: "10A", toSurface: "18" },
+  ],
+
+  doublets: [
+    { text: "D22", fromSurface: "3", toSurface: "5" },
+    { text: "D23", fromSurface: "6", toSurface: "8" },
+    { text: "D25", fromSurface: "12", toSurface: "14" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.7,
+  focusDescription:
+    "Unit focus — entire optical assembly translates via helicoid. Rangefinder coupled to 0.7 m (Version I).",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 1.24,
+  fstopSeries: [1.2, 1.4, 2, 2.8, 4, 5.6, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -19,6 +19,12 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-04-22 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-04-22",
+    type: "lens",
+    summary: "Added Canon RF f/1.2 primes and Voigtländer Nokton 35mm f/1.2",
+  },
   // ── 2026-04-21 ──────────────────────────────────────────────────────────
   {
     date: "2026-04-21",


### PR DESCRIPTION
## Summary

- Adds Canon RF 50mm f/1.2 L USM, Canon RF 85mm f/1.2L USM, and Voigtländer Nokton 35mm f/1.2 lens data with analysis pages.
- Documents tight semi-diameter clearance choices for the Canon RF prescriptions so the rendered element geometry stays collision-free.
- Updates the homepage changelog and README lens count for the expanded catalog.

## Root Cause / Context

The new Canon prescriptions initially failed production lens validation because two tight facing air gaps had semi-diameters slightly larger than the renderer's cross-gap clearance policy allows. The affected boundary semi-diameters were reduced conservatively while preserving the neighboring clear apertures.

## Validation

- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test`
- `npm run build`

Note: the build still emits existing non-fatal warnings for `%VITE_GOATCOUNTER_URL%` and large bundle chunks.