### PR TITLE
feat: add four new lenses and fix Contarex Planar focus direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `108` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
+- `112` lens data files are currently included under [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Nikon, Zeiss, Voigtlander, Canon, Ricoh, and Vivitar
 - Lens pages pair interactive diagrams with long-form optical analysis markdown
 

--- a/src/lens-data/carl-zeiss/CarlZeissContarexPlanar55mmf14.analysis.md
+++ b/src/lens-data/carl-zeiss/CarlZeissContarexPlanar55mmf14.analysis.md
@@ -1,0 +1,273 @@
+# Carl Zeiss Contarex Planar 55mm f/1.4
+
+## Patent & Attribution
+
+**Patent:** DE 1,170,157 B (Deutsches Patentamt, Auslegeschrift)
+**Filed:** 16 May 1959
+**Published:** 14 May 1964
+**Applicant:** Fa. Carl Zeiss, Heidenheim/Brenz
+**Inventors:** Johannes Berger; Dr. Günther Lange
+**Design type:** Modified asymmetric double-Gauss ("Planar")
+**Example:** Single numerical example (the only one in the patent; the production design)
+
+## Production History
+
+The Contarex Planar 55mm f/1.4 was introduced at Photokina 1960 and entered production in 1961 for the Zeiss Ikon Contarex and Contarex Special 35mm SLR cameras. It represented a significant achievement for the Berger–Lange design team at Zeiss Oberkochen: a seven-element modified double-Gauss achieving f/1.4 with sufficient back focal distance for SLR mirror clearance. The lens was the fastest standard lens in the Contarex system, complementing the Planar 50mm f/2 that launched with the original Contarex I "Cyclops" in 1959.
+
+The design preceded the more common later Zeiss Planar 50mm f/1.4 for the Contax/Yashica system (1973), which used a different 7-element/6-group formula. Berger and Lange initially calculated a 58mm f/1.4 prototype before settling on 55mm, which offered a better compromise between retrofocal clearance and imaging performance. After the patent expired in the early 1970s, the design was reportedly adopted by Rollei for the Rolleinar (Color-Ultron) 55mm f/1.4 (manufactured by Mamiya from 1975), though the degree of correspondence between the Rolleinar and the original patent formula remains debated among collectors.
+
+## Lens Specifications
+
+| Parameter | Value |
+|---|---|
+| Focal length | 55 mm (nominal and design) |
+| Maximum aperture | f/1.4 |
+| Angular field | ±20° designed (patent); ±21.5° geometric to 35mm diagonal (2ω ≈ 42.9°) |
+| Elements / Groups | 7 elements in 5 groups |
+| Aspherical surfaces | None — all spherical |
+| Close focus | 0.45 m (18 inches from film plane; 14 inches from front of lens) |
+| Filter | B56 (Contarex bayonet 56mm) |
+| Diaphragm | 9 blades, f/1.4–f/22 |
+| Image circle | 35mm (24×36mm) |
+| Back focal distance | 36.47 mm (0.663×f) |
+| Total track | 53.06 mm (front vertex to last vertex) |
+| Overall length | 89.53 mm (front vertex to image plane) |
+| Weight | ~375 g |
+| Focus method | Unit focus (entire optical assembly translates) |
+
+**Note on angular field:** Zeiss marketing literature for the Contarex system describes the angle of field as 41°, while the geometric diagonal for 35mm format at 55mm is 42.9°. The patent itself specifies ±20° (40° full), and the 41° marketing figure likely reflects rounding from this designed value. The 42.9° geometric value assumes full-format coverage to the diagonal corners.
+
+## Aspherical Surfaces
+
+**There are no aspherical surfaces in this design.** All fourteen optical surfaces are spherical. This is entirely typical of the era: aspherical surfaces on photographic lenses were not economically manufacturable at scale in 1959, and would not become common until the late 1970s (with Zeiss not adopting them until later still, on lenses like the 1990s Contax designs). The Berger–Lange team achieved f/1.4 correction using seven carefully chosen spherical elements and high-index lanthanum-containing glasses — a testament to the quality of the optical design.
+
+The patent's Δn/r column (surface refractive power contributions) confirms purely spherical construction. The notation "Δn/r" means (n′ − n)/R for each surface, which is the surface contribution to total optical power, with no polynomial or conic correction terms.
+
+## Optical Configuration
+
+The design is a modified asymmetric double-Gauss, classified by the patent as comprising five positive (collecting) lenses and two negative (diverging) lenses. The two negative elements flank the aperture stop, each enclosed within a cemented doublet — this is the defining structural feature of the design. Looking at the design front-to-rear:
+
+**Front group (before the stop):**
+- Group 1: L_I — standalone positive meniscus
+- Group 2: L_II + L_III — cemented doublet (positive crown cemented to negative flint)
+
+**Aperture stop** (in the large air gap between groups 2 and 3)
+
+**Rear group (after the stop):**
+- Group 3: L_IV + L_V — cemented doublet (negative flint cemented to positive)
+- Group 4: L_VI — standalone positive meniscus
+- Group 5: L_VII — standalone positive (biconvex)
+
+The asymmetry in the design (3 elements in 2 groups before the stop, 4 elements in 3 groups after it) is a deliberate departure from the symmetric double-Gauss. This asymmetry allows the rear group to carry a disproportionate share of the optical power (f = +44.2 mm vs. +123.7 mm for the front group) while still providing the long back focal distance (36.47 mm ≈ 0.66×f) needed for SLR mirror clearance.
+
+## Glass Identification
+
+The patent prescribes five distinct glass types. Using the six-digit nd/νd glass code convention and cross-referencing against Schott, OHARA, and HOYA catalogs, the identifications are as follows:
+
+### L_I and L_VII — Schott LaF3 (glass code 717479)
+
+**nd = 1.71700, νd = 47.90**
+
+This is a lanthanum flint glass. The nd value matches the historical Schott LaF3 exactly, with νd within 0.08 of the catalog value (47.98). The OHARA equivalent is S-LAM3 (717479), and HOYA produced it as LAF3 (717480). The use of the same glass type for both the first and last elements provides a degree of chromatic symmetry to the system. Its moderate refractive index (1.717) combined with a moderate Abbe number (47.9) places it at the boundary between crown and flint behavior. This glass was available from Schott Mainz, Zeiss's primary glass supplier throughout the Oberkochen era.
+
+**Confidence:** Exact match on nd; νd within catalog tolerance. High confidence.
+
+### L_II — Dense barium crown (glass code 623581)
+
+**nd = 1.62299, νd = 58.12**
+
+This glass falls in the dense barium crown (SSK) to barium crown (SK) transition region. No exact match exists in the current Schott catalog. The closest candidates are Schott SSK2 (nd = 1.62229, νd = 53.27 — close nd but νd is 4.85 lower) and SK16 (nd = 1.62041, νd = 60.32 — both parameters slightly off). This is most likely a Schott catalog glass from the late 1950s that has since been reformulated or discontinued. The high Abbe number (58.12) and moderate refractive index mark this as a crown-type glass, consistent with its use as the positive element in the front cemented doublet where low chromatic contribution is desirable.
+
+**Confidence:** Family-level identification (SK/SSK region). The specific catalog designation cannot be determined from the available data.
+
+### L_III — Schott LF7 (glass code 575413)
+
+**nd = 1.57501, νd = 41.31**
+
+This is a light flint glass. The nd matches Schott LF7 exactly (1.57501), with νd within 0.19 of the catalog value (41.50). It is the lowest-index glass in the system. As the negative element in the front cemented doublet, its role is to provide diverging power and correct chromatic aberration against L_II. The relatively low refractive index produces strong curvature (large surface power) at the concave rear surface (r₆), which is necessary for the negative contribution to the Petzval sum.
+
+**Confidence:** Exact match on nd; νd within catalog tolerance. High confidence.
+
+### L_IV — Schott SF6 (glass code 805255)
+
+**nd = 1.80518, νd = 25.46**
+
+This is a dense flint glass — the highest-index, highest-dispersion glass in the system. The values match Schott SF6 within rounding (nd = 1.80518, νd = 25.43). OHARA's equivalent is S-TIH6 (805255). SF6 was one of the standard high-index flint glasses of the period, widely used in fast double-Gauss designs for the concave meniscus elements flanking the stop. The high refractive index is essential: the strongly concave front surface (r₇, R = −19.9 mm) provides the negative power needed to flatten the Petzval field, and the high index keeps surface reflection losses and higher-order spherical aberration manageable at f/1.4.
+
+**Confidence:** Exact match on nd; νd within 0.03. Very high confidence.
+
+### L_V and L_VI — Schott LaF10 (glass code 784438)
+
+**nd = 1.78443, νd = 43.77**
+
+This is a lanthanum flint glass, used for both elements in the rear group. The nd matches Schott LaF10 exactly (1.78443), with νd within 0.07 of the catalog value (43.70). This is a high-index, moderate-dispersion lanthanum glass — the second-highest refractive index in the system, but with much lower dispersion than the SF6 it is cemented against. This glass pairing (SF6 + LaF10) in the rear cemented doublet is a classic choice for high-aperture double-Gauss designs. The lanthanum content provides the high refractive index needed for aberration control without introducing the extreme dispersion of a conventional dense flint.
+
+The fact that L_V and L_VI share the same glass type is notable: it simplifies manufacturing (fewer glass types to stock) and provides a degree of chromatic uniformity across the rear group.
+
+**Confidence:** Exact match on nd; νd within catalog tolerance. High confidence.
+
+### Glass Summary Table
+
+| Element | nd | νd | Glass Code | Identification | Family |
+|---|---|---|---|---|---|
+| L_I | 1.71700 | 47.90 | 717479 | Schott LaF3 | Lanthanum flint |
+| L_II | 1.62299 | 58.12 | 623581 | SK/SSK family (discontinued?) | Dense barium crown |
+| L_III | 1.57501 | 41.31 | 575413 | Schott LF7 | Light flint |
+| L_IV | 1.80518 | 25.46 | 805255 | Schott SF6 | Dense flint |
+| L_V | 1.78443 | 43.77 | 784438 | Schott LaF10 | Lanthanum flint |
+| L_VI | 1.78443 | 43.77 | 784438 | Schott LaF10 | Lanthanum flint |
+| L_VII | 1.71700 | 47.90 | 717479 | Schott LaF3 | Lanthanum flint |
+
+The extensive use of lanthanum-containing glasses (4 of 7 elements) is one of the hallmarks of this design. Lanthanum glasses became available from Schott in the late 1940s and were critical enablers of the post-war generation of fast lenses. They provide high refractive indices with moderate dispersion, allowing designers to achieve the strong surface curvatures needed at f/1.4 without paying the chromatic penalty of conventional dense flint glasses.
+
+## Element-by-Element Optical Analysis
+
+The following analysis examines the optical function of each element using paraxial surface powers verified by ABCD matrix ray trace. All focal lengths are given for the production scale (55mm system focal length). All values independently verified via Python paraxial computation.
+
+### L_I — Front Positive Meniscus (f ≈ +92.0 mm)
+
+**Shape:** Positive meniscus, convex toward the object
+**Radii:** R₁ = +46.56 mm, R₂ = +149.38 mm
+**Center thickness:** 6.32 mm
+**Glass:** LaF3 (nd = 1.717, νd = 47.9)
+
+L_I is the first optical surface encountered by light entering the lens. As a positive meniscus with both radii curving in the same direction, it gently converges the incoming beam without introducing the strong spherical aberration that a biconvex element would produce at this diameter (the entrance pupil is 39.3 mm across at f/1.4). The front surface (φ = +0.847/f) carries the bulk of the element's power, while the weakly curved rear surface (φ = −0.264/f) contributes a small negative correction. The resulting long focal length (+92 mm, about 1.67× the system focal length) means L_I contributes moderate convergence — enough to begin reducing the beam diameter before the more powerful L_II, but not so much as to over-correct spherical aberration.
+
+The choice of LaF3 glass (nd = 1.717) for this large-diameter element reflects a balance: high enough index to keep the curvatures moderate (reducing higher-order aberrations at the large beam diameter), but not so high as to require extreme manufacturing precision.
+
+### L_II — Plano-Convex Crown (f ≈ +42.6 mm)
+
+**Shape:** Plano-convex (strongly curved front, flat rear junction)
+**Radii:** R₃ = +26.57 mm, R₄ = ∞ (flat, cemented to L_III)
+**Center thickness:** 9.76 mm
+**Glass:** SK/SSK-type (nd = 1.623, νd = 58.1)
+**Cemented to:** L_III (front doublet, "D1")
+
+L_II is the strongest positive element in the front group, with a focal length of only +42.6 mm. Its strongly curved front surface (R₃ = +26.57 mm, φ = +1.290/f) is the most powerful positive surface in the entire system. This surface does the heavy lifting of converging the marginal rays toward the stop.
+
+The choice of a relatively low-index crown glass (nd = 1.623) paired with a high Abbe number (νd = 58.1) is deliberate. As a crown element in a cemented achromatic doublet, L_II should contribute minimal chromatic aberration — and the high Abbe number achieves this. The relatively low index means the front surface must be more strongly curved to achieve the required power, but this is acceptable because the beam diameter has already been reduced by L_I.
+
+The flat rear surface (R₄ = ∞) is notable. Rather than using a curved junction as in a conventional doublet, Berger and Lange chose a planar cemented interface, which means the chromatic correction in this doublet relies entirely on the glass dispersion difference between L_II and L_III, not on junction curvature. This simplifies alignment during cementing.
+
+### L_III — Plano-Concave Flint (f ≈ −28.7 mm)
+
+**Shape:** Plano-concave (flat front junction, strongly concave rear)
+**Radii:** R₅ = ∞ (flat, cemented to L_II), R₆ = +16.52 mm
+**Center thickness:** 1.39 mm
+**Glass:** LF7 (nd = 1.575, νd = 41.3)
+**Cemented to:** L_II (front doublet, "D1")
+
+L_III is the first of the two negative elements flanking the stop. Its rear surface (R₆ = +16.52 mm) is the second-most-powerful negative surface in the system (φ = −1.914/f, exceeded only by R₇ on L_IV), creating the strongly concave glass-to-air boundary that is the signature of the double-Gauss "waist." This concave surface faces the aperture stop and serves two critical functions: it provides one of the two dominant negative contributions to the Petzval sum (−1.215 in normalized Petzval units, alongside R₇'s −1.231), and it introduces negative spherical aberration to partially balance the over-correction from the positive elements. Together with R₇ across the stop gap, it defines the concave meniscus-shaped air space that is essential to the correction of coma and astigmatism.
+
+The element is remarkably thin (1.39 mm center thickness at 55mm scale) compared to the strongly curved rear surface. This thinness, combined with the low refractive index of LF7 (nd = 1.575), means the element operates essentially as a thin diverging meniscus. The low index also amplifies the surface power: for a given radius, a lower-index glass produces a stronger air-glass surface power, which is exactly what is needed for the Petzval correction role.
+
+**The cemented doublet D1 (L_II + L_III)** has a combined focal length of approximately −174.7 mm. Despite containing the system's strongest positive surface, the cemented combination is weakly negative. This seemingly paradoxical result arises because the thick, high-index positive element (L_II) is deliberately matched against the strongly negative rear surface of L_III such that the group acts as a chromatic corrector (doublet achromatization) while providing only a weak net refractive contribution. The real work of this group is aberration correction, not focusing power.
+
+### Aperture Stop
+
+The aperture stop sits in the large air gap between L_III and L_IV (15.80 mm at 55mm scale). This is the widest air gap in the entire system, and the patent drawing shows the iris diaphragm located approximately in the middle of this space. The stop position is not explicitly specified in the numerical data — it is inferred from the patent cross-section figure, placed at 50% of the gap (7.90 mm from L_III rear, 7.90 mm to L_IV front).
+
+The stop location between two strongly concave surfaces (R₆ and R₇ face each other across this gap) is the classical double-Gauss configuration. Both concave surfaces curve away from the stop, creating the characteristic "waist" in the lens cross-section.
+
+At f/1.4, the paraxial stop semi-diameter is approximately 12.8 mm, yielding an entrance pupil semi-diameter of 19.6 mm (EP magnification ≈ 1.54×). The entrance pupil is located approximately 31.2 mm in front of the first lens vertex.
+
+### L_IV — Biconcave Dense Flint (f ≈ −22.5 mm)
+
+**Shape:** Biconcave (but the rear surface is extremely weakly curved)
+**Radii:** R₇ = −19.92 mm, R₈ = +205.00 mm (cemented to L_V)
+**Center thickness:** 2.05 mm
+**Glass:** SF6 (nd = 1.805, νd = 25.5)
+**Cemented to:** L_V (rear doublet, "D2")
+
+L_IV is the second negative element flanking the stop and the second-thinnest glass element in the system (2.05 mm, exceeded in thinness only by L_III at 1.39 mm). Its front surface (R₇ = −19.92 mm, φ = −2.223/f) is the single most powerful surface in the entire lens — a deeply concave surface that provides massive negative contribution. This is the surface most responsible for the Petzval field-flattening correction (Petzval contribution: −1.231), and together with L_III's rear surface across the stop gap, it forms the negative "core" of the double-Gauss.
+
+The dense flint glass SF6 (nd = 1.805, νd = 25.5) is the highest-index, highest-dispersion material in the design. The extremely high index serves a dual purpose: it permits the strongly negative curvature needed at R₇ without exceeding manufacturable rim angles, and it generates substantial negative chromatic aberration that is corrected against the lanthanum glass in L_V.
+
+The junction surface (R₈ = R₉ = +205 mm) is very weakly curved, contributing almost no power (φ ≈ −0.006/f at the junction). This near-flat junction means most of the chromatic correction between L_IV and L_V comes from the glass dispersion contrast (SF6 at νd = 25.5 vs. LaF10 at νd = 43.8) rather than from junction curvature — the same planar-junction philosophy used in the front doublet.
+
+### L_V — Biconvex Lanthanum Flint (f ≈ +37.4 mm)
+
+**Shape:** Biconvex (weakly curved front junction, strongly curved rear)
+**Radii:** R₉ = +205.00 mm (cemented to L_IV), R₁₀ = −33.69 mm
+**Center thickness:** 8.17 mm
+**Glass:** LaF10 (nd = 1.784, νd = 43.8)
+**Cemented to:** L_IV (rear doublet, "D2")
+
+L_V is the primary power-carrier in the rear group. Its rear surface (R₁₀ = −33.69 mm, φ = +1.281/f) is the strongest positive surface behind the stop. This surface converges the diverging beam from L_IV toward the image plane. The element is notably thick (8.17 mm), which contributes to the spacing of principal planes needed for the correct back focal distance.
+
+The choice of LaF10 glass (nd = 1.784, νd = 43.8) pairs high refractive index with moderate dispersion. As the positive element in the rear doublet, it needs to provide convergent power without introducing excessive chromatic aberration — a role well-served by the lanthanum glass family. The close match in refractive index between L_IV (nd = 1.805) and L_V (nd = 1.784) means the junction surface has very little Fresnel reflection, reducing internal flare.
+
+**The cemented doublet D2 (L_IV + L_V)** has a combined focal length of approximately −84.4 mm — negative, like the front doublet D1. Both cemented groups are weakly negative, leaving the bulk of the system's positive power to the standalone elements (L_I, L_VI, L_VII). The negative power of the cemented groups is what provides the Petzval field correction: by concentrating negative surface power at high curvature (near the stop where beam diameters are smallest), the design achieves strong Petzval sum reduction without introducing unmanageable off-axis aberrations.
+
+### L_VI — Positive Meniscus (f ≈ +100.3 mm)
+
+**Shape:** Positive meniscus, concave toward the object
+**Radii:** R₁₁ = −88.98 mm, R₁₂ = −42.71 mm
+**Center thickness:** 4.65 mm
+**Glass:** LaF10 (nd = 1.784, νd = 43.8)
+
+L_VI is a positive meniscus with both surfaces concave toward the object. The front surface contributes moderate negative power (φ = −0.485/f), while the more strongly curved rear surface provides stronger positive power (φ = +1.010/f), resulting in a net positive element (f = +100.3 mm). This element sits between the rear doublet and the final element, acting as a field corrector that helps manage the off-axis ray bundle geometry.
+
+The use of LaF10 glass (the same material as L_V) means two consecutive elements in the rear group share identical glass, separated only by a 0.094 mm air gap — an economical choice that reduces the number of distinct glass types. Combined with L_I and L_VII sharing LaF3, the design uses only five distinct glass types across seven elements.
+
+### L_VII — Biconvex Positive (f ≈ +59.7 mm)
+
+**Shape:** Biconvex (weakly curved front, more strongly curved rear)
+**Radii:** R₁₃ = +131.23 mm, R₁₄ = −62.54 mm
+**Center thickness:** 4.65 mm
+**Glass:** LaF3 (nd = 1.717, νd = 47.9)
+
+L_VII is the final element, responsible for directing the converging beam to the image plane at the correct back focal distance. It has the shortest focal length of the three standalone (uncemented) elements (+59.7 mm) and carries the most concentrated positive power in the rear group. The rear surface (R₁₄ = −62.54 mm, φ = +0.631/f) is the strongest surface of this element.
+
+As the last refracting element, L_VII's surfaces also provide the final opportunity to correct residual aberrations — particularly field curvature and coma — before the beam reaches the image plane. Its biconvex shape, with the more strongly curved surface toward the image, is characteristic of the rear element in asymmetric double-Gauss designs: it provides the positive power needed to achieve the 36.47 mm back focal distance while maintaining correction quality across the field.
+
+## Petzval Sum and Field Curvature
+
+The computed Petzval sum for the system is 0.240 (normalized), giving a Petzval field radius of approximately 229 mm at the 55mm production scale. For a 35mm format lens, this corresponds to a Petzval surface with radius approximately 4.2× the focal length — a reasonable value for a fast standard lens. By comparison, a simple thin biconvex lens of the same focal length in a typical glass (n ≈ 1.7) would have a Petzval radius of n·f ≈ 93.5 mm — the double-Gauss configuration achieves a field about 2.5× flatter.
+
+The Petzval correction comes primarily from the four surfaces flanking the stop:
+
+| Surface | Petzval contribution | Role |
+|---|---|---|
+| r₆ (L_III rear) | −1.215 | Primary negative contributor (front) |
+| r₇ (L_IV front) | −1.231 | Primary negative contributor (rear) |
+| r₃ (L_II front) | +0.795 | Largest positive contributor |
+| r₁₀ (L_V rear) | +0.718 | Second-largest positive contributor |
+
+These four surfaces dominate the Petzval sum, with the two concave surfaces flanking the stop providing nearly all of the negative field correction.
+
+## Focus Method
+
+The Carl Zeiss Contarex Planar 55mm f/1.4 uses **unit focusing** — the entire optical assembly translates forward as a rigid body to focus on closer subjects. This is the standard focus method for virtually all SLR-era standard lenses. There is no internal focusing, rear focusing, or floating element group.
+
+The patent provides optical data only at infinity focus. No close-focus spacing tables are given. For unit focusing, only the back focal distance changes. Using thick-lens principal plane positions (ABCD matrix computation with H at +50.1 mm from the front vertex and H′ at −18.5 mm from the rear vertex), the required extension at the closest focus distance of 0.45 m (from the film plane) is:
+
+**Extension ≈ 8.7 mm** (thick-lens Gaussian conjugate computation: solved 1/s′ − 1/s = 1/f with s and s′ measured from the principal planes)
+
+The back focal distance decreases from 36.47 mm (infinity) to 27.75 mm (0.45 m close focus). The lens group moves forward by approximately 8.7 mm from its infinity position, well within the mechanical range of the Contarex helicoid focusing mount.
+
+## Patent Constraints
+
+The patent claims define the design space through six inequality constraints (a–f), all of which the numerical example satisfies:
+
+**(a)** The front lens (L_I) is a positive meniscus with its more strongly curved surface toward the object. *Satisfied:* R₁ < R₂, both positive, meniscus shape.
+
+**(b)** The penultimate collecting lens (L_VI) is a meniscus with its more strongly curved surface toward the image. *Satisfied:* |R₁₂| < |R₁₁|, both surfaces concave toward object.
+
+**(c)** 1.6 < n̄_z < n̄_s < 1.9, where n̄_z is the mean index of the diverging lenses (L_III, L_IV) and n̄_s is the mean index of the collecting lenses (L_I, L_II, L_V, L_VI, L_VII). *Satisfied:* n̄_z = 1.690, n̄_s = 1.725.
+
+**(d)** 1.5 < n₃ < (n₃ + n₅)/2 < n₄ < 2.0. This constrains the refractive index hierarchy of the elements flanking the stop. *Satisfied:* 1.575 < 1.680 < 1.805.
+
+**(e)** 0.45f < r̄_s < D_s < 0.8f, where r̄_s is the mean of the absolute radii of the two strongest collecting surfaces and D_s is the vertex separation between them. *Satisfied:* 0.450 < 0.548 < 0.676 < 0.800.
+
+**(f)** 0.8f < B < 1.2f, where B is the total track (first to last surface). *Satisfied:* B = 0.965f.
+
+These constraints define a rather specific region of design parameter space that achieves the balance of aberration correction, retrofocal distance, and compact size that characterizes the Berger–Lange Planar.
+
+## Design Significance
+
+The Contarex Planar 55mm f/1.4 is historically notable for several reasons. It was among the first generation of f/1.4 standard lenses designed from the outset for SLR cameras with their demanding back focal distance requirements. The design achieves a back focal distance of 66% of the focal length (36.47 mm) — comfortable clearance for the Contarex's reflex mirror — while maintaining excellent correction at f/1.4 using only spherical surfaces and glasses available in the late 1950s.
+
+The heavy reliance on lanthanum-containing glasses (LaF3 and LaF10 across four of seven elements) was innovative for the period. These materials, which had first become commercially available from Schott in the late 1940s, allowed Berger and Lange to use high refractive indices without the extreme dispersion penalties of traditional dense flint glasses. This glass strategy — high-index lanthanum flints for the positive elements, conventional dense flint (SF6) only for the most critical negative element — became the template for a generation of fast standard lenses that followed.
+
+The design's influence extended beyond Zeiss. After the patent expired, the formula was reportedly adopted by Rollei/Mamiya for the Rolleinar 55mm f/1.4, and its overall configuration (7 elements, 5 groups, cemented doublets flanking the stop) became a reference point for Japanese lens designers of the 1960s developing competing f/1.4 standard lenses for cameras such as the Nikon F and Topcon RE Super.

--- a/src/lens-data/carl-zeiss/CarlZeissContarexPlanar55mmf14.data.ts
+++ b/src/lens-data/carl-zeiss/CarlZeissContarexPlanar55mmf14.data.ts
@@ -1,0 +1,199 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — CARL ZEISS CONTAREX PLANAR 55mm f/1.4       ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: DE 1,170,157 B, sole example (Carl Zeiss).          ║
+ * ║  Modified asymmetric double-Gauss ("Planar").                     ║
+ * ║  7 elements / 5 groups, 0 aspherical surfaces.                   ║
+ * ║  Focus: Unit focus (entire optical assembly translates).          ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent at f = 1.00; all R, d, sd values scaled ×55             ║
+ * ║    to 55 mm production focal length.                              ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Estimated from paraxial marginal + chief ray trace at f/1.4    ║
+ * ║    and ±20° half-field, with 8–10% mechanical clearance.          ║
+ * ║    Constrained by B56 filter thread (≈52 mm clear aperture).      ║
+ * ║    Patent provides no explicit semi-diameter data.                ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP POSITION:                                            ║
+ * ║    Stop inferred from patent Fig. 1 — placed at 50% of the       ║
+ * ║    15.80 mm air gap between L_III rear and L_IV front.            ║
+ * ║                                                                    ║
+ * ║  IMPORTANT: This file describes ONLY the optical design:           ║
+ * ║    ✓ Glass elements and surfaces (front element to image plane)   ║
+ * ║    ✓ Aperture stop and variable focus gap                         ║
+ * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts      ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "carl-zeiss-contarex-planar-55f14",
+  maker: "Carl Zeiss",
+  name: "CARL ZEISS CONTAREX PLANAR 55mm f/1.4",
+  subtitle: "DE 1,170,157 B — CARL ZEISS / BERGER & LANGE",
+  specs: ["7 ELEMENTS / 5 GROUPS", "f = 55.0 mm", "F/1.4", "2ω ≈ 42.9°", "ALL SPHERICAL"],
+
+  /* ── Explicit metadata fields ── */
+  focalLengthMarketing: 55,
+  apertureMarketing: 1.4,
+  patentYear: 1964,
+  elementCount: 7,
+  groupCount: 5,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.717,
+      vd: 47.9,
+      fl: 92.0,
+      glass: "LaF3 (Schott 717479)",
+      apd: false,
+      role: "Front positive meniscus — gentle convergence at full aperture diameter",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Plano-Convex",
+      nd: 1.62299,
+      vd: 58.12,
+      fl: 42.6,
+      glass: "SK/SSK family (623581, discontinued?)",
+      apd: false,
+      role: "Strongest positive element — primary front-group convergence",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Plano-Concave",
+      nd: 1.57501,
+      vd: 41.31,
+      fl: -28.7,
+      glass: "LF7 (Schott 575413)",
+      apd: false,
+      role: "Negative flint — Petzval correction and front doublet achromatization",
+      cemented: "D1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.80518,
+      vd: 25.46,
+      fl: -22.5,
+      glass: "SF6 (Schott 805255)",
+      apd: false,
+      role: "Dense flint — strongest negative surface power; primary Petzval corrector",
+      cemented: "D2",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.78443,
+      vd: 43.77,
+      fl: 37.4,
+      glass: "LaF10 (Schott 784438)",
+      apd: false,
+      role: "Primary rear-group power carrier; cemented against L4 for chromatic correction",
+      cemented: "D2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Positive Meniscus",
+      nd: 1.78443,
+      vd: 43.77,
+      fl: 100.3,
+      glass: "LaF10 (Schott 784438)",
+      apd: false,
+      role: "Field corrector — manages off-axis ray bundle geometry",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.717,
+      vd: 47.9,
+      fl: 59.7,
+      glass: "LaF3 (Schott 717479)",
+      apd: false,
+      role: "Final element — directs converging beam to image plane at correct BFD",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Patent DE 1,170,157 B at f = 1.00, scaled ×55 to production.
+   *  Cemented doublets D1 (L_II+L_III) and D2 (L_IV+L_V) have merged junction surfaces.
+   *  Junction at D1 is flat (R = ∞); junction at D2 is very weakly curved (R = +205.0 mm).
+   */
+  surfaces: [
+    { label: "1", R: 46.563, d: 6.32, nd: 1.717, elemId: 1, sd: 22.0 }, // L1 front
+    { label: "2", R: 149.38, d: 0.094, nd: 1.0, elemId: 0, sd: 20.5 }, // L1 rear → air
+    { label: "3", R: 26.565, d: 9.757, nd: 1.62299, elemId: 2, sd: 19.5 }, // L2 front (D1)
+    { label: "4", R: 1e15, d: 1.392, nd: 1.57501, elemId: 3, sd: 16.0 }, // D1 junction (flat) → L3
+    { label: "5", R: 16.522, d: 7.898, nd: 1.0, elemId: 0, sd: 14.5 }, // L3 rear → air (to stop)
+    { label: "STO", R: 1e15, d: 7.898, nd: 1.0, elemId: 0, sd: 12.8 }, // STO inferred from Fig. 1, 50% of d6 gap
+    { label: "6", R: -19.921, d: 2.046, nd: 1.80518, elemId: 4, sd: 12.8 }, // L4 front (D2)
+    { label: "7", R: 205.0, d: 8.173, nd: 1.78443, elemId: 5, sd: 12.8 }, // D2 junction → L5
+    { label: "8", R: -33.688, d: 0.094, nd: 1.0, elemId: 0, sd: 14.0 }, // L5 rear → air
+    { label: "9", R: -88.979, d: 4.648, nd: 1.78443, elemId: 6, sd: 14.0 }, // L6 front
+    { label: "10", R: -42.713, d: 0.094, nd: 1.0, elemId: 0, sd: 14.5 }, // L6 rear → air
+    { label: "11", R: 131.23, d: 4.648, nd: 1.717, elemId: 7, sd: 14.5 }, // L7 front
+    { label: "12", R: -62.541, d: 36.47, nd: 1.0, elemId: 0, sd: 14.0 }, // L7 rear → image (BFD)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (unit focus) ──
+   *  Unit focus — entire lens translates forward.
+   *  Only the back focal distance changes.
+   *  Close focus at 0.45 m: lens extension ≈ 8.7 mm (thick-lens computation).
+   */
+  var: {
+    "12": [36.47, 45.17],
+  },
+
+  varLabels: [["12", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT", fromSurface: "1", toSurface: "5" },
+    { text: "REAR", fromSurface: "6", toSurface: "12" },
+  ],
+
+  doublets: [
+    { text: "D1", fromSurface: "3", toSurface: "5" },
+    { text: "D2", fromSurface: "6", toSurface: "8" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.45,
+  focusDescription: "Unit focus — entire optical assembly translates forward for close focus.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 1.4,
+  fstopSeries: [1.4, 2, 2.8, 4, 5.6, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.42,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/carl-zeiss/CarlZeissJenaPancolar50mmf2.analysis.md
+++ b/src/lens-data/carl-zeiss/CarlZeissJenaPancolar50mmf2.analysis.md
@@ -1,0 +1,229 @@
+# Carl Zeiss Jena Pancolar 50mm f/2 — Patent Analysis
+
+**Patent:** GB 850,117 (filed 28 March 1958, published 28 September 1960)
+**Inventors:** Eduard Hubert and Harry Zöllner, VEB Carl Zeiss Jena
+**Design:** Gauss-type (double-Gauss), 6 elements in 4 groups
+**Numerical Example:** Claim 2 — f = 100, relative aperture 1:2, S′ = 72.4
+
+---
+
+## 1. Historical Context
+
+The Pancolar 50mm f/2 was designed by Carl Zeiss Jena (the East German successor to the pre-war Carl Zeiss) as a replacement for the older Biotar 58mm f/2. The Biotar — itself a distinguished double-Gauss design dating to Willy Merté's 1927 formula — had been in production since 1936, but at 58mm it was slightly too long to serve as a true "standard" lens on 35mm SLR cameras. The growth of SLR popularity demanded a 50mm normal lens, but the Biotar's back focal length was too short at that focal length to clear the reflex mirror. Zeiss Jena's engineers, Harry Zöllner and Eduard Hubert, solved this problem by reshaping all front-group elements into menisci convex toward the object, which increased the back focal distance to 72.4% of the focal length — just enough to provide the approximately 37mm mirror clearance needed by contemporary SLR bodies.
+
+The optical design was completed on 5 October 1954. A DDR patent (No. 16,756) was filed on 9 September 1956, and the corresponding British patent GB 850,117 followed on 28 March 1958. The first approximately 100 production units were assembled in late 1956 as the "Biotar 2/50" for the Praktina IIA mount, but the lens was almost immediately renamed to "Flexon 2/50" — roughly 1,000 units followed under that name. The renaming was driven by Carl Zeiss Jena's trademark disputes with Carl Zeiss Oberkochen (the West German successor), which made it expedient to retire pre-war trade names. Beginning around summer 1959 the name was changed again to "Pancolar," which became Zeiss Jena's standard designation for double-Gauss type lenses. Importantly, some lenses bearing the Pancolar name still contained the original 1954 optics; the name change preceded an optical redesign that occurred in 1960, which improved edge-of-field performance at full aperture. The design described in GB 850,117 is the **original 1954 design**, not the 1960 revision.
+
+The lens was produced primarily for the Exakta and M42 screw mounts, with some Praktina variants. It remained in production alongside its faster successor, the Pancolar 50mm f/1.8 (introduced 1964), until approximately 1968. The design is a classic double-Gauss consisting of 6 elements arranged in 4 air-separated groups, with two cemented doublets flanking a central diaphragm. The patent prescription is given at a normalised focal length of f = 100; the production lens at f ≈ 50mm requires uniform scaling of all linear dimensions by a factor of 0.5.
+
+---
+
+## 2. Optical Configuration
+
+The Pancolar follows the modified Planar / double-Gauss archetype — arguably the most successful lens configuration ever devised for large-aperture standard lenses. The six elements divide into a symmetric front group and rear group separated by the iris diaphragm.
+
+**Front group** (elements I, II, III — before diaphragm): Element I is a standalone positive meniscus. Elements II and III form a cemented doublet — a positive crown meniscus (II) cemented to a negative flint meniscus (III). The doublet is concave toward the diaphragm.
+
+**Rear group** (elements IV, V, VI — after diaphragm): Elements IV and V form a cemented doublet — a negative flint biconcave (IV) cemented to a positive crown biconvex (V). The doublet is concave toward the diaphragm (i.e., concave toward the front of the lens). Element VI is a standalone positive biconvex element.
+
+The design exhibits the characteristic double-Gauss symmetry: two positive outer elements (I and VI) bracketing two cemented doublets that act as dispersive menisci. This near-symmetry is the key to cancelling odd-order aberrations (coma, distortion, and lateral colour), while the cemented interfaces provide chromatic correction.
+
+### Surface-to-Element Mapping (at f = 100)
+
+| Surface | Radius R | Thickness d | Medium nd | Element |
+|---------|----------|-------------|-----------|---------|
+| r₁ | +57.9 | d_I = 9.2 | 1.66200 | I (entry) |
+| r₂ | +174.9 | l₁ = 0.2 | 1.0 (air) | — |
+| r₃ | +43.5 | d_II = 6.7 | 1.66200 | II (entry) |
+| r₄ | +53.5 | d_III = 8.4 | 1.67246 | III (cemented junction) |
+| r₅ | +26.7 | l₂ = 19.9 | 1.0 (air) | — |
+| — | (STO) | — | 1.0 (air) | Diaphragm |
+| r₆ | −30.1 | d_IV = 3.8 | 1.60156 | IV (entry) |
+| r₇ | +137.0 | d_V = 14.1 | 1.66200 | V (cemented junction) |
+| r₈ | −42.8 | l₃ = 0.6 | 1.0 (air) | — |
+| r₉ | +227.3 | d_VI = 9.5 | 1.66200 | VI (entry) |
+| r₁₀ | −96.0 | BFD | 1.0 (air) | — |
+
+The diaphragm sits in the large air gap l₂ = 19.9 between surfaces r₅ and r₆. The patent does not specify its exact position within this gap; from the accompanying figure, it appears to be located roughly two-thirds of the way through the gap, close to the front face of element IV.
+
+---
+
+## 3. Aspherical Surfaces
+
+**There are no aspherical surfaces in this design.** All ten optical surfaces are purely spherical, defined only by their radii of curvature. The patent makes no mention of aspherical coefficients, conic constants, or any polynomial departure from spherical form.
+
+Some third-party sources — notably the JAPB data sheet — have claimed the Pancolar 50/2 was "one of the first mainstream lenses to include an aspherical element." This claim does not find support in GB 850,117. The patent prescription contains only spherical radii, and neither the descriptive text nor the claims reference aspherical technology. More significantly, the specialised German-language CZJ reference zeissikonveb.de — which documents the Pancolar's design history in considerable detail, including the 1954 original and the 1960 optical revision — makes no mention of aspherical elements in any version of the 50/2. The detailed Flickr-based version survey of all five Pancolar 50mm variants likewise omits any reference to aspherical surfaces. The aspherical claim appears to be unsubstantiated by primary or specialist sources. It may represent a confusion with other Zeiss Jena designs, or possibly an error that has been propagated through secondary literature without verification.
+
+---
+
+## 4. Glass Types
+
+The Pancolar employs a remarkably simple glass palette: only three distinct glass types are used across six elements, with four of the six elements sharing a single crown glass. This economy of glass types reflects both the design philosophy of the era and the practical constraints of East German glass supply.
+
+### Element I: nd = 1.66200, νd = 56.1 — Dense Barium Crown (SSK family)
+
+This glass appears in all four convergent (positive-power) elements: I, II, V, and VI. Its six-digit code is 662/561, placing it in the dense barium crown (SSK — *Schwer-Schwerkron*) or lanthanum crown (LaK) region of the Abbe diagram. It has a moderately high refractive index with good dispersion.
+
+No exact match exists in the modern Schott catalog. The glass sits in the boundary region between the dense barium crown (SSK) and lanthanum crown (LaK) families on the Abbe diagram — a zone that modern catalogs have reorganised. Schott N-LAK22 (nd = 1.65113, νd = 55.89) is in the same general neighbourhood but has noticeably lower index (Δnd = −0.011). This glass was almost certainly manufactured in Jena's own glassworks — VEB Carl Zeiss Jena maintained in-house optical glass production descended from the historic Schott & Genossen glassworks, which had been located in Jena before the postwar division. The patent's use of this single glass in four elements across both the front and rear groups is a deliberate design strategy: it simplifies production logistics while enabling the quasi-symmetric aberration correction that the double-Gauss form relies on.
+
+The patent's Claim 1, condition (g), explicitly requires that all four convergent elements share the same glass type with a refractive index between 1.65 and 1.70. The choice of nd = 1.662 satisfies this condition comfortably.
+
+### Element III: nd = 1.67246, νd = 32.3 — Dense Flint (SF family)
+
+This glass is used only in Element III, the negative (dispersive) component of the front cemented doublet. Its six-digit code is 672/323, placing it squarely in the dense flint (SF — *Schwer-Flint*) family. The closest modern equivalent is Schott SF2 (nd = 1.67270, νd = 32.17), which differs by only Δnd = −0.00024 and Δνd = +0.13 — close enough to constitute an effective match. The Jena equivalent was almost certainly their in-house SF2 formulation.
+
+Dense flint glass is the traditional choice for the negative elements in achromatic doublets. Its high dispersion (low Abbe number) provides the chromatic correction needed when cemented to the positive crown (Element II). The difference in refractive index between Elements II and III is remarkably small — only Δnd = 0.01046 — while the difference in dispersion is large (Δνd = 23.8). This is an order of magnitude smaller than the Δnd ≈ 0.10 typical of conventional Fraunhofer achromatic doublets, and it was highlighted as a design innovation in contemporary coverage: a 1957 article in Modern Photography described the selection of glasses for Elements II and III such that they had nearly identical refractive indices at yellow light. The practical consequence is that the cemented interface at r₄ contributes almost no refractive power at the design wavelength — it acts nearly purely as a chromatic corrector, introducing differential dispersion without generating significant monochromatic aberrations at the cemented surface. This "power-free chromatic surface" is a hallmark of sophisticated double-Gauss optimization.
+
+### Element IV: nd = 1.60156, νd = 35.2 — Special Light Flint
+
+This glass is used only in Element IV, the negative component of the rear cemented doublet. Its six-digit code is 602/352. This is a less common glass — a light-to-medium flint with moderate index and moderate dispersion. No exact match exists in modern major catalogs. The closest Schott glasses are F5 (nd = 1.60342, νd = 38.03) and the historical F4 (nd ≈ 1.600, νd ≈ 36.3), but neither is a precise match.
+
+The choice of a different flint glass in the rear doublet versus the front doublet is a deliberate asymmetry in an otherwise quasi-symmetric design. By using a lower-index, lower-dispersion flint in Element IV (nd = 1.60156, νd = 35.2) compared to Element III (nd = 1.67246, νd = 32.3), the designers introduced a controlled asymmetry that helps correct higher-order monochromatic aberrations — particularly oblique spherical aberration and sagittal coma — that a perfectly symmetric design would leave uncorrected. The patent's Claim 1, condition (h), explicitly requires that the refractive index difference between the rear element of the rear dispersive meniscus (Element V, crown) and its front element (Element IV, flint) falls between 0.06 and 0.10. The actual difference is 1.66200 − 1.60156 = 0.06044, satisfying this condition at its lower bound.
+
+### Summary of Glass Properties
+
+| Element | nd | νd | Glass Family | Role |
+|---------|----|----|-------------|------|
+| I | 1.66200 | 56.1 | Dense Ba Crown (SSK) | Front positive |
+| II | 1.66200 | 56.1 | Dense Ba Crown (SSK) | Doublet crown |
+| III | 1.67246 | 32.3 | Dense Flint (SF2 equiv.) | Doublet flint |
+| IV | 1.60156 | 35.2 | Special Light Flint | Doublet flint |
+| V | 1.66200 | 56.1 | Dense Ba Crown (SSK) | Doublet crown |
+| VI | 1.66200 | 56.1 | Dense Ba Crown (SSK) | Rear positive |
+
+---
+
+## 5. Element-by-Element Optical Analysis
+
+All focal lengths in this section are computed at the patent's normalised f = 100 scale using the ABCD matrix (thick-lens) method. Production-scale values are obtained by dividing by 2.
+
+### Element I — Front Positive Meniscus (f ≈ +126.8 mm)
+
+Surfaces r₁ = +57.9, r₂ = +174.9. Both radii are positive, meaning both surfaces are convex toward the incoming light. The front surface (r₁) is more steeply curved than the rear (r₂), making this a positive meniscus — the classic Gauss-type front element. At 9.2 mm thick (scaled: 4.6 mm), it is a substantial element with a focal length approximately 1.25× the system focal length.
+
+**Optical role:** Element I acts as the primary positive power element of the front group. Its meniscus shape reduces the angle of incidence of off-axis rays on the steeply curved front surface, which limits surface contributions to spherical aberration and coma. The relatively gentle rear surface (R = +174.9) produces only a weak negative refraction, so the element's net power is comfortably positive. By bending the element into a meniscus rather than a biconvex, the designers traded some raw power for significantly better off-axis performance — a hallmark of the Gauss evolution over the older Cooke triplet.
+
+### Elements II + III — Front Cemented Doublet (f ≈ −159.0 mm)
+
+Element II: surfaces r₃ = +43.5 (entry), r₄ = +53.5 (cemented junction). Positive meniscus, nd = 1.66200, νd = 56.1. Individually f ≈ +277.5 mm — a very weak positive element whose individual contribution to system power is modest.
+
+Element III: surfaces r₄ = +53.5 (cemented junction, shared with II), r₅ = +26.7 (exit). Negative meniscus, nd = 1.67246, νd = 32.3. Individually f ≈ −90.7 mm — significantly stronger than Element II, which gives the doublet its net negative power.
+
+The cemented doublet as a whole has a net focal length of approximately −159 mm — weakly negative. Its outer surfaces (r₃ and r₅) are both convex toward the front, making the doublet a meniscus that is concave toward the diaphragm, exactly as the patent describes.
+
+**Optical role:** This is the critical "Gauss meniscus" of the front group. Its primary function is not to contribute significant optical power (its net power is weak) but rather to serve three simultaneous purposes. First, it provides chromatic correction: the crown (II) and flint (III) elements cancel each other's chromatic dispersion through the cemented interface at r₄. Second, the strongly curved rear surface r₅ = +26.7 is the steepest radius in the entire front group; it introduces controlled negative spherical aberration that partially balances the positive spherical aberration of Element I and the front surface of Element II. Third, the Petzval contribution of this doublet is strongly negative (−0.01506 at surface r₅ alone), which is essential for flattening the field curvature introduced by the positive outer elements.
+
+The very weak individual power of Element II (f ≈ +277.5 mm) and the much stronger negative power of Element III (f ≈ −90.7 mm) reflect the unusual glass strategy described in Section 4. Because Elements II and III have nearly identical refractive indices (Δnd = 0.010), the cemented interface r₄ produces almost no refraction at the design wavelength. The two elements' individual powers arise almost entirely from their air-facing surfaces r₃ and r₅; the cemented interface contributes chromatic correction without introducing monochromatic aberrations.
+
+### Elements IV + V — Rear Cemented Doublet (f ≈ −1,315 mm)
+
+Element IV: surfaces r₆ = −30.1 (entry), r₇ = +137.0 (cemented junction). Biconcave, nd = 1.60156, νd = 35.2. Individually f ≈ −40.7 mm — the strongest negative element in the system.
+
+Element V: surfaces r₇ = +137.0 (cemented junction, shared with IV), r₈ = −42.8 (exit). Biconvex, nd = 1.66200, νd = 56.1. Individually f ≈ +50.9 mm — a strong positive element that nearly cancels Element IV's power.
+
+The cemented doublet as a whole has a very weak net focal length of approximately −1,315 mm — nearly afocal. This is a striking feature: while the front doublet has moderately negative power (f ≈ −159), the rear doublet contributes almost no net power at all.
+
+**Optical role:** The rear doublet's near-afocal character reveals the designers' intent: it is optimised almost entirely for aberration correction rather than power contribution. Element IV's biconcave shape with a steeply curved front surface (r₆ = −30.1) introduces strong negative spherical aberration, which is the primary tool for correcting the overcorrected spherical contribution from the large air gap around the diaphragm. Element V's biconvex shape with a relatively strong rear surface (r₈ = −42.8) rebalances the ray bundle for handoff to Element VI. The chromatic correction at the r₇ cemented interface is qualitatively different from the front doublet. In the front doublet, the index difference across the cemented surface is tiny (Δnd = 0.010) while the dispersion difference is large (Δνd = 23.8), creating an almost power-free chromatic corrector. In the rear doublet, the index difference is much larger (Δnd = 0.060) while the dispersion difference is slightly smaller (Δνd = 20.9) — so the cemented surface contributes more refractive power but less pure chromatic leverage. This asymmetry between the two doublets is central to the design's monochromatic aberration correction, as discussed in Section 4.
+
+The Petzval contributions of the rear doublet (−0.01248 at r₆ and +0.00931 at r₈) partially cancel, with a net negative residual that contributes to overall field flattening.
+
+Element V is notably thick: d_V = 14.1 at f = 100 (7.05 mm at production scale). This is the thickest element in the system. The thick biconvex acts almost like a buried singlet within the doublet, contributing positive power while the long path length through the glass helps manage the height and angle of the marginal ray as it traverses the rear group.
+
+### Element VI — Rear Positive Biconvex (f ≈ +103.2 mm)
+
+Surfaces r₉ = +227.3, r₁₀ = −96.0. Both radii produce convex surfaces — a biconvex element. The rear surface (r₁₀ = −96.0) is significantly more strongly curved than the front (r₉ = +227.3), making this an asymmetric biconvex with most of its power concentrated on the rear surface.
+
+**Optical role:** Element VI is the principal positive power element of the rear group, with a focal length (103.2 mm) very close to the system focal length (101.2 mm). Its asymmetric biconvex shape — with the strong surface facing the image — is the reverse of the "best-form" singlet orientation, but this is deliberate: in a double-Gauss design, the rear element must converge an already-converging ray bundle to the focus, and the strong rear surface provides the final refraction that directs rays toward the focal plane. The gently curved front surface (r₉ = +227.3) produces only a mild additional positive contribution, which minimises the surface contribution to spherical aberration at that interface.
+
+The Petzval contribution of Element VI is entirely positive (+0.00175 at r₉ and +0.00415 at r₁₀), which must be balanced by the negative Petzval contributions of the cemented doublets.
+
+---
+
+## 6. Petzval Sum and Field Curvature
+
+The surface-by-surface Petzval sum computes to **Σ = 0.001665**, yielding a Petzval radius of approximately 601 mm at f = 100 (or ~300 mm at production scale f ≈ 50.6). The ratio of Petzval radius to focal length is approximately 5.9 — a very good figure for a double-Gauss design of this era and speed, and comfortably larger than the minimum threshold of about 3× that would produce objectionable field curvature on 35mm format.
+
+For comparison, a simple positive thin singlet of the same glass (nd = 1.662) would have a Petzval radius of n·f = 166.2 mm (at f = 100), giving a Petzval radius / f ratio of only 1.66. The double-Gauss configuration improves this by a factor of approximately 3.6× through the strategic placement of negative-power surfaces (r₅, r₆) that contribute strongly negative Petzval terms.
+
+The largest individual Petzval contributions come from surface r₅ = +26.7 (−0.01506, strongly negative) and surface r₆ = −30.1 (−0.01248, strongly negative). Together, these two surfaces — the innermost surfaces of the two cemented doublets, facing each other across the diaphragm — account for the lion's share of the field-flattening correction. This is the fundamental mechanism of the double-Gauss: the steeply curved inner surfaces of the meniscus doublets provide the negative Petzval correction that the positive outer elements require.
+
+---
+
+## 7. Computed Paraxial Properties (at f = 100)
+
+The following values were independently computed from the patent prescription using the ABCD matrix method (thick-lens paraxial ray trace), not taken from the patent text.
+
+| Property | Computed Value | Patent Value |
+|----------|---------------|--------------|
+| Effective focal length (EFL) | 101.23 mm | 100 mm |
+| Back focal length (BFL) | 73.72 mm | 72.4 (S′) |
+| Front focal length (FFL) | −45.34 mm | — |
+| Total optical track (r₁ to r₁₀) | 72.4 mm | — |
+| Overall length (track + BFL) | 146.1 mm | — |
+
+The computed EFL of 101.23 mm differs from the patent's stated f = 100 by 1.23%, and the BFL of 73.72 differs from the stated S′ = 72.4 by 1.32 mm (1.8%). These discrepancies are attributable to rounding in the patent's single-decimal-place prescription values — entirely typical for patents of this era where radii and thicknesses are rounded to the nearest 0.1 mm. The agreement is well within acceptable tolerances for patent verification.
+
+### Marginal Ray Heights (f/2, collimated input, entrance pupil SD = 25.0)
+
+| Surface | Height (mm) | Notes |
+|---------|-------------|-------|
+| r₁ | 25.00 | Entrance pupil |
+| r₂ | 23.42 | |
+| r₃ | 23.38 | |
+| r₄ | 21.15 | |
+| r₅ | 18.35 | Minimum in front group |
+| r₆ | 16.46 | Near-minimum (diaphragm region) |
+| r₇ | 17.02 | |
+| r₈ | 18.94 | |
+| r₉ | 18.90 | |
+| r₁₀ | 18.21 | |
+
+The marginal ray height decreases monotonically through the front group, reaches its minimum near the diaphragm (between r₅ and r₆), then increases through the rear group. This smooth progression is consistent with a well-designed double-Gauss and indicates that the stop is correctly placed at the natural waist of the marginal ray bundle.
+
+---
+
+## 8. Focusing Mechanism
+
+The patent does not describe the focusing mechanism. For a standard lens of this era and configuration (6 elements, 4 groups, all-spherical, f/2 speed), the expected focusing method is **unit focusing** — the entire optical assembly translates forward as a rigid unit to focus at closer distances, with only the back focal distance (sensor-to-rear-element spacing) changing.
+
+This is consistent with the mechanical construction of the production Pancolar 50/2, which uses a conventional helicoid to translate the entire lens barrel. The minimum focusing distance is 0.5 m. (The shorter 0.35 m figure sometimes encountered in discussions refers to the later Pancolar 50mm f/1.8, a distinct design.) Using Newton's equation for the thick-lens conjugate, unit focusing from infinity to 0.5 m requires approximately 5.7 mm of forward extension at production scale (f ≈ 50.6 mm), or equivalently ~11.4 mm at the patent's normalised f = 100. At the close-focus limit, the back focal distance increases by a corresponding amount (from 36.86 to 42.56 mm at production scale) while all internal air gaps remain fixed.
+
+Since the patent provides data only at infinity focus, the close-focus BFD was computed via Newton's equation x·x′ = −f² using the thick-lens principal plane positions.
+
+---
+
+## 9. Patent Claims Analysis
+
+The patent's Claim 1 defines a set of parametric constraints that any design within its scope must satisfy. Claim 2 then presents the specific numerical example (the prescription analysed in this document) as one instance satisfying all of Claim 1's conditions. The conditions were independently verified against the numerical example:
+
+| Condition | Requirement | Actual | Status |
+|-----------|-------------|--------|--------|
+| (a) r₃ − \|r₈\| ≤ 0.02f | ≤ 2.0 | 0.7 | ✓ |
+| (b) \|r₃\| + \|r₈\| ∈ [0.85f, 0.90f] | 85.0–90.0 | 86.3 | ✓ |
+| (c) r₄ ∈ [0.50f, 0.55f] | 50.0–55.0 | 53.5 | ✓ |
+| (d) r₇ ∈ [1.2f, 1.7f] | 120.0–170.0 | 137.0 | ✓ |
+| (e) r₅ ∈ [0.26f, 0.28f] | 26.0–28.0 | 26.7 | ✓ |
+| (f) \|r₆\| ∈ [0.29f, 0.32f] | 29.0–32.0 | 30.1 | ✓ |
+| (g) All convergent elements: nd ∈ [1.65, 1.70] | — | 1.662 | ✓ |
+| (h) nd(V) − nd(IV) ∈ [0.06, 0.10] | — | 0.060 | ✓ |
+
+All eight conditions are satisfied. Condition (h) is met at its lower bound (0.06044 ≈ 0.06), suggesting the designers chose the minimum index difference that the patent scope allowed for the rear doublet — maximising the index contrast with the crown while keeping it just within the claimed range.
+
+---
+
+## 10. Production Scaling
+
+The patent prescription is normalised to f = 100. The production Pancolar 50mm f/2 operates at approximately half this focal length, requiring a uniform scale factor of 0.5 applied to all linear dimensions (R, d, sd). Angular quantities (f-number, field angle) and material properties (nd, νd) are scale-invariant and remain unchanged.
+
+At production scale (f ≈ 50.6 mm), the key physical dimensions become: total optical track ≈ 36.2 mm, back focal length ≈ 36.9 mm, overall length ≈ 73.1 mm, and the air gap containing the diaphragm narrows to approximately 10.0 mm. The half-field angle on 35mm format (24 × 36 mm) is approximately 23.2°, yielding a full diagonal field of view of roughly 46.3°.
+
+The back focal length deserves particular attention. As the German CZJ reference zeissikonveb.de explains, the BFL of 72.4% of focal length was the key optical achievement that made a 50mm SLR lens feasible. Contemporary SLR mirror boxes required a minimum of approximately 37mm of free air path behind the last lens vertex for the reflex mirror to operate. At f = 50mm, the BFL of ~36.2 mm (or ~36.9 mm using the computed EFL) is right at this threshold. By comparison, the older Biotar 58mm f/2 had a shorter BFL-to-focal-length ratio — perfectly adequate at 58mm but insufficient had the focal length been shortened to 50mm without a fundamental redesign of the front group. The Pancolar's meniscus-heavy front group design — with all five optical surfaces before the stop (r₁ through r₅) convex toward the object — is what achieved the necessary BFL increase, and it explains why the patent's descriptive text and claims focus so heavily on the meniscus forms and their radii.
+
+---
+
+## 11. Design Lineage and Significance
+
+The Pancolar sits firmly in the lineage of symmetric double-Gauss derivatives that began with Rudolph's Planar (1896) and evolved through the Biotar, Ultron, Xenon, and Summicron families. Its 6-element, 4-group configuration with two cemented meniscus doublets flanking a central stop is the most common form of this archetype.
+
+What distinguishes the Pancolar's design from many of its contemporaries is the extreme economy of its glass selection — four of six elements using identical glass. This is not merely a manufacturing convenience; it is a deliberate optical strategy. By using the same crown glass on both sides of the diaphragm, the designers ensured that the chromatic properties of the front and rear groups would be inherently matched, simplifying the chromatic balancing problem and allowing the (necessarily asymmetric) monochromatic correction to be tuned independently. The intentional asymmetry is then introduced through the flint glass selection: a heavier flint (SF2 equivalent, νd = 32.3) in the front doublet and a lighter special flint (νd = 35.2) in the rear doublet.
+
+The design achieves a Petzval sum of 0.00167 (at f = 100), corresponding to a Petzval radius approximately 5.9× the focal length — excellent field flatness for a double-Gauss of this era and speed.

--- a/src/lens-data/carl-zeiss/CarlZeissJenaPancolar50mmf2.data.ts
+++ b/src/lens-data/carl-zeiss/CarlZeissJenaPancolar50mmf2.data.ts
@@ -1,0 +1,183 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — Carl Zeiss Jena Pancolar 50mm f/2                     ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: GB 850,117 Claim 2 (Hubert & Zöllner, VEB CZJ).     ║
+ * ║  Classic double-Gauss (modified Planar) for M42/Exakta SLR.        ║
+ * ║  6 elements / 4 groups, 0 aspherical surfaces.                     ║
+ * ║  Focus: unit focusing (entire lens translates).                    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent prescription at f = 100; all R, d, and sd values scaled  ║
+ * ║    ×0.5 to match production focal length f ≈ 50 mm.               ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    SDs estimated from combined marginal + chief ray trace (0.7     ║
+ * ║    field) with ~8–10% mechanical clearance, constrained by edge    ║
+ * ║    thickness, sd/|R| ≤ 0.90, and cross-gap sag limits. The front  ║
+ * ║    group SDs are constrained by L1's edge thickness (et ≈ 0.2 mm  ║
+ * ║    at sd = 18.0) and r5's steep curvature (sd/|R| = 0.82).        ║
+ * ║    Vignetting at 0.7+ field is expected for this f/2 design.      ║
+ * ║                                                                    ║
+ * ║  STOP POSITION:                                                    ║
+ * ║    Patent does not specify exact diaphragm location within the     ║
+ * ║    l₂ air gap. Estimated at ~65% through the gap from the patent  ║
+ * ║    cross-section figure (close to the front face of element IV).   ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "carl-zeiss-jena-pancolar-50f2",
+  maker: "Carl Zeiss Jena",
+  name: "CARL ZEISS JENA PANCOLAR 50mm f/2",
+  subtitle: "GB 850,117 CLAIM 2 — VEB CARL ZEISS JENA / HUBERT & ZÖLLNER",
+  specs: ["6 ELEMENTS / 4 GROUPS", "f ≈ 50.6 mm", "F/2.0", "2ω ≈ 46.3°", "ALL SPHERICAL"],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: 50,
+  focalLengthDesign: 50.6,
+  apertureMarketing: 2.0,
+  // apertureDesign omitted — matches marketing
+  patentYear: 1960,
+  elementCount: 6,
+  groupCount: 4,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.662,
+      vd: 56.1,
+      fl: 63.4,
+      glass: "SSK / LaK (Jena in-house, 662/561)",
+      apd: false,
+      role: "Front positive power element; meniscus form reduces off-axis aberrations",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.662,
+      vd: 56.1,
+      fl: 138.7,
+      glass: "SSK / LaK (Jena in-house, 662/561)",
+      apd: false,
+      cemented: "D1",
+      role: "Front doublet crown; provides chromatic correction with L3",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.67246,
+      vd: 32.3,
+      fl: -45.3,
+      glass: "SF2 equivalent (Jena in-house, 672/323)",
+      apd: false,
+      cemented: "D1",
+      role: "Front doublet flint; steep r₅ generates negative Petzval and spherical correction",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.60156,
+      vd: 35.2,
+      fl: -20.3,
+      glass: "Special light flint (Jena in-house, 602/352)",
+      apd: false,
+      cemented: "D2",
+      role: "Rear doublet flint; strong negative spherical aberration corrects the diaphragm air gap",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.662,
+      vd: 56.1,
+      fl: 25.4,
+      glass: "SSK / LaK (Jena in-house, 662/561)",
+      apd: false,
+      cemented: "D2",
+      role: "Rear doublet crown; thick biconvex (7.05 mm) manages marginal ray height through rear group",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.662,
+      vd: 56.1,
+      fl: 51.6,
+      glass: "SSK / LaK (Jena in-house, 662/561)",
+      apd: false,
+      role: "Rear positive power element; asymmetric biconvex converges rays to focus",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  All values at production scale (patent f = 100 scaled ×0.5).
+   *  Diaphragm position inferred from patent Fig. 1 (~65% through l₂ gap).
+   */
+  surfaces: [
+    { label: "1", R: 28.95, d: 4.6, nd: 1.662, elemId: 1, sd: 18.0 },
+    { label: "2", R: 87.45, d: 0.1, nd: 1.0, elemId: 0, sd: 17.0 },
+    { label: "3", R: 21.75, d: 3.35, nd: 1.662, elemId: 2, sd: 17.0 },
+    { label: "4", R: 26.75, d: 4.2, nd: 1.67246, elemId: 3, sd: 15.0 }, // L2→L3 cemented junction
+    { label: "5", R: 13.35, d: 6.47, nd: 1.0, elemId: 0, sd: 11.0 }, // L3 rear → air; d = distance to STO
+    { label: "STO", R: 1e15, d: 3.48, nd: 1.0, elemId: 0, sd: 8.7 }, // STO position inferred from Fig. 1
+    { label: "6", R: -15.05, d: 1.9, nd: 1.60156, elemId: 4, sd: 10.0 },
+    { label: "7", R: 68.5, d: 7.05, nd: 1.662, elemId: 5, sd: 11.0 }, // L4→L5 cemented junction
+    { label: "8", R: -21.4, d: 0.3, nd: 1.0, elemId: 0, sd: 13.5 },
+    { label: "9", R: 113.65, d: 4.75, nd: 1.662, elemId: 6, sd: 13.5 },
+    { label: "10", R: -48.0, d: 36.86, nd: 1.0, elemId: 0, sd: 15.0 }, // BFD to image plane
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (unit focus) ──
+   *  Only the BFD changes during focus. Entire lens translates as a rigid unit.
+   *  Close-focus BFD computed via Newton's equation at MFD = 0.5 m.
+   */
+  var: {
+    "10": [36.86, 42.56],
+  },
+
+  varLabels: [["10", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT", fromSurface: "1", toSurface: "5" },
+    { text: "REAR", fromSurface: "6", toSurface: "10" },
+  ],
+
+  doublets: [
+    { text: "D1", fromSurface: "3", toSurface: "5" },
+    { text: "D2", fromSurface: "6", toSurface: "8" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.5,
+  focusDescription: "Unit focusing — entire lens translates forward via helicoid.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.0,
+  fstopSeries: [2, 2.8, 4, 5.6, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.32,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/carl-zeiss/CarlZeissPlanarT50mmf14.analysis.md
+++ b/src/lens-data/carl-zeiss/CarlZeissPlanarT50mmf14.analysis.md
@@ -1,0 +1,193 @@
+# Carl Zeiss Planar T* 50mm f/1.4 — Optical Analysis
+
+## Patent Attribution
+
+**US Patent 3,874,771** — *Photographic Objective of the Extended Gauss Type*
+Filed: June 25, 1973 (German priority DE 2232101, June 30, 1972)
+Granted: April 1, 1975
+Inventors: Karl-Heinrich Behrens, Erhard Glatzel
+Assignee: Carl Zeiss Stiftung d/b/a Carl Zeiss, Oberkochen, Germany
+
+This analysis is based on **Example 5** (Table 5) of the patent, one of two "fine-corrected" embodiments designed for color photography at f/1.4. The patent provides five examples; Examples 1–3 are monochromatic rough forms at f/1.5, while Examples 4 and 5 are fully achromatized designs at f/1.4 with glass dispersion data (Abbe numbers). Both Examples 4 and 5 use identical glass types and share the 7-element/6-group configuration of the production lens; without direct confirmation from Zeiss, either (or a closely related derivative) could be the basis of the production design. Example 5 is analyzed here as the more likely candidate, being the final and presumably most refined example in the patent sequence.
+
+The production Carl Zeiss Planar T* 50mm f/1.4 was announced in 1974 and first shipped in 1975 with the Contax RTS for the Contax/Yashica mount system. The optical design was subsequently carried over to the ZF.2 (Nikon F-mount) and ZE (Canon EF-mount) versions, making it one of the longest-lived fast-fifty optical formulas in continuous production.
+
+The patent is normalized to an equivalent focal length of F = 1.0000. For the production 50mm lens, all linear dimensions scale by a factor of 50.
+
+## Design Overview
+
+The Planar T* 50mm f/1.4 is a **7-element, 6-group extended double-Gauss** design. It is entirely spherical — the patent explicitly states that the design achieves its imaging quality "without the need for using extreme shapes or aspherical surfaces or for using extreme glass types" (col. 3, lines 10–14). This is a significant claim: at f/1.4 with a 46.8° diagonal field, achieving adequate correction without aspheres demands considerable skill in glass selection and air-space tuning.
+
+The seven elements divide into a front member (V, the German *Vorderglied*) comprising elements L1, L2, and L3 — all uncemented and air-spaced — and a rear member (H, *Hinterglied*) comprising elements L4 through L7, where L4 and L5 are cemented together while L6 and L7 are air-spaced. A large central air space (CS) separates the two members, serving as the location for the iris diaphragm.
+
+### Key Computed Parameters (Verified by ABCD Matrix Ray Trace)
+
+| Parameter | Normalized (F=1) | Scaled to 50mm |
+|---|---|---|
+| Effective focal length (EFL) | 1.0000 F | 50.00 mm |
+| Back focal distance (BFD) | 0.7100 F | 35.50 mm |
+| Overall length (OAL, vertex to vertex) | 0.8197 F | 40.98 mm |
+| Total track (OAL + BFD) | 1.5296 F | 76.48 mm |
+| Central air space (CS) | 0.2855 F | 14.27 mm |
+| Maximum aperture | f/1.4 | — |
+| Entrance pupil semi-diameter | 0.3571 F | 17.86 mm |
+| Diagonal half-field (35mm format) | — | 23.4° |
+| Petzval sum | 0.196 | — |
+| Petzval radius | 5.10 F | 255 mm |
+| Retrofit ratio (BFD/EFL) | 0.710 | — |
+
+The Petzval sum of 0.196 yields a Petzval radius of approximately 255 mm at the production focal length — moderate by modern standards but typical for a fast double-Gauss of this era. The retrofit ratio of 0.71 provides adequate mirror clearance for the Contax/Yashica mount (45.5 mm flange distance), placing the rear vertex of L7 approximately 10 mm in front of the lens mount flange.
+
+## Aspherical Surfaces
+
+**There are none.** This is unambiguous: the patent text, all five numerical examples, and the claims describe an entirely spherical system. The correction of spherical aberration, field curvature, and coma at f/1.4 is achieved through the extended Gauss configuration itself — specifically through the careful distribution of refractive power among five air lenses (α, β, CS, γ, δ), the use of high-index lanthanum glasses, and the air-spacing (rather than cementing) of the front negative combination N1. This last feature — splitting L2 and L3 apart to create the divergent air lens β — is the design's central mechanism for controlling higher-order spherical aberration.
+
+## Glass Identification
+
+The patent lists both refractive index (nd, at the helium d-line, 587.6 nm) and Abbe number (Vd) for each element in Examples 4 and 5. Because the assignee is Carl Zeiss Oberkochen, the production lens would have used glasses from the Schott catalog, Zeiss's in-house glass supplier. The identifications below match the patent's nd/Vd pairs against the Schott catalog. Note that many Schott glasses have been reformulated since the 1970s to remove lead and arsenic (the modern "N-" prefix denotes these eco-friendly reformulations), so the exact catalog names given here reflect the original 1970s designations where the nd/Vd match is nearest.
+
+| Element | nd | Vd | Six-digit code | Glass identification | Confidence |
+|---|---|---|---|---|---|
+| L1 | 1.71700 | 47.99 | 717/480 | **Schott LaK 21** (nd=1.71700, Vd=47.98) | Exact match |
+| L2 | 1.78831 | 47.37 | 788/474 | **Schott LaF 21** (nd≈1.788, Vd≈47.4) | Near-exact; modern N-LAF21 has nd=1.788, Vd=47.49 |
+| L3 | 1.68893 | 31.17 | 689/312 | **Schott SF 56** (nd=1.68893, Vd=31.18) | Exact match |
+| L4 | 1.72830 | 28.68 | 728/287 | **Schott SF 10 family** (nd=1.72825, Vd=28.41); Vd residual +0.27 | Close; likely a period-specific melt or related dense flint |
+| L5 | 1.78831 | 47.37 | 788/474 | **Schott LaF 21** (same as L2) | Near-exact |
+| L6 | 1.78831 | 47.37 | 788/474 | **Schott LaF 21** (same as L2 and L5) | Near-exact |
+| L7 | 1.74400 | 44.77 | 744/448 | **Schott LaF 2** (nd=1.74400, Vd=44.77) | Exact match |
+
+Several observations emerge from the glass map:
+
+The design uses only **five distinct glass types** across seven elements (three lanthanum-bearing, two dense flints). Three elements (L2, L5, L6) share the same lanthanum flint glass (LaF 21), and two of the remaining four use exact-match catalog glasses (LaK 21 for L1 and LaF 2 for L7). This economy of glass types is typical of 1970s Zeiss practice, where Schott and Zeiss maintained a curated catalog relationship.
+
+Five of the seven elements use **lanthanum-containing glasses** — LaK (lanthanum crown) and LaF (lanthanum flint) types — in the positive collecting positions (L1, L2, L5, L6, L7). These provide the high refractive index needed to flatten the Petzval surface while maintaining moderate dispersion for chromatic control. The two diverging elements (L3 and L4) are **dense flints** (SF family), which supply the high dispersion needed for chromatic correction at the cemented interface and across the air-spaced front negative combination.
+
+L4, the front element of the cemented doublet, presents the most uncertain identification. Its nd = 1.72830 matches Schott SF 10 closely (nd = 1.72825), but its Vd = 28.68 deviates from SF 10's standard Vd of 28.41 by about +0.27 units. This could indicate a period-specific melt variant, a related glass that has since been discontinued, or a deliberate design-stage rounding. The mismatch is small enough that it does not materially affect the chromatic analysis.
+
+## Element-by-Element Optical Analysis
+
+### Front Member (V): Elements L1, L2, L3
+
+The front member as a group has a focal length of 2.87F (143.5 mm at production scale), meaning it is a weakly positive collective group. Its role is to pre-converge the incoming beam toward the stop while introducing controlled amounts of negative spherical aberration and coma that will be balanced by the rear member.
+
+**Element L1** — *Positive Meniscus (convex forward)*
+- Surfaces: R1 = +44.45 mm, R'1 = +288.66 mm
+- Thickness: 5.09 mm
+- Glass: LaK 21 (nd = 1.71700, Vd = 47.99)
+- Element focal length: +1.45F (+72.7 mm)
+
+L1 is the front positive element (designated Pv in the patent's structural analysis). It is a strongly unequal-sided meniscus: the front surface has a relatively tight 44.5 mm radius while the rear surface is nearly flat at 288.7 mm. This meniscus shape reduces surface reflection losses and minimizes the contribution to spherical aberration compared to a biconvex form at the same power. Its role is to provide the primary positive refractive power of the front group, bending the incoming marginal rays inward. The LaK 21 glass is a lanthanum crown with high index (1.717) and moderate dispersion (Vd ≈ 48), enabling a shallower front curvature (and thus less surface aberration) than a lower-index glass would require for the same power.
+
+**Element L2** — *Positive Meniscus (convex forward)*
+- Surfaces: R2 = +21.80 mm, R'2 = +34.06 mm
+- Thickness: 4.86 mm
+- Glass: LaF 21 (nd = 1.78831, Vd = 47.37)
+- Element focal length: +1.31F (+65.4 mm)
+
+L2 is the second collecting element, and the one with the strongest curvatures among the positive front-group elements. Its front radius of only 21.8 mm at production scale is among the steepest in the system (exceeded only by L3's rear surface at 15.3 mm and L4's front surface at 17.3 mm). The meniscus shape (both surfaces convex toward the object) controls the angle of incidence at each surface, reducing higher-order spherical aberration. The LaF 21 glass (nd = 1.788) is the highest-index material in the design, and its use here is critical: the high index reduces the bending angle at each surface for a given power, directly suppressing fifth-order spherical aberration, which is the dominant residual at f/1.4. The air space between L1 and L2 is extraordinarily thin (0.059 mm at production scale), making them essentially a close-contact pair — but deliberately not cemented. This air gap (air lens α) has a positive refractive power sum, contributing to the delicate balance of air-lens powers that the patent's conditions A through C specify.
+
+**Element L3** — *Negative Meniscus (convex forward)*
+- Surfaces: R3 = +47.09 mm, R'3 = +15.32 mm
+- Thickness: 1.19 mm
+- Glass: SF 56 (nd = 1.68893, Vd = 31.17)
+- Element focal length: −0.67F (−33.5 mm)
+
+L3 is the first of two diverging elements and plays a pivotal role in the extended Gauss correction strategy. It is a thin, strongly negative meniscus with its steeper (rear) surface facing the central air space. The air space between L2 and L3 (air lens β, 1.59 mm at production) forms a powerfully divergent air lens whose refractive power sum is negative — one of the patent's key conditions (A1). This air lens β partially relieves the overcorrecting effect of the central air space (CS) by distributing the negative power across two air lenses rather than concentrating it at the stop, enabling control of higher-order spherical aberration.
+
+The SF 56 glass has the lowest Abbe number (31.17) and moderate index (1.689) among the front elements, identifying it as a dense flint. Its high dispersion relative to the surrounding lanthanum glasses creates a chromatic divergence that is later corrected by the rear group's cemented doublet.
+
+### Central Air Space (CS) and Aperture Stop
+
+The central space between L3 and L4 is 14.27 mm at production scale — by far the largest gap in the system, occupying over a third of the OAL. The iris diaphragm sits within this space. The CS constitutes the third air lens, and the patent's condition A2 requires its refractive power sum to be negative, with a magnitude between 8.09 and 12.50 times the refractive power of air lens β. This large multiplier reflects the CS's dominant role in overcorrecting the Petzval sum and introducing the negative spherical aberration contribution that characterizes all double-Gauss designs.
+
+The aperture stop position within the CS is not specified by the patent and must be inferred from the lens cross-section diagram (Fig. 1). In the production lens, it sits approximately at the midpoint of the CS, roughly 7.1 mm behind the rear vertex of L3.
+
+### Rear Member (H): Elements L4, L5, L6, L7
+
+The rear member has a focal length of 0.86F (42.8 mm) — significantly more powerful than the front group. This asymmetry is characteristic of retrofocus-influenced Gauss designs that must provide adequate back focal distance for SLR mirror clearance.
+
+**Element L4** — *Biconcave Negative* (cemented to L5)
+- Surfaces: R4 = −17.32 mm, R'4 = +374.02 mm (junction)
+- Thickness: 1.15 mm
+- Glass: SF 10 family (nd = 1.72830, Vd = 28.68)
+- Element focal length: −0.45F (−22.7 mm)
+- Cemented group: N2 (negative combination, with L5)
+
+L4 is the second diverging element, positioned immediately behind the stop. Its front surface (R4 = −17.32 mm) is a steeply concave surface facing the stop — the deepest concavity in the system. This surface is the primary source of negative Petzval contribution from the rear group. The junction surface at R'4 = +374 mm is nearly flat (radius over 370 mm), which means the cemented interface between L4 and L5 contributes almost no refractive power — its function is purely chromatic, creating the index step (Δn = 0.060) needed for color correction without introducing geometric aberrations.
+
+L4 is the strongest negative element in the system, with a focal length of −22.7 mm (−0.45F) — more powerful than L3 at −33.5 mm. Its steep front surface bending is necessary to generate sufficient negative Petzval contribution behind the stop, where the marginal ray height is large and the aberration leverage is greatest.
+
+The SF 10-family glass (dense flint, Vd = 28.68) is paired with the LaF 21 lanthanum flint of L5 to form the system's primary achromatic correction. Despite both being classified as "flints" in Schott nomenclature, their dispersions differ by nearly a factor of two (Vd = 28.68 vs. 47.37), which provides the differential dispersion needed for color correction.
+
+**Element L5** — *Biconvex Positive* (cemented to L4)
+- Surfaces: R5 = +374.02 mm (junction), R'5 = −30.36 mm
+- Thickness: 5.15 mm
+- Glass: LaF 21 (nd = 1.78831, Vd = 47.37)
+- Element focal length: +0.72F (+35.8 mm)
+- Cemented group: N2 (with L4)
+
+L5 is the strongest positive element in the rear group and the thickest element behind the stop (5.15 mm). Its rear surface (R'5 = −30.36 mm) is the primary positive refracting surface of the rear member, bending the rays back toward the axis after their divergence through the CS and L4. The high-index LaF 21 glass again reduces surface angles and suppresses higher-order aberrations.
+
+Together, the cemented doublet L4+L5 has a combined focal length of −1.66F (−82.9 mm) — net negative. This is a hallmark of the extended Gauss design: the inner doublet near the stop is a diverging unit, not a converging one. Its negative power contributes to Petzval flattening while the individual elements' opposite dispersions provide chromatic correction. The patent designates this pair as N2, the rear negative combination, mirroring the front negative combination N1 (L2+L3, which are air-spaced rather than cemented).
+
+**Element L6** — *Positive Meniscus (concave forward)*
+- Surfaces: R6 = −87.43 mm, R'6 = −28.25 mm
+- Thickness: 4.38 mm
+- Glass: LaF 21 (nd = 1.78831, Vd = 47.37)
+- Element focal length: +1.03F (+51.3 mm)
+
+L6 begins the rear positive combination (PH in the patent's nomenclature). It is a meniscus with both surfaces concave toward the object — a shape that is qualitatively the mirror image of L2's convex-forward meniscus in the front group. This approximate symmetry about the stop (though the curvatures differ substantially: L2 is far more strongly curved) is characteristic of the double-Gauss heritage and contributes to the cancellation of odd-order aberrations (coma, distortion, lateral chromatic aberration).
+
+The air space between L5 and L6 (air lens γ, 0.28 mm at production) is thin but not as extreme as the α space between L1 and L2 (0.059 mm). The patent's conditions B1 and B2 constrain the refractive power sums of the first air lens (α) and last air lens (δ, between L6 and L7) to be within specific ranges of the total system power, and condition C constrains their ratio (Q = φα / φδ) to be between 0.944 and 1.310. This balanced distribution of positive air-lens power at the extremes of the system is key to minimizing asymmetric coma in wide-open inclined beams.
+
+**Element L7** — *Biconvex Positive*
+- Surfaces: R7 = +164.68 mm, R'7 = −130.81 mm
+- Thickness: 2.83 mm
+- Glass: LaF 2 (nd = 1.74400, Vd = 44.77)
+- Element focal length: +1.97F (+98.4 mm)
+
+L7 is the final element, a weakly positive biconvex lens that provides the last course correction before the image plane. Its curvatures are gentle compared to the inner elements (164.7 mm and 130.8 mm at production), reflecting its role as a field-flattening corrector rather than a primary power element. The air space between L6 and L7 (air lens δ, 0.13 mm at production) is very thin — though not the thinnest gap in the system (that distinction belongs to the α space between L1 and L2 at just 0.059 mm). Together, L6 and L7 form a near-contact positive pair. The LaF 2 glass (nd = 1.744, Vd = 44.77) is a moderate-index lanthanum flint, slightly lower in index than the LaF 21 used elsewhere — this difference helps fine-tune the marginal chromatic balance at the system exit.
+
+## Focus Mechanism
+
+The patent provides prescription data at infinity focus only and does not describe a focusing mechanism. The production Zeiss Planar T* 50mm f/1.4 employs **unit focusing** — the entire optical assembly moves forward as a rigid unit when focusing to closer distances. The minimum focus distance of the C/Y mount version is 0.45 m (1.5 ft); the later ZF/ZE versions reduced this to 0.35 m.
+
+In a unit-focus system, only the back focal distance (BFD) changes during focusing. As the lens moves forward to focus closer, the image conjugate shortens and the BFD increases. No internal element spacings change, which means the aberration balance shifts at close focus — a characteristic of the design that manifests as the modest softness at wider apertures noted by reviewers of this lens when shooting near the minimum focus distance.
+
+Because this is unit focus with a single variable gap (the BFD), the close-focus BFD can be computed from the ABCD system matrix and the total conjugate distance. At 0.45 m object-to-film distance with the full thick-lens model, the required BFD increases from 35.50 mm to approximately 42.6 mm, an extension of about 7.1 mm. This corresponds to a magnification of approximately −0.14.
+
+## Aberration Correction Strategy
+
+The patent text lays out the design philosophy through six conditions (A1, A2, B1, B2, B3, and C) that govern the distribution of refractive power among the air lenses. These conditions encode the following correction strategy:
+
+**Conditions A1 and A2** control the spherical aberration balance. By distributing negative air-lens power between β (the L2–L3 air space) and CS (the central stop space) in a specific ratio, the overcorrecting effect of the central air lens is partially relieved. This reduces higher-order (fifth and seventh order) spherical aberration contributions, which are the dominant limitation at f/1.4.
+
+**Conditions B1, B2, and B3** control the field correction. The positive air lenses α (L1–L2 space) and δ (L6–L7 space) are constrained both individually and in sum to ensure that the imaging power extends to the margins of the field. The balanced positive power at the system extremes corrects field curvature and astigmatism across the full 47° diagonal.
+
+**Condition C** controls coma symmetry. The ratio of air lens α's power to air lens δ's power (Q = φα / φδ) is constrained to be near unity (between 0.944 and 1.310), ensuring that the asymmetric coma contributions from the front and rear positive air lenses nearly cancel. For Example 5, the patent's Table 6 gives Q = 1.0385, very close to balanced.
+
+The net result is a design that achieves at f/1.4 what earlier Gauss derivatives could only accomplish at f/2: adequate correction of the five Seidel aberrations plus higher-order spherical and coma terms, with reasonable chromatic performance for color photography, all without aspherical surfaces.
+
+## Summary
+
+The Carl Zeiss Planar T* 50mm f/1.4, as described in US Patent 3,874,771 Example 5, represents a mature and elegant expression of the extended double-Gauss design philosophy. Its seven all-spherical elements use only five distinct glass types from the Schott catalog — three lanthanum-bearing (LaK 21, LaF 21, LaF 2) and two dense flints (SF 56, SF 10) — achieving f/1.4 performance through meticulous tuning of the five air-lens powers rather than through exotic surfaces or materials. The design's longevity — announced in 1974 and manufactured through the 2020s in various mount iterations — is a testament to the robustness of Behrens and Glatzel's correction strategy, which trades the theoretical perfection of aspherical designs for a rugged, manufacturable system that delivers consistent imaging quality across millions of production units.
+
+---
+
+## Appendix: Verified Prescription Data (Example 5, Scaled to F = 50 mm)
+
+| Surface | R (mm) | d (mm) | nd (after) | Element |
+|---|---|---|---|---|
+| S1 (L1 front) | +44.452 | 5.091 | 1.71700 | L1 |
+| S2 (L1 rear) | +288.661 | 0.059 | 1.00000 | air |
+| S3 (L2 front) | +21.804 | 4.856 | 1.78831 | L2 |
+| S4 (L2 rear) | +34.062 | 1.589 | 1.00000 | air |
+| S5 (L3 front) | +47.086 | 1.187 | 1.68893 | L3 |
+| S6 (L3 rear) | +15.324 | 14.273 | 1.00000 | air (CS/stop) |
+| S7 (L4 front) | −17.319 | 1.148 | 1.72830 | L4 |
+| S8 (L4–L5 junction) | +374.022 | 5.150 | 1.78831 | L5 |
+| S9 (L5 rear) | −30.357 | 0.284 | 1.00000 | air |
+| S10 (L6 front) | −87.426 | 4.385 | 1.78831 | L6 |
+| S11 (L6 rear) | −28.250 | 0.128 | 1.00000 | air |
+| S12 (L7 front) | +164.680 | 2.835 | 1.74400 | L7 |
+| S13 (L7 rear) | −130.808 | 35.497 | 1.00000 | air (BFD) |

--- a/src/lens-data/carl-zeiss/CarlZeissPlanarT50mmf14.data.ts
+++ b/src/lens-data/carl-zeiss/CarlZeissPlanarT50mmf14.data.ts
@@ -1,0 +1,192 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — Carl Zeiss Planar T* 50mm f/1.4              ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 3,874,771 Example 5 (Behrens & Glatzel / Zeiss). ║
+ * ║  Extended double-Gauss, 7 elements / 6 groups, all spherical.     ║
+ * ║  Focus: unit focusing (entire lens moves).                         ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                   ║
+ * ║    Patent prescription normalized to F = 1.0000.                   ║
+ * ║    All R, d, sd values scaled ×50 to f = 50 mm production.        ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not list semi-diameters. SDs estimated from         ║
+ * ║    paraxial marginal ray trace at f/1.4 with 8% mechanical        ║
+ * ║    clearance. S6 (L3 rear) SD reduced to 13.5 mm to satisfy       ║
+ * ║    sd/|R| < 0.90 constraint (R = +15.324 mm).                     ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP POSITION:                                            ║
+ * ║    Patent does not specify iris placement within the central       ║
+ * ║    air space (CS = 14.273 mm). Stop placed at midpoint of CS,     ║
+ * ║    inferred from Fig. 1 iris location.                             ║
+ * ║                                                                    ║
+ * ║  IMPORTANT: This file describes ONLY the optical design:           ║
+ * ║    ✓ Glass elements and surfaces (front element to image plane)   ║
+ * ║    ✓ Aperture stop and variable focus gap                         ║
+ * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts      ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "zeiss-planar-t-50f14",
+  maker: "Carl Zeiss",
+  name: "CARL ZEISS PLANAR T* 50mm f/1.4",
+  subtitle: "US 3,874,771 EXAMPLE 5 — CARL ZEISS / BEHRENS & GLATZEL",
+  specs: ["7 ELEMENTS / 6 GROUPS", "f ≈ 50.0 mm", "F/1.4", "2ω ≈ 46.8°", "ALL SPHERICAL"],
+
+  /* ── Explicit metadata fields ── */
+  focalLengthMarketing: 50,
+  apertureMarketing: 1.4,
+  patentYear: 1975,
+  elementCount: 7,
+  groupCount: 6,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.717,
+      vd: 47.99,
+      fl: 72.7,
+      glass: "LaK 21 (SCHOTT)",
+      apd: false,
+      role: "Front positive collector; pre-converges marginal rays toward stop",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.78831,
+      vd: 47.37,
+      fl: 65.4,
+      glass: "LaF 21 (SCHOTT)",
+      apd: false,
+      role: "Second collector; high-index LaF reduces surface curvature to control 5th-order SA",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.68893,
+      vd: 31.17,
+      fl: -33.5,
+      glass: "SF 56 (SCHOTT)",
+      apd: false,
+      role: "Front diverging element; air lens β with L2 controls higher-order spherical aberration",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.7283,
+      vd: 28.68,
+      fl: -22.7,
+      glass: "SF 10 family (SCHOTT)",
+      apd: false,
+      role: "Rear diverging element of cemented doublet N2; primary negative Petzval contribution",
+      cemented: "N2",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.78831,
+      vd: 47.37,
+      fl: 35.8,
+      glass: "LaF 21 (SCHOTT)",
+      apd: false,
+      role: "Strongest positive element in rear group; rear surface is primary converging surface of rear member",
+      cemented: "N2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Positive Meniscus",
+      nd: 1.78831,
+      vd: 47.37,
+      fl: 51.3,
+      glass: "LaF 21 (SCHOTT)",
+      apd: false,
+      role: "First element of rear positive combination PH; concave-forward meniscus mirrors L2 about stop",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.744,
+      vd: 44.77,
+      fl: 98.4,
+      glass: "LaF 2 (SCHOTT)",
+      apd: false,
+      role: "Final field-flattening corrector; weak positive biconvex with gentle curvatures",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Front member V (L1, L2, L3) ──
+    { label: "1", R: 44.452, d: 5.091, nd: 1.717, elemId: 1, sd: 19.5 }, // L1 front
+    { label: "2", R: 288.661, d: 0.059, nd: 1.0, elemId: 0, sd: 18.5 }, // L1 rear → air (α)
+    { label: "3", R: 21.804, d: 4.856, nd: 1.78831, elemId: 2, sd: 18.5 }, // L2 front
+    { label: "4", R: 34.062, d: 1.589, nd: 1.0, elemId: 0, sd: 16.0 }, // L2 rear → air (β)
+    { label: "5", R: 47.086, d: 1.187, nd: 1.68893, elemId: 3, sd: 15.0 }, // L3 front
+    { label: "6", R: 15.324, d: 7.136, nd: 1.0, elemId: 0, sd: 13.5 }, // L3 rear → air (CS, first half)
+
+    // ── Aperture stop (inferred at midpoint of CS from Fig. 1) ──
+    { label: "STO", R: 1e15, d: 7.136, nd: 1.0, elemId: 0, sd: 14.0 },
+
+    // ── Rear member H (L4+L5 cemented, L6, L7) ──
+    { label: "7", R: -17.319, d: 1.148, nd: 1.7283, elemId: 4, sd: 12.5 }, // L4 front
+    { label: "8", R: 374.022, d: 5.15, nd: 1.78831, elemId: 5, sd: 12.5 }, // L4–L5 junction → L5 glass
+    { label: "9", R: -30.357, d: 0.284, nd: 1.0, elemId: 0, sd: 14.0 }, // L5 rear → air (γ)
+    { label: "10", R: -87.426, d: 4.385, nd: 1.78831, elemId: 6, sd: 14.0 }, // L6 front
+    { label: "11", R: -28.25, d: 0.128, nd: 1.0, elemId: 0, sd: 14.0 }, // L6 rear → air (δ)
+    { label: "12", R: 164.68, d: 2.835, nd: 1.744, elemId: 7, sd: 14.0 }, // L7 front
+    { label: "13", R: -130.808, d: 35.497, nd: 1.0, elemId: 0, sd: 13.5 }, // L7 rear → BFD
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (unit focus) ── */
+  var: {
+    "13": [35.497, 42.6],
+  },
+
+  varLabels: [["13", "BF"]],
+
+  /* ── Group annotations ── */
+  groups: [
+    { text: "FRONT (V)", fromSurface: "1", toSurface: "6" },
+    { text: "REAR (H)", fromSurface: "7", toSurface: "13" },
+  ],
+
+  doublets: [{ text: "N₂", fromSurface: "7", toSurface: "9" }],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.45,
+  focusDescription: "Unit focusing — entire optical assembly moves forward. C/Y mount MFD 0.45 m.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 1.4,
+  fstopSeries: [1.4, 2, 2.8, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.3,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/olympus/OlympusZuiko85mmf2.analysis.md
+++ b/src/lens-data/olympus/OlympusZuiko85mmf2.analysis.md
@@ -1,0 +1,285 @@
+# Olympus Zuiko Auto-T 85mm f/2 — Optical Design Analysis
+
+## Patent: US 4,063,802 · Embodiment 1
+
+**Inventors:** Toshihiro Imai, Yoshitsugi Ikeda
+**Assignee:** Olympus Optical Co., Ltd., Tokyo, Japan
+**Filed:** July 14, 1976 (Japanese priority: July 18, 1975)
+**Granted:** December 20, 1977
+
+---
+
+## 1. Overview
+
+US 4,063,802 describes a compact telephoto lens system of four components comprising five elements: two positive meniscus lenses, one negative meniscus lens, and one positive cemented doublet. The patent presents four numerical embodiments, all normalized to f = 100 mm. Embodiment 1 is analyzed here as the configuration most closely associated with the production Olympus Zuiko Auto-T 85mm f/2 for the OM system.
+
+The design achieves a telephoto ratio of only 1.07, meaning the physical length from front vertex to image plane is just 7% longer than the focal length. For comparison, prior art designs of this type (such as the lens disclosed in Japanese Patent Publication No. 9466/55) had telephoto ratios of 1.2 or higher. This compactness was a primary design objective and is reflected in the twelve inequality conditions the patent specifies. All twelve conditions are satisfied by Embodiment 1.
+
+The design is entirely spherical — no aspherical surfaces are used on any element.
+
+### Production Context
+
+The Olympus Zuiko Auto-T 85mm f/2 was produced in at least three major variants across the OM system's lifetime:
+
+- **V1** (~1972): 6 elements in 4 groups, designated "F.Zuiko" (where the prefix "F" indicates six elements per the Olympus naming convention). This earlier design corresponds to a separate patent (US 3,848,972, Nakamura, 1974), which is listed as a reference in the present patent.
+- **V2/V3/V4** (~1979 onward): 5 elements in 4 groups, designated "Zuiko" (the element-count prefix was dropped for later multicoated lenses). These versions correspond to the present patent, US 4,063,802.
+
+The redesign from 6 to 5 elements eliminated one element while improving sharpness, contrast, and chromatic aberration correction, particularly at wide apertures.
+
+### Key Production Specifications (Manufacturer)
+
+| Parameter | Value |
+|---|---|
+| Focal length | 85 mm |
+| Maximum aperture | f/2 |
+| Minimum aperture | f/16 |
+| Optical construction | 5 elements / 4 groups |
+| Minimum focus distance | 0.85 m (1:6.9) |
+| Angle of view | 29° |
+| Filter diameter | 49 mm |
+| Aperture blades | 8 |
+| Dimensions (Ø × L) | 60 × 48 mm |
+| Weight | 260 g |
+| Mount | Olympus OM |
+
+Note: The patent computes F/2.04 for Embodiment 1, while the production lens is marketed as f/2. This ~2% rounding is standard practice — manufacturers round to the nearest conventional f-stop for commercial designation.
+
+---
+
+## 2. Aspherical Surfaces
+
+**There are no aspherical surfaces in this design.** The patent makes no reference to aspherical coefficients, conic constants, or polynomial surface departures anywhere in the text, claims, or numerical data. All nine optical surfaces are purely spherical. The aberration correction is achieved entirely through the choice of radii, spacings, and glass types across the five elements.
+
+This is consistent with the design's era (mid-1970s) and the moderate aperture (f/2) and field angle (2ω ≈ 28°). Aspherical surfaces were not yet commonly employed in consumer SLR lenses at this time, and the telephoto configuration — with its relatively gentle ray angles compared to wide-angle or high-speed designs — does not demand aspherical correction to achieve adequate performance.
+
+---
+
+## 3. Optical Layout — Element by Element
+
+The lens comprises four components arranged in a classical telephoto configuration: a positive front group (Components 1–2) followed by a negative spacer element (Component 3) and a positive cemented doublet (Component 4). The aperture stop is located in the large air gap d₆ = 20.05 mm between Components 3 and 4. (The patent prescription table does not include an explicit stop surface; its position is inferred from Fig. 1, which clearly shows the iris diaphragm in this gap. The exact axial position within the 20.05 mm gap is not specified.)
+
+All prescription data below is at the patent normalization of f = 100 mm. To obtain production values at f = 85 mm, multiply all linear dimensions (R, d, sd) by 0.8503.
+
+### 3.1 Element L1 — Positive Meniscus (Component 1)
+
+| Surface | R (mm) | d (mm) | Medium after |
+|---|---|---|---|
+| r₁ (front) | +59.514 | 7.34 | nd = 1.72 |
+| r₂ (rear) | +387.226 | 0.18 (air gap) | air |
+
+**Shape:** Both radii are positive, forming a meniscus convex toward the object. The front surface (R = 59.5) is far more strongly curved than the nearly-flat rear surface (R = 387.2), giving the element a steeply convex front and gently convex rear.
+
+**Focal length:** f_L1 ≈ +96.8 mm (thick-lens, ABCD matrix computation)
+
+**Glass:** nd = 1.720, νd = 50.25 (six-digit code: 720/503). This places the glass in the lanthanum crown (LaK) family. The nearest modern catalog match is OHARA S-LAH53 (nd = 1.720, νd = 50.31, Δνd = 0.06), though the 1970s glass may have been a now-discontinued formulation from OHARA or HOYA. Confidence: family-level.
+
+**Optical role:** L1 is the first of two strong positive elements that collectively form the front converging group. Its high refractive index (1.72) is mandated by condition (9) of the patent (n₁ > 1.68) and serves two purposes: it provides converging power while keeping the Petzval sum low. A high-index positive element contributes less to field curvature than an equivalent low-index positive element. The meniscus shape directs the strongly curved surface toward the incoming collimated beam, which reduces the angle of incidence at each surface and thereby limits spherical aberration. No patent condition directly constrains L1's radii; instead, its curvature is set to balance power sharing with L2 while maintaining the total front-group focal length within condition (1) (0.4f < f₁₂ < 0.5f).
+
+### 3.2 Element L2 — Positive Meniscus (Component 2)
+
+| Surface | R (mm) | d (mm) | Medium after |
+|---|---|---|---|
+| r₃ (front) | +31.522 | 12.26 | nd = 1.623 |
+| r₄ (rear) | +64.950 | 4.10 (air gap) | air |
+
+**Shape:** Again both radii are positive, forming a meniscus convex toward the object. L2 has a more deeply curved front surface (R = 31.5) and is considerably thicker (12.26 mm) than L1, making it the most massive element in the design.
+
+**Focal length:** f_L2 ≈ +86.2 mm
+
+**Glass:** nd = 1.623, νd = 58.14 (six-digit code: 623/581). This glass falls in the dense phosphate crown (SK/PSK) family. No exact match was found in modern catalogs; it is likely a proprietary melt or discontinued catalog type from the 1970s OHARA or HOYA catalogs. The Abbe number (58.14) satisfies condition (12) (ν₁, ν₂ > 45), ensuring low chromatic contribution from the front group. Confidence: family-level.
+
+**Optical role:** L2 is the strongest single element in the design, slightly more powerful than L1 (f_L2 ≈ 86 mm vs f_L1 ≈ 97 mm). Together with L1, it produces a combined focal length of f₁₂ = 45.3 mm — substantially shorter than the system focal length of 100 mm. This strong convergence is essential to the telephoto compression: it is the short f₁₂ that allows the back focal distance to be reduced, achieving the 1.07 telephoto ratio. L2's front radius r₃ is tightly constrained by condition (3) (0.28f < r₃ < 0.35f = 28.0 to 35.0 mm; actual r₃ = 31.522), and its rear radius r₄ by condition (4) (0.6f < r₄ < 0.75f = 60.0 to 75.0 mm; actual r₄ = 64.950). These radii are critical for spherical aberration control: too-short radii undercorrect, while too-long radii overcorrect.
+
+### 3.3 Element L3 — Negative Meniscus (Component 3)
+
+| Surface | R (mm) | d (mm) | Medium after |
+|---|---|---|---|
+| r₅ (front) | +145.777 | 1.65 | nd = 1.7847 |
+| r₆ (rear) | +21.474 | 20.05 (air gap to stop/rear group) | air |
+
+**Shape:** Both radii are positive, but the rear surface (R = 21.5) is far more strongly curved than the nearly flat front (R = 145.8). This produces a meniscus concave toward the image side — the classic "diverging telephoto spacer" shape. The element is thin (1.65 mm), consistent with its role as a field-flattening diverger rather than a power-sharing refractive element.
+
+**Focal length:** f_L3 ≈ −32.3 mm (strong negative power)
+
+**Glass:** nd = 1.7847 (1.78472 at full precision from Embodiments 3–4), νd = 25.71 (six-digit code: 785/257). This is a dense flint glass in the SF family. The best match is **HOYA FD110** (nd = 1.78472, νd = 25.71), an exact match at full catalog precision. The low Abbe number (25.71) satisfies condition (12) (ν₃ < 28), which is necessary for chromatic aberration management: the strongly dispersive negative element partially compensates for the chromatic contribution of the positive front group. Confidence: high (exact match).
+
+**Optical role:** L3 is the most optically consequential element despite being the thinnest. Its strong negative power (f ≈ −32 mm) accomplishes several critical tasks simultaneously:
+
+1. **Telephoto compression.** L3's divergence lengthens the effective focal length of rays exiting the front group, allowing the entire system to achieve f = 100 mm while the front-group focal length is only 45.3 mm. Without L3, the back focal distance would be far too short for SLR mirror clearance.
+
+2. **Petzval sum correction.** The high refractive index (1.7847) is critical here. The Petzval contribution of a negative element is negative (flattening), and a higher index reduces the magnitude of that contribution. The patent achieves a normalized Petzval sum of 0.140, compared to 0.292 for the prior art — a dramatic improvement in field flatness.
+
+3. **Spherical aberration balancing.** The strongly curved rear surface r₆ introduces undercorrected spherical aberration that balances the overcorrection from the front group. Conditions (5) and (6) jointly constrain r₅ and r₆ to maintain this balance.
+
+4. **Coma symmetry.** The condition |r₆/r₈| ≈ 1.0 (condition 7: 0.98 < |r₆/r₈| < 1.03; actual value 1.002) means the rear surface of L3 (r₆ = +21.474) and the cemented junction of the doublet (r₈ = −21.424) have nearly equal radii of curvature magnitude but opposite sign. These two surfaces face each other across the stop gap from opposite sides, creating approximate local concentric symmetry around the aperture. This exploits the classical principle that surfaces arranged symmetrically about the stop tend to cancel odd-order aberrations, particularly coma. The near-symmetry balances upper and lower coma, enabling the lens to be used with slight, well-controlled residual coma for a soft-focus portrait effect at wide apertures — a deliberate design feature noted in the patent text.
+
+### 3.4 Elements L4 + L5 — Positive Cemented Doublet (Component 4)
+
+| Surface | R (mm) | d (mm) | Medium after |
+|---|---|---|---|
+| r₇ (L4 front) | +174.254 | 8.94 | nd = 1.7 |
+| r₈ (junction) | −21.424 | 1.06 | nd = 1.583 |
+| r₉ (L5 rear) | −163.873 | BFD | air |
+
+**L4 shape:** r₇ > 0, r₈ < 0 → biconvex. The front surface is very weakly curved (R = 174.3), while the cemented rear surface is strongly concave (R = −21.4). This produces a thick, asymmetric biconvex element with most of the curvature concentrated at the cemented junction.
+
+**L5 shape:** r₈ < 0, r₉ < 0, with |r₈| < |r₉| → negative meniscus, concave toward the object. The element is thin (1.06 mm) and acts primarily as a chromatic corrector rather than a power element.
+
+**Combined focal length:** f₄₅ ≈ +78.0 mm (thick-lens doublet)
+**L4 alone (in air):** f_L4 ≈ +27.8 mm
+**L5 alone (in air):** f_L5 ≈ −42.4 mm
+
+**L4 glass:** nd = 1.700, νd = 48.08 (six-digit code: 700/481). Lanthanum crown (LaK) family. The index satisfies conditions (9) (n₄ > 1.68) and (10) (n₄/n₅ > 1.05; actual ratio = 1.074). No exact catalog match was found in modern databases; nd = 1.70 is an unusual value that may correspond to a discontinued 1970s glass type. Confidence: family-level.
+
+**L5 glass:** nd = 1.583 (1.58313 at full precision from Embodiment 4), νd = 59.36 (six-digit code: 583/594). Barium crown (BaK) family. The nearest match is **OHARA S-BAL42** (nd = 1.58313, νd = 59.37, Δνd = 0.01). Confidence: high (near-exact match).
+
+**Optical role:** The cemented doublet serves as the achromatic rear group. Its principal functions are:
+
+1. **Chromatic aberration correction.** The Abbe number difference ν₅ − ν₄ = 11.28 satisfies condition (11) (ν₅ − ν₄ > 10). While this dispersion difference is modest compared to traditional achromats (which typically use Δν > 20), the index ratio n₄/n₅ = 1.074 compensates: the patent specifies condition (10) (n₄/n₅ > 1.05) precisely because a larger index difference allows effective achromatization with a smaller Abbe number spread. The doublet simultaneously corrects longitudinal chromatic aberration (axial color) and minimizes the variation of lateral chromatic aberration with image height.
+
+2. **Additional positive power.** The doublet contributes f₄₅ = 78 mm of positive power, supplementing the front group. The ratio f₁₂₃/f₄₅ = 4.15 satisfies condition (2) (4 < f₁₂₃/f₄₅ < 6).
+
+3. **Close-focus aberration correction via floating.** This component is the floating element described in the patent (see Section 5 below).
+
+---
+
+## 4. Glass Summary
+
+| Element | nd | νd | Six-digit | Family | Catalog Match | Confidence |
+|---|---|---|---|---|---|---|
+| L1 | 1.720 | 50.25 | 720/503 | LaK | OHARA S-LAH53 (Δνd = 0.06) | Family |
+| L2 | 1.623 | 58.14 | 623/581 | SK/PSK | No exact match (discontinued?) | Family |
+| L3 | 1.7847 | 25.71 | 785/257 | SF | **HOYA FD110** (exact) | High |
+| L4 | 1.700 | 48.08 | 700/481 | LaK | No exact match (discontinued?) | Family |
+| L5 | 1.583 | 59.36 | 583/594 | BaK | **OHARA S-BAL42** (Δνd = 0.01) | High |
+
+The design uses three distinct glass families: lanthanum crowns for the positive power elements (L1, L4), a dense phosphate crown for the second positive meniscus (L2), and a dense flint for the negative spacer (L3), with a lighter barium crown for the correcting element (L5). This distribution of high-index positive elements paired with a high-dispersion negative element is characteristic of well-corrected telephoto designs of the era.
+
+Note: Embodiments 3 and 4 use different glass choices for L2 (nd = 1.61375, νd = 56.36 — an exact match for Schott SK4) and slightly different formulations for L4 and L5, suggesting that Olympus evaluated multiple glass combinations during the design process. The glass selections for L3 and L5 are highly consistent across all four embodiments, indicating that the SF-family diverger and BaK-family corrector were considered essential to the design's aberration balance.
+
+---
+
+## 5. Focusing Mechanism
+
+The Olympus Zuiko 85mm f/2 employs a **floating rear-group** focusing system. Olympus production literature describes this as "a built-in automatic correction mechanism [that] compensates for aberrations at close focusing distances."
+
+### How it Works
+
+When focusing from infinity to close distances, the entire lens translates forward via the helicoid (unit focusing), but the fourth component (the L4+L5 cemented doublet) moves at a **slightly different rate** than the front three elements. Olympus describes this as a "built-in automatic correction mechanism," likely implemented via an internal cam. Because the rear group moves slightly less far forward than the front group, the air gap d₆ — the large spacing between L3 and the doublet — **increases** during close focusing. The back focal distance (BFD) also increases because the lens extends forward while the film plane remains fixed.
+
+The patent provides quantitative data for this mechanism. For Embodiment 4, d₆ increases from 20.02 mm at infinity to 20.65 mm at 1/20× magnification, a change of +0.63 mm at the f = 100 normalization. (The patent does not provide a close-focus d₆ value for Embodiment 1 specifically, but the mechanism is the same across all embodiments.)
+
+### Why it Matters
+
+Without the floating correction, astigmatism worsens substantially at close focus, and the symmetry of off-axis coma degrades. The patent illustrates this with three sets of aberration curves for Embodiment 2: at infinity focus (Figs. 3A–3D), at 1/20× magnification without correction (Figs. 4A–4D), and at 1/20× with the rear group floated (Figs. 5A–5D). The improvement in astigmatism and coma symmetry with the floating correction is clearly visible in the patent figures.
+
+This was an innovative feature for a telephoto lens of this era. The rear-group floating mechanism maintains high image quality across the full focusing range from infinity to 0.85 m without adding optical complexity or weight.
+
+### Variable Gaps (Infinity → Close Focus)
+
+The design has two independently variable gaps during focusing. The stop is mechanically part of the front group (L1–L3 + iris), so the gap from L3's rear surface to the stop (d₆ₐ) remains constant. The two variable gaps are:
+
+1. **d₆ᵦ (stop to L4 front):** Increases during close focusing because the rear group lags behind the front group.
+2. **BFD (L5 rear to image plane):** Increases because the entire lens extends forward while the film plane stays fixed.
+
+Close-focus variable gap values were computed for the 0.85 m MFD using a self-consistent model: the floating ratio (Δd₆ / total extension) was estimated at 12.6% from Embodiment 4's data (Δd₆ = 0.63 mm at an extension of approximately 5 mm for 1/20× magnification), and the imaging equation was solved iteratively to ensure the system correctly forms an image at the film plane for an object at 0.85 m. At production scale (f = 85 mm), the resulting values are:
+
+| Gap | Surface label | Infinity (mm) | Close focus (mm) | Change |
+|---|---|---|---|---|
+| d₆ᵦ (stop → L4) | STO | 10.25 | 11.79 | +1.54 |
+| BFD (L5 → image) | 9 | 44.01 | 54.71 | +10.70 |
+
+The total extension of approximately 12.2 mm (at production scale) is consistent with the expected unit-focus extension for an 85 mm lens at 0.85 m MFD.
+
+**Note on close-focus magnification:** The computed magnification at 0.85 m is approximately 1:7.9, which is about 14% lower than the manufacturer's stated 1:6.9. This discrepancy likely arises from the estimated floating ratio: the actual production cam profile may produce a larger d₆ change (and correspondingly smaller BFD change) than the linear extrapolation from Embodiment 4's 1/20× data point, and the production lens may differ slightly from Embodiment 1's prescription.
+
+---
+
+## 6. Paraxial Verification
+
+Independent ABCD matrix ray trace verification was performed on the patent prescription for Embodiment 1. All computations use thick-lens (transfer + refraction matrix) methods.
+
+### System Parameters
+
+| Parameter | Computed | Patent | Δ |
+|---|---|---|---|
+| EFL | 99.962 mm | 100 mm | −0.04% |
+| BFD (f_B) | 51.757 mm | 51.807 mm | −0.10% |
+| Telephoto ratio | 1.074 | 1.07 | +0.4% |
+| f₁₂ | 45.317 mm | 45.317 mm | exact |
+| f₁₂₃ | 323.592 mm | 323.67 mm | −0.02% |
+| f₄₅ | 77.984 mm | 78.016 mm | −0.04% |
+| f₁₂₃/f₄₅ | 4.149 | (condition: 4–6) | ✓ |
+
+All computed values agree with the patent's stated values to within rounding tolerance. The tiny discrepancies (< 0.1%) are consistent with the patent's use of truncated decimal values.
+
+### Element Focal Lengths
+
+| Element | Focal Length (mm) | Power |
+|---|---|---|
+| L1 | +96.8 | Weak positive |
+| L2 | +86.2 | Moderate positive |
+| L3 | −32.3 | Strong negative |
+| L4 (in air) | +27.8 | Strong positive |
+| L5 (in air) | −42.4 | Moderate negative |
+| L4+L5 doublet | +78.0 | Net positive |
+
+### Petzval Sum
+
+The surface-by-surface Petzval sum Σ (n'−n)/(n·n'·R) = 0.001400 at f = 100. Expressed as the normalized Petzval sum P × f = **0.140**, which matches the patent's stated value for Embodiment 1. (Note: the scanned patent text renders this as "0.40," which is an OCR artifact — the leading "1" was lost in scanning. The value 0.140 is consistent with Embodiments 2–4 at 0.130, 0.135, and 0.124 respectively, and with the patent's claim that the Petzval sum is improved over the prior art value of 0.292.) The corresponding Petzval radius is ~714 mm, or about 7.1× the focal length — indicating excellent field flatness for a telephoto lens.
+
+### Patent Condition Verification
+
+All twelve design conditions specified in the patent are satisfied by Embodiment 1:
+
+| Condition | Requirement | Actual | Status |
+|---|---|---|---|
+| (1) | 0.4f < f₁₂ < 0.5f | f₁₂ = 45.317 | ✓ (40.0 < 45.3 < 50.0) |
+| (2) | 4 < f₁₂₃/f₄₅ < 6 | 4.149 | ✓ |
+| (3) | 0.28f < r₃ < 0.35f | r₃ = 31.522 | ✓ (28.0 < 31.5 < 35.0) |
+| (4) | 0.6f < r₄ < 0.75f | r₄ = 64.950 | ✓ (60.0 < 65.0 < 75.0) |
+| (5) | 1.4f < r₅ < 2f | r₅ = 145.777 | ✓ (140.0 < 145.8 < 200.0) |
+| (6) | 0.18f < r₆ < 0.24f | r₆ = 21.474 | ✓ (18.0 < 21.5 < 24.0) |
+| (7) | 0.98 < \|r₆/r₈\| < 1.03 | 1.002 | ✓ |
+| (8) | 1.3f < r₇ < 1.8f | r₇ = 174.254 | ✓ (130.0 < 174.3 < 180.0) |
+| (9) | n₁, n₄ > 1.68; n₂ > 1.6 | 1.72, 1.7, 1.623 | ✓ |
+| (10) | n₄/n₅ > 1.05 | 1.074 | ✓ |
+| (11) | ν₅ − ν₄ > 10 | 11.28 | ✓ |
+| (12) | ν₁, ν₂ > 45; ν₃ < 28 | 50.25, 58.14, 25.71 | ✓ |
+
+---
+
+## 7. Design Heritage
+
+The Imai/Ikeda design sits within a recognizable lineage of telephoto lens formulas descending from the Ernostar (Bertele, 1923) and subsequently the Sonnar (Bertele, 1931). The shared architectural pattern is a sequence of positive meniscus elements followed by a negative spacer and a rear positive group, with the stop placed in the large gap between the diverging element and the rear group.
+
+The key differences from a classical Sonnar are:
+
+1. **No cemented triplet.** The original 1931 Sonnar (6 elements / 3 groups) used a cemented triplet as its middle group (before the stop) and a cemented doublet as its rear group. The Imai/Ikeda design eliminates the triplet entirely, using only singlets and a single rear cemented doublet in a 5/4 configuration. This reduces element count and opens air spaces between the front elements that provide additional degrees of freedom.
+
+2. **Four groups vs. three.** By air-spacing each of the first three elements (with gaps as small as d₂ = 0.18 mm between L1 and L2), the Imai/Ikeda design has four independent groups compared to the Sonnar's three. Each air gap provides an additional design variable for aberration balancing.
+
+3. **Floating rear group.** The Imai/Ikeda design employs a floating rear doublet that maintains image quality at short distances. This capability was also present in the earlier Nakamura design, though the specific implementation differs with the change in element count.
+
+The redesign from the earlier 6-element Nakamura formula (US 3,848,972, 1974) to the present 5-element design necessarily involved simplifying one cemented doublet into a singlet — this is the only way to reduce element count by one while maintaining the same four-group architecture. This eliminated one optical surface (the cemented junction), reducing internal absorption and removing one surface contribution to higher-order aberrations. Photographic comparisons by contemporary reviewers indicate the redesign improved sharpness and aberration correction at wide apertures.
+
+---
+
+## 8. Prescription Summary (Patent Scale, f = 100)
+
+| Surface | R (mm) | d (mm) | nd (after) | Element |
+|---|---|---|---|---|
+| r₁ | +59.514 | 7.34 | 1.720 | L1 front |
+| r₂ | +387.226 | 0.18 | 1.0 (air) | L1 rear |
+| r₃ | +31.522 | 12.26 | 1.623 | L2 front |
+| r₄ | +64.950 | 4.10 | 1.0 (air) | L2 rear |
+| r₅ | +145.777 | 1.65 | 1.7847 | L3 front |
+| r₆ | +21.474 | 20.05 | 1.0 (air) | L3 rear |
+| — | (stop) | — | — | Aperture |
+| r₇ | +174.254 | 8.94 | 1.700 | L4 front |
+| r₈ | −21.424 | 1.06 | 1.583 | L4/L5 junction |
+| r₉ | −163.873 | (BFD) | 1.0 (air) | L5 rear |
+
+**f = 100, F/2.04, BFD = 51.8, telephoto ratio = 1.07**
+
+To scale to production (f = 85 mm), multiply all R, d, and sd values by **0.8503**.

--- a/src/lens-data/olympus/OlympusZuiko85mmf2.data.ts
+++ b/src/lens-data/olympus/OlympusZuiko85mmf2.data.ts
@@ -1,0 +1,176 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — OLYMPUS ZUIKO AUTO-T 85mm f/2                ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,063,802 Embodiment 1 (Imai & Ikeda / Olympus). ║
+ * ║  Compact telephoto, 5 elements / 4 groups, all spherical.         ║
+ * ║  Focus: floating rear group (cemented doublet moves                ║
+ * ║         differentially via internal cam during helicoid focus).    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                   ║
+ * ║    Patent at f=100; all R, d, sd values scaled ×0.8503 to          ║
+ * ║    f≈85 mm production (Olympus OM mount).                          ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    SDs estimated from marginal ray trace at f/2 with 8–10%         ║
+ * ║    mechanical clearance, constrained by 49 mm filter thread        ║
+ * ║    (front SD ≤ 23 mm clear aperture).                              ║
+ * ║                                                                    ║
+ * ║  IMPORTANT: This file describes ONLY the optical design:           ║
+ * ║    ✓ Glass elements and surfaces (front element to image plane)   ║
+ * ║    ✓ Aperture stop and variable focus gaps                        ║
+ * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts      ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "olympus-zuiko-85mm-f2",
+  maker: "Olympus",
+  name: "OLYMPUS ZUIKO AUTO-T 85mm f/2",
+  subtitle: "US 4,063,802 EMBODIMENT 1 — OLYMPUS / IMAI & IKEDA",
+  specs: ["5 ELEMENTS / 4 GROUPS", "f ≈ 85.0 mm", "F/2", "2ω ≈ 29°", "ALL SPHERICAL"],
+
+  /* ── Explicit metadata fields ── */
+  focalLengthMarketing: 85,
+  focalLengthDesign: 85.0,
+  apertureMarketing: 2,
+  apertureDesign: 2.04,
+  patentYear: 1977,
+  elementCount: 5,
+  groupCount: 4,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.72,
+      vd: 50.25,
+      fl: 82.3,
+      glass: "LaK family (720/503)",
+      apd: false,
+      role: "Front positive meniscus; high-index (n>1.68 per condition 9) converging element that shares power with L2 while minimizing Petzval contribution",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.623,
+      vd: 58.14,
+      fl: 73.3,
+      glass: "SK/PSK family (623/581)",
+      apd: false,
+      role: "Strongest positive element; with L1 forms the converging front group (f₁₂ ≈ 38.5 mm) that drives the telephoto compression",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.7847,
+      vd: 25.71,
+      fl: -27.5,
+      glass: "HOYA FD110 (exact match, SF family, 785/257)",
+      apd: false,
+      role: "Strongly diverging telephoto spacer; its high-dispersion flint (ν<28) partially compensates front-group chromatic aberration. The near-equal |r₆/r₈|≈1 creates approximate coma symmetry about the stop",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.7,
+      vd: 48.08,
+      fl: 23.6,
+      glass: "LaK family (700/481)",
+      apd: false,
+      role: "Positive element of rear achromatic doublet; high index (n₄/n₅>1.05 per condition 10) enables achromatization with modest Abbe-number spread",
+      cemented: "D1",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.583,
+      vd: 59.36,
+      fl: -36.1,
+      glass: "OHARA S-BAL42 (near-exact, BaK family, 583/594)",
+      apd: false,
+      role: "Chromatic corrector in rear doublet; low-dispersion crown balances axial and lateral color from L4",
+      cemented: "D1",
+    },
+  ],
+
+  /* ── Surface prescription ── */
+  surfaces: [
+    // ── Component 1: L1 positive meniscus ──
+    { label: "1", R: 50.606, d: 6.241, nd: 1.72, elemId: 1, sd: 23.0 },
+    { label: "2", R: 329.267, d: 0.153, nd: 1.0, elemId: 0, sd: 21.8 },
+    // ── Component 2: L2 positive meniscus ──
+    { label: "3", R: 26.804, d: 10.425, nd: 1.623, elemId: 2, sd: 21.7 },
+    { label: "4", R: 55.228, d: 3.486, nd: 1.0, elemId: 0, sd: 16.7 },
+    // ── Component 3: L3 negative meniscus ──
+    { label: "5", R: 123.958, d: 1.403, nd: 1.7847, elemId: 3, sd: 14.9 },
+    { label: "6", R: 18.26, d: 6.803, nd: 1.0, elemId: 0, sd: 14.3 },
+    // ── Aperture stop (inferred from Fig. 1, ~40% into d₆ gap from L3) ──
+    { label: "STO", R: 1e15, d: 10.246, nd: 1.0, elemId: 0, sd: 12.5 },
+    // ── Component 4: L4+L5 cemented doublet (floating rear group) ──
+    { label: "7", R: 148.172, d: 7.602, nd: 1.7, elemId: 4, sd: 12.9 },
+    { label: "8", R: -18.217, d: 0.901, nd: 1.583, elemId: 5, sd: 12.6 }, // L4/L5 junction
+    { label: "9", R: -139.345, d: 44.011, nd: 1.0, elemId: 0, sd: 12.4 }, // BFD
+  ],
+
+  /* ── Aspherical coefficients (all-spherical design) ── */
+  asph: {},
+
+  /* ── Variable air spacings (floating rear group focus) ──
+   *  Two variable gaps during focusing:
+   *    STO: stop-to-L4 gap increases as rear doublet floats back
+   *    9:   BFD increases as the lens extends forward
+   *  The gap from L3 rear (surface 6) to the stop remains constant —
+   *  both move with the front group during helicoid focus.
+   *
+   *  Close-focus values computed for 0.85 m MFD (from film plane) using
+   *  a floating ratio estimated from Embodiment 4 at 1/20× magnification
+   *  (Δd₆ = 0.63 mm at f=100 → floating ratio ≈ 12.6%).
+   */
+  var: {
+    STO: [10.246, 11.789],
+    "9": [44.011, 54.708],
+  },
+
+  varLabels: [
+    ["STO", "D₆b"],
+    ["9", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT", fromSurface: "1", toSurface: "6" },
+    { text: "REAR", fromSurface: "7", toSurface: "9" },
+  ],
+
+  doublets: [{ text: "D1", fromSurface: "7", toSurface: "9" }],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.85,
+  focusDescription:
+    "Floating rear group: entire lens extends via helicoid (unit focus) while the cemented doublet (L4+L5) moves at a slightly different rate via an internal cam, changing d₆ to correct astigmatism and coma at close distances.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.0,
+  fstopSeries: [2, 2.5, 2.8, 3.5, 4, 5.6, 8, 11, 16],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.3,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -22,6 +22,17 @@ export const CHANGELOG: ChangelogEntry[] = [
   // ── 2026-04-26 ──────────────────────────────────────────────────────────
   {
     date: "2026-04-26",
+    type: "lens",
+    summary:
+      "Added three Carl Zeiss lenses: Contarex Planar 55mm f/1.4, Jena Pancolar 50mm f/2, and Planar T* 50mm f/1.4",
+  },
+  {
+    date: "2026-04-26",
+    type: "lens",
+    summary: "Added Olympus Zuiko Auto-T 85mm f/2 with floating rear-group focusing",
+  },
+  {
+    date: "2026-04-26",
     type: "feature",
     summary:
       "Added shareable URLs for selected elements, overlays (glass map, LCA, Petzval), bokeh preview, and analysis tabs",


### PR DESCRIPTION
## Summary

- Adds **Carl Zeiss Contarex Planar 55mm f/1.4** (DE 1,170,157 B — Berger & Lange, 1964): 7-element/5-group modified double-Gauss, unit focus
- Adds **Carl Zeiss Jena Pancolar 50mm f/2** (GB 850,117 — Hubert & Zöllner, 1960): 6-element/4-group double-Gauss for M42/Exakta, unit focus
- Adds **Carl Zeiss Planar T\* 50mm f/1.4** (US 3,874,771 — Behrens & Glatzel, 1975): 7-element/6-group extended double-Gauss, unit focus
- Adds **Olympus Zuiko Auto-T 85mm f/2** (US 4,063,802 — Imai & Ikeda, 1977): 5-element/4-group compact telephoto with floating rear group
- Fixes focus direction bug in Contarex Planar: BFD close-focus value was 27.75 mm (extension subtracted) instead of 45.17 mm (extension added), causing the lens to appear to shrink rather than extend when focusing closer

## Test plan

- [ ] All four lenses load and render without validation errors
- [ ] Contarex Planar 55mm f/1.4: moving the focus slider toward close focus causes the lens to visibly extend (BFD increases from 36.47 → 45.17 mm)
- [ ] Jena Pancolar and Planar T\* focus sliders move in the correct direction (BFD increases)
- [ ] Olympus Zuiko 85mm f/2 floating-group focus works (both STO and BFD gaps increase)
- [ ] `npm run typecheck && npm run format:check && npm run lint && npm run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)