### PR TITLE
[codex] expand priority glass catalog coverage

### DIFF
--- a/agent_docs/catalog-mismatches.generated.md
+++ b/agent_docs/catalog-mismatches.generated.md
@@ -16,8 +16,8 @@ with words like "probable" or "approx").
 - **140** lenses scanned
 - **1593** glass surfaces examined
 - **1590** surfaces with non-empty `glass` strings
-- **1002** of those resolved to a catalog entry
-- **237** mismatches found (23.7% of resolved surfaces)
+- **1018** of those resolved to a catalog entry
+- **237** mismatches found (23.3% of resolved surfaces)
 - **77** distinct lens files affected
 
 ## Most-frequent mismatched catalog targets

--- a/agent_docs/glass-catalog-buildout.md
+++ b/agent_docs/glass-catalog-buildout.md
@@ -2,7 +2,7 @@
 
 A focused follow-up to Phase 2 of the chromatic dispersion overhaul ([CHROMATIC_DISPERSION_NOTES.md](../CHROMATIC_DISPERSION_NOTES.md)). The chromatic ray-trace now consults a Sellmeier glass catalog at [src/optics/glassCatalog.ts](../src/optics/glassCatalog.ts) when an element's `glass` string resolves to a known entry; otherwise it falls back to dPgF-corrected indices, measured `nC`/`nF`/`ng` line indices, or the legacy Abbe approximation.
 
-The catalog currently has **111 verified entries** (38 after Phase 2, +15 in Phase 3 Apr 2026, +12 in Phase 4 Apr 2026, +27 in Phase 5 May 2026, +19 in Phase 6 May 2026). This document is the playbook for further expansion. The bottleneck is not infrastructure — the dispersion engine, resolver, validator, and tests are all in place — it is the careful sourcing of vendor-published dispersion coefficients.
+The catalog currently has **115 verified entries** (38 after Phase 2, +15 in Phase 3 Apr 2026, +12 in Phase 4 Apr 2026, +27 in Phase 5 May 2026, +19 in Phase 6 May 2026, +4 in Phase 7 May 2026). This document is the playbook for further expansion. The bottleneck is not infrastructure — the dispersion engine, resolver, validator, and tests are all in place — it is the careful sourcing of vendor-published dispersion coefficients.
 
 ## Why So Few Entries To Start With
 
@@ -62,11 +62,20 @@ Frequency derived from `glass:` declarations across all 123 lens data files (141
 | ★ S-BSM14 | 7 | Ohara | Phase 4 addition |
 | ★ SF1 | 6 | Schott | |
 | ★ N-LAK8 | 6 | Schott | |
-| TAFD25 | 6 | Hoya | **Skip** — all lens files annotating TAFD25 store nd in 1.834–2.001; Hoya published nd=1.816; gap >5e-3, no Sellmeier surfaces would resolve |
+| TAFD25 | 6 | Hoya | **Skip for now** — Hoya catalog TAFD25 is nd=1.90366/vd=31.32, while current lens annotations use several unrelated nd/vd regions; relabel per lens instead of adding a broad resolver target |
 | ★ S-LAH51 | 6 | Ohara | |
 | ★ BSC7 | 6 | Hoya | (aliased → S-BSL7) |
 | ★ **N-KZFS5** | (used in Leica APO designs) | Schott | KZFS family — **APO-relevant**, negative ΔPgF |
 | ★ **K-GFK68** | 1 (Voigtländer L4) | Sumita | Patent-listed, **APO-relevant** |
+
+**Phase 7 additions** (May 2026 — first pass from the latest unresolved-token priority list):
+
+| Glass | Vendor | Occurrences | Notes |
+|---|---|---|---|
+| ★ S-LAH63Q | Ohara | 4 | Q/thermal variant; distinct coefficients from S-LAH63; matches low-Tg asphere annotations |
+| ★ S-LAH65VS | Ohara | 3 | VS vacuum-melt variant; distinct from S-LAH65V |
+| ★ S-NBM51 | Ohara | 3 | KZFS-class short flint; added after removing one incorrect Nikon S-NBM51 label whose nd/vd did not match |
+| ★ TAFD40 | Hoya | 3 | Formula-3 polynomial entry; supports nd≈2.00069 high-index APD surfaces |
 
 **Phase 5 additions** (sourced from survey of unresolved glasses across all lens files, May 2026 — all from Ohara or Schott Zemax catalog via refractiveindex.info):
 
@@ -99,10 +108,10 @@ Frequency derived from `glass:` declarations across all 123 lens data files (141
 | ★ S-BSM81 | Ohara | 2 | Barium crown |
 | ★ S-LAM2 | Ohara | 2 | Lanthanum crown |
 | ★ N-SK10 | Schott | 2 | Barium crown; alias SK10 added |
-| NBFD3 | Hoya | 4 | **Skip** — formula 3 polynomial (Hoya), no direct Sellmeier; would need custom fitting like TAFD37A |
-| TAFD40 | Hoya | 3 | **Skip** — formula 3 polynomial (nd=2.001); same issue as NBFD3 |
+| NBFD3 | Hoya | 8 | **Skip for direct add** — Hoya catalog NBFD3 is nd=1.80450/vd=39.63, but current annotations span several nd/vd regions; relabel or mark unmatched per lens first |
+| ★ TAFD40 | Hoya | 3 | Added in Phase 7 as formula-3 polynomial |
 | S-TIF6 | Ohara | 2 | **Skip** — not in refractiveindex.info 2017 catalog |
-| S-NPH7 | Ohara | 2 | **Skip** — not in refractiveindex.info 2017 catalog |
+| S-NPH7 | Ohara | 6 | **Skip for direct add** — public Ohara tables list S-NPH7 as nd=1.77830/vd=23.91, but current annotations use high-index nd≈2.0 values; needs per-lens relabeling |
 | N-SK18 | Schott | 2 | **Skip** — not in refractiveindex.info 2017 catalog |
 
 **Phase 4 additions not in the original table** (sourced from survey of 127 lens files, Apr 2026):
@@ -210,6 +219,6 @@ The catalog never needs to be exhaustive. Diminishing returns kick in after the 
 
 1. The headline regression cases (Voigtländer APO-Lanthar 50/2, Leica APO 35/2 / 43/2) hit Sellmeier on every glass surface.
 2. `summarizeDispersionQuality(L)` returns `"sellmeier"` (not `"abbe"`) for the great majority of catalog lenses.
-3. Remaining unmatched glasses are genuinely proprietary (Sumita unidentified, "anomalous high-index flint" without a catalog name), or require custom fitting (Hoya formula-3 polynomial glasses like NBFD3 and TAFD40), or are absent from the rii.info 2017 archive — those should be backfilled per-lens with patent-published `nC`/`nF`/`ng`.
+3. Remaining unmatched glasses are genuinely proprietary (Sumita unidentified, "anomalous high-index flint" without a catalog name), or are catalog names used inconsistently across multiple nd/vd regions (notably NBFD3, TAFD25, and the current S-NPH7 annotations), or are absent from the rii.info 2017 archive — those should be resolved per lens or backfilled with patent-published `nC`/`nF`/`ng`.
 
 For per-lens audits that consume the catalog (relabeling, mismatch resolution, `dPgF`/line-index enrichment), follow [lens-patent-audit.md](lens-patent-audit.md).

--- a/agent_docs/glass-relabel-candidates.generated.md
+++ b/agent_docs/glass-relabel-candidates.generated.md
@@ -886,6 +886,7 @@ Surfaces:
 Candidates:
 - **S-LAH65V** (nd=1.80400, vd=46.58, Δnd=-0.0000, Δvd=-0.02, codeΔ=0.2)
 - **S-LAH65** (nd=1.80400, vd=46.57, Δnd=-0.0000, Δvd=-0.03, codeΔ=0.3)
+- **S-LAH65VS** (nd=1.80400, vd=46.53, Δnd=-0.0000, Δvd=-0.07, codeΔ=0.7)
 
 Surfaces:
 - [CANON FD 50mm f/1.2 L](../src/lens-data/canon/CanonFD50mmf12L.data.ts) `1`: `OHARA S-LAH58 (804466)`
@@ -894,6 +895,7 @@ Surfaces:
 
 Candidates:
 - **S-LAH65** (nd=1.80400, vd=46.57, Δnd=-0.0000, Δvd=-0.03)
+- **S-LAH65VS** (nd=1.80400, vd=46.53, Δnd=-0.0000, Δvd=-0.07)
 - **S-LAH65V** (nd=1.80400, vd=46.58, Δnd=-0.0000, Δvd=-0.02)
 
 Surfaces:
@@ -904,6 +906,7 @@ Surfaces:
 
 Candidates:
 - **S-LAH65** (nd=1.80400, vd=46.57, Δnd=-0.0002, Δvd=+0.07)
+- **S-LAH65VS** (nd=1.80400, vd=46.53, Δnd=-0.0002, Δvd=+0.03)
 - **S-LAH65V** (nd=1.80400, vd=46.58, Δnd=-0.0002, Δvd=+0.08)
 
 Surfaces:
@@ -942,6 +945,7 @@ Surfaces:
 
 Candidates:
 - **S-LAH53** (nd=1.80610, vd=40.93, Δnd=-0.0000, Δvd=-0.01)
+- **S-LAH63Q** (nd=1.80440, vd=39.58, Δnd=-0.0017, Δvd=-1.36)
 - **S-LAH63** (nd=1.80440, vd=39.59, Δnd=-0.0017, Δvd=-1.35)
 - **K-VC89** (nd=1.80998, vd=41.00, Δnd=+0.0039, Δvd=+0.06)
 
@@ -1291,6 +1295,7 @@ Surfaces:
 ## stored (nd=2.00060, vd=25.40)  — 1 surface, current label resolves to S-NPH2
 
 Candidates:
+- **TAFD40** (nd=2.00069, vd=25.46, Δnd=+0.0001, Δvd=+0.06)
 - **S-LAH79** (nd=2.00330, vd=28.27, Δnd=+0.0027, Δvd=+2.87)
 
 Surfaces:
@@ -1299,6 +1304,7 @@ Surfaces:
 ## stored (nd=2.00069, vd=25.50)  — 3 surfaces, current label resolves to S-NPH3
 
 Candidates:
+- **TAFD40** (nd=2.00069, vd=25.46, Δnd=+0.0000, Δvd=-0.04)
 - **S-LAH79** (nd=2.00330, vd=28.27, Δnd=+0.0026, Δvd=+2.77)
 
 Surfaces:
@@ -1309,6 +1315,7 @@ Surfaces:
 ## stored (nd=2.00069, vd=25.46)  — 1 surface, current label resolves to S-NPH5
 
 Candidates:
+- **TAFD40** (nd=2.00069, vd=25.46, Δnd=+0.0000, Δvd=+0.00)
 - **S-LAH79** (nd=2.00330, vd=28.27, Δnd=+0.0026, Δvd=+2.81)
 
 Surfaces:

--- a/agent_docs/unresolved-glass.generated.md
+++ b/agent_docs/unresolved-glass.generated.md
@@ -11,35 +11,29 @@ or per-lens patent backfills.
 - **140** lenses scanned
 - **1593** non-air surfaces examined
 - **1590** element glass declarations examined
-- **550** non-explicit-unmatched annotations did not resolve
-- **202** distinct unresolved glass-like tokens found
+- **533** non-explicit-unmatched annotations did not resolve
+- **195** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency
 
 | Token | Occurrences | Lens files | Notes |
 |---|---:|---:|---|
-| NBFD3 | 8 | 7 | |
+| NBFD3 | 7 | 6 | |
 | 593679 | 6 | 3 | |
 | S-NPH7 | 6 | 5 | |
 | L-PHM52 | 5 | 2 | |
 | TAFD25 | 5 | 4 | |
-| S-LAH63Q | 4 | 4 | |
-| 001255 | 3 | 3 | |
 | 694533 | 3 | 2 | |
 | E-FDS3HT | 3 | 2 | |
-| S-BAH11 | 3 | 3 | |
-| S-LAH65VS | 3 | 3 | |
 | S-LAH93 | 3 | 3 | |
 | S-LAL59 | 3 | 3 | |
 | S-LAM55 | 3 | 3 | |
 | S-NBH52V | 3 | 3 | |
-| S-NBM51 | 3 | 2 | |
 | S-TIF6 | 3 | 3 | |
 | S-TIH11 | 3 | 3 | |
 | S-TIH53W | 3 | 3 | |
 | S-TIL25 | 3 | 3 | |
 | S-TIL6 | 3 | 3 | |
-| TAFD40 | 3 | 3 | |
 | 051269 | 2 | 1 | |
 | 159319 | 2 | 1 | |
 | 519699 | 2 | 1 | |
@@ -69,6 +63,7 @@ or per-lens patent backfills.
 | L-LAM60 | 2 | 2 | |
 | N-LAK14 | 2 | 2 | |
 | NBFD11 | 2 | 2 | |
+| S-BAH11 | 2 | 2 | |
 | S-BAH27 | 2 | 2 | |
 | S-BAH28 | 2 | 2 | |
 | S-BAL2 | 2 | 2 | |
@@ -101,7 +96,6 @@ or per-lens patent backfills.
 | 583595 | 1 | 1 | |
 | 603564 | 1 | 1 | |
 | 612372 | 1 | 1 | |
-| 613443 | 1 | 1 | |
 | 619636 | 1 | 1 | |
 | 623581 | 1 | 1 | |
 | 624584 | 1 | 1 | |
@@ -216,14 +210,13 @@ or per-lens patent backfills.
 | SF8 | 1 | 1 | |
 | SK4 | 1 | 1 | |
 | TAF1 | 1 | 1 | |
-| TAF3D | 1 | 1 | |
 | TAFD5 | 1 | 1 | |
 | TAFD65 | 1 | 1 | |
 | TAFL3 | 1 | 1 | |
 
 ## Occurrences
 
-### NBFD3 — 8 occurrences
+### NBFD3 — 7 occurrences
 
 - [CANON SERENAR 50mm f/1.8](../src/lens-data/canon/CanonSerenar50mmf18.data.ts) 4: `NBFD3 (HOYA)`
 - [FUJIFILM FUJINON XF 80mm f/2.8 R LM OIS WR Macro](../src/lens-data/fujifilm/FujifilmXF80f28.data.ts) 11: `Barium flint (nearest: HOYA NBFD3; no exact OHARA match)`
@@ -232,7 +225,6 @@ or per-lens patent backfills.
 - [NIKON PC NIKKOR 19mm f/4E ED](../src/lens-data/nikon/NikonNikkorPCE19mmf4E.data.ts) 9: `NBFD3 (HOYA)`
 - [NIKON PC NIKKOR 19mm f/4E ED](../src/lens-data/nikon/NikonNikkorPCE19mmf4E.data.ts) 15: `NBFD3 (HOYA)`
 - [OLYMPUS G.ZUIKO AUTO-S 50mm f/1.4](../src/lens-data/olympus/OlympusZuikoAutoS50mmf14.data.ts) 10: `LaSF3 (Schott LaSF3 / HOYA NBFD3 — exact)`
-- [VOIGTLÄNDER ULTRON Vintage Line 28mm F2 Aspherical](../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) 17A: `NBFD3 (HOYA) / S-LAH63Q (OHARA)`
 
 ### 593679 — 6 occurrences
 
@@ -268,19 +260,6 @@ or per-lens patent backfills.
 - [NIKON PC NIKKOR 19mm f/4E ED](../src/lens-data/nikon/NikonNikkorPCE19mmf4E.data.ts) 27: `TAFD25 (HOYA)`
 - [NIKON NIKKOR Z 24-200mm f/4-6.3 VR](../src/lens-data/nikon/NikonNikkorZ24200mmf463VR.data.ts) 13: `TAFD25 equiv. (181600/4659)`
 
-### S-LAH63Q — 4 occurrences
-
-- [FUJIFILM FUJINON XF 23mm F1.4 R](../src/lens-data/fujifilm/FujifilmXF23mmf14.data.ts) 13A: `S-LAH63Q (OHARA, PGM)`
-- [NIKON AF-S MICRO-NIKKOR 60mm f/2.8G ED](../src/lens-data/nikon/NikonAFSMicroNikkor60f28G.data.ts) 1: `S-LAH63Q (OHARA)`
-- [NIKON AF-S NIKKOR 120-300mm f/2.8E FL ED SR VR](../src/lens-data/nikon/NikonNikkorAFS120300mmf28.data.ts) 36: `OHARA S-LAH63Q type`
-- [VOIGTLÄNDER ULTRON Vintage Line 28mm F2 Aspherical](../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) 17A: `NBFD3 (HOYA) / S-LAH63Q (OHARA)`
-
-### 001255 — 3 occurrences
-
-- [CANON RF 24-240mm F4-6.3 IS USM](../src/lens-data/canon/CanonRF24240mmf463.data.ts) 20: `001255 - ultra-high-index dense flint (patent nd=2.00069, vd=25.5)`
-- [NIKON NIKKOR Z 100-400mm f/4.5-5.6 VR S](../src/lens-data/nikon/NikonNikkorZ100400f4556.data.ts) 29: `001255 - ultra-high-index dense flint (nd=2.00069, vd~25.5)`
-- [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../src/lens-data/nikon/NikonZ105f28.data.ts) 24: `Ultra-high-index specialty (glass code 001255, nd > 2.0)`
-
 ### 694533 — 3 occurrences
 
 - [NIKON NIKKOR Z 14-30mm f/4 S](../src/lens-data/nikon/NikonNikkorZ1430mmf4S.data.ts) 1: `694533 — high-index crown (patent nd=1.69370, νd=53.32)`
@@ -292,18 +271,6 @@ or per-lens patent backfills.
 - [NIKON NIKKOR Z 35mm f/1.2 S](../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) 5: `Ultra-high-index dense flint (921240, HOYA TAFD5F / HIKARI E-FDS3HT)`
 - [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../src/lens-data/nikon/NikonZ105f28.data.ts) 11: `E-FDS3HT (Hikari) or equiv.`
 - [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../src/lens-data/nikon/NikonZ105f28.data.ts) 22: `E-FDS3HT (Hikari) or equiv.`
-
-### S-BAH11 — 3 occurrences
-
-- [CANON RF 28-70mm F2.8 IS STM](../src/lens-data/canon/CanonRF2870mmf28.data.ts) 24: `613443 — S-BAH11 family (OHARA)`
-- [NIKON AF-S NIKKOR 14-24mm f/2.8G ED](../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.ts) 3: `S-BAH11 (OHARA)`
-- [PANASONIC LUMIX S PRO 50mm f/1.4](../src/lens-data/panasonic/PanasonicSPro50mmf14.data.ts) 21: `S-BAH11 (OHARA)`
-
-### S-LAH65VS — 3 occurrences
-
-- [FUJIFILM FUJINON XF 35mmF1.4 R](../src/lens-data/fujifilm/FujifilmXF35mmf14R.data.ts) 3: `S-LAH65VS (OHARA)`
-- [NIKON AF-S NIKKOR 70-200mm f/2.8E FL ED VR](../src/lens-data/nikon/NikonNikkorAFS70200mmf28E.data.ts) 31: `S-LAH65VS (OHARA) / TAF3D (HOYA)`
-- [PANASONIC LUMIX S PRO 50mm f/1.4](../src/lens-data/panasonic/PanasonicSPro50mmf14.data.ts) 14: `S-LAH65VS (OHARA)`
 
 ### S-LAH93 — 3 occurrences
 
@@ -328,12 +295,6 @@ or per-lens patent backfills.
 - [NIKON AF-S NIKKOR 120-300mm f/2.8E FL ED SR VR](../src/lens-data/nikon/NikonNikkorAFS120300mmf28.data.ts) 12: `OHARA S-NBH52V`
 - [NIKON NIKKOR Z 50mm f/1.2 S](../src/lens-data/nikon/NikonNikkorZ50f12.data.ts) 16: `S-NBH52V (OHARA)`
 - [NIKON NIKKOR Z 58mm f/0.95 S Noct](../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) 24: `Dense flint (near S-NBH52V)`
-
-### S-NBM51 — 3 occurrences
-
-- [NIKON AF-S NIKKOR 58mm f/1.4G](../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) 13: `S-NBM51 / KZFS2-type (short flint, anomalous partial dispersion)`
-- [SIGMA 35mm F1.4 DG DN | Art](../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) 10: `OHARA S-NBM51 (613/443)`
-- [SIGMA 35mm F1.4 DG DN | Art](../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) 23: `OHARA S-NBM51 (613/443)`
 
 ### S-TIF6 — 3 occurrences
 
@@ -364,12 +325,6 @@ or per-lens patent backfills.
 - [CANON RF 15-35mm f/2.8 L IS USM](../src/lens-data/canon/CanonRF1535f28.data.ts) 12: `S-TIL6 (OHARA)`
 - [RICOH GR IIIx 26.1mm f/2.8](../src/lens-data/ricoh/RicohGR3x.data.ts) 10: `OHARA S-TIL6`
 - [SIGMA 30mm f/2.8 (DP2 Merrill)](../src/lens-data/sigma/SigmaDp2M30mmf28.data.ts) 12: `S-TIL6 (OHARA)`
-
-### TAFD40 — 3 occurrences
-
-- [FUJIFILM FUJINON XF 23mm F1.4 R](../src/lens-data/fujifilm/FujifilmXF23mmf14.data.ts) 5: `TAFD40 (HOYA)`
-- [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6G ED VR](../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) 26: `TAFD40 (HOYA)`
-- [NIKON NIKKOR Z 24-70mm f/4 S](../src/lens-data/nikon/NikonNikkorZ2470mmf4S.data.ts) 8: `TAFD40 (HOYA)`
 
 ### 051269 — 2 occurrences
 
@@ -516,6 +471,11 @@ or per-lens patent backfills.
 - [NIKON AF-S NIKKOR 200-500mm f/5.6E ED VR](../src/lens-data/nikon/NikonNikkorAFS200500mmf56.data.ts) 1: `NBFD11 (HOYA)`
 - [SONY SONNAR T* FE 35mm F2.8 ZA](../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) 10: `NBFD11 (Hoya)`
 
+### S-BAH11 — 2 occurrences
+
+- [NIKON AF-S NIKKOR 14-24mm f/2.8G ED](../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.ts) 3: `S-BAH11 (OHARA)`
+- [PANASONIC LUMIX S PRO 50mm f/1.4](../src/lens-data/panasonic/PanasonicSPro50mmf14.data.ts) 21: `S-BAH11 (OHARA)`
+
 ### S-BAH27 — 2 occurrences
 
 - [NIKON NIKKOR Z 135mm f/1.8 S Plena](../src/lens-data/nikon/NikonZ135f18.data.ts) 13: `Barium crown (near S-BAH27)`
@@ -661,10 +621,6 @@ or per-lens patent backfills.
 ### 612372 — 1 occurrence
 
 - [CARL ZEISS JENA TESSAR 50mm f/2.8](../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) 3: `612372 F (≈ Schott F3 legacy)`
-
-### 613443 — 1 occurrence
-
-- [CANON RF 28-70mm F2.8 IS STM](../src/lens-data/canon/CanonRF2870mmf28.data.ts) 24: `613443 — S-BAH11 family (OHARA)`
 
 ### 619636 — 1 occurrence
 
@@ -1121,10 +1077,6 @@ or per-lens patent backfills.
 ### TAF1 — 1 occurrence
 
 - [NIKON AI NIKKOR 85mm f/1.4S](../src/lens-data/nikon/Nikon85f14AIS.data.ts) 1: `LaK–LaF border (HOYA TAF1 / Schott N-LAF34 class, 773-494)`
-
-### TAF3D — 1 occurrence
-
-- [NIKON AF-S NIKKOR 70-200mm f/2.8E FL ED VR](../src/lens-data/nikon/NikonNikkorAFS70200mmf28E.data.ts) 31: `S-LAH65VS (OHARA) / TAF3D (HOYA)`
 
 ### TAFD5 — 1 occurrence
 

--- a/src/lens-data/nikon/Nikon58f14GDesignCandidate.analysis.md
+++ b/src/lens-data/nikon/Nikon58f14GDesignCandidate.analysis.md
@@ -117,7 +117,7 @@ The refractive index step at the cemented junction is Ncp − Ncn = +0.1548 (the
 
 - **Surfaces:** 12 (R = +118.766), 13 (junction, R = −44.232), 14 (junction, R = +44.268), 15A (aspherical, R = −77.294)
 - **Ldp1 glass:** nd = 1.88300, νd = 40.66 → **OHARA S-LAH64** (exact match). Note: this is a *different* catalog glass from Lcp's S-LAH58 (νd = 40.77), not a melt variation — S-LAH64 has a distinct composition.
-- **Ldn glass:** nd = 1.53172, νd = 48.78 → **OHARA S-NBM51** (exact match) or **Schott KZFS2** (Δνd = 0.06)
+- **Ldn glass:** nd = 1.53172, νd = 48.78 → KZFS2-type short flint; public OHARA S-NBM51 is not an nd/νd match.
 - **Ldp2 glass:** nd = 1.74443, νd = 49.53 → Same glass as La (Sumita K-LaKn2 / HIKARI E-LAF7 / OHARA S-LAH55)
 - **Combined focal length:** +35.2 mm (strong net positive)
 - **Aspherical surface:** Surface 15 (rear), patent κ = 14.1597, standard K = +13.1597 (oblate ellipsoid)
@@ -126,7 +126,7 @@ The refractive index step at the cemented junction is Ncp − Ncn = +0.1548 (the
 
 The patent's conditional expression 1 specifies that the average refractive index of the two positive elements must exceed the negative element's index by 0.01–0.50 (actual value: 0.2820). This ensures a strongly negative contribution to the Petzval sum from within the triplet, counteracting the overall positive power's tendency to curve the field inward.
 
-The central negative element Ldn uses S-NBM51 / KZFS2-type glass, which is a **short flint** known for anomalous partial dispersion (positive ΔPgF deviation from the normal line). Paired with the high-index lanthanum positive elements, the triplet achieves partial-dispersion balancing that reduces secondary spectrum within the rear group. This is consistent with the production lens's reported absence of purple fringing.
+The central negative element Ldn uses a KZFS2-type short flint with anomalous partial dispersion. Paired with the high-index lanthanum positive elements, the triplet achieves partial-dispersion balancing that reduces secondary spectrum within the rear group. This is consistent with the production lens's reported absence of purple fringing.
 
 The conditional expression 3 specifies the shape factor of Ldn: (rd2 + rd1)/(rd2 − rd1) = 0.0004, which means rd1 ≈ −rd2 — essentially a symmetric biconcave lens. The patent states this is optimal for simultaneously correcting spherical aberration, meridional coma, and sagittal coma (paragraph 0035).
 
@@ -145,13 +145,13 @@ The nine elements use **seven distinct glass types** (corrected from the origina
 | Dense flint (high) | Lcn | 1.72825 | 28.46 | OHARA S-TIH11 / Schott N-SF10 | Chromatic balancing |
 | High-index lanthanum | Lcp | 1.88300 | 40.77 | OHARA S-LAH58 | Petzval correction |
 | High-index lanthanum | Ldp1 | 1.88300 | 40.66 | OHARA S-LAH64 | Petzval correction |
-| Short flint (APD) | Ldn | 1.53172 | 48.78 | OHARA S-NBM51 | Secondary spectrum control |
+| Short flint (APD) | Ldn | 1.53172 | 48.78 | Unmatched KZFS2-type | Secondary spectrum control |
 
 **Key correction from earlier analysis:** The La/Ldp2 glass was previously identified as "Schott LASF35," which has νd ≈ 44.8 — a 4.7-unit Abbe number discrepancy. The correct match is Sumita K-LaKn2 (νd = 49.52, Δνd = 0.01) or HIKARI E-LAF7. Nikon frequently sources specialty glasses from Japanese suppliers including Sumita and HIKARI, making these identifications plausible. However, Nikon may also use in-house or custom-melt glasses not available in public catalogs; all identifications remain inferential.
 
 **Additional correction:** Lcp (S-LAH58, νd = 40.77) and Ldp1 (S-LAH64, νd = 40.66) are **distinct catalog glasses** with different compositions, not melt variations of the same type as previously suggested. The 0.11 νd difference corresponds to a meaningful dispersion difference relevant to chromatic balancing within the rear triplet.
 
-The design uses no ED glass (νd > 80), consistent with Nikon's marketing — the lens carries no ED designation. Chromatic correction relies on the FK5-type glass in Lb1n (νd = 70.3) for primary color, and the anomalous-dispersion S-NBM51 in Ldn for secondary spectrum control within the rear triplet.
+The design uses no ED glass (νd > 80), consistent with Nikon's marketing — the lens carries no ED designation. Chromatic correction relies on the FK5-type glass in Lb1n (νd = 70.3) for primary color, and the anomalous-dispersion KZFS2-type glass in Ldn for secondary spectrum control within the rear triplet.
 
 ---
 
@@ -291,7 +291,7 @@ The inventor, Haruo Sato, is one of Nikon's optical designers associated with th
 6. **NikonForums** — "AF-S Nikkor 58mm F1.4G Review": "Focusing is not internal, so at the minimum focusing distance, the front element moves forward by about one centimeter."
 7. **Thom Hogan (DSLRBodies)** — "Nikon 58mm f/1.4G AF-S Lens Review."
 8. **Nikon "NIKKOR — The Thousand and One Nights"** — Tale 16 (Ai Noct-NIKKOR 58mm f/1.2), Tale 40 (Nikkor-S Auto 5.8cm f/1.4). imaging.nikon.com.
-9. **OHARA Optical Glass Catalog** — Glass identification reference (S-LAH58, S-LAH64, S-LAL14, S-FSL5, S-TIH11, S-TIH4, S-NBM51).
+9. **OHARA Optical Glass Catalog** — Glass identification reference (S-LAH58, S-LAH64, S-LAL14, S-FSL5, S-TIH11, S-TIH4).
 10. **Schott Optical Glass Catalog** — Glass identification reference (N-LAK14, FK5, N-SF8, N-SF10, N-LASF44, KZFS2).
 11. **Sumita Optical Glass Catalog** — Glass identification reference (K-LaKn2).
 

--- a/src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts
+++ b/src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts
@@ -156,7 +156,7 @@ const LENS_DATA = {
       nd: 1.53172,
       vd: 48.78,
       fl: -41.4,
-      glass: "S-NBM51 / KZFS2-type (short flint, anomalous partial dispersion)",
+      glass: "Unmatched (KZFS2-type short flint; S-NBM51 name rejected by stored nd/vd)",
       apd: "inferred",
       apdNote: "Short flint with positive ΔPgF; paired with S-LAH58 positive elements for secondary spectrum control",
       cemented: "Ld",

--- a/src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.analysis.md
@@ -129,7 +129,7 @@ Nikon states the lens incorporates **four ED (Extra-low Dispersion) glass elemen
 | L42 | 1.90265 | 35.7 | 1903/357 | Same as L11 | Normal |
 | L51 | 1.74400 | 44.8 | 1744/448 | S-LAM2 (OHARA), exact | Normal |
 | L52 | 1.48749 | 70.3 | 1487/703 | S-FSL5 (OHARA) / N-FK5 (Schott) | Normal |
-| L53 | 1.95000 | 29.4 | 1950/294 | TAFD40 (HOYA), exact | Normal |
+| L53 | 1.95000 | 29.4 | 1950/294 | TAFD45 (HOYA), near match | Normal |
 | L54 | 1.51742 | 52.2 | 1517/522 | S-NSL36 (OHARA) / K10 (Schott) | Normal |
 | L55 | 1.64769 | 33.7 | 1648/337 | S-TIF6 (OHARA), exact | Normal |
 | L56 | 1.60300 | 65.4 | 1603/654 | No close catalog match; likely proprietary | Normal |

--- a/src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts
+++ b/src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts
@@ -260,7 +260,7 @@ const LENS_DATA = {
       nd: 1.95,
       vd: 29.4,
       fl: -27.8,
-      glass: "TAFD40 (HOYA)",
+      glass: "TAFD45 (HOYA)",
       apd: false,
       cemented: "T1",
       role: "Ultra-high-index center negative; Petzval flattener",

--- a/src/optics/glassCatalog.ts
+++ b/src/optics/glassCatalog.ts
@@ -10,7 +10,7 @@
  *   n²(λ) = 1 + B1·λ²/(λ²−C1) + B2·λ²/(λ²−C2) + B3·λ²/(λ²−C3)
  *   where λ is in micrometres and C1..C3 are in micrometres².
  *
- * Coverage status: Phase 6 (111 entries). See agent_docs/glass-catalog-buildout.md
+ * Coverage status: Phase 7 (115 entries). See agent_docs/glass-catalog-buildout.md
  * for the addition history and sourcing playbook.
  *
  * All coefficients are vendor-published physical measurements. Each entry
@@ -80,7 +80,7 @@ export function evaluateSellmeier(entry: GlassEntry, lambdaNm: number): number {
 }
 
 /* ──────────────────────────────────────────────────────────────────────────
- * GLASS CATALOG — 111 vendor-verified entries (Phase 6, May 2026)
+ * GLASS CATALOG — 115 vendor-verified entries (Phase 7, May 2026)
  *
  * Coefficients are taken from authoritative public vendor catalogs. Each
  * entry's `source` field cites the document or database used. To verify a
@@ -1263,6 +1263,38 @@ const RAW_CATALOG: readonly GlassEntry[] = [
     source: "Ohara Zemax catalog 2017-11-30 via refractiveindex.info; S-NPH5 page.",
   },
   {
+    name: "S-LAH63Q",
+    vendor: "Ohara",
+    B: [1.96723017, 0.194953915, 1.25386282],
+    C: [0.0110456086, 0.0497137061, 104.84352],
+    nd: 1.8044,
+    vd: 39.580489,
+    PgF: 0.576,
+    code6: "804396",
+    source: "Ohara Zemax catalog 2017-11-30 via refractiveindex.info; S-LAH63Q page.",
+  },
+  {
+    name: "S-LAH65VS",
+    vendor: "Ohara",
+    B: [1.76068422, 0.414128906, 1.33415439],
+    C: [0.00853607198, 0.0301826383, 98.09421],
+    nd: 1.804,
+    vd: 46.527532,
+    PgF: 0.557,
+    source: "Ohara Zemax catalog 2017-11-30 via refractiveindex.info; S-LAH65VS page.",
+  },
+  {
+    name: "S-NBM51",
+    vendor: "Ohara",
+    B: [1.37023101, 0.177665568, 1.30515471],
+    C: [0.00871920342, 0.0405725552, 112.703058],
+    nd: 1.613397,
+    vd: 44.267706,
+    PgF: 0.5628,
+    code6: "613443",
+    source: "Ohara Zemax catalog 2017-11-30 via refractiveindex.info; S-NBM51 page.",
+  },
+  {
     name: "S-FTM16",
     vendor: "Ohara",
     B: [1.32940907, 0.141512125, 1.44299068],
@@ -1389,6 +1421,16 @@ const RAW_CATALOG: readonly GlassEntry[] = [
     vd: 29.13,
     PgF: 0.5986,
     source: "Hoya Zemax catalog 2017-04-01 via refractiveindex.info; TAFD55 page (formula 3 polynomial).",
+  },
+  {
+    name: "TAFD40",
+    vendor: "Hoya",
+    polynomial: [3.8106232, -0.016351565, 0.058801097, 0.0034919026, -0.0001694811, 0.000032569333],
+    nd: 2.00069,
+    vd: 25.46,
+    PgF: 0.6121,
+    code6: "001255",
+    source: "Hoya Zemax catalog 2017-04-01 via refractiveindex.info; TAFD40 page (formula 3 polynomial).",
   },
 
   /* Sumita priority addition */

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -23,6 +23,11 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-05-04",
     type: "improvement",
+    summary: "Expanded Sellmeier coverage for moldable Ohara glasses and Hoya TAFD40",
+  },
+  {
+    date: "2026-05-04",
+    type: "improvement",
     summary: "Expanded the glass catalog to 111 verified entries with priority ED and high-index glasses",
   },
   {


### PR DESCRIPTION
## Summary

- Added verified catalog entries for S-LAH63Q, S-LAH65VS, S-NBM51, and Hoya TAFD40.
- Regenerated unresolved, mismatch, and relabel-candidate glass reports after the catalog expansion.
- Corrected two misleading Nikon glass annotations exposed by the new catalog entries: Nikon 58mm f/1.4G design candidate now marks the KZFS2-type element as unmatched, and Nikon 80-400mm f/4.5-5.6G ED VR uses TAFD45 for the nd/vd region that matches the existing catalog.
- Updated the glass buildout notes and changelog for the new Phase 7 catalog state.

## Validation

- `npm test -- dispersion.test.ts`
- `npm test -- unresolvedGlassScan`
- `npm test -- catalogMismatchScan`
- `npm test -- glassRelabelCandidatesScan`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`