### PR TITLE
Refine Article TOC IntersectionObserver behavior and add active-heading tests

### DIFF
--- a/__tests__/ArticleTOC.test.ts
+++ b/__tests__/ArticleTOC.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { extractTOCHeadings } from "../src/components/display/ArticleTOC.js";
+import {
+  ARTICLE_SCROLL_MARGIN_TOP,
+  TOC_OBSERVER_BOTTOM_ROOT_MARGIN,
+  TOC_OBSERVER_THRESHOLDS,
+  extractTOCHeadings,
+  resolveTopmostVisibleHeading,
+} from "../src/components/display/ArticleTOC.js";
 
 describe("extractTOCHeadings", () => {
   it("extracts h2 and h3 headings and ignores h1/h4+", () => {
@@ -42,5 +48,38 @@ describe("extractTOCHeadings", () => {
     const md = ["## Hello, World!", "## Stop-Shift Equations"].join("\n");
     const headings = extractTOCHeadings(md);
     expect(headings.map((h) => h.id)).toEqual(["hello-world", "stop-shift-equations"]);
+  });
+});
+
+describe("TOC active heading resolver", () => {
+  it("prefers the topmost heading for adjacent short H3s", () => {
+    const tops = new Map([
+      ["h3-a", 180],
+      ["h3-b", 192],
+    ]);
+    const active = resolveTopmostVisibleHeading(["h3-a", "h3-b"], (id) => tops.get(id) ?? null);
+    expect(active).toBe("h3-a");
+  });
+
+  it("keeps the only visible heading active for long sparse sections", () => {
+    const tops = new Map([["h2-long", 260]]);
+    const active = resolveTopmostVisibleHeading(["h2-long"], (id) => tops.get(id) ?? null);
+    expect(active).toBe("h2-long");
+  });
+
+  it("handles top-of-page and bottom-of-page transitions by choosing the smallest top", () => {
+    const topOfPage = resolveTopmostVisibleHeading(["intro"], (id) => (id === "intro" ? 88 : null));
+    expect(topOfPage).toBe("intro");
+
+    const nearBottom = resolveTopmostVisibleHeading(["middle", "end"], (id) =>
+      id === "middle" ? 40 : id === "end" ? -12 : null,
+    );
+    expect(nearBottom).toBe("end");
+  });
+
+  it("uses observer config aligned with markdown heading scroll margin behavior", () => {
+    expect(ARTICLE_SCROLL_MARGIN_TOP).toBe(88);
+    expect(TOC_OBSERVER_BOTTOM_ROOT_MARGIN).toBe("-35%");
+    expect(TOC_OBSERVER_THRESHOLDS).toEqual([0, 0.1, 0.25, 0.5]);
   });
 });

--- a/src/components/display/ArticleTOC.tsx
+++ b/src/components/display/ArticleTOC.tsx
@@ -38,6 +38,10 @@ export interface ArticleTOCProps {
   wideQuery?: string;
 }
 
+export const ARTICLE_SCROLL_MARGIN_TOP = 88;
+export const TOC_OBSERVER_THRESHOLDS = [0, 0.1, 0.25, 0.5];
+export const TOC_OBSERVER_BOTTOM_ROOT_MARGIN = "-35%";
+
 /**
  * Pure markdown → headings extractor. Exported for unit testing.
  * Skips fenced code blocks so `## ` inside ``` blocks isn't misread.
@@ -95,6 +99,22 @@ function useMediaQueryMatch(query: string): boolean {
 }
 
 /** Track the currently-visible heading via IntersectionObserver. */
+export function resolveTopmostVisibleHeading(
+  visibleIds: Iterable<string>,
+  getTop: (id: string) => number | null,
+): string | null {
+  let topId: string | null = null;
+  let topY = Infinity;
+  for (const id of visibleIds) {
+    const top = getTop(id);
+    if (top !== null && top < topY) {
+      topY = top;
+      topId = id;
+    }
+  }
+  return topId;
+}
+
 function useActiveHeading(ids: string[], offsetTop: number): string | null {
   const [activeId, setActiveId] = useState<string | null>(null);
   useEffect(() => {
@@ -103,6 +123,7 @@ function useActiveHeading(ids: string[], offsetTop: number): string | null {
     if (elements.length === 0) return;
 
     const visible = new Map<string, number>();
+    const rootTopOffset = Math.max(offsetTop, ARTICLE_SCROLL_MARGIN_TOP);
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
@@ -110,19 +131,17 @@ function useActiveHeading(ids: string[], offsetTop: number): string | null {
           else visible.delete(entry.target.id);
         }
         if (visible.size > 0) {
-          let topId: string | null = null;
-          let topY = Infinity;
-          for (const id of visible.keys()) {
+          const topId = resolveTopmostVisibleHeading(visible.keys(), (id) => {
             const rect = document.getElementById(id)?.getBoundingClientRect();
-            if (rect && rect.top < topY) {
-              topY = rect.top;
-              topId = id;
-            }
-          }
+            return rect ? rect.top : null;
+          });
           if (topId) setActiveId(topId);
         }
       },
-      { rootMargin: `-${offsetTop}px 0px -60% 0px`, threshold: [0, 1] },
+      {
+        rootMargin: `-${rootTopOffset}px 0px ${TOC_OBSERVER_BOTTOM_ROOT_MARGIN} 0px`,
+        threshold: TOC_OBSERVER_THRESHOLDS,
+      },
     );
 
     for (const el of elements) observer.observe(el);
@@ -136,7 +155,7 @@ export default function ArticleTOC({
   theme: t,
   title = "On this page",
   minHeadings = 3,
-  offsetTop = 80,
+  offsetTop = ARTICLE_SCROLL_MARGIN_TOP,
   width = 220,
   wideQuery = "(min-width: 1200px)",
 }: ArticleTOCProps) {


### PR DESCRIPTION
### Motivation

- Improve the table-of-contents active-heading selection so nearby short headings don't flip prematurely and long sparse sections remain selected while visible. 
- Align the TOC scrollspy geometry with the markdown heading anchor behavior (`scrollMarginTop`) so clicking anchors and the observer use the same top offset baseline. 

### Description

- Introduced exported constants `ARTICLE_SCROLL_MARGIN_TOP`, `TOC_OBSERVER_THRESHOLDS`, and `TOC_OBSERVER_BOTTOM_ROOT_MARGIN` and switched thresholds to `[0, 0.1, 0.25, 0.5]` while reducing the bottom root margin to `-35%`. 
- Compute the observer top offset as `Math.max(offsetTop, ARTICLE_SCROLL_MARGIN_TOP)` so the TOC observer aligns with heading `scrollMarginTop`, and set the TOC default `offsetTop` to `ARTICLE_SCROLL_MARGIN_TOP`. 
- Extracted and exported `resolveTopmostVisibleHeading()` to centralize the “topmost visible heading wins” logic and made `useActiveHeading()` use it. 
- Updated `__tests__/ArticleTOC.test.ts` to add unit tests that cover adjacent short H3 selection, long sparse-section persistence, top/bottom page transition behavior, and observer-configuration expectations. 

### Testing

- Ran formatting with `npm run format` and linting with `npm run lint`, both completed successfully. 
- Executed the targeted TOC tests with `npx vitest run __tests__/ArticleTOC.test.ts --testTimeout 30000`, which passed (11 tests). 
- Generated build metadata with `npm run generate:metadata` and ran `npm run typecheck`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e22eb48483268e57e5e9932598b6)