### PR TITLE
[codex] Expand risk-focused test coverage

### DIFF
--- a/__tests__/DiagramLegendCoverage.test.tsx
+++ b/__tests__/DiagramLegendCoverage.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import DiagramLegend from "../src/components/display/DiagramLegend.js";
+import themes from "../src/utils/themes.js";
+import type { RuntimeLens } from "../src/types/optics.js";
+
+function lens(hasAbbeData = true): RuntimeLens {
+  return {
+    halfField: 22,
+    offAxisFieldFrac: 0.7,
+    isZoom: false,
+    elements: [{ id: 1, vd: hasAbbeData ? 60 : undefined }],
+  } as unknown as RuntimeLens;
+}
+
+function renderLegend({
+  isWide = true,
+  legendExpanded = true,
+  showOnAxis = true,
+  showOffAxis = "trueAngle",
+  showChromatic = true,
+  chromR = true,
+  chromG = false,
+  chromB = true,
+  rayTracksF = true,
+  chromSpread = { lcaMm: 0.0012, tcaMm: 0.0004, intercepts: {}, imgHeights: {} },
+  onLegendExpandedChange = vi.fn(),
+  onOpenAbbeDiagram = vi.fn(),
+  L = lens(),
+}: Partial<Parameters<typeof DiagramLegend>[0]> = {}) {
+  return {
+    ...render(
+      <DiagramLegend
+        L={L}
+        t={themes.dark}
+        isWide={isWide}
+        zoomT={0}
+        showOnAxis={showOnAxis}
+        showOffAxis={showOffAxis}
+        showChromatic={showChromatic}
+        chromR={chromR}
+        chromG={chromG}
+        chromB={chromB}
+        chromSpread={chromSpread}
+        rayTracksF={rayTracksF}
+        legendExpanded={legendExpanded}
+        onLegendExpandedChange={onLegendExpandedChange}
+        onOpenAbbeDiagram={onOpenAbbeDiagram}
+      />,
+    ),
+    callbacks: { onLegendExpandedChange, onOpenAbbeDiagram },
+  };
+}
+
+describe("DiagramLegend", () => {
+  afterEach(() => cleanup());
+
+  it("collapses on mobile and expands through the legend toggle", () => {
+    const { callbacks } = renderLegend({ isWide: false, legendExpanded: false });
+
+    expect(screen.getByText("Tap an element for optical details")).toBeTruthy();
+    expect(screen.queryByText("Aspheric surface")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /legend/i }));
+
+    expect(callbacks.onLegendExpandedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("renders ray mode descriptions and chromatic LCA/TCA readouts", () => {
+    renderLegend();
+
+    expect(screen.getByText("Hover an element for optical details")).toBeTruthy();
+    expect(screen.getByText("On-axis rays (tracks focus)")).toBeTruthy();
+    expect(screen.getByText(/Off-axis rays \(15\.4°/)).toBeTruthy();
+    expect(screen.getByText("Vignetted (ghost)")).toBeTruthy();
+    expect(screen.getByText(/Chromatic \(R\/B\)/)).toBeTruthy();
+    expect(screen.getAllByText("1 µm").length).toBeGreaterThan(0);
+    expect(screen.getByText("0.4 µm")).toBeTruthy();
+  });
+
+  it("renders the Abbe button only when data and a callback are available", () => {
+    const { callbacks, rerender } = renderLegend();
+
+    fireEvent.click(screen.getByRole("button", { name: /Abbe/i }));
+    expect(callbacks.onOpenAbbeDiagram).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <DiagramLegend
+        L={lens(false)}
+        t={themes.dark}
+        isWide={true}
+        zoomT={0}
+        showOnAxis={false}
+        showOffAxis="off"
+        showChromatic={false}
+        chromR={false}
+        chromG={false}
+        chromB={false}
+        chromSpread={null}
+        rayTracksF={false}
+        legendExpanded={true}
+        onOpenAbbeDiagram={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /Abbe/i })).toBeNull();
+    expect(screen.queryByText("On-axis rays (tracks focus)")).toBeNull();
+    expect(screen.queryByText("Vignetted (ghost)")).toBeNull();
+  });
+});

--- a/__tests__/LensDiagramPanelCoverage.test.tsx
+++ b/__tests__/LensDiagramPanelCoverage.test.tsx
@@ -1,0 +1,331 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Dispatch, ReactNode } from "react";
+import LensDiagramPanel from "../src/components/layout/LensDiagramPanel.js";
+import type { LensAction, LensState } from "../src/types/state.js";
+import type { RuntimeLens } from "../src/types/optics.js";
+import { CATALOG_KEYS } from "../src/utils/lensCatalog.js";
+import {
+  LensDispatchContext,
+  LensStateContext,
+  PanelStateContext,
+  type LensCtxValue,
+} from "../src/utils/LensContext.js";
+import { createInitialState } from "../src/utils/lensReducer.js";
+import themes from "../src/utils/themes.js";
+
+const mocks = vi.hoisted(() => {
+  const adapters = {
+    onAnalysisDrawerToggle: vi.fn(),
+    onAnalysisTabChange: vi.fn(),
+    onBokehPreviewToggle: vi.fn(),
+    onAberrationsExpandedChange: vi.fn(),
+    onEffectiveApertureChange: vi.fn(),
+    onZoomChange: vi.fn(),
+    onFocusChange: vi.fn(),
+    onStopdownChange: vi.fn(),
+    onFocusExpandedChange: vi.fn(),
+    onApertureExpandedChange: vi.fn(),
+    onLegendExpandedChange: vi.fn(),
+    onSliderPointerUp: vi.fn(),
+    onAbbeShowGlassTypeChange: vi.fn(),
+    onShowOnAxisChange: vi.fn(),
+    onShowOffAxisChange: vi.fn(),
+    onRayTracksFChange: vi.fn(),
+    onShowChromaticChange: vi.fn(),
+    onChromRChange: vi.fn(),
+    onChromGChange: vi.fn(),
+    onChromBChange: vi.fn(),
+    onShowPupilsChange: vi.fn(),
+    onHeaderInfoExpandedChange: vi.fn(),
+    onZoomPanToggle: vi.fn(),
+  };
+  const zoomReset = vi.fn();
+  const lensComputation = vi.fn();
+  const rayTracing = vi.fn();
+  const loadedState = vi.fn();
+  const errorState = vi.fn();
+  return { adapters, zoomReset, lensComputation, rayTracing, loadedState, errorState };
+});
+
+vi.mock("../src/components/hooks/useLensComputation.js", () => ({
+  default: (props: unknown) => mocks.lensComputation(props),
+}));
+
+vi.mock("../src/components/hooks/useRayTracing.js", () => ({
+  default: (props: unknown) => mocks.rayTracing(props),
+}));
+
+vi.mock("../src/components/hooks/useDispatchAdapters.js", () => ({
+  default: () => mocks.adapters,
+}));
+
+vi.mock("../src/components/hooks/useOverlayState.js", () => ({
+  default: () => ({
+    showLcaOverlay: false,
+    showPetzvalOverlay: false,
+    showAbbeDiagram: false,
+    closeLcaOverlay: vi.fn(),
+    closePetzvalOverlay: vi.fn(),
+    openLcaOverlay: vi.fn(),
+    openPetzvalOverlay: vi.fn(),
+    openAbbeDiagram: vi.fn(),
+    closeAbbeDiagram: vi.fn(),
+  }),
+}));
+
+vi.mock("../src/components/hooks/useHeaderHeight.js", () => ({
+  default: () => ({ headerRef: { current: null }, headerHeight: 88 }),
+}));
+
+vi.mock("../src/components/hooks/useFlashOverlay.js", () => ({
+  default: () => ({ flashKey: 7, flashVisible: true, flashFading: false }),
+}));
+
+vi.mock("../src/components/hooks/useSideLayoutDetection.js", () => ({
+  default: () => true,
+}));
+
+vi.mock("../src/components/hooks/useViewBoxZoom.js", () => ({
+  default: () => ({
+    state: { zoom: 1 },
+    viewBox: "0 0 1200 600",
+    isPanning: false,
+    reset: mocks.zoomReset,
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    panBy: vi.fn(),
+    handleWheel: vi.fn(),
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn(),
+    handlePointerUp: vi.fn(),
+    handleTouchStart: vi.fn(),
+    handleTouchMove: vi.fn(),
+    handleTouchEnd: vi.fn(),
+  }),
+}));
+
+vi.mock("../src/utils/useMediaQuery.js", () => ({
+  default: () => false,
+}));
+
+vi.mock("../src/components/controls/DiagramHeader.js", () => ({
+  default: () => <div data-testid="diagram-header">Header</div>,
+}));
+
+vi.mock("../src/components/display/BokehPreviewOverlay.js", () => ({
+  default: () => <div data-testid="bokeh-preview">Bokeh preview</div>,
+}));
+
+vi.mock("../src/components/layout/lensDiagram/AnalysisDrawerContent.js", () => ({
+  default: ({ activeTab }: { activeTab: string }) => <div data-testid="analysis-content">{activeTab}</div>,
+}));
+
+vi.mock("../src/components/layout/lensDiagram/LensDiagramErrorState.js", () => ({
+  default: (props: Record<string, unknown>) => {
+    mocks.errorState(props);
+    return <div>{String(props.title)}</div>;
+  },
+}));
+
+vi.mock("../src/components/layout/lensDiagram/LensDiagramLoadedState.js", () => ({
+  default: (props: Record<string, unknown>) => {
+    mocks.loadedState(props);
+    return (
+      <div>
+        <div data-testid="loaded-state">{`act:${String(props.act ?? "none")} sel:${String(props.sel ?? "none")}`}</div>
+        <div data-testid="analysis-slot">{props.analysisContent as ReactNode}</div>
+        <div data-testid="bokeh-slot">{props.bokehPreviewContent as ReactNode}</div>
+        <div data-testid="header-slot">{props.header as ReactNode}</div>
+        <button type="button" onClick={() => (props.onHover as (eid: number | null) => void)(1)}>
+          hover-one
+        </button>
+        <button type="button" onClick={() => (props.onSelect as (eid: number | null) => void)(1)}>
+          select-one
+        </button>
+        <button type="button" onClick={() => (props.onZoomPanToggle as (active: boolean) => void)(false)}>
+          zoom-off
+        </button>
+      </div>
+    );
+  },
+}));
+
+function runtimeLens(): RuntimeLens {
+  return {
+    key: "mock-lens",
+    name: "Mock Lens",
+    svgW: 1200,
+    svgH: 600,
+    elements: [{ id: 1, nd: 1.5 }],
+  } as unknown as RuntimeLens;
+}
+
+function computation(overrides: Record<string, unknown> = {}) {
+  return {
+    L: runtimeLens(),
+    buildError: null,
+    IMG_MM: 43,
+    zPos: [10],
+    sx: (z: number) => z,
+    sy: (y: number) => y,
+    clampedRayEnd: 100,
+    CX: 20,
+    IX: 900,
+    effectiveSC: 1,
+    shapes: [],
+    shapeError: null,
+    stopZ: 12,
+    currentFOPEN: 2,
+    fNumber: 2,
+    currentPhysStopSD: 5,
+    baseEPSD: 8,
+    currentEPSD: 8,
+    varReadouts: [],
+    dynamicEFL: 50,
+    effectiveFNum: 2,
+    filterId: "mock-filter",
+    ...overrides,
+  };
+}
+
+function rayResult(overrides: Record<string, unknown> = {}) {
+  return {
+    rays: [],
+    offAxisRays: [],
+    chromaticRays: [],
+    chromSpread: null,
+    rayError: null,
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<LensState> = {}): LensState {
+  const state = createInitialState({}, {}, true, CATALOG_KEYS);
+  return {
+    ...state,
+    ...overrides,
+    lens: { ...state.lens, ...overrides.lens },
+    display: { ...state.display, ...overrides.display },
+    rays: { ...state.rays, ...overrides.rays },
+    sliders: { ...state.sliders, ...overrides.sliders },
+    sharedSliders: { ...state.sharedSliders, ...overrides.sharedSliders },
+    panels: { ...state.panels, ...overrides.panels },
+    overlays: { ...state.overlays, ...overrides.overlays },
+  };
+}
+
+function renderPanel(state = makeState(), dispatch = vi.fn<Dispatch<LensAction>>()) {
+  const value: LensCtxValue = { state, theme: themes.dark, isWide: true, updateURLWithSliders: vi.fn() };
+  return render(
+    <LensStateContext.Provider value={value}>
+      <LensDispatchContext.Provider value={dispatch}>
+        <PanelStateContext.Provider value={state.panels}>
+          <LensDiagramPanel lensKey="lens-a" scaleRatio={null} panelId="a" compact={false} />
+        </PanelStateContext.Provider>
+      </LensDispatchContext.Provider>
+    </LensStateContext.Provider>,
+  );
+}
+
+describe("LensDiagramPanel orchestration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.lensComputation.mockReturnValue(computation());
+    mocks.rayTracing.mockReturnValue(rayResult());
+  });
+
+  afterEach(() => cleanup());
+
+  it("routes build, shape, and ray errors to the shared error state", () => {
+    mocks.lensComputation.mockReturnValueOnce(computation({ buildError: new Error("build") }));
+    const { rerender } = renderPanel();
+    expect(screen.getByText("Failed to build lens")).toBeTruthy();
+    expect(mocks.errorState.mock.calls[0][0]).toMatchObject({
+      component: "LensDiagramPanel (buildLens)",
+      title: "Failed to build lens",
+    });
+
+    mocks.lensComputation.mockReturnValueOnce(computation({ shapeError: new Error("shape") }));
+    rerender(
+      <LensStateContext.Provider value={{ state: makeState(), theme: themes.dark, isWide: true, updateURLWithSliders: vi.fn() }}>
+        <LensDispatchContext.Provider value={vi.fn()}>
+          <PanelStateContext.Provider value={makeState().panels}>
+            <LensDiagramPanel lensKey="lens-a" scaleRatio={null} panelId="a" compact={false} />
+          </PanelStateContext.Provider>
+        </LensDispatchContext.Provider>
+      </LensStateContext.Provider>,
+    );
+    expect(screen.getByText("Failed to compute lens element shapes")).toBeTruthy();
+
+    mocks.lensComputation.mockReturnValue(computation());
+    mocks.rayTracing.mockReturnValueOnce(rayResult({ rayError: new Error("ray") }));
+    rerender(
+      <LensStateContext.Provider value={{ state: makeState(), theme: themes.dark, isWide: true, updateURLWithSliders: vi.fn() }}>
+        <LensDispatchContext.Provider value={vi.fn()}>
+          <PanelStateContext.Provider value={makeState().panels}>
+            <LensDiagramPanel lensKey="lens-a" scaleRatio={null} panelId="a" compact={false} />
+          </PanelStateContext.Provider>
+        </LensDispatchContext.Provider>
+      </LensStateContext.Provider>,
+    );
+    expect(screen.getByText("Ray tracing failed")).toBeTruthy();
+  });
+
+  it("wires loaded state, optional analysis and bokeh content, and zoom reset", () => {
+    const state = makeState({
+      panels: {
+        ...makeState().panels,
+        analysisDrawerOpen: true,
+        analysisDrawerTab: "vignetting",
+        bokehPreviewOpen: true,
+        zoomPanActive: true,
+      },
+    });
+    renderPanel(state);
+
+    expect(screen.getByTestId("analysis-content").textContent).toBe("vignetting");
+    expect(screen.getByTestId("bokeh-preview")).toBeTruthy();
+    expect(screen.queryByTestId("diagram-header")).toBeNull();
+
+    fireEvent.click(screen.getByText("zoom-off"));
+
+    expect(mocks.zoomReset).toHaveBeenCalledTimes(1);
+    expect(mocks.adapters.onZoomPanToggle).toHaveBeenCalledWith(false);
+    expect(mocks.loadedState.mock.calls.at(-1)?.[0]).toMatchObject({
+      useSideLayout: true,
+      flashVisible: true,
+      focusT: 0,
+      zoomT: 0,
+      stopdownT: 0,
+    });
+  });
+
+  it("tracks hover/selection and clears them when the lens changes", async () => {
+    const { rerender } = renderPanel();
+
+    fireEvent.click(screen.getByText("hover-one"));
+    expect(screen.getByTestId("loaded-state").textContent).toBe("act:1 sel:none");
+
+    fireEvent.click(screen.getByText("select-one"));
+    expect(screen.getByTestId("loaded-state").textContent).toBe("act:1 sel:1");
+
+    const state = makeState();
+    const value: LensCtxValue = { state, theme: themes.dark, isWide: true, updateURLWithSliders: vi.fn() };
+    rerender(
+      <LensStateContext.Provider value={value}>
+        <LensDispatchContext.Provider value={vi.fn()}>
+          <PanelStateContext.Provider value={state.panels}>
+            <LensDiagramPanel lensKey="lens-b" scaleRatio={null} panelId="a" compact={false} />
+          </PanelStateContext.Provider>
+        </LensDispatchContext.Provider>
+      </LensStateContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loaded-state").textContent).toBe("act:none sel:none");
+    });
+  });
+});

--- a/__tests__/SharedSlidersBarCoverage.test.tsx
+++ b/__tests__/SharedSlidersBarCoverage.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SharedSlidersBar from "../src/comparison/SharedSlidersBar.js";
+import themes from "../src/utils/themes.js";
+import type { RuntimeLens } from "../src/types/optics.js";
+import type { AperturePairResult, FocusPairResult, ZoomPairResult } from "../src/comparison/comparisonSliders.js";
+
+function lens(overrides: Partial<RuntimeLens> & Record<string, unknown> = {}): RuntimeLens {
+  return {
+    name: "Mock Lens",
+    EFL: 50,
+    FOPEN: 2,
+    maxFstop: 16,
+    closeFocusM: 0.5,
+    isZoom: false,
+    fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16],
+    ...overrides,
+  } as unknown as RuntimeLens;
+}
+
+const focusPair: FocusPairResult = {
+  focusA: 0.25,
+  focusB: 0.5,
+  commonPoint: 0.5,
+  minCloseFocus: 0.5,
+  maxCloseFocus: 1,
+};
+
+const aperturePair: AperturePairResult = {
+  stopdownA: 0.2,
+  stopdownB: 0.4,
+  commonPoint: 0.35,
+  widerFOPEN: 1.4,
+  narrowerFOPEN: 2,
+  sharedMaxFstop: 16,
+};
+
+function renderSharedSliders({
+  LA = lens({ name: "A", FOPEN: 1.4 }),
+  LB = lens({ name: "B", FOPEN: 2, closeFocusM: 1 }),
+  zoomPair = null,
+  sharedZoomT = 0.5,
+  showEffectiveAperture = false,
+  effectiveFNumA = 2.1,
+  effectiveFNumB = 2.2,
+  onSharedFocusChange = vi.fn(),
+  onSharedStopdownChange = vi.fn(),
+  onSharedZoomChange = vi.fn(),
+  onFocusPointerDown = vi.fn(),
+  onAperturePointerDown = vi.fn(),
+  onSliderPointerUp = vi.fn(),
+  onToggleEffectiveAperture = vi.fn(),
+}: {
+  LA?: RuntimeLens;
+  LB?: RuntimeLens;
+  zoomPair?: ZoomPairResult | null;
+  sharedZoomT?: number;
+  showEffectiveAperture?: boolean;
+  effectiveFNumA?: number;
+  effectiveFNumB?: number;
+  onSharedFocusChange?: (value: number) => void;
+  onSharedStopdownChange?: (value: number) => void;
+  onSharedZoomChange?: (value: number) => void;
+  onFocusPointerDown?: () => void;
+  onAperturePointerDown?: () => void;
+  onSliderPointerUp?: () => void;
+  onToggleEffectiveAperture?: () => void;
+} = {}) {
+  return {
+    ...render(
+      <SharedSlidersBar
+        LA={LA}
+        LB={LB}
+        sharedFocusT={0.25}
+        sharedStopdownT={0.3}
+        sharedZoomT={sharedZoomT}
+        onSharedFocusChange={onSharedFocusChange}
+        onSharedStopdownChange={onSharedStopdownChange}
+        onSharedZoomChange={onSharedZoomChange}
+        onFocusPointerDown={onFocusPointerDown}
+        onAperturePointerDown={onAperturePointerDown}
+        onSliderPointerUp={onSliderPointerUp}
+        focusPair={focusPair}
+        aperturePair={aperturePair}
+        zoomPair={zoomPair}
+        dynamicEflA={52}
+        dynamicEflB={50}
+        effectiveFNumA={effectiveFNumA}
+        effectiveFNumB={effectiveFNumB}
+        showEffectiveAperture={showEffectiveAperture}
+        onToggleEffectiveAperture={onToggleEffectiveAperture}
+        theme={themes.dark}
+        isWide={true}
+      />,
+    ),
+    callbacks: {
+      onSharedFocusChange,
+      onSharedStopdownChange,
+      onSharedZoomChange,
+      onFocusPointerDown,
+      onAperturePointerDown,
+      onSliderPointerUp,
+      onToggleEffectiveAperture,
+    },
+  };
+}
+
+describe("SharedSlidersBar", () => {
+  afterEach(() => cleanup());
+
+  it("renders focus and aperture controls without zoom for two primes", () => {
+    const { callbacks } = renderSharedSliders();
+
+    expect(screen.queryByText("ZOOM")).toBeNull();
+    expect(screen.getByText("FOCUS")).toBeTruthy();
+    expect(screen.getByText("APERTURE")).toBeTruthy();
+    expect(screen.getAllByRole("slider")).toHaveLength(2);
+
+    const [focusSlider, apertureSlider] = screen.getAllByRole("slider");
+    fireEvent.pointerDown(focusSlider);
+    fireEvent.change(focusSlider, { target: { value: "0.6" } });
+    fireEvent.pointerUp(focusSlider);
+    fireEvent.pointerDown(apertureSlider);
+    fireEvent.change(apertureSlider, { target: { value: "0.7" } });
+
+    expect(callbacks.onFocusPointerDown).toHaveBeenCalledTimes(1);
+    expect(callbacks.onSharedFocusChange).toHaveBeenCalledWith(0.6);
+    expect(callbacks.onSliderPointerUp).toHaveBeenCalledTimes(1);
+    expect(callbacks.onAperturePointerDown).toHaveBeenCalledTimes(1);
+    expect(callbacks.onSharedStopdownChange).toHaveBeenCalledWith(0.7);
+  });
+
+  it("renders single-zoom readouts and forwards zoom slider changes", () => {
+    const LA = lens({ name: "Zoom A", isZoom: true, zoomPositions: [24, 70], zoomEFLs: [24, 70] });
+    const { callbacks } = renderSharedSliders({
+      LA,
+      zoomPair: { zoomA: 0.5, zoomB: 0, showZoom: true },
+    });
+
+    expect(screen.getByText("ZOOM")).toBeTruthy();
+    expect(screen.getByText("47 mm")).toBeTruthy();
+    expect(screen.getByText("A: 47 mm")).toBeTruthy();
+    expect(screen.getByText("B: —")).toBeTruthy();
+    expect(screen.getAllByRole("slider")).toHaveLength(3);
+
+    fireEvent.change(screen.getAllByRole("slider")[0], { target: { value: "0.8" } });
+    expect(callbacks.onSharedZoomChange).toHaveBeenCalledWith(0.8);
+  });
+
+  it("renders dual-zoom union endpoints, marker positions, and quick f-stop callbacks", () => {
+    const LA = lens({ name: "Zoom A", isZoom: true, zoomPositions: [24, 70], zoomEFLs: [24, 70] });
+    const LB = lens({ name: "Zoom B", isZoom: true, zoomPositions: [28, 120], zoomEFLs: [28, 120] });
+    const onSharedStopdownChange = vi.fn();
+    const onSliderPointerUp = vi.fn();
+    const { container } = renderSharedSliders({
+      LA,
+      LB,
+      onSharedStopdownChange,
+      onSliderPointerUp,
+      zoomPair: {
+        zoomA: 0.1,
+        zoomB: 0.8,
+        showZoom: true,
+        sharedFL: 50,
+        minFL: 24,
+        maxFL: 120,
+        commonPointLow: 0.2,
+        commonPointHigh: 0.8,
+      },
+    });
+
+    expect(screen.getByText("24 mm")).toBeTruthy();
+    expect(screen.getByText("120 mm")).toBeTruthy();
+    expect(container.innerHTML).toContain("left: 20%");
+    expect(container.innerHTML).toContain("left: 80%");
+
+    fireEvent.click(screen.getByText("f/4"));
+
+    expect(onSharedStopdownChange).toHaveBeenCalledWith(expect.any(Number));
+    expect(onSliderPointerUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders and toggles effective aperture readouts", () => {
+    const onToggleEffectiveAperture = vi.fn();
+    renderSharedSliders({
+      showEffectiveAperture: true,
+      effectiveFNumA: 3.2,
+      effectiveFNumB: 3.6,
+      onToggleEffectiveAperture,
+    });
+
+    expect(screen.getByText("A eff. f/3.2")).toBeTruthy();
+    expect(screen.getByText("B eff. f/3.6")).toBeTruthy();
+
+    fireEvent.click(screen.getByText(/Show effective aperture/i));
+    expect(onToggleEffectiveAperture).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/analysisChartsAdditional.test.tsx
+++ b/__tests__/analysisChartsAdditional.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import FieldCurvatureMeanPlot from "../src/components/display/FieldCurvatureMeanPlot.js";
+import VignettingChart from "../src/components/display/VignettingChart.js";
+import LCAInsetWidget from "../src/components/diagram/LCAInsetWidget.js";
+import themes from "../src/utils/themes.js";
+import type { FieldCurvatureResult } from "../src/optics/aberrationAnalysis.js";
+import type { FieldCurvatureFieldResult } from "../src/optics/aberration/types.js";
+import type { VignettingSample } from "../src/optics/vignetteAnalysis.js";
+
+function field(
+  fieldFraction: number,
+  petzvalShiftMm: number,
+  chiefImageHeight: number,
+  usable = true,
+): FieldCurvatureFieldResult {
+  return {
+    fieldFraction,
+    label: `${fieldFraction}`,
+    fieldAngleDeg: fieldFraction * 20,
+    sampleCount: 4,
+    validSampleCount: usable ? 4 : 0,
+    clippedSampleCount: usable ? 0 : 4,
+    chiefImageHeight,
+    tangentialBestFocusZ: 0,
+    sagittalBestFocusZ: 0,
+    petzvalBestFocusZ: 0,
+    tangentialShiftMm: 0,
+    sagittalShiftMm: 0,
+    petzvalShiftMm,
+    astigmaticDifferenceMm: 0,
+    astigmaticDifferenceUm: 0,
+    chromaticFieldShifts: null,
+    usable,
+  };
+}
+
+function fieldCurvatureResult(fields: ReturnType<typeof field>[]): FieldCurvatureResult {
+  return {
+    fieldFractions: fields.map((sample) => sample.fieldFraction),
+    curveFieldFractions: fields.map((sample) => sample.fieldFraction),
+    fields,
+    curveFields: fields,
+    usableFieldCount: fields.filter((sample) => sample.usable).length,
+    imagePlaneZ: 0,
+    sharedFocusShiftHalfRangeMm: 0,
+    maxAstigmaticDifferenceMm: 0,
+    maxAstigmaticDifferenceUm: 0,
+    edgeTangentialShiftMm: 0,
+    edgeSagittalShiftMm: 0,
+    chromaticFocusSpreadMm: null,
+  };
+}
+
+const vignetteSamples: VignettingSample[] = [
+  { fieldAngleDeg: 0, geometricTransmission: 1, relativeIllumination: 1 },
+  { fieldAngleDeg: 10, geometricTransmission: 0.82, relativeIllumination: 0.76 },
+  { fieldAngleDeg: 20, geometricTransmission: 0.55, relativeIllumination: 0.43 },
+];
+
+describe("analysis chart coverage", () => {
+  afterEach(() => cleanup());
+
+  it("renders the Petzval mean plot from usable fields only and shows capped scale state", () => {
+    const result = fieldCurvatureResult([
+      field(0, 0, 0),
+      field(0.5, 2.5, 1),
+      field(1, -0.6, 1),
+      field(0.75, 99, 99, false),
+    ]);
+
+    const { container } = render(<FieldCurvatureMeanPlot result={result} t={themes.dark} />);
+
+    expect(screen.getByText(/Petzval reference curve/i)).toBeTruthy();
+    expect(screen.getByText("Current image plane")).toBeTruthy();
+    expect(screen.getByText("Scale capped to image circle")).toBeTruthy();
+    expect(container.querySelector("polyline")?.getAttribute("points")).not.toContain("99");
+    expect(container.querySelectorAll("circle")).toHaveLength(3);
+    expect(container.querySelector("polygon")).toBeTruthy();
+  });
+
+  it("keeps the Petzval mean plot stable when no field samples are usable", () => {
+    const result = fieldCurvatureResult([field(0.5, 3, 2, false)]);
+    const { container } = render(<FieldCurvatureMeanPlot result={result} t={themes.dark} />);
+
+    expect(screen.getByText("Current image plane")).toBeTruthy();
+    expect(container.querySelector("polyline")).toBeNull();
+    expect(container.querySelector("polygon")).toBeNull();
+  });
+
+  it("renders vignetting fallback for insufficient samples", () => {
+    render(<VignettingChart samples={[vignetteSamples[0]]} t={themes.dark} />);
+
+    expect(screen.getByText("Not enough data to plot vignetting curve.")).toBeTruthy();
+  });
+
+  it("renders vignetting curves, ticks, labels, and custom dimensions", () => {
+    const { container } = render(<VignettingChart samples={vignetteSamples} t={themes.dark} width={420} height={260} />);
+
+    expect(container.querySelector("svg")?.getAttribute("viewBox")).toBe("0 0 420 260");
+    expect(screen.getByText("Geometric")).toBeTruthy();
+    expect(screen.getByText("Relative (cos⁴)")).toBeTruthy();
+    expect(screen.getByText("20°")).toBeTruthy();
+    expect(screen.getByText("Field angle (°)")).toBeTruthy();
+    expect(container.querySelectorAll("path")).toHaveLength(2);
+    expect(container.querySelectorAll("circle")).toHaveLength(6);
+  });
+
+  it("renders LCA inset channels, formatting, custom placement, and click handling", () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <svg>
+        <LCAInsetWidget
+          chromSpread={{ lcaMm: 0.0004, tcaMm: 0, intercepts: { R: -0.02, G: 0, B: 0.03 }, imgHeights: {} }}
+          effectiveSC={1}
+          IMG_MM={0}
+          IX={100}
+          svgW={400}
+          sy={() => 80}
+          t={themes.dark}
+          width={160}
+          height={140}
+          originX={12}
+          originY={18}
+          fontScale={1.4}
+          onClick={onClick}
+        />
+      </svg>,
+    );
+
+    expect(screen.getByText("LCA")).toBeTruthy();
+    expect(screen.getByText("R")).toBeTruthy();
+    expect(screen.getByText("G")).toBeTruthy();
+    expect(screen.getByText("B")).toBeTruthy();
+    expect(screen.getByText("0.4 µm")).toBeTruthy();
+    expect(container.querySelector("rect")?.getAttribute("x")).toBe("12");
+
+    fireEvent.click(container.querySelector("g")!);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-flips the LCA inset when it would overflow the right edge", () => {
+    const { container } = render(
+      <svg>
+        <LCAInsetWidget
+          chromSpread={{ lcaMm: 0.02, tcaMm: 0, intercepts: { G: 0 }, imgHeights: {} }}
+          effectiveSC={1}
+          IMG_MM={0}
+          IX={260}
+          svgW={300}
+          sy={() => 80}
+          t={themes.dark}
+        />
+      </svg>,
+    );
+
+    expect(container.querySelector("rect")?.getAttribute("x")).toBe("140");
+    expect(screen.getByText("20 µm")).toBeTruthy();
+  });
+});

--- a/__tests__/pageMarkdownBreadcrumbCoverage.test.tsx
+++ b/__tests__/pageMarkdownBreadcrumbCoverage.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Dispatch } from "react";
+import BreadcrumbBar from "../src/components/layout/BreadcrumbBar.js";
+import DescriptionPanel from "../src/components/layout/DescriptionPanel.js";
+import UpdatesPage from "../src/pages/UpdatesPage.js";
+import type { LensAction, LensState } from "../src/types/state.js";
+import { CATALOG_KEYS, ALL_LENSES_BY_DATE, LENS_CATALOG } from "../src/utils/lensCatalog.js";
+import { LensDispatchContext, LensStateContext, type LensCtxValue } from "../src/utils/LensContext.js";
+import { createInitialState } from "../src/utils/lensReducer.js";
+import { CHANGELOG } from "../src/utils/changelogData.js";
+import themes from "../src/utils/themes.js";
+import { clearBrowserState, installMatchMediaMock, renderWithRouter } from "./testUtils.js";
+
+function makeState(overrides: Partial<LensState> = {}): LensState {
+  const state = createInitialState({}, {}, true, CATALOG_KEYS);
+  return {
+    ...state,
+    ...overrides,
+    lens: { ...state.lens, ...overrides.lens },
+    display: { ...state.display, ...overrides.display },
+    rays: { ...state.rays, ...overrides.rays },
+    sliders: { ...state.sliders, ...overrides.sliders },
+    sharedSliders: { ...state.sharedSliders, ...overrides.sharedSliders },
+    panels: { ...state.panels, ...overrides.panels },
+    overlays: { ...state.overlays, ...overrides.overlays },
+  };
+}
+
+function renderBreadcrumb({
+  lensKey = CATALOG_KEYS[0],
+  state = makeState(),
+  dispatch = vi.fn(),
+  isWide = true,
+}: {
+  lensKey?: string;
+  state?: LensState;
+  dispatch?: Dispatch<LensAction>;
+  isWide?: boolean;
+}) {
+  const value: LensCtxValue = { state, theme: themes.dark, isWide, updateURLWithSliders: vi.fn() };
+  return render(
+    <MemoryRouter>
+      <LensStateContext.Provider value={value}>
+        <LensDispatchContext.Provider value={dispatch}>
+          <BreadcrumbBar theme={themes.dark} isWide={isWide} lensKey={lensKey} />
+        </LensDispatchContext.Provider>
+      </LensStateContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+describe("page, markdown, and breadcrumb coverage", () => {
+  const scrollTo = vi.fn();
+
+  beforeEach(() => {
+    clearBrowserState();
+    installMatchMediaMock(false);
+    Object.defineProperty(window, "scrollTo", { writable: true, value: scrollTo });
+    scrollTo.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders UpdatesPage changelog, lens links, footer links, and scroll reset", () => {
+    const firstLensEntry = ALL_LENSES_BY_DATE.find((entry) => LENS_CATALOG[entry.key]);
+
+    renderWithRouter(
+      <HelmetProvider>
+        <UpdatesPage />
+      </HelmetProvider>,
+      { initialEntries: ["/updates"] },
+    );
+
+    expect(screen.getByRole("heading", { name: "Updates" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Changelog" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Lenses Added" })).toBeTruthy();
+    expect(screen.getByText(CHANGELOG[0].summary)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Lens Library" })).toBeTruthy();
+    if (firstLensEntry) {
+      expect(screen.getByText(LENS_CATALOG[firstLensEntry.key].name)).toBeTruthy();
+    }
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0 });
+  });
+
+  it("renders DescriptionPanel empty, markdown, table, code, links, and math content", () => {
+    const markdown = [
+      "# Main Heading",
+      "",
+      "A paragraph with **strong text**, `inline code`, and [a link](https://example.com).",
+      "",
+      "```ts",
+      "const focal = 50;",
+      "```",
+      "",
+      "| A | B |",
+      "| - | - |",
+      "| 1 | 2 |",
+      "",
+      "$x^2$",
+    ].join("\n");
+
+    const { rerender } = render(<DescriptionPanel markdown={null} theme={themes.dark} />);
+    expect(screen.getByText("No description available for this lens.")).toBeTruthy();
+
+    rerender(<DescriptionPanel markdown={markdown} theme={themes.dark} />);
+
+    expect(screen.getByRole("heading", { name: "Main Heading" })).toBeTruthy();
+    expect(screen.getByText("strong text")).toBeTruthy();
+    expect(screen.getByText("inline code")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "a link" }).getAttribute("target")).toBe("_blank");
+    expect(screen.getByText("const focal = 50;")).toBeTruthy();
+    expect(screen.getByRole("table")).toBeTruthy();
+    expect(screen.getAllByText("x").length).toBeGreaterThan(0);
+  });
+
+  it("renders single-lens breadcrumbs and dispatches settings changes", () => {
+    const dispatch = vi.fn();
+    const lensKey = CATALOG_KEYS[0];
+    renderBreadcrumb({ lensKey, state: makeState({ lens: { lensKeyA: lensKey } as LensState["lens"] }), dispatch });
+
+    expect(screen.getByRole("link", { name: "Home" }).getAttribute("href")).toBe("/");
+    expect(screen.getByRole("link", { name: "Makers" }).getAttribute("href")).toBe("/makers");
+    expect(screen.getByText(LENS_CATALOG[lensKey].name)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HC/i }));
+    fireEvent.click(screen.getByRole("button", { name: /AUTO/i }));
+
+    expect(dispatch).toHaveBeenCalledWith({ type: "SET_HIGH_CONTRAST", highContrast: true });
+    expect(dispatch).toHaveBeenCalledWith({ type: "SET_DARK", dark: true });
+  });
+
+  it("renders comparison breadcrumbs and returns null for unknown lens keys", () => {
+    const [lensKeyA, lensKeyB] = CATALOG_KEYS;
+    const state = makeState({
+      lens: {
+        lensKeyA,
+        lensKeyB,
+        comparing: true,
+        scaleMode: "independent",
+      },
+    });
+
+    const { rerender, container } = renderBreadcrumb({ lensKey: lensKeyA, state });
+
+    expect(screen.getByRole("link", { name: "Lenses" }).getAttribute("href")).toBe("/lenses");
+    expect(screen.getByText(`${LENS_CATALOG[lensKeyA].name} vs ${LENS_CATALOG[lensKeyB].name}`)).toBeTruthy();
+
+    const value: LensCtxValue = { state, theme: themes.dark, isWide: true, updateURLWithSliders: vi.fn() };
+    rerender(
+      <MemoryRouter>
+        <LensStateContext.Provider value={value}>
+          <LensDispatchContext.Provider value={vi.fn()}>
+            <BreadcrumbBar theme={themes.dark} isWide={true} lensKey="missing-lens" />
+          </LensDispatchContext.Provider>
+        </LensStateContext.Provider>
+      </MemoryRouter>,
+    );
+    expect(container.textContent).toBe("");
+  });
+});

--- a/__tests__/responsiveHooks.test.tsx
+++ b/__tests__/responsiveHooks.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useRef } from "react";
+import useHeaderHeight from "../src/components/hooks/useHeaderHeight.js";
+import useSideLayoutDetection from "../src/components/hooks/useSideLayoutDetection.js";
+import { installResizeObserverMock } from "./testUtils.js";
+
+const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+let scrollHeight = 120;
+let rectTop = 100;
+
+function installElementMeasurements() {
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get() {
+      return scrollHeight;
+    },
+  });
+  HTMLElement.prototype.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        top: rectTop,
+        bottom: rectTop + scrollHeight,
+        left: 0,
+        right: 300,
+        width: 300,
+        height: scrollHeight,
+        x: 0,
+        y: rectTop,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  );
+}
+
+function restoreElementMeasurements() {
+  if (originalScrollHeight) {
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", originalScrollHeight);
+  } else {
+    delete (HTMLElement.prototype as { scrollHeight?: number }).scrollHeight;
+  }
+  HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+}
+
+function HeaderHeightProbe({
+  panelId = "a",
+  lensKey = "lens-a",
+  onHeaderHeight,
+}: {
+  panelId?: string;
+  lensKey?: string;
+  onHeaderHeight?: (panelId: string, height: number) => void;
+}) {
+  const { headerRef, headerHeight } = useHeaderHeight({ panelId, lensKey, onHeaderHeight });
+  return (
+    <>
+      <div ref={headerRef}>Header</div>
+      <output>{headerHeight}</output>
+    </>
+  );
+}
+
+function SideLayoutProbe({ enabled, dep }: { enabled: boolean; dep: string }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const useSideLayout = useSideLayoutDetection({ enabled, containerRef, deps: [dep] });
+  return (
+    <div ref={containerRef}>
+      <output>{useSideLayout ? "side" : "stacked"}</output>
+    </div>
+  );
+}
+
+describe("responsive layout hooks", () => {
+  beforeEach(() => {
+    scrollHeight = 120;
+    rectTop = 100;
+    Object.defineProperty(window, "innerHeight", { configurable: true, writable: true, value: 400 });
+    installElementMeasurements();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    restoreElementMeasurements();
+    vi.unstubAllGlobals();
+  });
+
+  it("reports measured header height and remeasures through ResizeObserver", () => {
+    const resizeObserver = installResizeObserverMock();
+    const onHeaderHeight = vi.fn();
+
+    render(<HeaderHeightProbe panelId="left" lensKey="lens-a" onHeaderHeight={onHeaderHeight} />);
+
+    expect(screen.getByText("120")).toBeTruthy();
+    expect(onHeaderHeight).toHaveBeenLastCalledWith("left", 120);
+    expect(resizeObserver.instances[0].observe).toHaveBeenCalledTimes(1);
+
+    scrollHeight = 148;
+    act(() => resizeObserver.trigger());
+
+    expect(screen.getByText("148")).toBeTruthy();
+    expect(onHeaderHeight).toHaveBeenLastCalledWith("left", 148);
+  });
+
+  it("cleans up header ResizeObserver subscriptions on unmount", () => {
+    const resizeObserver = installResizeObserverMock();
+    const { unmount } = render(<HeaderHeightProbe />);
+
+    unmount();
+
+    expect(resizeObserver.instances[0].disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps side layout disabled when detection is off", () => {
+    installResizeObserverMock();
+    scrollHeight = 1000;
+
+    render(<SideLayoutProbe enabled={false} dep="a" />);
+
+    expect(screen.getByText("stacked")).toBeTruthy();
+  });
+
+  it("enables side layout on overflow and disables after hysteresis spare room", () => {
+    const resizeObserver = installResizeObserverMock();
+
+    scrollHeight = 360;
+    render(<SideLayoutProbe enabled={true} dep="a" />);
+
+    expect(screen.getByText("side")).toBeTruthy();
+
+    scrollHeight = 80;
+    act(() => resizeObserver.trigger());
+
+    expect(screen.getByText("stacked")).toBeTruthy();
+  });
+
+  it("subscribes to resize changes and removes listeners on unmount", () => {
+    const resizeObserver = installResizeObserverMock();
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = render(<SideLayoutProbe enabled={true} dep="a" />);
+
+    expect(addEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(resizeObserver.instances[0].observe).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(resizeObserver.instances[0].disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/testUtils.tsx
+++ b/__tests__/testUtils.tsx
@@ -16,6 +16,15 @@ export interface MatchMediaController {
   removeEventListener: ReturnType<typeof vi.fn>;
 }
 
+export interface ResizeObserverController {
+  instances: Array<{
+    callback: ResizeObserverCallback;
+    observe: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+  }>;
+  trigger: (target?: Element) => void;
+}
+
 function createMatchMediaController(matches: boolean): {
   controller: MatchMediaController;
   factory: (query: string) => MediaQueryList;
@@ -65,6 +74,41 @@ export function installMatchMediaMock(matches = false): MatchMediaController {
     value: vi.fn().mockImplementation((query: string) => factory(query)),
   });
   return controller;
+}
+
+export function installResizeObserverMock(): ResizeObserverController {
+  const instances: ResizeObserverController["instances"] = [];
+
+  class MockResizeObserver {
+    private callback: ResizeObserverCallback;
+    observe = vi.fn();
+    disconnect = vi.fn();
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      instances.push({
+        callback,
+        observe: this.observe,
+        disconnect: this.disconnect,
+      });
+    }
+  }
+
+  Object.defineProperty(window, "ResizeObserver", {
+    configurable: true,
+    writable: true,
+    value: MockResizeObserver,
+  });
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+  return {
+    instances,
+    trigger(target = document.body) {
+      instances.forEach((instance) => {
+        instance.callback([{ target } as ResizeObserverEntry], {} as ResizeObserver);
+      });
+    },
+  };
 }
 
 export function mockReplaceState() {

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,11 @@ export default defineConfig({
         "src/components/**",
         "src/comparison/**",
       ],
+      exclude: [
+        "src/comparison/comparisonTypes.ts",
+        "src/components/diagram/diagramSvgTypes.ts",
+        "src/pages/lensIndex/types.ts",
+      ],
       reporter: ["text", "html"],
       reportsDirectory: "coverage",
     },


### PR DESCRIPTION
## Summary
- Add focused coverage for analysis charts, diagram legend behavior, comparison shared sliders, responsive layout hooks, markdown/page rendering, breadcrumbs, and LensDiagramPanel orchestration seams.
- Add a reusable ResizeObserver test helper for hook coverage.
- Exclude exact type-only modules from V8 coverage so the report better reflects executable code.

## Impact
- Raises risk-focused coverage around user-visible UI and fragile orchestration paths without changing production behavior.
- Coverage improved from roughly 84% to 89.24% statements, 70% to 76.84% branches, and 86% to 91.69% lines.

## Validation
- `npx vitest run __tests__/analysisChartsAdditional.test.tsx __tests__/responsiveHooks.test.tsx __tests__/pageMarkdownBreadcrumbCoverage.test.tsx __tests__/SharedSlidersBarCoverage.test.tsx __tests__/DiagramLegendCoverage.test.tsx __tests__/LensDiagramPanelCoverage.test.tsx`
- `npm run typecheck`
- `npm run format:check`
- `npm run test`
- `npm run test:coverage`
- `npm run lint`