### PR TITLE
[codex] stabilize LCA inset channel toggles

### DIFF
--- a/__tests__/lcaScaling.test.ts
+++ b/__tests__/lcaScaling.test.ts
@@ -38,6 +38,13 @@ describe("computeLcaBarOffsets", () => {
     expect(result.barOffsets.B).toBeUndefined();
   });
 
+  it("includes violet offsets when present", () => {
+    const result = computeLcaBarOffsets({ G: 50.0, V: 49.95 }, 50.0, 66, SC);
+    expect(result.barOffsets.G).toBeCloseTo(0, 10);
+    expect(result.barOffsets.V).toBeDefined();
+    expect(result.barOffsets.V).toBeLessThan(0);
+  });
+
   it("scales proportionally with wider view width", () => {
     const narrow = computeLcaBarOffsets({ R: 50.05, G: 50.0, B: 49.95 }, 50.0, 66, SC);
     const wide = computeLcaBarOffsets({ R: 50.05, G: 50.0, B: 49.95 }, 50.0, 132, SC);

--- a/__tests__/optics.test.ts
+++ b/__tests__/optics.test.ts
@@ -460,7 +460,7 @@ describe("computeChromaticSpread", () => {
     // B: 0.5 + 10*0.03 = 0.8
     expect(result.imgHeights.R).toBeCloseTo(0.7, 8);
     expect(result.imgHeights.B).toBeCloseTo(0.8, 8);
-    expect(result.tcaMm).toBeCloseTo(-0.1, 8);
+    expect(result.tcaMm).toBeCloseTo(0.1, 8);
   });
 
   it("handles missing channels gracefully", () => {
@@ -502,6 +502,32 @@ describe("computeChromaticSpread", () => {
     const bIntercept = 40 - 1.0 / -0.06;
     expect(result.lcaMm).toBeCloseTo(gIntercept - bIntercept, 4);
     expect(result.lcaMm).not.toBe(0);
+  });
+
+  it("uses the selected channel span so hiding a channel cannot increase LCA", () => {
+    const marginalRays = {
+      R: { y: 1.0, u: -0.1, clipped: false }, // intercept = 50
+      G: { y: 1.0, u: -0.0666666667, clipped: false }, // intercept = 55
+      B: { y: 1.0, u: -0.0833333333, clipped: false }, // intercept = 52
+    };
+    const allChannels = computeChromaticSpread(marginalRays, 60, 40);
+    const withoutBlue = computeChromaticSpread({ R: marginalRays.R, G: marginalRays.G }, 60, 40);
+    const withoutGreen = computeChromaticSpread({ R: marginalRays.R, B: marginalRays.B }, 60, 40);
+
+    expect(allChannels.lcaMm).toBeCloseTo(5, 4);
+    expect(withoutBlue.lcaMm).toBeLessThanOrEqual(allChannels.lcaMm);
+    expect(withoutGreen.lcaMm).toBeLessThanOrEqual(allChannels.lcaMm);
+  });
+
+  it("includes violet in chromatic spread when supplied", () => {
+    const marginalRays = {
+      R: { y: 1.0, u: -0.1, clipped: false },
+      G: { y: 1.0, u: -0.0833333333, clipped: false },
+      V: { y: 1.0, u: -0.05, clipped: false },
+    };
+    const result = computeChromaticSpread(marginalRays, 70, 40);
+    expect(result.intercepts.V).toBeCloseTo(60, 4);
+    expect(result.lcaMm).toBeCloseTo(10, 4);
   });
 });
 

--- a/__tests__/useChromaticRays.test.ts
+++ b/__tests__/useChromaticRays.test.ts
@@ -305,6 +305,47 @@ describe("useChromaticRays", () => {
     expect(typeof result.current.chromSpread!.tcaMm).toBe("number");
   });
 
+  it("does not report a larger LCA when a selected RGB channel is hidden", () => {
+    const { L, zPos, IMG_MM, sx, sy, clampedRayEnd, currentPhysStopSD, currentEPSD } = buildTestFixture();
+    const getLca = (channels: { chromR: boolean; chromG: boolean; chromB: boolean }) => {
+      const { result } = renderHook(() =>
+        useChromaticRays({
+          L,
+          zPos,
+          IMG_MM,
+          focusT: 0,
+          zoomT: 0,
+          sx,
+          sy,
+          clampedRayEnd,
+          currentPhysStopSD,
+          currentEPSD,
+          rayDensity: "normal",
+          rayTracksF: false,
+          focusK: 0,
+          showChromatic: true,
+          showOnAxis: true,
+          showOffAxis: "off",
+          ...channels,
+          chromV: false,
+          lensKey: "ZeissSonnar50f15",
+        }),
+      );
+      expect(result.current.error).toBeNull();
+      expect(result.current.chromSpread).not.toBeNull();
+      return result.current.chromSpread!.lcaMm;
+    };
+
+    const allRgb = getLca({ chromR: true, chromG: true, chromB: true });
+    const noRed = getLca({ chromR: false, chromG: true, chromB: true });
+    const noGreen = getLca({ chromR: true, chromG: false, chromB: true });
+    const noBlue = getLca({ chromR: true, chromG: true, chromB: false });
+
+    expect(noRed).toBeLessThanOrEqual(allRgb + 1e-9);
+    expect(noGreen).toBeLessThanOrEqual(allRgb + 1e-9);
+    expect(noBlue).toBeLessThanOrEqual(allRgb + 1e-9);
+  });
+
   it("falls back to the outermost usable sample when marginal chromatic rays clip", () => {
     const { L, zPos, IMG_MM, sx, sy, clampedRayEnd, currentPhysStopSD, currentEPSD } = buildTestFixture(
       0,

--- a/src/components/diagram/LCAInsetWidget.tsx
+++ b/src/components/diagram/LCAInsetWidget.tsx
@@ -19,6 +19,13 @@ const QUALITY_LABEL: Record<DispersionQuality, string> = {
   air: "",
 };
 
+function referenceIntercept(intercepts: Partial<Record<ChromaticChannel, number>>, fallback: number): number {
+  if (intercepts.G !== undefined) return intercepts.G;
+  const values = Object.values(intercepts);
+  if (values.length === 0) return fallback;
+  return (Math.min(...values) + Math.max(...values)) / 2;
+}
+
 interface LCAInsetWidgetProps {
   chromSpread: ChromaticSpread;
   effectiveSC: number;
@@ -61,7 +68,7 @@ export default function LCAInsetWidget({
 }: LCAInsetWidgetProps) {
   const insetW = width ?? 110;
   const insetH = height ?? 100;
-  const gRef = chromSpread.intercepts.G ?? IMG_MM;
+  const gRef = referenceIntercept(chromSpread.intercepts, IMG_MM);
   const viewWidthPx = insetW - 24;
   const { barOffsets, mag } = computeLcaBarOffsets(chromSpread.intercepts, gRef, viewWidthPx, effectiveSC);
   const activeChans = (["R", "G", "B", "V"] as ChromaticChannel[]).filter(

--- a/src/optics/lcaScaling.ts
+++ b/src/optics/lcaScaling.ts
@@ -46,7 +46,7 @@ export function computeLcaBarOffsets(
   const barOffsets: Partial<Record<ChromaticChannel, number>> = {};
   let maxAbsPx = 0;
 
-  for (const ch of ["R", "G", "B"] as ChromaticChannel[]) {
+  for (const ch of ["R", "G", "B", "V"] as ChromaticChannel[]) {
     if (intercepts[ch] === undefined) continue;
     const px = (intercepts[ch] - referenceIntercept) * baseMag * effectiveSC;
     barOffsets[ch] = px;

--- a/src/optics/rayTrace.ts
+++ b/src/optics/rayTrace.ts
@@ -409,6 +409,11 @@ interface MarginalRayData {
   clipped: boolean;
 }
 
+function spanOf(values: number[]): number {
+  if (values.length < 2) return 0;
+  return Math.max(...values) - Math.min(...values);
+}
+
 export function computeChromaticSpread(
   marginalRays: Partial<Record<ChromaticChannel, MarginalRayData>>,
   imgZ: number,
@@ -416,7 +421,7 @@ export function computeChromaticSpread(
 ): ChromaticSpread {
   const intercepts: Partial<Record<ChromaticChannel, number>> = {};
   const imgHeights: Partial<Record<ChromaticChannel, number>> = {};
-  for (const ch of ["R", "G", "B"] as ChromaticChannel[]) {
+  for (const ch of ["R", "G", "B", "V"] as ChromaticChannel[]) {
     const ray = marginalRays[ch];
     if (!ray || ray.clipped) continue;
     if (Math.abs(ray.u) > 1e-15) {
@@ -426,15 +431,8 @@ export function computeChromaticSpread(
     imgHeights[ch] = ray.y + dz * ray.u;
   }
 
-  let lcaMm = 0;
-  if (intercepts.R !== undefined && intercepts.B !== undefined) lcaMm = intercepts.R - intercepts.B;
-  else if (intercepts.R !== undefined && intercepts.G !== undefined) lcaMm = intercepts.R - intercepts.G;
-  else if (intercepts.G !== undefined && intercepts.B !== undefined) lcaMm = intercepts.G - intercepts.B;
-
-  let tcaMm = 0;
-  if (imgHeights.R !== undefined && imgHeights.B !== undefined) tcaMm = imgHeights.R - imgHeights.B;
-  else if (imgHeights.R !== undefined && imgHeights.G !== undefined) tcaMm = imgHeights.R - imgHeights.G;
-  else if (imgHeights.G !== undefined && imgHeights.B !== undefined) tcaMm = imgHeights.G - imgHeights.B;
+  const lcaMm = spanOf(Object.values(intercepts));
+  const tcaMm = spanOf(Object.values(imgHeights));
   return { lcaMm, tcaMm, intercepts, imgHeights };
 }
 

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -23,6 +23,11 @@ export const CHANGELOG: ChangelogEntry[] = [
 
   {
     date: "2026-05-05",
+    type: "fix",
+    summary: "Fixed LCA inset values when chromatic color channels are toggled",
+  },
+  {
+    date: "2026-05-05",
     type: "feature",
     summary: "Added aberration control variable support for lenses with separate soft-focus rings",
   },


### PR DESCRIPTION
## Summary

Fixes the LCA inset calculation so chromatic channel selections still affect the chart, but hiding a selected channel cannot make the reported LCA/TCA value larger just because the comparison pair changed.

## Root Cause

The chromatic spread helper used fixed pair fallbacks (`R-B`, then `R-G`, then `G-B`). When a user hid one channel, the helper could switch to a wider remaining pair and increase the inset value unexpectedly.

## Changes

- Report LCA/TCA as the span across the selected usable channels.
- Center the inset on the selected span when the G reference channel is hidden.
- Include violet in the spread and bar-offset helpers when it is selected.
- Added a changelog entry and regression tests for channel-toggle behavior.

## Validation

- `npm run test -- __tests__/optics.test.ts __tests__/lcaScaling.test.ts __tests__/useChromaticRays.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`