### PR TITLE
[codex] Guard build metadata dates

### DIFF
--- a/__tests__/buildMetadataHelpers.test.ts
+++ b/__tests__/buildMetadataHelpers.test.ts
@@ -14,9 +14,41 @@ describe("build metadata helpers", () => {
   it("rejects shallow git history before freshness generation", () => {
     expect(() =>
       assertFullGitHistory({
+        allowFetch: false,
         execFileImpl: () => "true\n",
       }),
     ).toThrow(/checkout is shallow/);
+  });
+
+  it("unshallows git history before freshness generation when possible", () => {
+    const calls: string[][] = [];
+    const shallowStates = ["true\n", "false\n"];
+
+    expect(() =>
+      assertFullGitHistory({
+        execFileImpl: (_file, args) => {
+          calls.push(args);
+          if (args[0] === "fetch") return "";
+          return shallowStates.shift() ?? "false\n";
+        },
+      }),
+    ).not.toThrow();
+    expect(calls).toEqual([
+      ["rev-parse", "--is-shallow-repository"],
+      ["fetch", "--unshallow"],
+      ["rev-parse", "--is-shallow-repository"],
+    ]);
+  });
+
+  it("rejects shallow git history when unshallowing fails", () => {
+    expect(() =>
+      assertFullGitHistory({
+        execFileImpl: (_file, args) => {
+          if (args[0] === "fetch") throw new Error("network unavailable");
+          return "true\n";
+        },
+      }),
+    ).toThrow(/git fetch --unshallow failed/);
   });
 
   it("allows complete git history before freshness generation", () => {

--- a/__tests__/buildMetadataHelpers.test.ts
+++ b/__tests__/buildMetadataHelpers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertFreshnessDiversity,
+  assertFullGitHistory,
   buildRouteFreshness,
   combineFreshnessEntries,
   getFirstGitFileFreshness,
@@ -9,6 +11,22 @@ import {
 } from "../scripts/build-metadata-lib.mjs";
 
 describe("build metadata helpers", () => {
+  it("rejects shallow git history before freshness generation", () => {
+    expect(() =>
+      assertFullGitHistory({
+        execFileImpl: () => "true\n",
+      }),
+    ).toThrow(/checkout is shallow/);
+  });
+
+  it("allows complete git history before freshness generation", () => {
+    expect(() =>
+      assertFullGitHistory({
+        execFileImpl: () => "false\n",
+      }),
+    ).not.toThrow();
+  });
+
   it("parses git log output into published and modified dates", () => {
     const dates = parseGitLogDates(
       ["2026-03-27T10:00:00-04:00", "2026-03-25T10:00:00-04:00", "2026-03-19T10:00:00-04:00"].join("\n"),
@@ -100,6 +118,57 @@ describe("build metadata helpers", () => {
       publishedOn: "2026-03-19",
       lastModified: "2026-03-27",
     });
+  });
+
+  it("rejects mature metadata when publication dates collapse to one date", () => {
+    const lenses = Array.from({ length: 10 }, (_, index) => ({
+      key: `lens-${index}`,
+      makerSlug: "canon",
+      freshness: { publishedOn: "2026-05-05", lastModified: "2026-05-05" },
+    }));
+    const articles = Array.from({ length: 5 }, (_, index) => ({
+      slug: `article-${index}`,
+      publishedOn: "2026-05-05",
+      lastModified: "2026-05-05",
+    }));
+
+    expect(() => assertFreshnessDiversity({ lenses, articles })).toThrow(/only 1 publication date/);
+  });
+
+  it("allows mature metadata with diverse publication dates", () => {
+    const lenses = [
+      {
+        key: "lens-a",
+        makerSlug: "canon",
+        freshness: { publishedOn: "2026-03-19", lastModified: "2026-04-01" },
+      },
+      {
+        key: "lens-b",
+        makerSlug: "nikon",
+        freshness: { publishedOn: "2026-04-01", lastModified: "2026-04-01" },
+      },
+    ];
+    const articles = [
+      {
+        slug: "article-a",
+        publishedOn: "2026-03-19",
+        lastModified: "2026-04-01",
+      },
+      {
+        slug: "article-b",
+        publishedOn: "2026-04-01",
+        lastModified: "2026-04-01",
+      },
+    ];
+
+    expect(() =>
+      assertFreshnessDiversity({
+        lenses,
+        articles,
+        minimumLensEntries: 2,
+        minimumArticleEntries: 2,
+      }),
+    ).not.toThrow();
   });
 
   it("builds route freshness from content freshness", () => {

--- a/__tests__/buildRouteSync.test.ts
+++ b/__tests__/buildRouteSync.test.ts
@@ -68,6 +68,19 @@ describe("build-route-sync", () => {
     }
   });
 
+  it("published dates retain historical ordering instead of collapsing to one build date", () => {
+    const lensFreshness = Object.values(
+      buildMeta.lensFreshness as Record<string, { publishedOn: string; lastModified: string }>,
+    );
+    const lensPublishedDates = new Set(lensFreshness.map((entry) => entry.publishedOn));
+    const articlePublishedDates = new Set(
+      (buildMeta.articles as { publishedOn: string; lastModified: string }[]).map((article) => article.publishedOn),
+    );
+
+    expect(lensPublishedDates.size).toBeGreaterThan(1);
+    expect(articlePublishedDates.size).toBeGreaterThan(1);
+  });
+
   it("makerSlugs match routes with /makers/ prefix", () => {
     const makerRoutes = buildMeta.routes.filter((r: string) => r.startsWith("/makers/"));
 

--- a/scripts/build-metadata-lib.d.mts
+++ b/scripts/build-metadata-lib.d.mts
@@ -15,11 +15,9 @@ export interface ArticleFreshnessInput {
   lastModified: string;
 }
 
-export type ExecFileSyncLike = (
-  file: string,
-  args: string[],
-  options: { cwd?: string; encoding: string },
-) => string;
+export type ExecFileSyncLike = (file: string, args: string[], options: { cwd?: string; encoding: string }) => string;
+
+export function assertFullGitHistory(options?: { cwd?: string; execFileImpl?: ExecFileSyncLike }): void;
 
 export function parseGitLogDates(raw: string): FreshnessEntry | null;
 
@@ -78,6 +76,14 @@ export function combineFreshnessEntries(
   entries: Array<FreshnessEntry | null | undefined>,
   fallbackDate: string,
 ): FreshnessEntry;
+
+export function assertFreshnessDiversity(options: {
+  lenses: LensFreshnessInput[];
+  articles: ArticleFreshnessInput[];
+  minimumLensEntries?: number;
+  minimumArticleEntries?: number;
+  minimumDistinctPublishedDates?: number;
+}): void;
 
 export function buildRouteFreshness(options: {
   lenses: LensFreshnessInput[];

--- a/scripts/build-metadata-lib.d.mts
+++ b/scripts/build-metadata-lib.d.mts
@@ -17,7 +17,11 @@ export interface ArticleFreshnessInput {
 
 export type ExecFileSyncLike = (file: string, args: string[], options: { cwd?: string; encoding: string }) => string;
 
-export function assertFullGitHistory(options?: { cwd?: string; execFileImpl?: ExecFileSyncLike }): void;
+export function assertFullGitHistory(options?: {
+  cwd?: string;
+  execFileImpl?: ExecFileSyncLike;
+  allowFetch?: boolean;
+}): void;
 
 export function parseGitLogDates(raw: string): FreshnessEntry | null;
 

--- a/scripts/build-metadata-lib.mjs
+++ b/scripts/build-metadata-lib.mjs
@@ -4,6 +4,28 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 /**
+ * Metadata dates depend on complete file history. A shallow checkout makes
+ * every tracked file look newly published at the shallow boundary.
+ */
+export function assertFullGitHistory({ cwd, execFileImpl = execFileSync } = {}) {
+  try {
+    const isShallow = execFileImpl("git", ["rev-parse", "--is-shallow-repository"], {
+      cwd,
+      encoding: "utf-8",
+    }).trim();
+
+    if (isShallow === "true") {
+      throw new Error(
+        "Build metadata requires full git history, but this checkout is shallow. " +
+          "Use actions/checkout with fetch-depth: 0, or run git fetch --unshallow before generating metadata.",
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("checkout is shallow")) throw error;
+  }
+}
+
+/**
  * Parse `git log --format=%aI` output into published + modified dates.
  *
  * `git log` returns newest-first, so the first line is the most recent
@@ -127,6 +149,41 @@ export function combineFreshnessEntries(entries, fallbackDate) {
       valid[0].lastModified,
     ),
   };
+}
+
+function assertPublishedDateDiversity(label, entries, { minimumEntries, minimumDistinctDates }) {
+  if (entries.length < minimumEntries) return;
+
+  const publishedDates = new Set(entries.map((entry) => entry.publishedOn));
+  if (publishedDates.size >= minimumDistinctDates) return;
+
+  const onlyDate = [...publishedDates][0] ?? "none";
+  throw new Error(
+    `Build metadata generated ${entries.length} ${label} with only ${publishedDates.size} publication date (${onlyDate}). ` +
+      "This usually means git history is unavailable, shallow, or the content was moved without preserving history. " +
+      "Check the checkout depth and rerun metadata generation before deploying.",
+  );
+}
+
+export function assertFreshnessDiversity({
+  lenses,
+  articles,
+  minimumLensEntries = 10,
+  minimumArticleEntries = 5,
+  minimumDistinctPublishedDates = 2,
+}) {
+  assertPublishedDateDiversity(
+    "lenses",
+    lenses.map((lens) => lens.freshness),
+    {
+      minimumEntries: minimumLensEntries,
+      minimumDistinctDates: minimumDistinctPublishedDates,
+    },
+  );
+  assertPublishedDateDiversity("articles", articles, {
+    minimumEntries: minimumArticleEntries,
+    minimumDistinctDates: minimumDistinctPublishedDates,
+  });
 }
 
 /**

--- a/scripts/build-metadata-lib.mjs
+++ b/scripts/build-metadata-lib.mjs
@@ -7,12 +7,30 @@ const execFileAsync = promisify(execFile);
  * Metadata dates depend on complete file history. A shallow checkout makes
  * every tracked file look newly published at the shallow boundary.
  */
-export function assertFullGitHistory({ cwd, execFileImpl = execFileSync } = {}) {
+export function assertFullGitHistory({ cwd, execFileImpl = execFileSync, allowFetch = true } = {}) {
   try {
-    const isShallow = execFileImpl("git", ["rev-parse", "--is-shallow-repository"], {
+    let isShallow = execFileImpl("git", ["rev-parse", "--is-shallow-repository"], {
       cwd,
       encoding: "utf-8",
     }).trim();
+
+    if (isShallow === "true" && allowFetch) {
+      try {
+        execFileImpl("git", ["fetch", "--unshallow"], {
+          cwd,
+          encoding: "utf-8",
+        });
+        isShallow = execFileImpl("git", ["rev-parse", "--is-shallow-repository"], {
+          cwd,
+          encoding: "utf-8",
+        }).trim();
+      } catch {
+        throw new Error(
+          "Build metadata requires full git history, but this checkout is shallow and git fetch --unshallow failed. " +
+            "Configure the build provider to clone full history, or run git fetch --unshallow before generating metadata.",
+        );
+      }
+    }
 
     if (isShallow === "true") {
       throw new Error(

--- a/scripts/generate-build-metadata.mjs
+++ b/scripts/generate-build-metadata.mjs
@@ -19,6 +19,8 @@ import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import {
+  assertFreshnessDiversity,
+  assertFullGitHistory,
   buildRouteFreshness,
   getFirstGitFileFreshnessAsync,
   getGitFileFreshnessAsync,
@@ -153,6 +155,7 @@ async function collectArticles(fallbackDate) {
 
 async function main() {
   if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+  assertFullGitHistory({ cwd: ROOT });
   const fallbackDate = new Date().toISOString().slice(0, 10);
 
   writeFileSync(MAKER_PREFIXES_FILE, JSON.stringify(MAKER_PREFIXES, null, 2) + "\n", "utf-8");
@@ -169,6 +172,7 @@ async function main() {
   ]);
 
   const lenses = allLenses.filter((lens) => lens.visible !== false);
+  assertFreshnessDiversity({ lenses, articles });
   const lensKeys = lenses.map((l) => l.key).sort();
   const makerSlugs = [...new Set(lenses.map((l) => l.makerSlug))].sort();
   const routes = collectRoutes(lenses, articles, makerSlugs);


### PR DESCRIPTION
## Summary

- Fail metadata generation when git history is shallow, so content dates cannot silently collapse to the checkout boundary.
- Add a publication-date diversity guard for mature lens/article metadata.
- Add regression coverage for shallow history detection, collapsed-date detection, and generated metadata ordering.

## Root Cause

Publication and modification dates are derived from `git log --follow`. If CI or a future migration runs metadata generation without full history, many files can appear to have been first published on the build or migration date, which distorts article and lens ordering.

## Validation

- `npm run generate:metadata`
- `npm test -- buildMetadataHelpers buildRouteSync`
- `npm run typecheck`
- `npm run format:check`