### PR TITLE
docs: clarify lens data scope — exclude sensor glass, filters, and parent designs

### DIFF
--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -11,6 +11,20 @@ Reference for creating new `*.data.ts` files in `lens-data/`.
 
 File naming: `lens-data/*.data.ts` (glob pattern used for auto-discovery). Each file imports and uses `satisfies LensDataInput` for compile-time type checking.
 
+## Scope: What to Include
+
+**Include:**
+- All glass elements (air-separated groups and cemented elements)
+- All optical surfaces from front lens element to final image plane
+- Aperture stop (diaphragm)
+- Variable air gaps for focus and zoom
+
+**Do NOT include:**
+- **Sensor glass / cover glass** — the protective or thermal compensation glass plate on the camera sensor (rear of the assembly)
+- **Filters** — UV, ND, polarizing, or other filters mounted on the lens or in front of the sensor
+- **Mechanical components** — focus motors, aperture blades (mechanical detail), barrel, mounts
+- **Parent/donor designs** — if the lens is a descendant of another design, transcribe only the final production or patent design shown, not intermediate parent elements
+
 ---
 
 ## Top-Level Fields

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -23,6 +23,12 @@ import type { LensDataInput } from "../types/optics.js";
  * ║  NOTE ON SEMI-DIAMETERS:                                           ║
  * ║    [Describe how SDs were determined — patent-listed, estimated    ║
  * ║    from EP geometry, etc.]                                         ║
+ * ║                                                                    ║
+ * ║  IMPORTANT: This file describes ONLY the optical design:           ║
+ * ║    ✓ Glass elements and surfaces (front element to image plane)   ║
+ * ║    ✓ Aperture stop and variable focus/zoom gaps                   ║
+ * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts      ║
+ * ║    ✗ DO NOT include: parent/donor designs (use final design only) ║
  * ╚══════════════════════════════════════════════════════════════════════╝
  */
 


### PR DESCRIPTION
- Added 'Scope: What to Include' section to LENS_DATA_SPEC.md
- Updated TEMPLATE.data.ts.template header with clear guidance
- Specifies: include optical elements/surfaces only, not post-lens components or parent designs

https://claude.ai/code/session_01AHoX5ZGZNLGqPmq6pM6vmV