### PR TITLE
Wire soft-focus control through analysis views

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `147` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
+- `150` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Canon, Carl Zeiss Jena, Carl Zeiss Oberkochen, Fujifilm, Leica,
   Nikon, Olympus, Ricoh, Sony, Vivitar, and Voigtländer
 - Lens pages pair interactive diagrams with long-form optical analysis markdown

--- a/__tests__/AberrationsPanel.test.tsx
+++ b/__tests__/AberrationsPanel.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import AberrationsPanel from "../src/components/display/AberrationsPanel.js";
+import ComaTab from "../src/components/display/ComaTab.js";
 import type { RuntimeLens } from "../src/types/optics.js";
 import type { Theme } from "../src/types/theme.js";
 
@@ -449,6 +450,88 @@ describe("AberrationsPanel", () => {
     expect(screen.getAllByText("EDGE T / S").length).toBeGreaterThan(0);
     expect(screen.getByText("T -0.45 mm / S -0.21 mm")).toBeTruthy();
     expect(screen.getAllByText("5/5").length).toBeGreaterThan(0);
+  });
+
+  it("forwards aberration-control state into spherical and field-curvature calculations", () => {
+    mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
+
+    render(<AberrationsPanel {...baseProps} aberrationT={0.42} />);
+
+    expect(mockComputeSphericalAberration).toHaveBeenCalledWith(
+      baseProps.L,
+      baseProps.zPos,
+      baseProps.focusT,
+      baseProps.zoomT,
+      baseProps.currentEPSD,
+      baseProps.currentPhysStopSD,
+      0.42,
+    );
+    expect(mockComputeSAProfile).toHaveBeenCalledWith(
+      baseProps.L,
+      baseProps.zPos,
+      baseProps.focusT,
+      baseProps.zoomT,
+      baseProps.currentEPSD,
+      baseProps.currentPhysStopSD,
+      0.42,
+    );
+    expect(mockComputeSphericalAberrationBlurCharacter).toHaveBeenCalledWith(
+      baseProps.L,
+      baseProps.zPos,
+      baseProps.focusT,
+      baseProps.zoomT,
+      baseProps.currentEPSD,
+      baseProps.currentPhysStopSD,
+      expect.anything(),
+      0.42,
+    );
+    expect(mockComputeFieldCurvature).toHaveBeenNthCalledWith(
+      1,
+      baseProps.L,
+      baseProps.zPos,
+      baseProps.focusT,
+      baseProps.zoomT,
+      baseProps.currentEPSD,
+      baseProps.currentPhysStopSD,
+      false,
+      0.42,
+    );
+    expect(mockComputeFieldCurvature).toHaveBeenNthCalledWith(
+      2,
+      baseProps.L,
+      baseProps.zPos,
+      baseProps.focusT,
+      baseProps.zoomT,
+      baseProps.currentEPSD,
+      baseProps.currentPhysStopSD,
+      true,
+      0.42,
+    );
+  });
+
+  it("forwards aberration-control state into coma calculations", () => {
+    render(
+      <ComaTab
+        L={baseProps.L}
+        t={baseProps.t}
+        zPos={baseProps.zPos}
+        focusT={baseProps.focusT}
+        zoomT={baseProps.zoomT}
+        aberrationT={0.42}
+        currentEPSD={baseProps.currentEPSD}
+        currentPhysStopSD={baseProps.currentPhysStopSD}
+      />,
+    );
+
+    expect(mockComputeComaAnalysis).toHaveBeenCalledWith(
+      baseProps.L,
+      baseProps.zPos,
+      baseProps.focusT,
+      baseProps.zoomT,
+      baseProps.currentEPSD,
+      baseProps.currentPhysStopSD,
+      0.42,
+    );
   });
 
   it("labels field curve direction correctly: positive shift toward sensor, negative toward lens", () => {

--- a/__tests__/AnalysisDrawerContent.test.tsx
+++ b/__tests__/AnalysisDrawerContent.test.tsx
@@ -108,10 +108,11 @@ describe("AnalysisDrawerContent", () => {
   });
 
   it("maps the coma tab to ComaTab", () => {
-    render(<AnalysisDrawerContent {...baseProps} activeTab="coma" />);
+    render(<AnalysisDrawerContent {...baseProps} activeTab="coma" aberrationT={0.37} />);
 
     expect(screen.getByText("Coma")).toBeTruthy();
     expect(mockComaTab).toHaveBeenCalledTimes(1);
+    expect(mockComaTab.mock.calls[0][0].aberrationT).toBe(0.37);
     expect(mockAberrationsPanel).not.toHaveBeenCalled();
   });
 
@@ -130,10 +131,11 @@ describe("AnalysisDrawerContent", () => {
   });
 
   it("maps the pupils tab to PupilAberrationTab", () => {
-    render(<AnalysisDrawerContent {...baseProps} activeTab="pupils" />);
+    render(<AnalysisDrawerContent {...baseProps} activeTab="pupils" aberrationT={0.37} />);
 
     expect(screen.getByText("Pupils")).toBeTruthy();
     expect(mockPupilAberrationTab).toHaveBeenCalledTimes(1);
+    expect(mockPupilAberrationTab.mock.calls[0][0].aberrationT).toBe(0.37);
     expect(mockVignettingTab).not.toHaveBeenCalled();
   });
 

--- a/__tests__/BokehPreviewOverlay.test.tsx
+++ b/__tests__/BokehPreviewOverlay.test.tsx
@@ -80,7 +80,11 @@ function makeField(
   };
 }
 
-function makeResult(label: string, defocusDeltaMm: number, brightnessCharacter: BokehBrightnessCharacter): BokehPreviewResult {
+function makeResult(
+  label: string,
+  defocusDeltaMm: number,
+  brightnessCharacter: BokehBrightnessCharacter,
+): BokehPreviewResult {
   return {
     label,
     defocusDeltaMm,
@@ -148,5 +152,27 @@ describe("BokehPreviewOverlay", () => {
     );
 
     expect(screen.getByText(/Insufficient focus range to compute bokeh preview/i)).toBeTruthy();
+  });
+
+  it("passes aberration-control state into the bokeh computation", () => {
+    mockComputeBokehPreviewPair.mockReturnValue({
+      infinity: makeResult("Infinity", 0.35, "edge-bright"),
+      nearFocus: null,
+    });
+    const L = { N: 2 } as RuntimeLens;
+
+    render(
+      <BokehPreviewOverlay
+        L={L}
+        focusT={0.5}
+        zoomT={0}
+        aberrationT={0.64}
+        currentEPSD={10}
+        currentPhysStopSD={5}
+        t={theme}
+      />,
+    );
+
+    expect(mockComputeBokehPreviewPair).toHaveBeenCalledWith(L, 0.5, 0, 10, 5, 0.64);
   });
 });

--- a/__tests__/aberrationAnalysis.test.ts
+++ b/__tests__/aberrationAnalysis.test.ts
@@ -19,7 +19,6 @@ import {
 } from "../src/optics/aberrationAnalysis.js";
 import {
   bestFocusPlaneForDirection,
-  computeOffAxisFieldGeometry,
   computeStateAwareOffAxisFieldGeometry,
   traceOffAxisChiefRay,
   traceCircularOffAxisBundle,
@@ -1121,7 +1120,7 @@ describe("computeFieldCurvature", () => {
     expect(field).toBeDefined();
     expect(field!.usable).toBe(true);
 
-    const geometry = computeOffAxisFieldGeometry(L, zPos, 0, field!.fieldFraction);
+    const geometry = computeStateAwareOffAxisFieldGeometry(L, zPos, 0, 0, field!.fieldFraction);
     expect(geometry).not.toBeNull();
     const standardizedField = standardizedFieldFocusAt(L, geometry!, 0, 0, currentEPSD, currentPhysStopSD);
 

--- a/__tests__/minoltaVarisoftFocus.test.ts
+++ b/__tests__/minoltaVarisoftFocus.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it } from "vitest";
 import buildLens from "../src/optics/buildLens.js";
-import { doLayout, thick, traceToImage } from "../src/optics/optics.js";
+import {
+  computeChromaticSpread,
+  computeFieldGeometryAtState,
+  doLayout,
+  entrancePupilAtState,
+  thick,
+  traceRayChromatic,
+  traceToImage,
+} from "../src/optics/optics.js";
+import {
+  computeComaAnalysis,
+  computeFieldCurvature,
+  computeSAProfile,
+  computeSphericalAberration,
+} from "../src/optics/aberrationAnalysis.js";
+import { computeBokehPreviewPair } from "../src/optics/aberration/bokeh.js";
+import { computeBothPupilAberrationProfiles } from "../src/optics/pupilAberration.js";
 import LENS_DEFAULTS from "../src/lens-data/defaults.js";
 import MinoltaVarisoftRaw from "../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.js";
-import type { LensData, RuntimeLens } from "../src/types/optics.js";
+import type { ChromaticChannel, LensData, RuntimeLens } from "../src/types/optics.js";
 
 function buildMinoltaVarisoft(): RuntimeLens {
   return buildLens({ ...LENS_DEFAULTS, ...MinoltaVarisoftRaw } as LensData);
@@ -20,6 +36,32 @@ function fixedImagePlanePositions(L: RuntimeLens, focusT: number): number[] {
   const cur = doLayout(focusT, 0, L);
   const dz = ref.imgZ - cur.imgZ;
   return cur.z.map((z) => z + dz);
+}
+
+function analysisState(L: RuntimeLens, focusT: number, aberrationT: number) {
+  const layout = doLayout(focusT, 0, L, aberrationT);
+  const fieldGeometry = computeFieldGeometryAtState(focusT, 0, L, aberrationT);
+  return {
+    zPos: layout.z,
+    fieldGeometry,
+    currentPhysStopSD: L.stopPhysSD,
+    currentEPSD: entrancePupilAtState(L.stopPhysSD, focusT, 0, L, fieldGeometry, aberrationT).epSD,
+  };
+}
+
+function expectMeaningfulDifference(actual: number, expected: number, message: string) {
+  expect(Math.abs(actual - expected), message).toBeGreaterThan(1e-7);
+}
+
+function lcaAt(L: RuntimeLens, aberrationT: number) {
+  const { zPos, currentEPSD, currentPhysStopSD } = analysisState(L, 0, aberrationT);
+  const lastSurfZ = zPos[L.N - 1];
+  const rays: Partial<Record<ChromaticChannel, { y: number; u: number; clipped: boolean }>> = {};
+  for (const channel of ["R", "G", "B"] as const) {
+    const ray = traceRayChromatic(0.95 * currentEPSD, 0, zPos, 0, 0, currentPhysStopSD, true, L, channel, aberrationT);
+    rays[channel] = { y: ray.y, u: ray.u, clipped: ray.clipped };
+  }
+  return computeChromaticSpread(rays, doLayout(0, 0, L, aberrationT).imgZ, lastSurfZ);
 }
 
 describe("Minolta Varisoft 85mm f/2.8 focus model", () => {
@@ -73,5 +115,132 @@ describe("Minolta Varisoft 85mm f/2.8 focus model", () => {
 
     const softParaxialFocus = traceToImage(1, 0, 0, 0, L, 1);
     expect(softParaxialFocus).toBeCloseTo(0, 2);
+  });
+
+  it("applies the soft-focus ring to spherical aberration diagnostics", () => {
+    const L = buildMinoltaVarisoft();
+    const sharp = analysisState(L, 0, 0);
+    const soft = analysisState(L, 0, 1);
+
+    const sharpSA = computeSphericalAberration(L, sharp.zPos, 0, 0, sharp.currentEPSD, sharp.currentPhysStopSD, 0);
+    const softSA = computeSphericalAberration(L, soft.zPos, 0, 0, soft.currentEPSD, soft.currentPhysStopSD, 1);
+    expect(sharpSA).not.toBeNull();
+    expect(softSA).not.toBeNull();
+    expectMeaningfulDifference(
+      softSA!.longitudinalSaMm,
+      sharpSA!.longitudinalSaMm,
+      "soft ring should change longitudinal spherical aberration",
+    );
+
+    const sharpProfile = computeSAProfile(L, sharp.zPos, 0, 0, sharp.currentEPSD, sharp.currentPhysStopSD, 0);
+    const softProfile = computeSAProfile(L, soft.zPos, 0, 0, soft.currentEPSD, soft.currentPhysStopSD, 1);
+    expect(sharpProfile.length).toBeGreaterThan(0);
+    expect(softProfile.length).toBeGreaterThan(0);
+    expectMeaningfulDifference(
+      softProfile.at(-1)!.transverseSaMm,
+      sharpProfile.at(-1)!.transverseSaMm,
+      "soft ring should change the spherical aberration profile",
+    );
+  });
+
+  it("applies the soft-focus ring to field curvature, astigmatism, and Petzval placement", () => {
+    const L = buildMinoltaVarisoft();
+    const sharp = analysisState(L, 0, 0);
+    const soft = analysisState(L, 0, 1);
+
+    const sharpField = computeFieldCurvature(L, sharp.zPos, 0, 0, sharp.currentEPSD, sharp.currentPhysStopSD, false, 0);
+    const softField = computeFieldCurvature(L, soft.zPos, 0, 0, soft.currentEPSD, soft.currentPhysStopSD, false, 1);
+    expect(sharpField).not.toBeNull();
+    expect(softField).not.toBeNull();
+
+    const sharpEdge = sharpField!.fields.find((field) => field.usable && field.fieldFraction === 1);
+    const softEdge = softField!.fields.find((field) => field.usable && field.fieldFraction === 1);
+    expect(sharpEdge).toBeTruthy();
+    expect(softEdge).toBeTruthy();
+    expectMeaningfulDifference(
+      softEdge!.tangentialShiftMm,
+      sharpEdge!.tangentialShiftMm,
+      "soft ring should change tangential field curvature",
+    );
+    expectMeaningfulDifference(
+      softEdge!.astigmaticDifferenceMm,
+      sharpEdge!.astigmaticDifferenceMm,
+      "soft ring should change astigmatic field split",
+    );
+    expectMeaningfulDifference(
+      softEdge!.petzvalBestFocusZ,
+      sharpEdge!.petzvalBestFocusZ,
+      "soft ring should reposition the Petzval reference relative to the current image plane",
+    );
+  });
+
+  it("applies the soft-focus ring to coma diagnostics", () => {
+    const L = buildMinoltaVarisoft();
+    const sharp = analysisState(L, 0, 0);
+    const soft = analysisState(L, 0, 1);
+
+    const sharpComa = computeComaAnalysis(L, sharp.zPos, 0, 0, sharp.currentEPSD, sharp.currentPhysStopSD, 0);
+    const softComa = computeComaAnalysis(L, soft.zPos, 0, 0, soft.currentEPSD, soft.currentPhysStopSD, 1);
+    expect(sharpComa.pointCloudPreview).not.toBeNull();
+    expect(softComa.pointCloudPreview).not.toBeNull();
+
+    const sharpField = sharpComa.pointCloudPreview!.fields.find((field) => field.usable && field.fieldFraction === 0.5);
+    const softField = softComa.pointCloudPreview!.fields.find((field) => field.usable && field.fieldFraction === 0.5);
+    expect(sharpField).toBeTruthy();
+    expect(softField).toBeTruthy();
+    expectMeaningfulDifference(
+      softField!.rmsRadiusMm,
+      sharpField!.rmsRadiusMm,
+      "soft ring should change the coma point-cloud footprint",
+    );
+  });
+
+  it("applies the soft-focus ring to bokeh previews", () => {
+    const L = buildMinoltaVarisoft();
+    const sharp = analysisState(L, 0.5, 0);
+    const soft = analysisState(L, 0.5, 1);
+
+    const sharpBokeh = computeBokehPreviewPair(L, 0.5, 0, sharp.currentEPSD, sharp.currentPhysStopSD, 0);
+    const softBokeh = computeBokehPreviewPair(L, 0.5, 0, soft.currentEPSD, soft.currentPhysStopSD, 1);
+    expect(sharpBokeh.infinity).not.toBeNull();
+    expect(softBokeh.infinity).not.toBeNull();
+
+    const sharpCenter = sharpBokeh.infinity!.fields.find((field) => field.usable && field.fieldFraction === 0);
+    const softCenter = softBokeh.infinity!.fields.find((field) => field.usable && field.fieldFraction === 0);
+    expect(sharpCenter).toBeTruthy();
+    expect(softCenter).toBeTruthy();
+    expectMeaningfulDifference(
+      softCenter!.rmsRadiusMm,
+      sharpCenter!.rmsRadiusMm,
+      "soft ring should change bokeh blur size",
+    );
+  });
+
+  it("applies the soft-focus ring to pupil aberration diagnostics", () => {
+    const L = buildMinoltaVarisoft();
+    const sharp = analysisState(L, 0, 0);
+    const soft = analysisState(L, 0, 1);
+
+    const sharpPupils = computeBothPupilAberrationProfiles(0, 0, L, undefined, sharp.fieldGeometry, 0);
+    const softPupils = computeBothPupilAberrationProfiles(0, 0, L, undefined, soft.fieldGeometry, 1);
+    expectMeaningfulDifference(
+      softPupils.maxAbsEpShiftMm,
+      sharpPupils.maxAbsEpShiftMm,
+      "soft ring should change entrance-pupil aberration",
+    );
+    expectMeaningfulDifference(
+      softPupils.maxAbsXpShiftMm,
+      sharpPupils.maxAbsXpShiftMm,
+      "soft ring should change exit-pupil aberration",
+    );
+  });
+
+  it("applies the soft-focus ring to LCA", () => {
+    const L = buildMinoltaVarisoft();
+    const sharpLca = lcaAt(L, 0);
+    const softLca = lcaAt(L, 1);
+    expect(sharpLca).not.toBeNull();
+    expect(softLca).not.toBeNull();
+    expectMeaningfulDifference(softLca!.lcaMm, sharpLca!.lcaMm, "soft ring should change longitudinal CA");
   });
 });

--- a/agent_docs/catalog-mismatches.generated.md
+++ b/agent_docs/catalog-mismatches.generated.md
@@ -13,12 +13,12 @@ with words like "probable" or "approx").
 
 ## Summary
 
-- **148** lenses scanned
-- **1668** glass surfaces examined
-- **1665** surfaces with non-empty `glass` strings
-- **1064** of those resolved to a catalog entry
-- **244** mismatches found (22.9% of resolved surfaces)
-- **82** distinct lens files affected
+- **151** lenses scanned
+- **1707** glass surfaces examined
+- **1704** surfaces with non-empty `glass` strings
+- **1094** of those resolved to a catalog entry
+- **253** mismatches found (23.1% of resolved surfaces)
+- **84** distinct lens files affected
 
 ## Most-frequent mismatched catalog targets
 
@@ -33,13 +33,16 @@ annotation pattern (e.g. an obsolete name, a `probable` guess) that's used acros
 | S-TIH14 | 8 | |
 | S-LAH58 | 7 | |
 | S-BSL7 | 7 | |
+| S-LAH64 | 6 | |
 | S-NPH4 | 6 | |
 | S-BAL14 | 6 | |
+| S-TIH53 | 6 | |
 | S-TIM25 | 6 | |
 | S-BAL35 | 5 | |
 | S-LAM54 | 5 | |
 | S-LAM51 | 5 | |
 | S-TIM28 | 5 | |
+| S-TIM27 | 5 | |
 | S-NBH55 | 5 | |
 | S-LAH51 | 5 | |
 | S-LAL14 | 5 | |
@@ -47,10 +50,7 @@ annotation pattern (e.g. an obsolete name, a `probable` guess) that's used acros
 | S-TIM35 | 5 | |
 | S-FPM3 | 5 | |
 | S-TIM2 | 5 | |
-| S-LAH64 | 4 | |
 | S-LAH65V | 4 | |
-| S-TIM27 | 4 | |
-| S-TIH53 | 4 | |
 | S-NPH53 | 4 | |
 | S-NBH8 | 4 | |
 | S-TIM22 | 4 | |
@@ -62,19 +62,20 @@ annotation pattern (e.g. an obsolete name, a `probable` guess) that's used acros
 | S-LAM2 | 3 | |
 | S-LAL8 | 3 | |
 | TAFD45 | 3 | |
+| S-LAH66 | 3 | |
 | S-LAH65 | 3 | |
+| S-BAL42 | 3 | |
 | SF6 | 3 | |
 | S-LAH97 | 3 | |
 | S-LAL9 | 2 | |
 | S-NPH1 | 2 | |
+| S-LAH59 | 2 | |
 | S-LAH60 | 2 | |
-| S-LAH66 | 2 | |
 | N-SK14 | 2 | |
 | SF2 | 2 | |
 | S-NBH5 | 2 | |
 | S-NPH5 | 2 | |
 | S-BAM4 | 2 | |
-| S-BAL42 | 2 | |
 | S-LAH99 | 2 | |
 | SF4 | 2 | |
 | N-SK16 | 2 | |
@@ -88,7 +89,6 @@ annotation pattern (e.g. an obsolete name, a `probable` guess) that's used acros
 | S-LAL18 | 1 | |
 | S-NPH3 | 1 | |
 | S-LAH55V | 1 | |
-| S-LAH59 | 1 | |
 | S-FPM2 | 1 | |
 | S-LAM60 | 1 | |
 | S-LAH63 | 1 | |
@@ -97,6 +97,7 @@ annotation pattern (e.g. an obsolete name, a `probable` guess) that's used acros
 | S-BSM81 | 1 | |
 | TAFD55 | 1 | |
 | E-FDS1 | 1 | |
+| S-LAH63Q | 1 | |
 | S-PHM52 | 1 | |
 | TAFD37 | 1 | |
 | N-SK2 | 1 | |
@@ -216,6 +217,17 @@ annotation pattern (e.g. an obsolete name, a `probable` guess) that's used acros
 | 27 | `S-NBH56 (OHARA)` | S-NBH56 | 1.80610 | 1.85478 | +0.0487 |
 | 29A | `S-LAH66 (OHARA)` | S-LAH66 | 1.85400 | 1.77250 | -0.0815 |
 | 32 | `S-NPH2 (OHARA)` | S-NPH2 | 2.00100 | 1.92286 | -0.0781 |
+
+### [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) — US 7,289,274 B1
+
+| Surface | Glass annotation | Catalog match | Stored nd | Catalog nd | Δnd |
+|---|---|---|---|---|---|
+| 1 | `S-LAH66 (OHARA)` | S-LAH66 | 1.74400 | 1.77250 | +0.0285 |
+| 6 | `S-TIH53 (OHARA)` | S-TIH53 | 1.80518 | 1.84666 | +0.0415 |
+| 17 | `S-LAH64 (OHARA)` | S-LAH64 | 1.77250 | 1.78800 | +0.0155 |
+| 20 | `S-TIH53 (OHARA)` | S-TIH53 | 1.80518 | 1.84666 | +0.0415 |
+| 22 | `S-LAH64 (OHARA)` | S-LAH64 | 1.77250 | 1.78800 | +0.0155 |
+| 29 | `S-LAH59 (OHARA)` | S-LAH59 | 1.80100 | 1.81600 | +0.0150 |
 
 ### [CANON FD 50mm f/1.2 L](../src/lens-data/canon/CanonFD50mmf12L.data.ts) — US 4,364,644
 
@@ -476,6 +488,14 @@ annotation pattern (e.g. an obsolete name, a `probable` guess) that's used acros
 | 8 | `Anomalous flint (S-NBH8-class, νd=25.15)` | S-NBH8 | 1.85451 | 1.72047 | -0.1340 |
 | 15 | `Anomalous flint (S-NBH8-class, νd=25.15)` | S-NBH8 | 1.85451 | 1.72047 | -0.1340 |
 | 18 | `Anomalous flint (S-NBH8-class, νd=25.15)` | S-NBH8 | 1.85451 | 1.72047 | -0.1340 |
+
+### [smc PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM](../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) — US 7,301,711 B2
+
+| Surface | Glass annotation | Catalog match | Stored nd | Catalog nd | Δnd |
+|---|---|---|---|---|---|
+| 2 | `S-BAL42 (OHARA)` | S-BAL42 | 1.71300 | 1.58313 | -0.1299 |
+| 4 | `S-LAH63Q (OHARA)` | S-LAH63Q | 1.77250 | 1.80440 | +0.0319 |
+| 11 | `S-TIM27 (OHARA)` | S-TIM27 | 1.64769 | 1.63980 | -0.0079 |
 
 ### [SONY SONNAR T* E 24mm F1.8 ZA](../src/lens-data/sony/SonyFE24mmf18ZA.data.ts) — US 2013/0033768 A1
 

--- a/agent_docs/glass-relabel-candidates.generated.md
+++ b/agent_docs/glass-relabel-candidates.generated.md
@@ -19,7 +19,7 @@ both match the stored values within tolerance (nd ±0.005, vd ±3).
 - **No candidate**: relabel as `Unmatched (...reason)` and add a row to
   [glass-relabel-followup.md](glass-relabel-followup.md) for per-lens patent verification.
 
-**Scope**: 244 mismatched surfaces across 160 unique groups.
+**Scope**: 253 mismatched surfaces across 163 unique groups.
 
 ## stored (nd=1.51742, vd=52.40)  — 2 surfaces, current label resolves to S-NSL5
 
@@ -333,7 +333,7 @@ Candidates:
 Surfaces:
 - [FUJIFILM FUJINON XF 90mm f/2 R LM WR](../src/lens-data/fujifilm/FujifilmXF90mmf2.data.ts) `10`: `S-BAM4 (OHARA)`
 
-## stored (nd=1.64769, vd=33.80)  — 1 surface, current label resolves to S-TIH53
+## stored (nd=1.64769, vd=33.80)  — 2 surfaces, current label resolves to S-TIH53
 
 Candidates:
 - **SF2** (nd=1.64769, vd=33.85, Δnd=-0.0000, Δvd=+0.05)
@@ -341,6 +341,7 @@ Candidates:
 
 Surfaces:
 - [NIKON AF-S NIKKOR 85mm f/1.4G](../src/lens-data/nikon/NikonNikkor85f14G.data.ts) `17`: `S-TIH53 (OHARA)`
+- [smc PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM](../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) `11`: `S-TIM27 (OHARA)`
 
 ## stored (nd=1.64769, vd=33.70)  — 1 surface, current label resolves to S-TIM27
 
@@ -540,6 +541,15 @@ Candidates:
 Surfaces:
 - [FUJIFILM FUJINON XF 90mm f/2 R LM WR](../src/lens-data/fujifilm/FujifilmXF90mmf2.data.ts) `17`: `S-LAM60 (OHARA)`
 
+## stored (nd=1.71300, vd=53.90)  — 1 surface, current label resolves to S-BAL42
+
+Candidates:
+- **N-LAK8** (nd=1.71300, vd=53.83, Δnd=+0.0000, Δvd=-0.07)
+- **S-LAL8** (nd=1.71299, vd=53.87, Δnd=-0.0000, Δvd=-0.03)
+
+Surfaces:
+- [smc PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM](../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) `2`: `S-BAL42 (OHARA)`
+
 ## stored (nd=1.71999, vd=50.27)  — 3 surfaces, current label resolves to S-LAM51
 
 **No catalog candidate within tolerance** — needs per-lens follow-up.
@@ -711,6 +721,14 @@ Candidates:
 Surfaces:
 - [CANON RF 28-70mm F2.8 IS STM](../src/lens-data/canon/CanonRF2870mmf28.data.ts) `26`: `744448 — S-LAL14 family (OHARA)`
 
+## stored (nd=1.74400, vd=44.80)  — 1 surface, current label resolves to S-LAH66
+
+Candidates:
+- **S-LAM2** (nd=1.74400, vd=44.79, Δnd=-0.0000, Δvd=-0.01)
+
+Surfaces:
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) `1`: `S-LAH66 (OHARA)`
+
 ## stored (nd=1.74710, vd=27.40)  — 1 surface, current label resolves to SF4
 
 **No catalog candidate within tolerance** — needs per-lens follow-up.
@@ -828,7 +846,7 @@ Candidates:
 Surfaces:
 - [CANON FD 50mm f/1.2 L](../src/lens-data/canon/CanonFD50mmf12L.data.ts) `11`: `OHARA S-LAL18 (773496)`
 
-## stored (nd=1.77250, vd=49.60)  — 2 surfaces, current label resolves to S-LAM54
+## stored (nd=1.77250, vd=49.60)  — 5 surfaces, current label resolves to S-LAM54
 
 Candidates:
 - **S-LAH66** (nd=1.77250, vd=49.60, Δnd=-0.0000, Δvd=-0.00)
@@ -836,6 +854,9 @@ Candidates:
 Surfaces:
 - [CANON RF 100mm f/2.8 L MACRO IS USM](../src/lens-data/canon/CanonRF100f28.data.ts) `11`: `S-LAM54 (OHARA)`
 - [CANON RF 100mm f/2.8 L MACRO IS USM](../src/lens-data/canon/CanonRF100f28.data.ts) `18`: `S-LAM54 (OHARA)`
+- [smc PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM](../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) `4`: `S-LAH63Q (OHARA)`
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) `17`: `S-LAH64 (OHARA)`
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) `22`: `S-LAH64 (OHARA)`
 
 ## stored (nd=1.77300, vd=49.60)  — 1 surface, current label resolves to S-LAH65
 
@@ -911,12 +932,13 @@ Candidates:
 Surfaces:
 - [NIKON NIKKOR Z 24-70mm f/4 S](../src/lens-data/nikon/NikonNikkorZ2470mmf4S.data.ts) `19`: `S-TIH18 (OHARA)`
 
-## stored (nd=1.80100, vd=35.00)  — 1 surface, current label resolves to TAFD30
+## stored (nd=1.80100, vd=35.00)  — 2 surfaces, current label resolves to S-LAH59
 
 Candidates:
 - **S-LAM66** (nd=1.80100, vd=34.97, Δnd=-0.0000, Δvd=-0.03)
 
 Surfaces:
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) `29`: `S-LAH59 (OHARA)`
 - [PENTAX FA 31mm F1.8 AL Limited](../src/lens-data/pentax/PentaxFA31mmf18ALLtd.data.ts) `7`: `TAFD30 (HOYA)`
 
 ## stored (nd=1.80400, vd=46.60) [code=804/466]  — 1 surface, current label resolves to S-LAH58
@@ -960,6 +982,17 @@ Candidates:
 
 Surfaces:
 - [NIKON NIKKOR Z 28mm f/2.8](../src/lens-data/nikon/NikonZ28f28.data.ts) `7`: `S-TIH14 (OHARA)`
+
+## stored (nd=1.80518, vd=25.40)  — 2 surfaces, current label resolves to S-TIH53
+
+Candidates:
+- **S-TIH6** (nd=1.80518, vd=25.43, Δnd=+0.0000, Δvd=+0.03)
+- **SF6** (nd=1.80518, vd=25.43, Δnd=+0.0000, Δvd=+0.03)
+- **S-NPH1** (nd=1.80809, vd=22.76, Δnd=+0.0029, Δvd=-2.64)
+
+Surfaces:
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) `6`: `S-TIH53 (OHARA)`
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) `20`: `S-TIH53 (OHARA)`
 
 ## stored (nd=1.80518, vd=25.50)  — 1 surface, current label resolves to S-TIH14
 
@@ -1406,5 +1439,5 @@ Surfaces:
 
 ## Summary
 
-- **112** (nd, vd) groups have at least one candidate (178 surfaces) — actionable relabels.
+- **115** (nd, vd) groups have at least one candidate (187 surfaces) — actionable relabels.
 - **48** (nd, vd) groups have NO candidate (66 surfaces) — needs patent verification or Unmatched relabeling.

--- a/agent_docs/unresolved-glass.generated.md
+++ b/agent_docs/unresolved-glass.generated.md
@@ -8,11 +8,11 @@ or per-lens patent backfills.
 
 ## Summary
 
-- **148** lenses scanned
-- **1668** non-air surfaces examined
-- **1665** element glass declarations examined
-- **551** non-explicit-unmatched annotations did not resolve
-- **201** distinct unresolved glass-like tokens found
+- **151** lenses scanned
+- **1707** non-air surfaces examined
+- **1704** element glass declarations examined
+- **560** non-explicit-unmatched annotations did not resolve
+- **203** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency
 
@@ -21,10 +21,11 @@ or per-lens patent backfills.
 | NBFD3 | 7 | 6 | |
 | 593679 | 6 | 3 | |
 | S-NPH7 | 6 | 5 | |
+| TAFD25 | 6 | 5 | |
 | L-PHM52 | 5 | 2 | |
-| TAFD25 | 5 | 4 | |
 | E-FD15 | 4 | 3 | |
 | S-TIH11 | 4 | 4 | |
+| S-TIH53W | 4 | 4 | |
 | S-TIL25 | 4 | 4 | |
 | 694533 | 3 | 2 | |
 | E-FDS3HT | 3 | 2 | |
@@ -35,7 +36,6 @@ or per-lens patent backfills.
 | S-LAM55 | 3 | 3 | |
 | S-NBH52V | 3 | 3 | |
 | S-TIF6 | 3 | 3 | |
-| S-TIH53W | 3 | 3 | |
 | S-TIL27 | 3 | 3 | |
 | S-TIL6 | 3 | 3 | |
 | TAFD5F | 3 | 3 | |
@@ -132,6 +132,7 @@ or per-lens patent backfills.
 | 863415 | 1 | 1 | |
 | 903354 | 1 | 1 | |
 | 921240 | 1 | 1 | |
+| BACD14 | 1 | 1 | |
 | BK3 | 1 | 1 | |
 | BSC3 | 1 | 1 | |
 | E-F3 | 1 | 1 | |
@@ -187,6 +188,7 @@ or per-lens patent backfills.
 | S-LAH75 | 1 | 1 | |
 | S-LAH78 | 1 | 1 | |
 | S-LAL10 | 1 | 1 | |
+| S-LAL12 | 1 | 1 | |
 | S-LAL60 | 1 | 1 | |
 | S-LAL61 | 1 | 1 | |
 | S-LAM61 | 1 | 1 | |
@@ -250,6 +252,15 @@ or per-lens patent backfills.
 - [NIKON NIKKOR Z 35mm f/1.2 S](../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) 29: `S-NPH7 (946180, OHARA S-NPH7)`
 - [SONY FE 85mm F1.4 GM II](../src/lens-data/sony/SonyFE85mmf14GMII.data.ts) 22: `S-NPH7 (OHARA)`
 
+### TAFD25 — 6 occurrences
+
+- [CANON RF 15-35mm f/2.8 L IS USM](../src/lens-data/canon/CanonRF1535f28.data.ts) 15: `TAFD25 (HOYA)`
+- [NIKON 28Ti NIKKOR 28mm f/2.8](../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) 3: `TAFD25 (HOYA)`
+- [NIKON PC NIKKOR 19mm f/4E ED](../src/lens-data/nikon/NikonNikkorPCE19mmf4E.data.ts) 12: `TAFD25 (HOYA)`
+- [NIKON PC NIKKOR 19mm f/4E ED](../src/lens-data/nikon/NikonNikkorPCE19mmf4E.data.ts) 27: `TAFD25 (HOYA)`
+- [NIKON NIKKOR Z 24-200mm f/4-6.3 VR](../src/lens-data/nikon/NikonNikkorZ24200mmf463VR.data.ts) 13: `TAFD25 equiv. (181600/4659)`
+- [smc PENTAX-F 85mm f/2.8 Soft](../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) 6: `TAFD25 (HOYA)`
+
 ### L-PHM52 — 5 occurrences
 
 - [FUJIFILM FUJINON XF 16-55mm f/2.8 R LM WR](../src/lens-data/fujifilm/FujifilmXF1655mmf28R.data.ts) 22A: `Near OHARA L-PHM52 (619636)`
@@ -257,14 +268,6 @@ or per-lens patent backfills.
 - [NIKON NIKKOR Z 35mm f/1.2 S](../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) 21: `Phosphate crown ED (593679, OHARA L-PHM52 nearest)`
 - [NIKON NIKKOR Z 35mm f/1.2 S](../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) 23: `PGM phosphate crown ED (593679, OHARA L-PHM52)`
 - [NIKON NIKKOR Z 35mm f/1.2 S](../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) 27: `Phosphate crown ED (593679, OHARA L-PHM52 nearest)`
-
-### TAFD25 — 5 occurrences
-
-- [CANON RF 15-35mm f/2.8 L IS USM](../src/lens-data/canon/CanonRF1535f28.data.ts) 15: `TAFD25 (HOYA)`
-- [NIKON 28Ti NIKKOR 28mm f/2.8](../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) 3: `TAFD25 (HOYA)`
-- [NIKON PC NIKKOR 19mm f/4E ED](../src/lens-data/nikon/NikonNikkorPCE19mmf4E.data.ts) 12: `TAFD25 (HOYA)`
-- [NIKON PC NIKKOR 19mm f/4E ED](../src/lens-data/nikon/NikonNikkorPCE19mmf4E.data.ts) 27: `TAFD25 (HOYA)`
-- [NIKON NIKKOR Z 24-200mm f/4-6.3 VR](../src/lens-data/nikon/NikonNikkorZ24200mmf463VR.data.ts) 13: `TAFD25 equiv. (181600/4659)`
 
 ### E-FD15 — 4 occurrences
 
@@ -279,6 +282,13 @@ or per-lens patent backfills.
 - [NIKON AF-S NIKKOR 58mm f/1.4G](../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) 9: `S-TIH11 / N-SF10 (dense flint)`
 - [NIKON AI Nikkor 135mm f/2.8](../src/lens-data/nikon/NikonAI135mmf28.data.ts) 8: `SF10 (Schott) / S-TIH11 (OHARA)`
 - [SIGMA 50mm F1.4 DG DN | Art](../src/lens-data/sigma/SigmaDGDNArt50mmf14.data.ts) 10: `S-TIH11 (OHARA)`
+
+### S-TIH53W — 4 occurrences
+
+- [CANON RF 24-240mm F4-6.3 IS USM](../src/lens-data/canon/CanonRF24240mmf463.data.ts) 27: `S-TIH53W type (855/248)`
+- [CANON RF 28-70mm F2.8 IS STM](../src/lens-data/canon/CanonRF2870mmf28.data.ts) 17: `855248 — S-TIH53W family (OHARA)`
+- [NIKON AF-S NIKKOR 120-300mm f/2.8E FL ED SR VR](../src/lens-data/nikon/NikonNikkorAFS120300mmf28.data.ts) 27: `OHARA S-TIH53W`
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) 13: `S-TIH53W (OHARA)`
 
 ### S-TIL25 — 4 occurrences
 
@@ -340,12 +350,6 @@ or per-lens patent backfills.
 - [FUJIFILM FUJINON XF 56mm F1.2 R](../src/lens-data/fujifilm/FujifilmXF56mmf12.data.ts) 16: `S-TIF6 (OHARA)`
 - [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6G ED VR](../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) 29: `S-TIF6 (OHARA)`
 - [RICOH GR LENS A12 28mm f/2.5](../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) 10: `S-TIF6 (OHARA) / N-SF5 (SCHOTT)`
-
-### S-TIH53W — 3 occurrences
-
-- [CANON RF 24-240mm F4-6.3 IS USM](../src/lens-data/canon/CanonRF24240mmf463.data.ts) 27: `S-TIH53W type (855/248)`
-- [CANON RF 28-70mm F2.8 IS STM](../src/lens-data/canon/CanonRF2870mmf28.data.ts) 17: `855248 — S-TIH53W family (OHARA)`
-- [NIKON AF-S NIKKOR 120-300mm f/2.8E FL ED SR VR](../src/lens-data/nikon/NikonNikkorAFS120300mmf28.data.ts) 27: `OHARA S-TIH53W`
 
 ### S-TIL27 — 3 occurrences
 
@@ -782,6 +786,10 @@ or per-lens patent backfills.
 
 - [NIKON NIKKOR Z 35mm f/1.2 S](../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) 5: `Ultra-high-index dense flint (921240, HOYA TAFD5F / HIKARI E-FDS3HT)`
 
+### BACD14 — 1 occurrence
+
+- [smc PENTAX-F 85mm f/2.8 Soft](../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) 1: `BACD14 (HOYA)`
+
 ### BK3 — 1 occurrence
 
 - [VIVITAR SERIES 1 35–85mm f/2.8 VMC](../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) 10: `BK3 (Schott)`
@@ -1001,6 +1009,10 @@ or per-lens patent backfills.
 ### S-LAL10 — 1 occurrence
 
 - [MINOLTA MD ROKKOR 50mm f/1.4](../src/lens-data/minolta/MinoltaRokkor50mmf14MD.data.ts) 12: `S-LAL10 (OHARA)`
+
+### S-LAL12 — 1 occurrence
+
+- [smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM](../src/lens-data/pentax/PentaxDA50135mmf28.data.ts) 25: `S-LAL12 (OHARA)`
 
 ### S-LAL60 — 1 occurrence
 

--- a/src/components/display/PupilAberrationTab.tsx
+++ b/src/components/display/PupilAberrationTab.tsx
@@ -4,7 +4,7 @@
  *
  * Both profiles are computed in a single pass via computeBothPupilAberrationProfiles,
  * which shares the per-angle chief-ray bisection between the two computations.
- * The memoized result reacts to changes in focusT or zoomT.
+ * The memoized result reacts to changes in focusT, zoomT, or aberrationT.
  */
 
 import { useMemo } from "react";
@@ -20,13 +20,21 @@ interface PupilAberrationTabProps {
   t: Theme;
   focusT: number;
   zoomT: number;
+  aberrationT?: number;
   fieldGeometry?: FieldGeometryState | null;
 }
 
-export default function PupilAberrationTab({ L, t, focusT, zoomT, fieldGeometry }: PupilAberrationTabProps) {
+export default function PupilAberrationTab({
+  L,
+  t,
+  focusT,
+  zoomT,
+  aberrationT = 0,
+  fieldGeometry,
+}: PupilAberrationTabProps) {
   const profiles = useMemo(
-    () => computeBothPupilAberrationProfiles(focusT, zoomT, L, undefined, fieldGeometry ?? undefined),
-    [L, focusT, zoomT, fieldGeometry],
+    () => computeBothPupilAberrationProfiles(focusT, zoomT, L, undefined, fieldGeometry ?? undefined, aberrationT),
+    [L, focusT, zoomT, aberrationT, fieldGeometry],
   );
 
   if (profiles.ep.samples.length < 2) {

--- a/src/components/display/aberrations/useComaData.ts
+++ b/src/components/display/aberrations/useComaData.ts
@@ -18,7 +18,7 @@ export default function useComaData({
   zPos,
   focusT,
   zoomT,
-  aberrationT: _aberrationT = 0,
+  aberrationT = 0,
   currentEPSD,
   currentPhysStopSD,
 }: Params) {
@@ -27,7 +27,9 @@ export default function useComaData({
       meridionalComa: comaResult,
       sagittalComa: sagittalComaResult,
       pointCloudPreview: comaPreviewResult,
-    } = probe("computeComaAnalysis", () => computeComaAnalysis(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD));
+    } = probe("computeComaAnalysis", () =>
+      computeComaAnalysis(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT),
+    );
     return { comaResult, sagittalComaResult, comaPreviewResult };
-  }, [L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD]);
+  }, [L, zPos, focusT, zoomT, aberrationT, currentEPSD, currentPhysStopSD]);
 }

--- a/src/components/display/aberrations/useFieldCurvatureData.ts
+++ b/src/components/display/aberrations/useFieldCurvatureData.ts
@@ -17,12 +17,21 @@ export default function useFieldCurvatureData({
   zPos,
   focusT,
   zoomT,
-  aberrationT: _aberrationT = 0,
+  aberrationT = 0,
   currentEPSD,
   currentPhysStopSD,
 }: Params) {
   return useMemo(() => {
-    const fieldCurvatureResult = computeFieldCurvature(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
+    const fieldCurvatureResult = computeFieldCurvature(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      false,
+      aberrationT,
+    );
     const chromaticFieldCurvatureResult = computeFieldCurvature(
       L,
       zPos,
@@ -31,7 +40,8 @@ export default function useFieldCurvatureData({
       currentEPSD,
       currentPhysStopSD,
       true,
+      aberrationT,
     );
     return { fieldCurvatureResult, chromaticFieldCurvatureResult };
-  }, [L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD]);
+  }, [L, zPos, focusT, zoomT, aberrationT, currentEPSD, currentPhysStopSD]);
 }

--- a/src/components/display/aberrations/useSphericalAberrationData.ts
+++ b/src/components/display/aberrations/useSphericalAberrationData.ts
@@ -22,15 +22,15 @@ export default function useSphericalAberrationData({
   zPos,
   focusT,
   zoomT,
-  aberrationT: _aberrationT = 0,
+  aberrationT = 0,
   currentEPSD,
   currentPhysStopSD,
 }: Params) {
   return useMemo(() => {
     const saResult = probe("computeSphericalAberration", () =>
-      computeSphericalAberration(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD),
+      computeSphericalAberration(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT),
     );
-    const saProfile = computeSAProfile(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
+    const saProfile = computeSAProfile(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT);
     const saBlurCharacter = computeSphericalAberrationBlurCharacter(
       L,
       zPos,
@@ -39,7 +39,8 @@ export default function useSphericalAberrationData({
       currentEPSD,
       currentPhysStopSD,
       saResult,
+      aberrationT,
     );
     return { saResult, saProfile, saBlurCharacter };
-  }, [L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD]);
+  }, [L, zPos, focusT, zoomT, aberrationT, currentEPSD, currentPhysStopSD]);
 }

--- a/src/components/layout/lensDiagram/analysisTabRenderers.tsx
+++ b/src/components/layout/lensDiagram/analysisTabRenderers.tsx
@@ -88,6 +88,13 @@ export const ANALYSIS_TAB_RENDERERS: Record<AnalysisTabId, AnalysisTabRenderer> 
     />
   ),
   pupils: ({ L, t, inputs }) => (
-    <PupilAberrationTab L={L} t={t} focusT={inputs.focusT} zoomT={inputs.zoomT} fieldGeometry={inputs.fieldGeometry} />
+    <PupilAberrationTab
+      L={L}
+      t={t}
+      focusT={inputs.focusT}
+      zoomT={inputs.zoomT}
+      aberrationT={inputs.aberrationT}
+      fieldGeometry={inputs.fieldGeometry}
+    />
   ),
 };

--- a/src/lens-data/pentax/PentaxDA1650mmf28.analysis.md
+++ b/src/lens-data/pentax/PentaxDA1650mmf28.analysis.md
@@ -1,0 +1,318 @@
+# Optical Design Analysis: smc Pentax-DA★ 16-50mm f/2.8 ED AL[IF] SDM
+
+## US 7,301,711 B2 — Example 6 (Embodiment 6)
+
+---
+
+## 1. Patent Reference and Design Identification
+
+**Patent:** US 7,301,711 B2, "Fast Zoom Lens System"
+**Inventor:** Masakazu Saori (Saitama, JP)
+**Assignee:** PENTAX Corporation, Tokyo, JP
+**Filed:** November 6, 2006
+**Granted:** November 27, 2007
+**Priority:** JP P2005-322558, filed November 7, 2005
+
+**Embodiment used:** Numerical Example 6 (Table 6; Figs. 21–24E)
+
+The identification of Example 6 as the production design rests on the following convergent evidence:
+
+1. **Element and group count.** Example 6 contains 15 glass elements in 12 air-separated groups, matching the manufacturer specification exactly (Ricoh Imaging product page: "15 elements in 12 groups").
+2. **Focal length range.** The patent states f = 16.48–48.50 mm with a zoom ratio of 2.94×. The production lens covers 16–50 mm — a close match after rounding to a marketing-friendly focal length.
+3. **Constant aperture.** F/2.9 across all zoom positions. The production lens is marketed as f/2.8, the nearest standard f-stop; the patent's F/2.9 is the precise paraxial value.
+4. **Aspherical element count.** Three elements carry aspherical surfaces in Example 6: a hybrid composite resin asphere in Group 20, a glass asphere in Group 30, and a double-asphere in Group 40. The production lens is specified as having "three aspherical elements."
+5. **ED element count.** Two elements use S-FPL51 (nd = 1.49700, νd = 81.6) — one in Group 30 and one in Group 40. The production spec states "two ED (Extra-low Dispersion) elements."
+6. **APS-C image circle.** The half-field angles (42.0° wide / 16.2° tele) and back focal distances (39.00–65.07 mm) are consistent with an APS-C sensor (23.5 × 15.7 mm) behind a K-mount flange.
+7. **Patent timing.** Priority filed November 2005, granted November 2007; the DA★ 16-50mm was announced and shipped in 2007.
+8. **Tokina collaboration.** The lens was jointly developed with Tokina (marketed as the Tokina AT-X Pro 165 AF SD 16-50mm f/2.8 DX for Canon and Nikon mounts). Saori's patent history includes multiple Pentax/Tokina zoom designs from this period.
+
+All six numerical examples in the patent share the same four-group positive–negative–positive–positive architecture, but they differ in element count, group structure, and aspherical placement. Examples 1–3 use a six-element second group (yielding 18 elements / 14 groups); Examples 4–6 use a more compact five-element second group (15 elements / 12 groups). Example 6 specifically differs from Example 5 in several radii, thicknesses, and glass selections — it represents the final optimized production prescription.
+
+---
+
+## 2. Optical Architecture
+
+The design is a four-group positive-lead zoom with power distribution **positive–negative–positive–positive** (P–N–P–P), arranged from object to image. The diaphragm is positioned immediately in front of Group 30 and moves together with it during zooming.
+
+**Group structure at a glance:**
+
+| Group | Power | f (mm) | Elements | Groups | Role |
+|-------|-------|--------|----------|--------|------|
+| 10 (G1) | Positive | +130.1 | 3 (cemented doublet + singlet) | 2 | Front collector / variator |
+| 20 (G2) | Negative | −15.5 | 5 (4 singlets + cemented doublet) | 4 | Variator / compensator |
+| 30 (G3) | Positive | +92.6 | 3 singlets | 3 | Relay (fixed imaging group, with stop) |
+| 40 (G4) | Positive | +29.0 | 4 (singlet + cemented doublet + singlet) | 3 | Field flattener / imaging relay |
+
+The total power budget is dominated by the strong negative second group (f₂ = −15.5 mm), which acts as the principal zoom variator, and the positive fourth group (f₄ = +29.0 mm), which relays the image to the sensor plane. The first group is intentionally weak (f₁ = +130.1 mm), providing gentle positive power at the front to keep the overall length compact while avoiding excessive spherical aberration at long focal lengths. The third group, also relatively weak (f₃ = +92.6 mm), serves primarily as a relay immediately behind the stop and carries two of the three aspherical elements (indirectly — one of the two ED elements, plus an aspherical glass element).
+
+**Zoom kinematics (Fig. 25):** Upon zooming from wide (W) to tele (T), all four groups and the stop move toward the object. Groups 10, 30, and 40 move monotonically forward; Group 20 first moves rearward (toward the image), then reverses direction and moves forward — a classic non-monotonic variator cam path that allows the patent's three-position piecewise-linear interpolation to capture the reversal. The three variable air gaps evolve as follows:
+
+| Gap | Wide (mm) | Mid (mm) | Tele (mm) | Behavior |
+|-----|-----------|----------|-----------|----------|
+| d5 (G1–G2) | 3.10 | 17.89 | 36.27 | Increases monotonically |
+| d15 (G2–G3) | 20.76 | 10.31 | 3.90 | Decreases monotonically |
+| d21 (G3–G4) | 5.39 | 2.80 | 1.27 | Decreases monotonically |
+
+The back focal distance increases from 39.00 mm (wide) to 65.07 mm (tele), accommodating the K-mount flange distance of 45.46 mm plus the reflex mirror clearance required by an SLR.
+
+The architecture is distinguished from the more common negative-lead (N–P–N–P or N–P–P) wide-angle zooms by its positive-lead topology. As the patent text explains (columns 1–2), this positive-lead arrangement is advantageous for miniaturization of the front element diameter and overall lens weight, though it makes securing a long back focal distance more challenging — a problem the patent solves by using a strong negative second group and two positive rear groups.
+
+---
+
+## 3. Element-by-Element Analysis
+
+The following analysis proceeds front-to-rear. Element names use the convention L*gn* where *g* is the group number and *n* is the element position within the group. Focal lengths are thick-lens in-air values computed via ABCD matrix.
+
+### Group 10 — Positive First Lens Group (f₁ = +130.1 mm)
+
+#### L11 — Negative Meniscus (convex to object), cemented
+
+nd = 1.84666, νd = 23.8. Glass: S-TIH53 (OHARA) — high-index dense flint. f = −179.6 mm.
+
+The most object-side element is a negative meniscus of very high-index, high-dispersion flint glass. Its primary role is chromatic: paired with the adjacent positive crown L12 in a cemented doublet, it corrects the longitudinal chromatic aberration that would otherwise accumulate from the positive power of Group 10. The high refractive index (nd = 1.847) allows strong curvatures while keeping the sag manageable at the large front aperture. The meniscus form (R₁ = +228.853, R₂ = +90.908 — both convex toward the object) minimizes the introduction of spherical aberration. The cemented interface at R₂ = 90.908 mm simultaneously serves as an achromatizing junction and eliminates one air–glass reflection, improving contrast.
+
+#### L12 — Positive Meniscus (convex to object), cemented with L11
+
+nd = 1.71300, νd = 53.9. Glass: S-BAL42 (OHARA) — barium crown. f = +141.9 mm.
+
+The positive partner of the cemented doublet. Barium crown was selected for its moderate refractive index and relatively low dispersion compared to the flint partner, yielding a well-corrected achromatic pair. The combined doublet has a long positive focal length, contributing gently to the overall positive power of Group 10 without introducing excessive aberrations. The meniscus shape follows the entering wavefront curvature, a hallmark of well-corrected front groups in zoom systems.
+
+#### L13 — Positive Meniscus (convex to object), singlet
+
+nd = 1.77250, νd = 49.6. Glass: S-LAH63Q (OHARA) — lanthanum crown. f = +158.1 mm.
+
+An air-spaced positive meniscus that adds further positive power to Group 10. The lanthanum crown glass provides a high refractive index at moderate dispersion, allowing the element to bend rays significantly while contributing minimally to chromatic aberration. This element primarily corrects the coma that would arise if all positive power were concentrated in the cemented doublet alone. The air gap between L12 and L13 (d3 = 0.20 mm) is very thin, indicating that the two groups are nearly in contact — the separation exists to decouple aberration contributions and provide a manufacturing alignment datum.
+
+### Group 20 — Negative Second Lens Group (f₂ = −15.5 mm)
+
+Group 20 is the dominant variator. Its strong negative power diverges the beam between Groups 10 and 30, and its axial travel during zooming determines the focal-length change. The group contains five glass elements and one aspherical resin layer, arranged in four air-separated sub-groups.
+
+#### L21 — Negative Meniscus with Hybrid Aspherical Layer (convex to object)
+
+**Resin layer (L21r):** nd = 1.52972, νd = 42.7. Material: UV-cure aspherical resin (not a catalog glass). f = −352.9 mm (resin alone).
+
+**Glass body (L21g):** nd = 1.83481, νd = 42.7. Glass: S-LAH55V (OHARA) — lanthanum dense flint. f = −23.1 mm (glass body alone).
+
+The first element of Group 20 is a hybrid composite: a conventionally polished negative meniscus lens of S-LAH55V glass, with a thin (d = 0.10 mm center thickness) aspherical resin layer bonded to its front surface. The resin layer's outer surface (surface 6*) carries the aspherical profile. This construction avoids the cost and difficulty of grinding and polishing a glass aspherical surface at this relatively large diameter, while still placing the aspherical correction exactly where the marginal ray height is large — maximizing its effectiveness against spherical aberration and distortion at the wide-angle end.
+
+The glass body is a strong negative meniscus (f = −23.1 mm) that provides most of Group 20's diverging power. The high refractive index of S-LAH55V allows the necessary curvatures (R = 50.745 front, R = 13.792 rear — both convex toward the object) without excessive sag at the element rim.
+
+**Aspherical surface 6*:** K = 0, A₄ = +1.7834 × 10⁻⁵, A₆ = −2.4983 × 10⁻⁸, A₈ = +8.4108 × 10⁻¹¹. The positive fourth-order coefficient means the aspherical profile adds refractive power that weakens toward the periphery relative to the spherical base curve. On a negative meniscus near the front of the diverging group, this sign pattern corrects the undercorrected spherical aberration and coma that the strong curvatures of the variator group would otherwise produce — particularly critical at the wide-angle position where d5 is small and the beam entering Group 20 is nearly collimated.
+
+#### L22 — Negative Biconcave
+
+nd = 1.83481, νd = 42.7. Glass: S-LAH55V (OHARA). f = −27.4 mm.
+
+A strongly negative biconcave element (R₁ = −48.189, R₂ = +44.128) sharing the same glass as L21. This element adds further divergence and splits the negative power of Group 20 across multiple surfaces, which distributes the aberration load. The biconcave form is efficient at generating negative power but produces significant higher-order spherical aberration; this is partially compensated by the adjacent positive element L23.
+
+#### L23 — Positive Biconvex
+
+nd = 1.64769, νd = 33.8. Glass: S-TIM27 (OHARA) — titanium flint. f = +27.1 mm.
+
+A positive biconvex element (R₁ = +29.394, R₂ = −39.787) that interrupts the run of negative elements in Group 20. Its purpose is threefold: (1) it provides chromatic correction within the group by pairing a high-dispersion flint (νd = 33.8) against the low-dispersion lanthanum elements L21/L22; (2) it partially offsets the spherical aberration introduced by L22; and (3) it introduces controlled Petzval field-flattening by inserting positive power at a position where the marginal ray height is moderate but the chief ray height is growing. The relatively unusual choice of a titanium flint (high dispersion, moderate index) for a positive element indicates that the designer prioritized chromatic balance within the variator group over minimizing the element's own monochromatic aberrations.
+
+#### L24 — Negative Biconcave (cemented with L25)
+
+nd = 1.80400, νd = 46.6. Glass: S-LAH65V (OHARA) — lanthanum crown. f = −19.1 mm.
+
+The front element of the cemented doublet that closes Group 20. This strong negative (R₁ = −22.186, R₂ = +50.962) is made from a lanthanum crown with moderate dispersion (νd = 46.6). Its primary function is to contribute the remaining negative power needed for the group's overall f₂ = −15.5 mm focal length, while its cemented interface with L25 provides an achromatizing junction that controls the lateral chromatic aberration contribution of the group at the wide-angle end.
+
+#### L25 — Positive Biconvex (cemented with L24)
+
+nd = 1.84666, νd = 23.8. Glass: S-TIH53 (OHARA) — high-index dense flint. f = +30.6 mm.
+
+The positive partner of the cemented doublet. Notably, this is the same glass (S-TIH53) as L11 — a high-index, high-dispersion flint. In a cemented doublet with the lanthanum crown L24, the pairing is unusual: normally the positive element has lower dispersion. Here the designer exploits the very high refractive index of S-TIH53 (nd = 1.847) to achieve the necessary positive power in a thin element, while accepting the chromatic contribution because it is partially compensated by the overall Group 20 chromatic balance. The symmetrical radii (R = ±50.962) suggest deliberate coma cancellation at the cemented interface.
+
+### Diaphragm (Aperture Stop)
+
+The diaphragm is located 2.40 mm in front of the first surface of Group 30 (surface 16). It moves together with Group 30 during zooming. The production lens has 9 aperture blades. The stop position between Groups 20 and 30 is characteristic of four-group zooms: it allows Groups 10 and 20 to handle the entering beam with minimal vignetting, while Groups 30 and 40 work in a near-telecentric exit condition that reduces the angle of incidence on the APS-C sensor.
+
+### Group 30 — Positive Third Lens Group (f₃ = +92.6 mm)
+
+Group 30 is the relay group immediately behind the stop. It moves together with the diaphragm and provides a relatively weak positive contribution, distributing the total positive power between Groups 30 and 40. The patent's conditional expressions emphasize the importance of this power balance: conditions (4) and (5) specifically constrain f₃/f₄ and f₁ × f₄/(f₃)² to prevent over-concentration of power near the stop.
+
+#### L31 — Positive Biconvex (ED)
+
+nd = 1.49700, νd = 81.6. Glass: S-FPL51 (OHARA) — fluorophosphate crown, ED. f = +77.7 mm.
+
+The first of two ED elements. S-FPL51 is an extra-low dispersion fluorophosphate glass with very low refractive index (nd = 1.497) and very high Abbe number (νd = 81.6). Its primary role is secondary-spectrum correction: by placing a low-dispersion positive element immediately behind the stop where the marginal ray height is near its minimum, the designer can reduce the axial chromatic aberration of the overall system without significantly increasing the higher-order monochromatic aberrations. The biconvex form (R₁ = +55.754, R₂ = −122.733) distributes the positive power across two moderately curved surfaces.
+
+#### L32 — Positive Biconvex (Aspherical rear surface)
+
+nd = 1.58636, νd = 60.9. Glass: BSM-class (586/609) — barium silicate crown or phosphate crown; exact catalog match uncertain. f = +39.8 mm.
+
+The strongest positive element in Group 30 and the second aspherical element in the system. The rear surface (surface 19*) carries the aspherical profile. This element provides the bulk of Group 30's convergent power (f = +39.8 mm versus f₃ = +92.6 mm for the group, indicating that L33 partially compensates).
+
+**Aspherical surface 19*:** K = 0, A₄ = −6.7065 × 10⁻⁶, A₆ = −2.7300 × 10⁻⁸, A₈ = 0. The negative fourth-order coefficient on a diverging rear surface (R = −67.745) means the surface becomes less steeply curved at the periphery than a sphere would — the positive power weakens away from the axis. This corrects the field-dependent aberrations (astigmatism and field curvature) that would otherwise arise from a strong positive element near the stop, and contributes to flattening the sagittal field.
+
+#### L33 — Negative Biconcave
+
+nd = 1.83400, νd = 37.2. Glass: S-LAH60 (OHARA) — lanthanum dense flint. f = −26.0 mm.
+
+A negative biconcave element (R₁ = −22.339, R₂ = +719.208 — strongly concave on the object side, nearly flat on the image side) that serves as a Petzval-sum corrector. Its strong negative power partially offsets the positive Petzval contribution of L31 and L32, flattening the field. The high-dispersion lanthanum flint glass (νd = 37.2) also provides chromatic correction within the group by creating an air-spaced achromatic pair with L32. The steep concave front surface faces the diverging chief ray at moderate height, an efficient geometry for field curvature correction without excessive higher-order off-axis aberration.
+
+### Group 40 — Positive Fourth Lens Group (f₄ = +29.0 mm)
+
+Group 40 is the imaging relay that forms the final image on the sensor. It contains the most complex aspherical element and contributes the strongest positive power of any group. The patent text specifically requires (condition 6) that the most object-side positive element in Group 40 have νd > 70 — satisfied here by L41 with νd = 81.6.
+
+#### L41 — Positive Biconvex (ED)
+
+nd = 1.49700, νd = 81.6. Glass: S-FPL51 (OHARA) — fluorophosphate crown, ED. f = +37.6 mm.
+
+The second ED element, identical glass to L31. This element provides the primary positive power of Group 40 (f = +37.6 mm, nearly equal to the group's f₄ = +29.0 mm). The patent's condition (6) requires νd > 70 for this element specifically because it is the dominant contributor to lateral chromatic aberration at the wide-angle end: a high-Abbe-number glass minimizes the chromatic spread of off-axis ray bundles as they converge toward the image. The symmetrical biconvex form (R = ±35.999) is a deliberate choice that equalizes the spherical aberration contributions from the two surfaces, a technique effective when the element is in a converging beam of roughly symmetric cone angle.
+
+#### L42 — Negative Meniscus (cemented with L43)
+
+nd = 1.80518, νd = 25.4. Glass: S-TIH6 (OHARA) — dense flint. f = −81.0 mm.
+
+A weak negative meniscus (R₁ = +1796.044, nearly flat front; R₂ = +62.947) of very high-dispersion flint. Its function is almost purely chromatic: cemented with the positive crown L43, it forms an achromatizing doublet that corrects the longitudinal and lateral chromatic aberration introduced by L41. The very high dispersion (νd = 25.4) means only a thin element is needed to produce the required chromatic correction, keeping the doublet compact. The near-flat front surface indicates that the element contributes minimal power — its role is dispersion control, not ray bending.
+
+#### L43 — Positive Biconvex (cemented with L42)
+
+nd = 1.48749, νd = 70.2. Glass: S-FSL5 (OHARA) — fluorosilicate crown. f = +65.4 mm.
+
+The positive partner of the cemented doublet. S-FSL5 is a low-index, low-dispersion crown that complements the high-dispersion S-TIH6 of L42. The symmetrical biconvex form (R = ±62.947) provides moderate positive power while the cemented interface eliminates ghost reflections between the two elements. This doublet as a whole is weakly positive, serving as a chromatic corrector rather than a primary power element.
+
+#### L44 — Positive Meniscus with Double Aspherical Surfaces (concave to object)
+
+nd = 1.58636, νd = 60.9. Glass: BSM-class (586/609) — same glass as L32. f = +127.1 mm.
+
+The final element of the system and the third aspherical element. Both surfaces (27* and 28*) carry aspherical profiles, making this a double-asphere. The meniscus form is concave to the object (R₁ = −500.000, nearly flat; R₂ = −65.096, moderately concave), with weak positive power (f = +127.1 mm). The patent text specifically recommends placing an aspherical surface on the most image-side element where off-axis ray bundles are most spread, enabling effective correction of coma, astigmatism, and distortion without disturbing on-axis performance.
+
+**Aspherical surface 27* (front):** K = 0, A₄ = −2.0218 × 10⁻⁵, A₆ = −2.7300 × 10⁻⁸, A₈ = +1.0251 × 10⁻¹⁰. The dominant negative A₄ term means the surface's positive power weakens from center to edge — the defining characteristic the patent prescribes for this surface. Because the base radius is very weak (R = −500 mm), the polynomial terms dominate the sag profile: at an estimated semi-diameter of 12 mm, the aspherical departure is approximately 0.46 mm — a substantial departure indicating that this surface carries significant correction burden. This is consistent with the patent's teaching that the final element's asphere is the most effective position for coma correction.
+
+**Aspherical surface 28* (rear):** K = 0, A₄ = −1.6910 × 10⁻⁷, A₆ = −4.1153 × 10⁻⁹, A₈ = +1.4111 × 10⁻¹⁰. The A₄ coefficient is two orders of magnitude weaker than surface 27*, indicating that this surface provides fine-tuning of the off-axis correction rather than primary correction. It primarily adjusts the residual astigmatism and field curvature that surface 27* could not fully eliminate.
+
+---
+
+## 4. Glass Identification and Selection
+
+The design uses 12 distinct optical materials (11 catalog glasses plus one aspherical resin). Seven are used only once; three glasses are used twice. The palette is dominated by OHARA catalog types, consistent with Japanese optical manufacturing practice of this period.
+
+| Glass | nd | νd | Code | Used in | Type | Role |
+|-------|----|----|------|---------|------|------|
+| S-TIH53 (OHARA) | 1.84666 | 23.8 | 846/238 | L11, L25 | High-index dense flint | Achromatizing flint (high nd enables thin elements) |
+| S-BAL42 (OHARA) | 1.71300 | 53.9 | 713/539 | L12 | Barium crown | Achromatic crown partner in G1 doublet |
+| S-LAH63Q (OHARA) | 1.77250 | 49.6 | 772/496 | L13 | Lanthanum crown | High-nd positive element in G1 |
+| UV-cure resin | 1.52972 | 42.7 | 529/427 | L21r | Synthetic resin | Aspherical molded layer on L21 |
+| S-LAH55V (OHARA) | 1.83481 | 42.7 | 834/427 | L21, L22 | Lanthanum dense flint | High-nd negative elements in variator |
+| S-TIM27 (OHARA) | 1.64769 | 33.8 | 647/338 | L23 | Titanium flint | Chromatic corrector within G2 |
+| S-LAH65V (OHARA) | 1.80400 | 46.6 | 804/466 | L24 | Lanthanum crown | Negative power + achromatizing in G2 |
+| S-FPL51 (OHARA) | 1.49700 | 81.6 | 497/816 | L31, L41 | Fluorophosphate crown (ED) | Primary chromatic correction |
+| BSM-class | 1.58636 | 60.9 | 586/609 | L32, L44 | Barium silicate crown | Aspherical substrates (moderate nd, low dispersion) |
+| S-LAH60 (OHARA) | 1.83400 | 37.2 | 834/372 | L33 | Lanthanum dense flint | Petzval corrector / chromatic balance |
+| S-TIH6 (OHARA) | 1.80518 | 25.4 | 805/254 | L42 | Dense flint | Achromatizing flint in G4 doublet |
+| S-FSL5 (OHARA) | 1.48749 | 70.2 | 487/702 | L43 | Fluorosilicate crown | Low-dispersion crown in G4 doublet |
+
+**Chromatic strategy:** The design relies on two ED elements (S-FPL51, νd = 81.6) positioned in Groups 30 and 40 — one behind the stop and one in the imaging relay. These are the "two special optical glass elements" referenced in the manufacturer's product description. The achromatizing strategy within each group uses conventional crown–flint pairings: S-TIH53/S-BAL42 in Group 10, S-LAH55V/S-TIM27 within Group 20, and S-TIH6/S-FSL5 in Group 40.
+
+**Note on the 586/609 glass:** The glass used for L32 and L44 (nd = 1.58636, νd = 60.9) does not precisely match any current OHARA S-type catalog entry. It falls in the barium silicate crown region of the nd–νd diagram. Given the Pentax–Tokina collaboration, it may be a Tokina-sourced melt, a Hoya equivalent, or a discontinued OHARA type. The six-digit code 586/609 is consistent with a moderate-index, moderate-dispersion crown suitable for precision glass molding — appropriate for the two aspherical substrates that use this glass.
+
+---
+
+## 5. Focus Mechanism
+
+The production lens is designated **[IF]** (Internal Focus), meaning the front element does not rotate or translate during focusing. The patent, however, only publishes zoom-position data (three focal-length positions at infinity focus) and does not include close-focus air-gap tables. Consequently, the specific focusing group(s) and their travel cannot be determined solely from this patent.
+
+From the manufacturer specification:
+- Minimum focusing distance: **0.30 m** (11.81 inches)
+- Maximum magnification: **0.21×**
+- Focus drive: **SDM** (Supersonic Direct-drive Motor), an ultrasonic-type AF motor built into the lens barrel
+
+In typical IF zoom designs of this era and configuration, focusing is commonly achieved by axially translating a lightweight internal group — most likely a sub-group within Group 30 or Group 20. The light weight of the focusing group is what enables the SDM motor to achieve the rapid, quiet autofocus operation that the lens is known for. The "Quick-Shift Focus System" allows instant override to manual focus without mode switching.
+
+The variable air gaps published in the patent describe only the zoom cam motion:
+
+| Gap | Position | Wide (mm) | Mid (mm) | Tele (mm) | Notes |
+|-----|----------|-----------|----------|-----------|-------|
+| d5 | G1 rear → G2 front | 3.10 | 17.89 | 36.27 | Increases (G1 moves forward faster) |
+| d15 | G2 rear → Stop/G3 | 20.76 | 10.31 | 3.90 | Decreases (G2 lags; G3 advances) |
+| d21 | G3 rear → G4 front | 5.39 | 2.80 | 1.27 | Decreases (G3 and G4 converge) |
+| BFD | G4 rear → Image | 39.00 | 50.99 | 65.07 | Increases (sensor plane fixed) |
+
+The variable-gap sum is not conserved (29.25 / 31.00 / 41.44 mm at W/M/T), confirming that the overall length of the lens changes during zooming — consistent with the production lens's extending barrel.
+
+---
+
+## 6. Aspherical Surfaces
+
+The design contains **four aspherical surfaces** distributed across **three elements**:
+
+| Surface | Element | Location | Type | Primary correction target |
+|---------|---------|----------|------|--------------------------|
+| 6* | L21r (resin layer on L21) | G2 front element, object side | Hybrid composite (resin on glass) | SA and coma at wide angle |
+| 19* | L32 (glass body) | G3 second element, image side | Polished or molded glass | Field curvature and astigmatism |
+| 27* | L44 (glass body) | G4 final element, object side | Polished or molded glass | Coma and distortion |
+| 28* | L44 (glass body) | G4 final element, image side | Polished or molded glass | Fine-tune residual field aberrations |
+
+The patent's aspherical sag equation is the standard even-power polynomial with conic constant:
+
+$$Z(h) = \frac{h^2 / R}{1 + \sqrt{1 - (1+K)(h/R)^2}} + A_4 h^4 + A_6 h^6 + A_8 h^8 + A_{10} h^{10}$$
+
+All four surfaces have K = 0 (spherical base curve; the aspherical departure is carried entirely by the polynomial terms). The coefficients are:
+
+| Surface | A₄ | A₆ | A₈ |
+|---------|----|----|-----|
+| 6* | +1.7834 × 10⁻⁵ | −2.4983 × 10⁻⁸ | +8.4108 × 10⁻¹¹ |
+| 19* | −6.7065 × 10⁻⁶ | −2.7300 × 10⁻⁸ | 0 |
+| 27* | −2.0218 × 10⁻⁵ | −2.7300 × 10⁻⁸ | +1.0251 × 10⁻¹⁰ |
+| 28* | −1.6910 × 10⁻⁷ | −4.1153 × 10⁻⁹ | +1.4111 × 10⁻¹⁰ |
+
+A₁₀ coefficients are not specified by the patent and are zero.
+
+**Note on A₆ values:** Surfaces 19* and 27* share an identical A₆ coefficient (−2.7300 × 10⁻⁸). In Embodiment 5 (Table 5), the corresponding surfaces carry different A₆ values (−0.27625 × 10⁻⁷ and −0.14970 × 10⁻⁷ respectively). The coincidence in Embodiment 6 may reflect a typographical error in the granted patent, or it may be a genuine outcome of the optimization. We take the published values as authoritative.
+
+**Manufacturing notes:** Surface 6* is formed by molding a thin UV-cure resin layer onto the polished glass substrate (L21), a common cost-effective technique for large-diameter aspherics in this era. Surfaces 19*, 27*, and 28* are on glass bodies of the 586/609 material, which may be precision glass-molded (PGM) given its moderate softening temperature and the tight aspherical tolerances required. Surface 27* is a polynomial-dominated asphere: because the base radius is very weak (R = −500 mm, nearly flat), the polynomial terms carry the bulk of the sag. At an estimated semi-diameter of 12 mm (the patent does not publish semi-diameters), the aspherical departure from the base sphere reaches approximately 0.46 mm; at 15 mm it would reach approximately 1.07 mm. These are significant departures that indicate the surface plays a major role in off-axis correction. The "AL" designation in the production lens name stands for "Aspherical Lens."
+
+---
+
+## 7. Paraxial Verification Summary
+
+All computations were performed using ABCD (transfer-matrix) paraxial ray tracing with the patent's full thick-lens prescription at all three zoom positions.
+
+| Parameter | Wide | Mid | Tele | Source |
+|-----------|------|-----|------|--------|
+| EFL (computed) | 16.481 mm | 28.007 mm | 48.510 mm | ABCD trace |
+| EFL (patent) | 16.48 mm | 28.00 mm | 48.50 mm | Table 6 |
+| EFL error | 0.001 mm | 0.007 mm | 0.010 mm | — |
+| Half-field (computed) | 40.7° | 27.0° | 16.4° | arctan(14.13/EFL) |
+| Half-field (patent) | 42.0° | 26.7° | 16.2° | Table 6 |
+
+The minor half-field discrepancy at wide-angle (40.7° vs. 42.0°) reflects the difference between the paraxial marginal-ray half-field and the real-ray vignetting-limited field. The patent's stated 42.0° likely corresponds to the real ray trace with mechanical vignetting constraints.
+
+**Patent conditional expressions (Table 7 verification):**
+
+| Condition | Formula | Computed | Patent (Table 7) | Range | Status |
+|-----------|---------|----------|------------------|-------|--------|
+| (1) | f₁/f_w | 7.89 | 7.89 | 6.0–10.0 | ✓ |
+| (2) | f₃/f_w | 5.62 | 5.62 | 3.0–8.0 | ✓ |
+| (3) | f₁/|f₂| | 8.40 | 8.40 | 7.0–10.0 | ✓ |
+| (4) | f₃/f₄ | 3.19 | 3.19 | 2.0–5.0 | ✓ |
+| (5) | f₁×f₄/(f₃)² | 0.44 | 0.44 | < 1.0 | ✓ |
+| (6) | ν_{4p} | 81.6 | 81.6 | > 70 | ✓ |
+| (7) | f₁/√(f_w×f_t) | 4.60 | 4.60 | 3.5–6.5 | ✓ |
+| (8) | f₃/√(f_w×f_t) | 3.27 | 3.27 | 2.0–5.0 | ✓ |
+
+All eight conditions are satisfied and all computed values match the patent's Table 7 to the reported precision, confirming correct transcription.
+
+**Petzval sum:** 0.00214 mm⁻¹ (Petzval radius ≈ 467 mm). This is a well-corrected value for an APS-C zoom — the image field curvature is gentle relative to the 28.3 mm image diagonal, contributing to the lens's reputation for reasonable edge sharpness when stopped down.
+
+---
+
+## 8. Design Heritage and Context
+
+The smc Pentax-DA★ 16-50mm f/2.8 ED AL[IF] SDM was developed within the longstanding optical collaboration between Pentax Corporation and Tokina. Tokina marketed a closely related design as the **Tokina AT-X 165 PRO DX AF 16-50mm f/2.8** for Canon EF and Nikon F mounts, sharing the same 15-element / 12-group configuration. The two companies are known to have traded optical designs during this period, with each manufacturer applying its own coatings, focus mechanisms, and mechanical construction. The Tokina version uses Tokina's One-touch Focus Clutch mechanism rather than SDM, lacks the DA★ weather-sealing, and carries Tokina's WP (Water Proof) front-element coating rather than Pentax's SP coating. Tokina's marketing references "1 SD (Super-Low Dispersion) glass element" versus Pentax's "2 ED elements," which may reflect either a difference in glass selection or simply a difference in marketing terminology for the same materials. Whether the optical prescriptions are numerically identical or merely closely related cannot be determined from publicly available documentation; the patent (US 7,301,711) is assigned solely to Pentax Corporation.
+
+The positive-lead P–N–P–P four-group architecture is uncommon for wide-angle standard zooms, where negative-lead designs dominate. The patent's introduction explicitly addresses this trade-off: while negative-lead designs offer superior wide-angle coverage and easier back-focal-distance management, they tend to be heavier and larger in diameter. The positive-lead design adopted here achieves a remarkably compact front diameter (77 mm filter thread) and moderate weight (565 g) for a constant f/2.8 zoom with 3× zoom ratio covering the ultra-wide to normal range on APS-C.
+
+The lens was produced from 2007 until 2021, when it was succeeded by the entirely redesigned HD Pentax-DA★ 16-50mm f/2.8 ED PLM AW (a 16-element, 12-group design with PLM focusing motor and updated coatings).
+
+---
+
+## Sources
+
+- US 7,301,711 B2 (Saori, 2007). Full patent text, Tables 1–7, Figures 1–25.
+- Ricoh Imaging Americas product page: smc PENTAX-DA★ 16-50mm F2.8 ED AL[IF] SDM (us.ricoh-imaging.com).
+- OHARA Optical Glass Catalog (2018/2023 editions): glass-type data sheets for S-TIH53, S-BAL42, S-LAH63Q, S-LAH55V, S-TIM27, S-LAH65V, S-FPL51, S-LAH60, S-TIH6, S-FSL5.
+- KEH Camera and Imaging Resource product specifications for element/group counts and MFD.
+- lens-db.com entry confirming Pentax–Tokina collaboration and Tokina AT-X 165 cross-listing.

--- a/src/lens-data/pentax/PentaxDA1650mmf28.data.ts
+++ b/src/lens-data/pentax/PentaxDA1650mmf28.data.ts
@@ -1,0 +1,434 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — smc PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM          ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 7,301,711 B2, Numerical Example 6 (Table 6).     ║
+ * ║  Inventor: Masakazu Saori. Assignee: PENTAX Corporation.          ║
+ * ║  Fast positive-lead four-group zoom (P–N–P–P) for APS-C SLR.     ║
+ * ║  15 elements / 12 groups, 3 aspherical elements (4 asph surfaces).║
+ * ║  Zoom positions: 16.48 mm (W), 28.00 mm (M), 48.50 mm (T).      ║
+ * ║  Constant F/2.9 (patent); marketed as f/2.8.                      ║
+ * ║                                                                    ║
+ * ║  Zoom variable gaps: D5 (G1–G2), D15 (G2–STO), D21 (G3–G4),     ║
+ * ║                       BFD (G4–image).                              ║
+ * ║  D15 is the portion of patent gap d15 before the stop;             ║
+ * ║  the stop is fixed at 2.40 mm in front of G3 surface 16.          ║
+ * ║                                                                    ║
+ * ║  CLOSE-FOCUS NOTE:                                                 ║
+ * ║    Patent publishes only zoom-position data at infinity focus.     ║
+ * ║    Close-focus air-gap tables are not available. All var entries   ║
+ * ║    use identical [d_inf, d_close] pairs (zoom-only).              ║
+ * ║    The production lens is IF (internal focus), MFD = 0.30 m.      ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not publish semi-diameters. SDs estimated from      ║
+ * ║    paraxial marginal ray (at F/2.9) + chief ray (60% field),      ║
+ * ║    envelope across all three zoom positions, with 8% mechanical   ║
+ * ║    clearance. Front elements constrained by 77 mm filter thread.  ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "pentax-da-16-50-f28",
+  maker: "Pentax",
+  name: "smc PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM",
+  subtitle: "US 7,301,711 B2 Example 6 — PENTAX / Saori",
+  specs: [
+    "15 ELEMENTS / 12 GROUPS",
+    "f = 16.48–48.50 mm (2.94×)",
+    "F/2.8 (constant)",
+    "2ω ≈ 84.0–32.4°",
+    "3 ASPHERICAL ELEMENTS (4 SURFACES)",
+    "2 ED ELEMENTS",
+  ],
+
+  focalLengthMarketing: [16, 50],
+  focalLengthDesign: [16.48, 48.5],
+  apertureMarketing: 2.8,
+  apertureDesign: 2.9,
+  patentYear: 2007,
+  elementCount: 15,
+  groupCount: 12,
+
+  /* ── Elements ──
+   *  16 entries: the hybrid composite on L21 is split into resin layer (L21r, id 4)
+   *  and glass body (L21g, id 5). The manufacturer counts them as one element (15 total).
+   */
+  elements: [
+    // ── Group 10 (Positive First Lens Group, f₁ = +130.1 mm) ──
+    {
+      id: 1,
+      name: "L11",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.84666,
+      vd: 23.8,
+      fl: -179.6,
+      glass: "S-TIH53 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "Achromatizing flint in G1 cemented doublet",
+    },
+    {
+      id: 2,
+      name: "L12",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.713,
+      vd: 53.9,
+      fl: 141.9,
+      glass: "S-BAL42 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "Barium crown partner in G1 achromatic doublet",
+    },
+    {
+      id: 3,
+      name: "L13",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.7725,
+      vd: 49.6,
+      fl: 158.1,
+      glass: "S-LAH63Q (OHARA)",
+      apd: false,
+      role: "Lanthanum crown singlet adding positive power to G1",
+    },
+
+    // ── Group 20 (Negative Second Lens Group, f₂ = −15.5 mm) ──
+    {
+      id: 4,
+      name: "L21r",
+      label: "Element 4 (resin)",
+      type: "Neg. Meniscus (1× Asph)",
+      nd: 1.52972,
+      vd: 42.7,
+      fl: -352.9,
+      glass: "UV-cure aspherical resin (not catalog glass)",
+      apd: false,
+      cemented: "H1",
+      role: "Aspherical resin layer on front of hybrid composite; corrects SA and coma at wide",
+    },
+    {
+      id: 5,
+      name: "L21g",
+      label: "Element 4 (glass)",
+      type: "Negative Meniscus",
+      nd: 1.83481,
+      vd: 42.7,
+      fl: -23.1,
+      glass: "S-LAH55V (OHARA)",
+      apd: false,
+      cemented: "H1",
+      role: "Glass body of hybrid composite; primary negative power in G2 front sub-group",
+    },
+    {
+      id: 6,
+      name: "L22",
+      label: "Element 5",
+      type: "Biconcave Negative",
+      nd: 1.83481,
+      vd: 42.7,
+      fl: -27.4,
+      glass: "S-LAH55V (OHARA)",
+      apd: false,
+      role: "Strong negative element distributing G2 divergence",
+    },
+    {
+      id: 7,
+      name: "L23",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.64769,
+      vd: 33.8,
+      fl: 27.1,
+      glass: "S-TIM27 (OHARA)",
+      apd: false,
+      role: "Chromatic corrector within G2; Petzval field-flattening",
+    },
+    {
+      id: 8,
+      name: "L24",
+      label: "Element 7",
+      type: "Biconcave Negative",
+      nd: 1.804,
+      vd: 46.6,
+      fl: -19.1,
+      glass: "S-LAH65V (OHARA)",
+      apd: false,
+      cemented: "D2",
+      role: "Strong negative in G2 cemented doublet; achromatizing junction with L25",
+    },
+    {
+      id: 9,
+      name: "L25",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.84666,
+      vd: 23.8,
+      fl: 30.6,
+      glass: "S-TIH53 (OHARA)",
+      apd: false,
+      cemented: "D2",
+      role: "Positive flint partner in G2 closing doublet",
+    },
+
+    // ── Group 30 (Positive Third Lens Group, f₃ = +92.6 mm) ──
+    {
+      id: 10,
+      name: "L31",
+      label: "Element 9",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 77.7,
+      glass: "S-FPL51 (OHARA)",
+      apd: false,
+      role: "ED element behind stop; primary chromatic correction",
+    },
+    {
+      id: 11,
+      name: "L32",
+      label: "Element 10",
+      type: "Biconvex Positive (1× Asph)",
+      nd: 1.58636,
+      vd: 60.9,
+      fl: 39.8,
+      glass: "BSM-class (586/609, vendor uncertain)",
+      apd: false,
+      role: "Strongest positive element in G3; aspherical rear corrects field curvature and astigmatism",
+    },
+    {
+      id: 12,
+      name: "L33",
+      label: "Element 11",
+      type: "Biconcave Negative",
+      nd: 1.834,
+      vd: 37.2,
+      fl: -26.0,
+      glass: "S-LAH60 (OHARA)",
+      apd: false,
+      role: "Petzval-sum corrector; air-spaced achromatic pair with L32",
+    },
+
+    // ── Group 40 (Positive Fourth Lens Group, f₄ = +29.0 mm) ──
+    {
+      id: 13,
+      name: "L41",
+      label: "Element 12",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 37.6,
+      glass: "S-FPL51 (OHARA)",
+      apd: false,
+      role: "ED element; primary positive power in G4, lateral chromatic correction (condition 6: νd > 70)",
+    },
+    {
+      id: 14,
+      name: "L42",
+      label: "Element 13",
+      type: "Negative Meniscus",
+      nd: 1.80518,
+      vd: 25.4,
+      fl: -81.0,
+      glass: "S-TIH6 (OHARA)",
+      apd: false,
+      cemented: "D3",
+      role: "High-dispersion flint for achromatizing cemented doublet in G4",
+    },
+    {
+      id: 15,
+      name: "L43",
+      label: "Element 14",
+      type: "Biconvex Positive",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 65.4,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      cemented: "D3",
+      role: "Low-dispersion crown partner in G4 cemented doublet",
+    },
+    {
+      id: 16,
+      name: "L44",
+      label: "Element 15",
+      type: "Pos. Meniscus (2× Asph)",
+      nd: 1.58636,
+      vd: 60.9,
+      fl: 127.1,
+      glass: "BSM-class (586/609, vendor uncertain)",
+      apd: false,
+      role: "Double-asphere final element; corrects coma, astigmatism, distortion per patent teaching",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Patent surfaces 1–28, with STO inserted between patent surfaces 15 and 16.
+   *  The stop is 2.40 mm in front of surface 16 (patent text: "2.40 in front of...surface No. 16").
+   *  Patent gap d15 = 20.76/10.31/3.90 is split into:
+   *    surface "15" d = (d15 − 2.40) = 18.36/7.91/1.50  (variable)
+   *    "STO" d = 2.40                                      (fixed)
+   */
+  surfaces: [
+    // ── Group 10 ──
+    { label: "1", R: 228.853, d: 2.4, nd: 1.84666, elemId: 1, sd: 25.7 }, // L11 front
+    { label: "2", R: 90.908, d: 6.36, nd: 1.713, elemId: 2, sd: 25.3 }, // L11→L12 cemented junction
+    { label: "3", R: 868.199, d: 0.2, nd: 1.0, elemId: 0, sd: 24.4 }, // L12 rear → air
+    { label: "4", R: 66.977, d: 4.95, nd: 1.7725, elemId: 3, sd: 24.4 }, // L13 front
+    { label: "5", R: 143.503, d: 3.1, nd: 1.0, elemId: 0, sd: 23.0 }, // L13 rear → air (variable: G1–G2)
+
+    // ── Group 20 ──
+    { label: "6A", R: 69.698, d: 0.1, nd: 1.52972, elemId: 4, sd: 10.6 }, // L21r resin front (asph)
+    { label: "7", R: 50.745, d: 1.45, nd: 1.83481, elemId: 5, sd: 10.6 }, // L21r→L21g hybrid junction
+    { label: "8", R: 13.792, d: 6.68, nd: 1.0, elemId: 0, sd: 10.0 }, // L21g rear → air
+    { label: "9", R: -48.189, d: 1.2, nd: 1.83481, elemId: 6, sd: 9.0 }, // L22 front
+    { label: "10", R: 44.128, d: 0.34, nd: 1.0, elemId: 0, sd: 9.0 }, // L22 rear → air
+    { label: "11", R: 29.394, d: 6.7, nd: 1.64769, elemId: 7, sd: 9.2 }, // L23 front
+    { label: "12", R: -39.787, d: 1.14, nd: 1.0, elemId: 0, sd: 9.6 }, // L23 rear → air
+    { label: "13", R: -22.186, d: 1.2, nd: 1.804, elemId: 8, sd: 9.6 }, // L24 front
+    { label: "14", R: 50.962, d: 3.51, nd: 1.84666, elemId: 9, sd: 10.0 }, // L24→L25 cemented junction
+    { label: "15", R: -50.962, d: 18.36, nd: 1.0, elemId: 0, sd: 10.6 }, // L25 rear → air (variable: G2–STO)
+
+    // ── Aperture Stop ──
+    { label: "STO", R: 1e15, d: 2.4, nd: 1.0, elemId: 0, sd: 10.1 }, // stop, 2.40 mm before G3
+
+    // ── Group 30 ──
+    { label: "16", R: 55.754, d: 3.71, nd: 1.497, elemId: 10, sd: 12.0 }, // L31 front (ED)
+    { label: "17", R: -122.733, d: 0.2, nd: 1.0, elemId: 0, sd: 12.9 }, // L31 rear → air
+    { label: "18", R: 34.402, d: 6.4, nd: 1.58636, elemId: 11, sd: 12.9 }, // L32 front
+    { label: "19A", R: -67.745, d: 4.82, nd: 1.0, elemId: 0, sd: 13.3 }, // L32 rear → air (asph)
+    { label: "20", R: -22.339, d: 1.25, nd: 1.834, elemId: 12, sd: 13.1 }, // L33 front
+    { label: "21", R: 719.208, d: 5.39, nd: 1.0, elemId: 0, sd: 13.5 }, // L33 rear → air (variable: G3–G4)
+
+    // ── Group 40 ──
+    { label: "22", R: 35.999, d: 8.16, nd: 1.497, elemId: 13, sd: 14.1 }, // L41 front (ED)
+    { label: "23", R: -35.999, d: 0.62, nd: 1.0, elemId: 0, sd: 15.6 }, // L41 rear → air
+    { label: "24", R: 1796.044, d: 1.2, nd: 1.80518, elemId: 14, sd: 15.7 }, // L42 front
+    { label: "25", R: 62.947, d: 4.67, nd: 1.48749, elemId: 15, sd: 15.7 }, // L42→L43 cemented junction
+    { label: "26", R: -62.947, d: 0.3, nd: 1.0, elemId: 0, sd: 16.1 }, // L43 rear → air
+    { label: "27A", R: -500.0, d: 4.77, nd: 1.58636, elemId: 16, sd: 16.1 }, // L44 front (asph)
+    { label: "28A", R: -65.096, d: 39.0, nd: 1.0, elemId: 0, sd: 16.3 }, // L44 rear → image (BFD, variable)
+  ],
+
+  /* ── Aspherical coefficients ──
+   *  Patent sag equation: Z(h) = (h²/R)/[1+√(1−(1+K)(h/R)²)] + A4·h⁴ + A6·h⁶ + A8·h⁸ + A10·h¹⁰
+   *  All conic constants K = 0 (spherical base curve).
+   *  A10 not specified by patent; set to 0.
+   *
+   *  NOTE: Surfaces 19A and 27A share an identical A6 = −2.7300e-8.
+   *  In Embodiment 5 these differ (−2.7625e-8 vs −1.4970e-8). May be a
+   *  patent typographical artifact; we take the published values as authoritative.
+   */
+  asph: {
+    "6A": {
+      K: 0,
+      A4: 1.7834e-5,
+      A6: -2.4983e-8,
+      A8: 8.4108e-11,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+    "19A": {
+      K: 0,
+      A4: -6.7065e-6,
+      A6: -2.73e-8,
+      A8: 0,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+    "27A": {
+      K: 0,
+      A4: -2.0218e-5,
+      A6: -2.73e-8,
+      A8: 1.0251e-10,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+    "28A": {
+      K: 0,
+      A4: -1.691e-7,
+      A6: -4.1153e-9,
+      A8: 1.4111e-10,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+  },
+
+  /* ── Zoom positions ── */
+  zoomPositions: [16.48, 28.0, 48.5],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  /* ── Variable air spacings (zoom only — no close-focus data in patent) ──
+   *  Patent gap d15 is split: surface "15" carries (d15 − 2.40), STO carries fixed 2.40.
+   *  All entries use identical [d_inf, d_close] pairs since close-focus tables
+   *  were not published.
+   */
+  var: {
+    "5": [
+      [3.1, 3.1],
+      [17.89, 17.89],
+      [36.27, 36.27],
+    ], // G1–G2
+    "15": [
+      [18.36, 18.36],
+      [7.91, 7.91],
+      [1.5, 1.5],
+    ], // G2–STO (d15 − 2.40)
+    "21": [
+      [5.39, 5.39],
+      [2.8, 2.8],
+      [1.27, 1.27],
+    ], // G3–G4
+    "28A": [
+      [39.0, 39.0],
+      [50.99, 50.99],
+      [65.07, 65.07],
+    ], // BFD
+  },
+  varLabels: [
+    ["5", "D5"],
+    ["15", "D15"],
+    ["21", "D21"],
+    ["28A", "BF"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 (+)", fromSurface: "1", toSurface: "5" },
+    { text: "G2 (−)", fromSurface: "6A", toSurface: "15" },
+    { text: "G3 (+)", fromSurface: "16", toSurface: "21" },
+    { text: "G4 (+)", fromSurface: "22", toSurface: "28A" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "H1", fromSurface: "6A", toSurface: "8" },
+    { text: "D2", fromSurface: "13", toSurface: "15" },
+    { text: "D3", fromSurface: "24", toSurface: "26" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.3,
+  focusDescription:
+    "Internal focus (IF) via SDM ultrasonic motor. Patent provides zoom-only data; close-focus gaps not modeled.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.8,
+  apertureBlades: 9,
+  fstopSeries: [2.8, 3.5, 4, 4.5, 5.6, 6.3, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.48,
+  yScFill: 0.32,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/pentax/PentaxDA1650mmf28.data.ts
+++ b/src/lens-data/pentax/PentaxDA1650mmf28.data.ts
@@ -34,7 +34,7 @@ const LENS_DATA = {
   /* ── Identity ── */
   key: "pentax-da-16-50-f28",
   maker: "Pentax",
-  name: "smc PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM",
+  name: "PENTAX-DA★ 16-50mm f/2.8 ED AL[IF] SDM",
   subtitle: "US 7,301,711 B2 Example 6 — PENTAX / Saori",
   specs: [
     "15 ELEMENTS / 12 GROUPS",

--- a/src/lens-data/pentax/PentaxDA50135mmf28.analysis.md
+++ b/src/lens-data/pentax/PentaxDA50135mmf28.analysis.md
@@ -1,0 +1,344 @@
+# Optical Analysis: smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM
+
+## US Patent 7,289,274 B1 — Embodiment 5
+
+---
+
+## 1. Patent Reference and Design Identification
+
+**Patent:** US 7,289,274 B1, "Telescopic Zoom Lens System"
+**Inventor:** Masakazu Saori (Saitama, Japan)
+**Assignee:** PENTAX Corporation, Tokyo, Japan
+**Filed:** February 7, 2007 (US); Priority date February 10, 2006 (JP 2006-033506)
+**Granted:** October 30, 2007
+
+**Embodiment used:** Numerical Example 5 (Table 5, Figs. 17–20E)
+
+### Identification Evidence
+
+The following convergent evidence links Embodiment 5 of this patent to the production smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM:
+
+1. **Element and group count.** The prescription contains 18 elements in 14 air-separated groups, matching the manufacturer specification exactly (Ricoh Imaging product page; B&H Photo listing).
+2. **Focal length range.** The patent states $f = 51.50$–$131.00$ mm (zoom ratio 2.54). The marketed range is 50–135 mm. This is typical of Japanese patent practice, where the design focal length differs slightly from the rounded marketing value.
+3. **Constant aperture.** $F/2.9$ at all zoom positions in the patent; the production lens is marketed as $F/2.8$. Japanese patent prescriptions routinely report the computed f-number to one decimal, and the difference ($F/2.9$ vs. $F/2.8$) falls within the rounding tolerance typical for marketed specifications.
+4. **ED element count.** Three elements use glass with $\nu_d = 81.6$ (S-FPL51 class), matching the manufacturer's stated "three extra-low dispersion elements."
+5. **Internal focusing (IF).** The focusing group is the rear sub-group of Group 1 (10R), consisting of two elements that move together while the front group (10F) and all other groups remain stationary during focus — matching the "IF" designation.
+6. **Back focal distance.** $f_B = 39.70$ mm at all zoom positions, consistent with the Pentax K-mount flange distance of 45.46 mm and an APS-C image circle.
+7. **Patent timing.** The US patent was filed February 7, 2007; the DA★ 50-135mm was announced the same year and the inventor Masakazu Saori is associated with multiple PENTAX zoom lens patents from this period.
+8. **Zoom mechanism.** Groups 1 and 4 remain stationary while Groups 2 and 3 move — matching the patent's described "telescopic zoom" architecture and the lens's constant overall length during zooming.
+
+No other Pentax lens from this period matches all eight criteria simultaneously.
+
+---
+
+## 2. Optical Architecture
+
+The DA★ 50-135mm is a four-group telephoto zoom of the positive–negative–positive–positive power distribution type. Its architecture is summarized as follows:
+
+| Group | Power | Elements | Sub-groups | Role |
+|-------|-------|----------|------------|------|
+| 1 (10) | Positive | 5 (in 2 sub-groups) | 10F (front, 3 elem.) + 10R (rear, 2 elem.) | Front collector; 10R = focusing group |
+| 2 (20) | Negative | 4 | — | Variator (moves toward image on zoom-in) |
+| 3 (30) | Positive | 3 | — | Compensator (moves image-ward then object-ward) |
+| 4 (40) | Positive | 6 (in 2 sub-groups) | 40F (front, 3 elem.) + 40R (rear, 3 elem.) | Relay / field correction; contains fixed-aperture stop FS |
+
+Two diaphragms are present: a **variable-aperture diaphragm (KS)** positioned 1.00 mm in front of surface 22 (the entrance to Group 4), and a **fixed-aperture diaphragm (FS)** positioned 3.50 mm behind surface 26 (between sub-groups 40F and 40R). The fixed stop FS acts as a field stop that shields off-axis ray bundles from the rear sub-group regardless of focal length.
+
+### Zoom Mechanism
+
+Upon zooming from the short focal length extremity (51.5 mm) to the long focal length extremity (131.0 mm), Groups 1 and 4 remain stationary, Group 2 moves monotonically toward the image, and Group 3 first moves toward the image and then reverses toward the object. The total track length is constant because the sum of the three variable air gaps is conserved at 34.52 mm across all zoom positions:
+
+| Zoom Position | $d_9$ (G1–G2) | $d_{16}$ (G2–G3) | $d_{21}$ (G3–G4) | Sum |
+|---------------|---------------|-------------------|-------------------|-----|
+| Wide (51.5 mm) | 2.30 | 19.04 | 13.18 | 34.52 |
+| Mid (85.0 mm) | 19.73 | 11.78 | 3.01 | 34.52 |
+| Tele (131.0 mm) | 29.44 | 1.50 | 3.58 | 34.52 |
+
+This constant-track design enables the lens's fully internal zoom mechanism, where the barrel length does not change during zooming — a key feature for weather sealing and handling balance.
+
+### Computed Group Focal Lengths
+
+The following were verified by ABCD matrix paraxial ray trace:
+
+| Sub-system | Focal Length (mm) | Power |
+|------------|-------------------|-------|
+| Group 1 (full) | +92.2 | Positive |
+| Sub-group 10F | +192.7 | Weakly positive |
+| Sub-group 10R (focus) | +152.9 | Positive |
+| Group 2 | −22.9 | Strongly negative |
+| Group 3 | +71.1 | Positive |
+| Group 4 (full) | +66.8 | Positive |
+| Sub-group 40F | +108.6 | Positive |
+| Sub-group 40R | +118.7 | Positive |
+
+### Paraxial Verification
+
+Computed EFL values at each zoom position (ABCD matrix trace including back focal distance):
+
+| Position | Patent Stated $f$ | Computed EFL | Match |
+|----------|-------------------|-------------|-------|
+| Wide | 51.50 mm | 51.51 mm | ✓ |
+| Mid | 85.00 mm | 85.01 mm | ✓ |
+| Tele | 131.00 mm | 130.99 mm | ✓ |
+
+The back focal distance is 39.70 mm at all zoom positions, confirming that Groups 1 and 4 are truly stationary and the image plane does not shift.
+
+---
+
+## 3. Element-by-Element Analysis
+
+### Group 1 — Front Collector and Focus Unit
+
+#### Sub-group 10F (fixed; surfaces 1–5; L1–L3)
+
+**L1 — Negative Meniscus, convex to object (cemented with L2)**
+$n_d = 1.74400$, $\nu_d = 44.8$. Glass: S-LAH66 (OHARA). $f = -164.4$ mm.
+
+L1 forms the front half of a cemented doublet with L2. As a high-index lanthanum crown ($n_d = 1.744$), it provides a strongly curved front surface ($R_1 = 105.4$ mm) that gathers light from the large entrance pupil while the meniscus shape minimizes the angle of incidence and thus surface reflections. Its negative power partially offsets the positive power of L2, creating an achromatic pair that corrects axial chromatic aberration at the front of the system.
+
+**L2 — Positive Meniscus, convex to object (cemented with L1)**
+$n_d = 1.48749$, $\nu_d = 70.2$. Glass: S-FSL5 (OHARA) / FC5 (HOYA) class. $f = +163.6$ mm.
+
+L2 is a low-dispersion fluorophosphate crown that partners with L1 to form a weakly positive achromatic doublet. The large Abbe number difference ($\Delta\nu_d = 70.2 - 44.8 = 25.4$) between L2 and L1 ensures effective achromatization. The cemented interface at $R_2 = 56.082$ mm carries most of the chromatic correction load while allowing both elements to share the same clear aperture.
+
+**L3 — Positive Meniscus, convex to object (ED)**
+$n_d = 1.49700$, $\nu_d = 81.6$. Glass: S-FPL51 (OHARA) / FCD1 (HOYA) — **Extra-low Dispersion**. $f = +184.2$ mm.
+
+L3 is the first of three ED elements in the design. With $\nu_d = 81.6$, S-FPL51 is a fluorophosphate crown with anomalous partial dispersion that enables secondary spectrum correction beyond what ordinary achromatic pairs can achieve. The patent notes (in the claims) that only one positive element in Group 1 should use glass with $\nu_d \geq 80$ to avoid over-correcting lateral chromatic aberration and to limit the thermal sensitivity inherent to fluorophosphate glasses at large diameters (claims 4, 8). L3's meniscus shape with convex surface toward the object ($R_4 = 66.1$ mm, $R_5 = 230.2$ mm) contributes moderate positive power while keeping the marginal ray bending gentle.
+
+#### Sub-group 10R — Focusing Group (surfaces 6–9; L4–L5)
+
+**L4 — Negative Meniscus, convex to object**
+$n_d = 1.80518$, $\nu_d = 25.4$. Glass: S-TIH53 (OHARA) / TAFD25 (HOYA) class — dense flint. $f = -269.7$ mm.
+
+L4 is the front element of the two-element focusing sub-group. It is a dense flint with high dispersion ($\nu_d = 25.4$), paired with the positive L5 to form a chromatically self-correcting focusing unit. The patent text (col. 6, lines 5–15) emphasizes that a two-element focusing group is superior to a single positive element because it can internally correct chromatic aberration, reducing focus-dependent chromatic shift across the zoom range. The meniscus shape (both surfaces convex to the object, $R_6 = 54.225$, $R_7 = 42.675$) keeps incident angles small and controls spherical aberration within the group.
+
+**L5 — Positive Biconvex**
+$n_d = 1.48749$, $\nu_d = 70.2$. Glass: S-FSL5 (OHARA) class. $f = +96.4$ mm.
+
+L5 provides the net positive power of sub-group 10R ($f_{10R} = +152.9$ mm). Its biconvex shape ($R_8 = 48.3$ mm, $R_9 = -1617.7$ mm — nearly plano-convex) distributes the refraction across both surfaces. The crown glass ($\nu_d = 70.2$) achromatizes against L4's dense flint, so the focusing group produces minimal chromatic shift when it translates axially during focusing. Upon focusing from infinity to the minimum focus distance of 1.0 m, sub-group 10R moves from the image side toward the object side.
+
+### Group 2 — Variator (surfaces 10–16; L6–L9)
+
+**L6 — Negative Biconcave**
+$n_d = 1.80400$, $\nu_d = 46.6$. Glass: S-LAH65V (OHARA) class. $f = -28.8$ mm.
+
+L6 is the strongest individual element in the entire system. Its short focal length ($-28.8$ mm) drives the variator's powerfully diverging action. As Group 2 translates toward the image during zoom-in, L6's strong divergence progressively increases the system's effective focal length. The high-index lanthanum glass ($n_d = 1.804$) keeps the surface curvatures manageable ($R_{10} = -181.7$ mm, $R_{11} = +26.6$ mm) despite the extreme power.
+
+**L7 — Negative Biconcave (cemented with L8)**
+$n_d = 1.48749$, $\nu_d = 70.2$. Glass: S-FSL5 (OHARA) class. $f = -38.6$ mm.
+
+**L8 — Positive Meniscus, convex to object (cemented with L7)**
+$n_d = 1.84666$, $\nu_d = 23.8$. Glass: S-TIH53W (OHARA) / TAFD30 (HOYA) — very dense flint. $f = +39.2$ mm.
+
+L7 and L8 form a cemented doublet with an unusual construction: the negative element (L7) uses a low-index crown ($n_d = 1.487$) while the positive element (L8) uses the highest-index glass in the entire design ($n_d = 1.847$). In a conventional achromatic doublet the crown is positive and the flint is negative; here the roles are reversed in terms of power sign but the chromatic correction logic holds because the Abbe number difference ($\Delta\nu_d = 70.2 - 23.8 = 46.4$) is very large. The cemented doublet's net power is nearly zero ($f \approx -2903$ mm — essentially afocal), meaning its primary function is chromatic correction rather than power contribution. The negative and positive powers of L7 and L8 nearly cancel, leaving a pair that corrects lateral chromatic aberration within the variator without materially altering the group's overall divergence — L6 and L9 carry the power load.
+
+**L9 — Negative Meniscus, convex to image**
+$n_d = 1.72916$, $\nu_d = 54.7$. Glass: S-LAL18 (OHARA) / LAC14 (HOYA) class. $f = -151.5$ mm.
+
+L9 is a weakly negative meniscus ($R_{15} = -52.3$ mm, $R_{16} = -100.3$ mm) that acts as a field-flattening and coma-correction element at the rear of Group 2. Its concave-toward-object orientation ($R_{15}$ more strongly curved than $R_{16}$) generates negative field curvature contribution that partially compensates the under-corrected Petzval sum from the preceding strong negative elements.
+
+### Group 3 — Compensator (surfaces 17–21; L10–L12)
+
+**L10 — Positive Biconvex, symmetrical**
+$n_d = 1.77250$, $\nu_d = 49.6$. Glass: S-LAH64 (OHARA) class. $f = +113.4$ mm.
+
+L10 has a remarkable property: its front and rear radii are equal in magnitude and opposite in sign ($R_{17} = +174.749$ mm, $R_{18} = -174.749$ mm), making it a perfectly symmetrical biconvex element. Symmetrical biconvex elements produce zero coma and zero distortion at unity conjugate, and even off-conjugate they contribute very little to odd-order aberrations. The high-index lanthanum glass ($n_d = 1.773$) achieves the needed positive power with relatively gentle curvatures, keeping spherical aberration moderate. L10 provides the bulk of Group 3's collecting power and begins re-converging the beam after Group 2's strong divergence.
+
+**L11 — Positive Meniscus, convex to image (ED; cemented with L12)**
+$n_d = 1.49700$, $\nu_d = 81.6$. Glass: S-FPL51 (OHARA) / FCD1 (HOYA) — **Extra-low Dispersion**. $f = +58.8$ mm.
+
+L11 is the second ED element in the design and a potent positive element ($f = +58.8$ mm). Its nearly flat front surface ($R_{19} = -4485.5$ mm) and strongly curved rear surface ($R_{20} = -29.0$ mm) create a meniscus with the convex face toward the image. The ED glass provides secondary spectrum correction within Group 3 and achromatizes against the dense flint L12 in the cemented pair.
+
+**L12 — Negative Meniscus, convex to image (cemented with L11)**
+$n_d = 1.80518$, $\nu_d = 25.4$. Glass: S-TIH53 (OHARA) — dense flint. $f = -88.7$ mm.
+
+L12 partners with L11 in a strongly achromatizing cemented doublet ($\Delta\nu_d = 81.6 - 25.4 = 56.2$, the largest Abbe number difference of any cemented pair in the design). The doublet's net focal length is $+179.6$ mm (moderately positive), contributing convergent power to Group 3 while providing the design's most potent chromatic correction station. Because Group 3 translates during zooming, the correction it provides shifts in the optical path — requiring the fixed Groups 1 and 4 to carry independent chromatic correction as well.
+
+### Group 4 — Relay and Field Correction (surfaces 22–32; L13–L18)
+
+#### Sub-group 40F (surfaces 22–26; L13–L15)
+
+**L13 — Positive Meniscus, convex to object**
+$n_d = 1.77250$, $\nu_d = 49.6$. Glass: S-LAH64 (OHARA) class. $f = +105.9$ mm.
+
+L13 uses the same glass as L10 (S-LAH64). Its meniscus shape ($R_{22} = 73.8$ mm, $R_{23} = 743.1$ mm — weakly curved rear) provides moderate positive power at the entrance to Group 4. Positioned just after the variable-aperture diaphragm KS, L13 sees the on-axis beam at near-maximum convergence and begins the relay toward the image plane.
+
+**L14 — Positive Biconvex (ED; cemented with L15)**
+$n_d = 1.49700$, $\nu_d = 81.6$. Glass: S-FPL51 (OHARA) / FCD1 (HOYA) — **Extra-low Dispersion**. $f = +37.6$ mm.
+
+L14 is the third and final ED element and also the single most powerful positive element in the design ($f = +37.6$ mm). Its biconvex shape ($R_{24} = 22.1$ mm, $R_{25} = -105.6$ mm) concentrates strong convergent power just before the fixed field stop FS. Cemented with L15, it forms the most critical achromatic pair in the relay section, where the angular spread of the beam is largest and chromatic correction has the greatest leverage.
+
+**L15 — Negative Biconcave (cemented with L14)**
+$n_d = 1.65844$, $\nu_d = 50.9$. Glass: S-LAL12 (OHARA) / LAC12 (HOYA) class. $f = -30.1$ mm.
+
+L15 achromatizes against L14 in the cemented doublet. Despite L14's strong positive power ($+37.6$ mm), the combined L14+L15 doublet is weakly negative ($f \approx -519$ mm) — meaning L15 over-corrects L14's convergence. This is intentional: the negative net power of the doublet contributes to Petzval sum correction (flattening the field), while the individual elements still provide the necessary chromatic correction via their large $\Delta\nu_d$. The actual convergent power for Group 4's 40F sub-group comes from the combination of the L13 singlet ahead of the doublet ($f_{40F} = +108.6$ mm overall).
+
+#### Sub-group 40R — Field Correction Group (surfaces 27–32; L16–L18)
+
+The fixed-aperture diaphragm FS separates 40F from 40R. By placing FS within the stationary Group 4, the patent ensures that off-axis ray bundles are consistently clipped regardless of the zoom position — improving off-axis performance uniformity across the zoom range.
+
+**L16 — Positive Biconvex**
+$n_d = 1.60562$, $\nu_d = 43.7$. Glass: S-BAM4 (OHARA) / BAC4 (HOYA) class. $f = +39.0$ mm.
+
+L16 is a strong biconvex element ($R_{27} = 120.4$ mm, $R_{28} = -28.9$ mm) positioned behind the fixed field stop. It provides the primary image-forming power for the rear sub-group and directs the converging beam toward the sensor. The moderate-index barium crown glass ($n_d = 1.606$) offers a balance between refractive power and manufacturing ease.
+
+**L17 — Negative Meniscus, convex to image**
+$n_d = 1.80100$, $\nu_d = 35.0$. Glass: S-LAH59 (OHARA) class. $f = -42.2$ mm.
+
+L17 is a high-index lanthanum glass with moderate dispersion. Its negative meniscus shape ($R_{29} = -22.3$ mm, $R_{30} = -67.0$ mm) curves away from the image, generating strong negative field curvature contribution. This element is the primary Petzval sum corrector for the rear section: its high index and negative power flatten the field. It also introduces negative distortion that partially compensates the pincushion tendency inherent to telephoto zoom designs.
+
+**L18 — Positive Meniscus, convex to object**
+$n_d = 1.48749$, $\nu_d = 70.2$. Glass: S-FSL5 (OHARA) class. $f = +202.0$ mm.
+
+L18 is the final optical element before the image plane, functioning as a low-power field lens. Its weak positive meniscus shape ($R_{31} = 95.9$ mm, $R_{32} = 3646.8$ mm — nearly flat rear) telecentrizes the exit beam, adjusting the chief ray angle toward the sensor to improve illumination uniformity across the APS-C image circle. The low refractive index keeps the surface reflections minimal at the position closest to the sensor.
+
+---
+
+## 4. Glass Selection and Chromatic Strategy
+
+### Glass Palette Summary
+
+The design uses 11 distinct glass types across 18 elements:
+
+| Glass (probable ID) | $n_d$ | $\nu_d$ | Class | Elements | Count |
+|---------------------|-------|---------|-------|----------|-------|
+| S-FPL51 (OHARA) | 1.49700 | 81.6 | ED fluorophosphate crown | L3, L11, L14 | 3 |
+| S-FSL5 (OHARA) | 1.48749 | 70.2 | Fluorophosphate crown | L2, L5, L7, L18 | 4 |
+| S-LAH66 (OHARA) | 1.74400 | 44.8 | Lanthanum crown | L1 | 1 |
+| S-LAH64 (OHARA) | 1.77250 | 49.6 | Lanthanum crown | L10, L13 | 2 |
+| S-LAH65V (OHARA) | 1.80400 | 46.6 | Lanthanum crown | L6 | 1 |
+| S-LAH59 (OHARA) | 1.80100 | 35.0 | Dense lanthanum flint | L17 | 1 |
+| S-TIH53 (OHARA) | 1.80518 | 25.4 | Dense flint | L4, L12 | 2 |
+| S-TIH53W (OHARA) | 1.84666 | 23.8 | Very dense flint | L8 | 1 |
+| S-LAL18 (OHARA) | 1.72916 | 54.7 | Lanthanum crown | L9 | 1 |
+| S-LAL12 (OHARA) | 1.65844 | 50.9 | Lanthanum crown | L15 | 1 |
+| S-BAM4 (OHARA) | 1.60562 | 43.7 | Barium crown | L16 | 1 |
+
+Glass identifications are based on six-digit $n_d$/$\nu_d$ code matching against the OHARA, HOYA, and Schott catalogs. OHARA is the preferred vendor for a Pentax design of this era; HOYA equivalents exist for most entries (FCD1 for S-FPL51, FC5 for S-FSL5, TAFD25 for S-TIH53, etc.) but the patent does not specify a vendor. All glass assignments carry a confidence level of "probable" rather than "confirmed."
+
+### Chromatic Correction Architecture
+
+The three ED elements (L3, L11, L14) are distributed strategically — one in each of the three positive-power regions of the design:
+
+- **L3 in Group 1 (10F):** Corrects axial chromatic aberration for the front collector, which sees the full beam diameter. The patent restricts Group 1 to a single ED element (claims 4, 8) because multiple large-diameter ED elements would increase thermal sensitivity (fluorophosphate glasses have larger thermal expansion coefficients than conventional optical glasses).
+- **L11 in Group 3:** Corrects chromatic aberration within the moving compensator group. This is critical because Group 3's axial position varies with zoom, and any residual chromatic error in this group would manifest differently at each focal length.
+- **L14 in Group 4 (40F):** Corrects chromatic aberration in the relay group near the image plane, where it has maximum leverage on lateral chromatic aberration across the field.
+
+Each ED element is paired with a dense flint partner to form a high-$\Delta\nu$ achromatic doublet: L3 is air-spaced near L1 ($\Delta\nu = 36.8$); L11 is cemented with L12 ($\Delta\nu = 56.2$); L14 is cemented with L15 ($\Delta\nu = 30.7$). The L11+L12 pair has the most extreme dispersion difference and carries the heaviest chromatic correction load.
+
+The most-used glass is S-FSL5 ($n_d = 1.487$, $\nu_d = 70.2$), appearing in four elements. This fluorophosphate crown sits between conventional crowns ($\nu_d \approx 60$) and ED glasses ($\nu_d > 80$) on the dispersion spectrum and provides a versatile low-cost achromatizing partner.
+
+---
+
+## 5. Aspherical Surfaces
+
+**This design contains no aspherical surfaces.** All 32 optical surfaces are spherical.
+
+This is confirmed by three independent lines of evidence:
+
+1. **Patent data.** The patent does not list any aspherical coefficient tables for any of the five embodiments. No surface labels carry an "A" suffix or any aspherical annotation.
+2. **Manufacturer designation.** The official Ricoh Imaging product name — "smc PENTAX-DA★ 50-135mmF2.8 ED [IF] SDM" — does not include the "AL" (Aspherical Lens) suffix that Pentax uses for lenses with aspherical elements. For comparison, the companion lens smc PENTAX-DA★ 16-50mm F2.8 ED **AL** [IF] SDM does carry the "AL" designation and its patent includes aspherical surfaces.
+3. **Aberration correction strategy.** The design relies entirely on glass selection (three ED elements, high-index lanthanum glasses) and element count (18 elements) to achieve its aberration correction goals. This is consistent with a telephoto zoom design philosophy where the long back focal distance and moderate field angle do not demand the strong astigmatism and distortion correction that aspherical surfaces typically provide in wide-angle designs.
+
+Some third-party sources (notably Amazon product listings and one user manual database) erroneously attribute aspherical elements to this lens, likely due to confusion with the companion DA★ 16-50mm.
+
+---
+
+## 6. Focus Mechanism
+
+### Architecture
+
+The lens uses **internal focusing (IF)** via the rear sub-group of Group 1 (sub-group 10R), consisting of elements L4 and L5. Upon focusing from infinity to the minimum object distance of 1.0 m, 10R translates axially from the image side toward the object side. All other groups remain stationary during focus.
+
+This architecture provides several advantages described in the patent (col. 5, lines 30–65):
+
+- The focusing group is lightweight (only 2 elements), enabling the SDM ultrasonic motor to drive fast autofocus.
+- The front sub-group 10F and the entire barrel remain stationary, so the overall lens length never changes — important for weather sealing and handling balance.
+- The focus travel is the same at all focal lengths (unlike variator-based focusing), simplifying the AF control system.
+- The two-element focusing group is self-correcting for chromatic aberration (col. 6, lines 5–15): L4's dense flint ($\nu_d = 25.4$) and L5's crown ($\nu_d = 70.2$) form an achromatic pair that minimizes focus-dependent chromatic shift.
+
+### Focus Travel and Close-Focus Data
+
+The patent provides variable air gap data ($d_9$, $d_{16}$, $d_{21}$) at three zoom positions but only at infinity focus. No close-focus air gap table is published for Embodiment 5 (or for any of the five embodiments). The close-focus gaps were therefore computed by paraxial ray trace (y-nu method), solving for the axial translation of sub-group 10R that places the image of a 1.0 m MFD object at the fixed sensor plane ($f_B = 39.70$ mm behind the last surface).
+
+Upon focusing from infinity to a close object, sub-group 10R moves from the image side toward the object side (col. 5, lines 28–30). This **decreases** the 10F–10R air gap ($d_5$) and **increases** the 10R–G2 gap ($d_9$); the sum $d_5 + d_9$ is conserved at each zoom position because both gaps lie within the stationary Group 1. The computed focus travel is $\approx 13.53$ mm, nearly constant across all zoom positions — as expected for a focusing group within a stationary lens group.
+
+| Zoom Position | $d_5$ (∞) | $d_5$ (1.0 m) | $d_9$ (∞) | $d_9$ (1.0 m) | $d_5 + d_9$ | Focus Travel |
+|---------------|-----------|---------------|-----------|---------------|-------------|-------------|
+| Wide (51.5 mm) | 15.23 | 1.70 | 2.30 | 15.83 | 17.53 | 13.53 mm |
+| Mid (85.0 mm) | 15.23 | 1.69 | 19.73 | 33.27 | 34.96 | 13.54 mm |
+| Tele (131.0 mm) | 15.23 | 1.68 | 29.44 | 42.99 | 44.67 | 13.55 mm |
+
+The computed magnification at the telephoto extremity and MFD = 1.0 m is $\beta = -0.170$, matching the manufacturer's stated maximum magnification of 0.17× (Ricoh Imaging specifications). This cross-check between the computed close-focus configuration and the production specification provides additional confidence in the embodiment identification.
+
+The focus travel is constant across all focal lengths because the focusing group is in the stationary Group 1 — unlike variator-based designs where focus travel varies with zoom position.
+
+### Focal Length of the Focusing Group
+
+The computed focal length of sub-group 10R is $f_{10R} = +152.9$ mm. The patent's Table 6 reports $\text{Cond.}(1) = 2.97$ for Embodiment 5. This ratio is $f_{10R} / f_w = 152.9 / 51.5 = 2.97$, satisfying the corrected condition $2.7 < f_{1R}/f_w < 3.5$ (see note below).
+
+**Note on the patent text:** The patent defines Condition (1) using "$f_t$" (the long focal length extremity) in the denominator (col. 5, line 25; Claims 1 and 6). However, the numerical values in Table 6 for all five embodiments are consistent only when $f_w$ (the short focal length extremity) is used as the denominator. Cross-referencing computed $f_{1R}$ values against Table 6 for all five embodiments confirms this:
+
+| Embodiment | $f_{1R}$ (mm) | $f_w$ (mm) | $f_t$ (mm) | $f_{1R}/f_t$ | $f_{1R}/f_w$ | Table 6 | Matches $f_t$? | Matches $f_w$? |
+|------------|---------------|------------|------------|---------------|---------------|---------|----------------|----------------|
+| 1 | 151.6 | 51.50 | 146.00 | 1.04 | 2.94 | 2.94 | No | **Yes** |
+| 2 | 160.9 | 51.50 | 145.50 | 1.11 | 3.12 | 3.12 | No | **Yes** |
+| 3 | 161.9 | 51.50 | 131.00 | 1.24 | 3.14 | 3.14 | No | **Yes** |
+| 4 | 161.0 | 51.50 | 131.00 | 1.23 | 3.13 | 3.13 | No | **Yes** |
+| 5 | 152.9 | 51.50 | 131.00 | 1.17 | 2.97 | 2.97 | No | **Yes** |
+
+All $f_{1R}/f_t$ values fall between 1.04 and 1.24 — well below the stated lower bound of 2.7. All $f_{1R}/f_w$ values fall between 2.94 and 3.14, satisfying the stated bounds and matching Table 6 to two decimal places. Conditions (2) and (3) both use $f_w$ in the patent text and their Table 6 values are computationally verified, confirming that the error is isolated to Condition (1). The condition should read $2.7 < f_{1R}/f_w < 3.5$.
+
+---
+
+## 7. Petzval Sum and Field Curvature
+
+The surface-by-surface Petzval sum, computed as $\sum \frac{\phi_i}{n_{\text{before}} \cdot n_{\text{after}}}$ for each refracting surface, yields:
+
+$$\text{Petzval sum} = 0.001821 \text{ mm}^{-1}$$
+$$\text{Petzval radius} = 549 \text{ mm}$$
+
+For a telephoto zoom covering an APS-C image circle (half-diagonal $\approx 14.1$ mm), this Petzval radius represents a moderate residual. The uncorrected sagittal field curvature at the corner of the APS-C frame would be approximately $\frac{h^2}{2 R_P} = \frac{14.1^2}{2 \times 549} \approx 0.18$ mm. In practice, the designer compensates much of this Petzval curvature with deliberate introduction of astigmatism (balancing sagittal and tangential surfaces) and the negative field-curvature contributions of L9, L15, and L17. The patent's aberration diagrams for Embodiment 5 (Figs. 18D and 20D) show that the residual astigmatism at the maximum field angle is contained within approximately $\pm 0.5$ mm, confirming effective field correction for the APS-C format.
+
+The moderately positive Petzval sum is primarily contributed by the strong positive elements in Groups 3 and 4 (L11, L14, L16), partially compensated by the high-index negative elements L6, L15, and L17.
+
+---
+
+## 8. Conditional Expressions
+
+The patent specifies three conditional inequalities. All three are satisfied by Embodiment 5:
+
+| Condition | Expression | Embodiment 5 Value | Satisfied? |
+|-----------|------------|-------------------|------------|
+| (1) | $2.7 < f_{1R}/f_w < 3.5$* | 2.97 | ✓ |
+| (2) | $1.8 < f_{4R}/f_w < 3.6$ | 2.30 | ✓ |
+| (3) | $1.6 < f_1/f_w < 2.5$ | 1.79 | ✓ |
+
+\* The patent text writes $f_t$ in the denominator, but as discussed in §6, the Table 6 values correspond to $f_w$.
+
+**Condition (1)** governs the power of the focusing group. Too weak (exceeding 3.5) means excessive focus travel and large focus-dependent off-axis aberrations; too strong (below 2.7) makes spherical aberration and coma correction within 10R difficult.
+
+**Condition (2)** governs the power of the rear sub-group of Group 4. Too weak means insufficient distortion correction; too strong causes spherical aberration and coma.
+
+**Condition (3)** governs the overall power of Group 1. Too weak means insufficient lateral chromatic aberration correction; too strong means difficult spherical and axial chromatic correction.
+
+---
+
+## 9. Design Heritage and Context
+
+The DA★ 50-135mm F2.8 was announced alongside the DA★ 16-50mm F2.8 ED AL [IF] SDM as the first pair of weatherproof K-mount lenses and the first Pentax lenses to incorporate the SDM (Supersonic Direct-drive Motor) autofocus system. Together, the two lenses provided a professional-grade 16–135mm (24.5–207mm equivalent) zoom range for Pentax's APS-C DSLR system.
+
+The four-group positive–negative–positive–positive zoom architecture with stationary first and fourth groups is a well-established telephoto zoom topology, with antecedents in the prior art cited by the patent (JP 2000-019398, JP 2002-006215, JP 2003-090958, among others). The DA★ 50-135mm's contribution relative to these predecessors is the optimization of this architecture for APS-C digital SLR use, specifically: the constant overall length (enabled by stationary Groups 1 and 4 plus internal zooming via Groups 2 and 3), the compact focusing mechanism within Group 1, and the combination of three ED elements in an all-spherical design that achieves competitive chromatic performance without the manufacturing complexity of aspherical surfaces.
+
+The lens remained in Pentax's product lineup from 2007 until its discontinuation in 2023 — a 16-year production run that speaks to the robustness of the optical design.
+
+---
+
+## 10. Sources
+
+1. US Patent 7,289,274 B1, "Telescopic Zoom Lens System," Masakazu Saori, PENTAX Corporation, granted October 30, 2007.
+2. Ricoh Imaging official product page: smc PENTAX-DA★ 50-135mmF2.8 ED [IF] SDM.
+3. Ricoh Imaging Star Lens Lineup page (confirms 18 elements / 14 groups, three ED glass elements, no AL designation).
+4. OHARA optical glass catalog (S-FPL51, S-FSL5, S-LAH66, S-LAH64, S-LAH65V, S-TIH53, S-TIH53W, S-LAL18, S-LAL12, S-BAM4, S-LAH59).
+5. HOYA optical glass catalog (FCD1, FC5, TAFD25, TAFD30, NBFD10, LAC14, LAC12, BAC4, NBFD15).

--- a/src/lens-data/pentax/PentaxDA50135mmf28.data.ts
+++ b/src/lens-data/pentax/PentaxDA50135mmf28.data.ts
@@ -1,0 +1,439 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM             ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 7,289,274 B1, Embodiment 5 (Table 5).            ║
+ * ║  Inventor: Masakazu Saori. Assignee: PENTAX Corporation.          ║
+ * ║  Four-group telephoto zoom, +/−/+/+ power distribution.           ║
+ * ║  18 elements / 14 groups, 0 aspherical surfaces, 3 ED elements.   ║
+ * ║  Focus: Internal focus via sub-group 10R in stationary Group 1.   ║
+ * ║                                                                    ║
+ * ║  Internal zoom (constant overall length ≈180 mm front-to-image).  ║
+ * ║    Groups 1 and 4 stationary; Groups 2 and 3 move.               ║
+ * ║    Zoom variable gaps: D16, D21 (zoom only).                      ║
+ * ║    Focus variable gaps: D5, D9 (zoom + focus).                    ║
+ * ║    Reversing group: Group 3 (D21 non-monotonic across zoom).      ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    SDs estimated from marginal ray envelope at F/2.9 across all   ║
+ * ║    zoom positions, plus 8% mechanical clearance. No patent SDs    ║
+ * ║    published. Front group constrained by 67 mm filter thread.     ║
+ * ║                                                                    ║
+ * ║  NOTE ON CLOSE FOCUS:                                              ║
+ * ║    Patent publishes only infinity-focus variable gap data.         ║
+ * ║    Close-focus gaps at MFD = 1.0 m computed by paraxial ray       ║
+ * ║    trace (y-nu method), solving for the 10R translation that      ║
+ * ║    places the image at the fixed sensor plane (BFD = 39.70 mm).   ║
+ * ║    Computed tele magnification = −0.170, matching the             ║
+ * ║    manufacturer's stated 0.17× maximum magnification.             ║
+ * ║                                                                    ║
+ * ║  NOTE ON DIAPHRAGMS:                                               ║
+ * ║    Two diaphragms in the patent:                                   ║
+ * ║      KS — variable-aperture (iris), 1.00 mm before surface 22.   ║
+ * ║           Modeled as STO.                                         ║
+ * ║      FS — fixed-aperture (flare stop), 3.50 mm after surface 26. ║
+ * ║           Modeled as flat air surface labeled "FS".               ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "pentax-da-50-135-f28",
+  maker: "Pentax",
+  name: "smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM",
+  subtitle: "US 7,289,274 B1 Example 5 — PENTAX / Saori",
+  specs: [
+    "18 ELEMENTS / 14 GROUPS",
+    "f = 51.5–131.0 mm (patent) / 50–135 mm (marketing)",
+    "F/2.8 (constant)",
+    "3 ED ELEMENTS",
+    "ALL-SPHERICAL",
+  ],
+
+  focalLengthMarketing: [50, 135] as [number, number],
+  focalLengthDesign: [51.5, 131.0] as [number, number],
+  apertureMarketing: 2.8,
+  apertureDesign: 2.9,
+  patentYear: 2007,
+  elementCount: 18,
+  groupCount: 14,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.744,
+      vd: 44.8,
+      fl: -164.4,
+      glass: "S-LAH66 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "Front negative meniscus; achromatic partner with L2",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 163.6,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      cemented: "D1",
+      role: "Fluorophosphate crown; achromatic partner with L1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 184.2,
+      glass: "S-FPL51 (OHARA)",
+      apd: false,
+      apdNote: "ED fluorophosphate crown (νd = 81.6)",
+      role: "ED element 1/3; secondary spectrum correction in front collector",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.80518,
+      vd: 25.4,
+      fl: -269.7,
+      glass: "S-TIH53 (OHARA)",
+      apd: false,
+      role: "Dense flint in focus group; achromatic partner with L5",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 96.4,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      role: "Net positive power of focus group 10R; crown partner with L4",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.804,
+      vd: 46.6,
+      fl: -28.8,
+      glass: "S-LAH65V (OHARA)",
+      apd: false,
+      role: "Strongest element; primary variator divergence driver",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconcave Negative",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: -38.6,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      cemented: "D2",
+      role: "Low-index crown in near-afocal chromatic corrector doublet",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Positive Meniscus",
+      nd: 1.84666,
+      vd: 23.8,
+      fl: 39.2,
+      glass: "S-TIH53W (OHARA)",
+      apd: false,
+      cemented: "D2",
+      role: "Highest-index glass in design; chromatic corrector in variator",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Negative Meniscus",
+      nd: 1.72916,
+      vd: 54.7,
+      fl: -151.5,
+      glass: "S-LAL18 (OHARA)",
+      apd: false,
+      role: "Field flattener and coma corrector at rear of variator",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.7725,
+      vd: 49.6,
+      fl: 113.4,
+      glass: "S-LAH64 (OHARA)",
+      apd: false,
+      role: "Symmetric biconvex (R17 = −R18); zero coma at unit conjugate",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 58.8,
+      glass: "S-FPL51 (OHARA)",
+      apd: false,
+      apdNote: "ED fluorophosphate crown (νd = 81.6)",
+      cemented: "D3",
+      role: "ED element 2/3; strongest chromatic corrector station (Δνd = 56.2 with L12)",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Negative Meniscus",
+      nd: 1.80518,
+      vd: 25.4,
+      fl: -88.7,
+      glass: "S-TIH53 (OHARA)",
+      apd: false,
+      cemented: "D3",
+      role: "Dense flint; achromatizing partner with L11 in compensator",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Positive Meniscus",
+      nd: 1.7725,
+      vd: 49.6,
+      fl: 105.9,
+      glass: "S-LAH64 (OHARA)",
+      apd: false,
+      role: "Entrance to Group 4; converges beam after variable KS stop",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 37.6,
+      glass: "S-FPL51 (OHARA)",
+      apd: false,
+      apdNote: "ED fluorophosphate crown (νd = 81.6)",
+      cemented: "D4",
+      role: "ED element 3/3; strongest positive element and primary relay chromatic corrector",
+    },
+    {
+      id: 15,
+      name: "L15",
+      label: "Element 15",
+      type: "Biconcave Negative",
+      nd: 1.65844,
+      vd: 50.9,
+      fl: -30.1,
+      glass: "S-LAL12 (OHARA)",
+      apd: false,
+      cemented: "D4",
+      role: "Petzval-sum corrector; net doublet with L14 is weakly negative",
+    },
+    {
+      id: 16,
+      name: "L16",
+      label: "Element 16",
+      type: "Biconvex Positive",
+      nd: 1.60562,
+      vd: 43.7,
+      fl: 39.0,
+      glass: "S-BAM4 (OHARA)",
+      apd: false,
+      role: "Primary image-forming power in rear sub-group 40R",
+    },
+    {
+      id: 17,
+      name: "L17",
+      label: "Element 17",
+      type: "Negative Meniscus",
+      nd: 1.801,
+      vd: 35.0,
+      fl: -42.2,
+      glass: "S-LAH59 (OHARA)",
+      apd: false,
+      role: "High-index field flattener; primary Petzval sum corrector for rear relay",
+    },
+    {
+      id: 18,
+      name: "L18",
+      label: "Element 18",
+      type: "Positive Meniscus",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 202.0,
+      glass: "S-FSL5 (OHARA)",
+      apd: false,
+      role: "Weak field lens; telecentrizes exit beam for APS-C sensor",
+    },
+  ],
+
+  /* ── Surfaces ── */
+  surfaces: [
+    /* ── Group 1: Front collector — Sub-group 10F (fixed) ── */
+    // D1 cemented doublet: L1 + L2
+    { label: "1", R: 105.398, d: 2.3, nd: 1.744, elemId: 1, sd: 24.4 }, // L1 front
+    { label: "2", R: 56.082, d: 7.84, nd: 1.48749, elemId: 2, sd: 24.2 }, // L1→L2 junction
+    { label: "3", R: 180.272, d: 0.1, nd: 1.0, elemId: 0, sd: 23.8 }, // L2 rear → air
+    // L3 singlet (ED)
+    { label: "4", R: 66.104, d: 6.43, nd: 1.497, elemId: 3, sd: 23.8 }, // L3 front
+    { label: "5", R: 230.241, d: 15.23, nd: 1.0, elemId: 0, sd: 23.1 }, // L3 rear → air [FOCUS VAR: d5]
+
+    /* ── Group 1: Sub-group 10R — focusing group ── */
+    // L4 singlet
+    { label: "6", R: 54.225, d: 2.0, nd: 1.80518, elemId: 4, sd: 21.2 }, // L4 front
+    { label: "7", R: 42.675, d: 1.05, nd: 1.0, elemId: 0, sd: 20.7 }, // L4 rear → air
+    // L5 singlet
+    { label: "8", R: 48.313, d: 8.82, nd: 1.48749, elemId: 5, sd: 20.6 }, // L5 front
+    { label: "9", R: -1617.704, d: 2.3, nd: 1.0, elemId: 0, sd: 19.1 }, // L5 rear → air [ZOOM+FOCUS VAR: d9]
+
+    /* ── Group 2: Variator (moves toward image on zoom-in) ── */
+    // L6 singlet
+    { label: "10", R: -181.711, d: 1.2, nd: 1.804, elemId: 6, sd: 11.3 }, // L6 front
+    { label: "11", R: 26.585, d: 4.85, nd: 1.0, elemId: 0, sd: 11.1 }, // L6 rear → air
+    // D2 cemented doublet: L7 + L8
+    { label: "12", R: -50.615, d: 1.2, nd: 1.48749, elemId: 7, sd: 11.7 }, // L7 front
+    { label: "13", R: 30.138, d: 3.6, nd: 1.84666, elemId: 8, sd: 11.9 }, // L7→L8 junction
+    { label: "14", R: 311.871, d: 1.65, nd: 1.0, elemId: 0, sd: 11.4 }, // L8 rear → air
+    // L9 singlet
+    { label: "15", R: -52.317, d: 1.1, nd: 1.72916, elemId: 9, sd: 11.4 }, // L9 front
+    { label: "16", R: -100.273, d: 19.04, nd: 1.0, elemId: 0, sd: 12.5 }, // L9 rear → air [ZOOM VAR: d16]
+
+    /* ── Group 3: Compensator (moves image-ward then object-ward) ── */
+    // L10 singlet (symmetric biconvex)
+    { label: "17", R: 174.749, d: 2.14, nd: 1.7725, elemId: 10, sd: 12.8 }, // L10 front
+    { label: "18", R: -174.749, d: 1.06, nd: 1.0, elemId: 0, sd: 13.0 }, // L10 rear → air
+    // D3 cemented doublet: L11 (ED) + L12
+    { label: "19", R: -4485.526, d: 4.73, nd: 1.497, elemId: 11, sd: 13.1 }, // L11 front
+    { label: "20", R: -29.038, d: 1.1, nd: 1.80518, elemId: 12, sd: 13.4 }, // L11→L12 junction
+    { label: "21", R: -49.755, d: 12.18, nd: 1.0, elemId: 0, sd: 13.6 }, // L12 rear → air [ZOOM VAR: d21 – gap to KS]
+
+    /* ── KS: Variable-aperture diaphragm (1.00 mm before patent surface 22) ── */
+    { label: "STO", R: 1e15, d: 1.0, nd: 1.0, elemId: 0, sd: 13.6 },
+
+    /* ── Group 4: Relay and field correction — Sub-group 40F ── */
+    // L13 singlet
+    { label: "22", R: 73.832, d: 2.65, nd: 1.7725, elemId: 13, sd: 13.6 }, // L13 front
+    { label: "23", R: 743.114, d: 0.5, nd: 1.0, elemId: 0, sd: 13.4 }, // L13 rear → air
+    // D4 cemented doublet: L14 (ED) + L15
+    { label: "24", R: 22.109, d: 7.93, nd: 1.497, elemId: 14, sd: 13.4 }, // L14 front
+    { label: "25", R: -105.602, d: 1.58, nd: 1.65844, elemId: 15, sd: 11.2 }, // L14→L15 junction
+    { label: "26", R: 24.579, d: 3.5, nd: 1.0, elemId: 0, sd: 10.8 }, // L15 rear → air [gap to FS]
+
+    /* ── FS: Fixed-aperture diaphragm (3.50 mm behind patent surface 26) ── */
+    { label: "FS", R: 1e15, d: 11.07, nd: 1.0, elemId: 0, sd: 10.4 },
+
+    /* ── Group 4: Sub-group 40R — field correction ── */
+    // L16 singlet
+    { label: "27", R: 120.433, d: 5.2, nd: 1.60562, elemId: 16, sd: 9.3 }, // L16 front
+    { label: "28", R: -28.928, d: 3.0, nd: 1.0, elemId: 0, sd: 8.8 }, // L16 rear → air
+    // L17 singlet
+    { label: "29", R: -22.288, d: 1.24, nd: 1.801, elemId: 17, sd: 7.8 }, // L17 front
+    { label: "30", R: -67.039, d: 0.65, nd: 1.0, elemId: 0, sd: 7.7 }, // L17 rear → air
+    // L18 singlet (field lens)
+    { label: "31", R: 95.907, d: 2.07, nd: 1.48749, elemId: 18, sd: 7.7 }, // L18 front
+    { label: "32", R: 3646.801, d: 39.7, nd: 1.0, elemId: 0, sd: 7.4 }, // L18 rear → image (BFD)
+  ],
+
+  /* ── Aspherical coefficients (all-spherical design) ── */
+  asph: {},
+
+  /* ── Zoom positions ── */
+  zoomPositions: [51.5, 85.0, 131.0],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  /* ── Variable air spacings (zoom + focus) ──
+   *  Focus mechanism: sub-group 10R (L4 + L5) translates toward the object
+   *  when focusing from infinity to close. d5 decreases, d9 increases.
+   *  Focus travel ≈ 13.53 mm (constant across zoom positions).
+   *
+   *  Zoom variable gaps: d16, d21 (zoom only — identical inf/close values).
+   *  Focus variable gaps: d5, d9 (change with focus; d9 also with zoom).
+   *  Gap conservation: d5 + d9 = const per zoom position (Groups 1 stationary).
+   *                    d9 + d16 + d21_full = 34.52 mm (Groups 1,4 stationary).
+   */
+  var: {
+    "5": [
+      [15.23, 1.7],
+      [15.23, 1.69],
+      [15.23, 1.68],
+    ],
+    "9": [
+      [2.3, 15.83],
+      [19.73, 33.27],
+      [29.44, 42.99],
+    ],
+    "16": [
+      [19.04, 19.04],
+      [11.78, 11.78],
+      [1.5, 1.5],
+    ],
+    "21": [
+      [12.18, 12.18],
+      [2.01, 2.01],
+      [2.58, 2.58],
+    ],
+  },
+  varLabels: [
+    ["5", "D5"],
+    ["9", "D9"],
+    ["16", "D16"],
+    ["21", "D21"],
+  ],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "G1 — 10F", fromSurface: "1", toSurface: "5" },
+    { text: "G1 — 10R (focus)", fromSurface: "6", toSurface: "9" },
+    { text: "G2 (variator)", fromSurface: "10", toSurface: "16" },
+    { text: "G3 (compensator)", fromSurface: "17", toSurface: "21" },
+    { text: "G4 — 40F", fromSurface: "22", toSurface: "26" },
+    { text: "G4 — 40R", fromSurface: "27", toSurface: "32" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "1", toSurface: "3" },
+    { text: "D2", fromSurface: "12", toSurface: "14" },
+    { text: "D3", fromSurface: "19", toSurface: "21" },
+    { text: "D4", fromSurface: "24", toSurface: "26" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 1.0,
+  focusDescription:
+    "Internal focus (IF) via sub-group 10R (L4 + L5); constant travel ≈13.5 mm across all focal lengths.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.8,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16, 22],
+  apertureBlades: 9,
+
+  /* ── Layout tuning ── */
+  scFill: 0.62,
+  yScFill: 0.5,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/pentax/PentaxDA50135mmf28.data.ts
+++ b/src/lens-data/pentax/PentaxDA50135mmf28.data.ts
@@ -42,7 +42,7 @@ const LENS_DATA = {
   /* ── Identity ── */
   key: "pentax-da-50-135-f28",
   maker: "Pentax",
-  name: "smc PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM",
+  name: "PENTAX-DA★ 50-135mm F2.8 ED [IF] SDM",
   subtitle: "US 7,289,274 B1 Example 5 — PENTAX / Saori",
   specs: [
     "18 ELEMENTS / 14 GROUPS",

--- a/src/lens-data/pentax/PentaxF85mmf28Soft.analysis.md
+++ b/src/lens-data/pentax/PentaxF85mmf28Soft.analysis.md
@@ -1,0 +1,277 @@
+# Optical Analysis: smc PENTAX-F 85mm f/2.8 Soft
+
+## US Patent 5,267,086 — Example 1
+
+---
+
+## Patent Reference and Design Identification
+
+**Patent:** US 5,267,086, "Soft Focus Lens System"
+**Applicant:** Asahi Kogaku Kogyo K.K. (Pentax Corporation), Tokyo, Japan
+**Inventor:** Hiroyuki Hirano
+**Filed:** October 19, 1990 (US); **Priority:** October 25, 1989 (JP 1-277895)
+**Granted:** November 30, 1993
+
+**Embodiment used:** Example 1 (Numerical Example 1), corresponding to Figs. 1–4 of the patent.
+
+The identification of Example 1 as the production smc PENTAX-F 85mm f/2.8 Soft rests on the following convergent evidence:
+
+1. **Element and group count.** The patent's Example 1 has 5 elements in 4 groups; the production lens is documented as 5 elements in 4 groups by the K-Mount Page and Pentax catalog material.
+2. **Focal length.** The patent prescription is normalized to f = 100.00 mm. Applying a uniform scale factor of 0.85× yields an EFL of 85.00 mm, matching the marketed focal length exactly.
+3. **Aperture.** F<sub>NO</sub> = 1:2.8, matching the marketed f/2.8.
+4. **Half-field angle.** ω = 14.2° (2ω = 28.4°), consistent with Pentax's published 28.5° angle of view for the 85mm f/2.8 Soft on 35mm format.
+5. **Focus mechanism.** The patent describes front-group focusing with a fixed rear group, matching the production lens's known autofocus design via Pentax K-mount in-body motor.
+6. **Close-focus magnification.** The patent achieves M = −0.337 (approximately 1/3 life-size) at the maximum extension; the production lens is mechanically limited to 0.50 m MFD with a maximum magnification of 0.23× (1:4.35).
+7. **Patent timing.** The Japanese priority date of October 1989 aligns with the production lens's introduction in 1990.
+
+All three examples in the patent share the same general architecture (positive front group, single negative rear element), but differ in element counts and separations. Example 2 has 5 elements in 5 groups (no cemented doublet); Example 3 has 5 elements in 3 groups (two cemented pairs). Only Example 1 matches the production lens's documented 5-in-4 configuration.
+
+---
+
+## Production Specifications
+
+| Parameter | Value | Source |
+|---|---|---|
+| Designation | smc PENTAX-F 1:2.8 85mm SOFT | Pentax catalog |
+| Optical formula | 5 elements in 4 groups | K-Mount Page / LENS-DB |
+| Aperture range | f/2.8 – f/32 | K-Mount Page |
+| Aperture blades | 9 | K-Mount Page |
+| Minimum focus distance | 0.50 m | K-Mount Page |
+| Maximum magnification | 0.23× (1:4.35) | K-Mount Page / LENS-DB |
+| Filter diameter | 52 mm | K-Mount Page |
+| Maximum diameter | 66 mm | K-Mount Page |
+| Length | 60 mm | K-Mount Page |
+| Weight | 300 g | K-Mount Page |
+| Year of introduction | 1990 | LENS-DB |
+| Mount | Pentax K (in-body AF motor) | K-Mount Page |
+
+A notable mechanical feature is the **partially manual diaphragm**: the aperture operates in stop-down mode between f/2.8 and f/5.6 (the "soft range," where the deliberate spherical aberration is visible), and switches to automatic operation between f/5.6 and f/32 (the "sharp range"). This gives the photographer direct viewfinder feedback of the soft effect at shooting apertures without requiring depth-of-field preview.
+
+---
+
+## Optical Architecture
+
+The lens is a **two-group positive-negative design** with a positive front group and a weak negative rear element. The front group (L1–L4) carries a net positive focal length of +71.3 mm (at 85mm scale) and the rear group (L5 alone) contributes a weak negative focal length of −258.7 mm. The total track from the first surface to the image plane is 93.3 mm — slightly longer than the 85.0 mm EFL (ratio 1.10), so the design is not telephoto in the strict optical sense (a true telephoto requires a total track shorter than the EFL).
+
+The **positive–negative group arrangement** is telephoto-like in topology and serves the same functional purpose as a true telephoto: the negative rear group extends the back focal distance beyond what the front group alone would provide, permitting mirror-box clearance for the K-mount SLR. However, the rear group's power is too weak (−f/f_R = 0.33) to compress the total track below the focal length, so the design falls slightly outside the telephoto regime.
+
+Within the front group, the power sequence is **positive (L1+L2 doublet), negative (L3), positive (L4)**, giving a triplet-like correction architecture that balances coma and astigmatism while deliberately leaving spherical aberration under-corrected to achieve the soft focus effect.
+
+The aperture stop is located in the air gap between L3 and L4 (gap d₅ = 4.32 mm at patent scale, inferred from the cross-section drawing Fig. 1), placing it roughly at the center of the front group. This position is critical to the soft focus mechanism: it maximizes the marginal ray height at S1 (the primary SA-generating surface) while keeping off-axis aberrations controlled.
+
+The design is **entirely spherical** — no aspherical surfaces are present anywhere in the prescription. This is confirmed by the patent text, which makes no mention of aspherical coefficients, and by the absence of any aspheric sag tables in the numerical examples. The soft focus effect is achieved purely through deliberate residual spherical aberration, not through aspherical surface manipulation.
+
+---
+
+## Element-by-Element Analysis
+
+### Group 1: Cemented Doublet (L1 + L2) — Positive Crown / Negative Flint
+
+#### L1 — Positive Meniscus, Convex to Object
+
+nd = 1.65844, νd = 50.9. Glass: BACD14 (HOYA) — barium crown equivalent. f = +49.2 mm (scaled to 85mm).
+
+L1 is the optically dominant element of the entire system and the primary source of the deliberate soft focus effect. Its strongly curved front surface (R₁ = 30.29 mm at 85mm scale) generates large positive spherical aberration, which is the fundamental mechanism behind the lens's soft rendering.
+
+The patent's Condition (1) governs this surface directly: 0.25 < r₁/f < 0.50, with Example 1 yielding r₁/f = 0.356. This places the design squarely in the center of the allowed range — enough curvature to produce meaningful SA for the soft effect, but not so extreme that coma and higher-order aberrations overwhelm the image. The patent text (col. 2, lines 45–55) explains that exceeding the upper limit would produce too little SA for an effective soft focus lens, while falling below the lower limit would generate excessive coma at the first surface that cannot be compensated downstream.
+
+The glass choice — a barium crown with moderate dispersion (νd = 50.9) — is a compromise. A higher-index glass would reduce the surface curvature needed for a given power, which would reduce SA. The moderate index of 1.658 keeps the curvature strong enough to generate the desired SA level.
+
+The element is thick (d = 9.85 mm at 85mm scale), which contributes additional SA through the transfer effect: the marginal ray height at the rear surface is lower than at the front, so the rear surface (weakly curved R₂ = +399.8 mm) contributes relatively little counter-SA. The net effect is a strongly positive SA contribution from L1 that propagates through the rest of the system.
+
+#### L2 — Negative Meniscus, Concave to Image (Cemented to L1)
+
+nd = 1.78472, νd = 25.7. Glass: FD110 (HOYA) — dense flint. f = −82.6 mm (scaled to 85mm).
+
+L2 is cemented to L1 at their shared surface (R₂ = +470.382 at patent scale), forming a classic crown-flint achromatic doublet. The Abbe number difference ν₁ − ν₂ = 25.2 satisfies the patent's Condition (2): 10 < ν₁ − ν₂ < 30. This difference controls the chromatic correction of the doublet — enough dispersion contrast to achromatize the strong positive power of L1, but not so much that secondary spectrum becomes problematic.
+
+As a dense flint glass (nd = 1.785, νd = 25.7), L2 provides the necessary negative dispersion to counteract L1's chromatic aberration. The cemented interface has extremely weak power (φ₂ = +0.000268 mm⁻¹) because the index difference across the junction is small (Δn = 0.127), meaning almost all of L2's optical work is done at its rear surface S3 (R = 65.330 mm), where the transition from high-index flint to air produces strong negative refraction (φ₃ = −0.012012 mm⁻¹).
+
+The doublet as a unit has a focal length of approximately +96 mm (at 85mm scale), about 13% longer than the system focal length. This relatively weak net power for such a physically large doublet is intentional: it controls the balance between SA generation (mostly at S1) and chromatic correction (at the cemented junction and S3) without overcorrecting the SA that the soft focus effect requires.
+
+### L3 — Negative Meniscus, Concave to Image
+
+nd = 1.72825, νd = 28.5. Glass: FD60 (HOYA) — dense flint. f = −56.0 mm (scaled to 85mm).
+
+L3 is the strongest negative element in the system (f = −56.0 mm) and serves multiple roles. It is an air-spaced flint element positioned between the cemented doublet and the biconvex L4, separated by a large air gap (d₃ = 12.23 mm at 85mm scale) from the doublet and by the aperture stop gap (d₅ = 3.67 mm) from L4.
+
+Optically, L3 acts as a field-flattening diverging element. Its strong negative meniscus shape (R₁ = +358.8 mm, R₂ = +36.5 mm at 85mm scale) introduces a net negative Petzval contribution of −0.00881 mm⁻¹ from its two surfaces, which partially counteracts the positive Petzval from L1, L4, and the doublet. Without L3's Petzval correction, the field curvature would be severe enough to degrade the soft focus effect — the halo would be non-uniform across the field.
+
+L3 also provides a second flint element for chromatic correction. Together with L2, it gives the front group two negative-dispersion elements to balance the chromatic contributions of the positive crown elements L1 and L4. The φ/ν contribution of L3 (−0.000533) is the largest single chromatic correction term in the system, partly compensating for L4's large positive chromatic contribution (+0.000492).
+
+The choice of a second dense flint (νd = 28.5) rather than a lighter flint is driven by the Petzval sum: higher-index flint glasses produce more Petzval correction per unit of negative power, keeping the element thin and light.
+
+### L4 — Biconvex Positive
+
+nd = 1.80440, νd = 39.6. Glass: TAFD25 (HOYA) — lanthanum flint. f = +43.6 mm (scaled to 85mm).
+
+L4 is the strongest positive element in the system (f = +43.6 mm) and acts as the primary converging element that brings the image to focus behind the rear group. It is a biconvex lens (R₁ = +54.3 mm, R₂ = −95.0 mm at 85mm scale), positioned immediately behind the aperture stop.
+
+The glass choice is notable: TAFD25 is a lanthanum flint with high index (nd = 1.804) but moderate dispersion (νd = 39.6). This is not a crown glass — it sits in the "short flint" or "lanthanum dense flint" region of the glass map. The high index allows strong positive power from moderate curvatures, which controls higher-order aberrations. The moderate Abbe number means L4 does introduce some chromatic aberration, but this is partially balanced by the dispersion from L3 and L2.
+
+L4's position immediately after the stop means its contribution to spherical aberration is relatively small — the marginal ray height at L4 (≈ 12.3 mm at f/2.8, 85mm scale) is lower than at L1 (≈ 17.9 mm at patent scale, ≈15.2 mm at 85mm scale), and its surfaces are less aggressively curved. This is by design: L4 provides the converging power needed to form the image without significantly altering the SA balance established by L1.
+
+The biconvex shape distributes the positive power between two surfaces, minimizing coma at each. The front surface (φ₆ = +0.01260 mm⁻¹) does the majority of the converging, while the rear surface (φ₇ = +0.00720 mm⁻¹) adds additional positive power while helping to flatten the field.
+
+### Group 2 (Rear): L5 — Negative Meniscus, Concave to Image
+
+nd = 1.51633, νd = 64.1. Glass: BSC7 (HOYA) — equivalent to Schott N-BK7. f = −258.7 mm (scaled to 85mm).
+
+L5 is a single negative element that constitutes the entire rear group. It is a weak negative meniscus (f = −258.7 mm) with a nearly flat front surface (R₈ = +999.6 mm at 85mm scale) and a moderately curved rear surface (R₉ = +117.7 mm). The element is thin (d = 2.50 mm at 85mm scale) and made of ordinary borosilicate crown glass — the least expensive optical glass in the system.
+
+L5's primary role is as a **field flattener and back focal distance extender**. Its weak negative power extends the back focal distance (BFD = 49.98 mm at 85mm scale) to clear the K-mount flange distance (45.46 mm) while maintaining adequate clearance for the SLR mirror (4.5 mm margin). Without L5, the front group's BFD would be too short for the mirror box.
+
+The patent's Condition (4) governs the rear group's power ratio: 0.1 < −f/f_R < 0.5, with Example 1 yielding −f/f_R = 0.329. This bounds the rear group's diverging contribution — too strong a rear negative group would require excessive front-group extension for focusing (defeating the compact focus advantage), while too weak a rear group would not provide enough back focal clearance.
+
+Condition (5) requires ν₅ > 55, and BSC7/BK7 at νd = 64.1 satisfies this comfortably. The high Abbe number ensures that the rear group's chromatic aberration contribution is minimal (φ/ν = −0.0000513, the smallest term in the system). This is important because L5 is the **fixed** group during focusing — any chromatic error it introduces would remain constant while the front group's chromatic balance shifts with focus. A low-dispersion glass minimizes this tracking error.
+
+L5 also amplifies the front group's aberrations via its image magnification effect (the rear group acts as a negative relay, slightly magnifying the intermediate image). This is referenced in the patent (col. 3, lines 1–5): if the front group's focal ratio f_F/f is too low, "the image magnification by the rear lens group is increased to amplify the aberrations that develop in the front lens group." The design keeps this amplification modest (rear group magnification ≈ 1.19×).
+
+---
+
+## Aspherical Surfaces
+
+**None.** The design is entirely spherical. No aspherical surfaces are present in any of the three patent examples, and the patent text makes no reference to aspherical coefficients, aspherical surface equations, or aspherical manufacturing processes anywhere in its specification or claims.
+
+This is deliberate and characteristic of soft focus lens design philosophy. Aspherical surfaces are typically used to *correct* spherical aberration — precisely the aberration that this lens intentionally *preserves*. Introducing an asphere would undermine the design's fundamental purpose. The soft focus effect is generated entirely through the balance of spherical surfaces, particularly the strongly curved front surface of L1.
+
+---
+
+## Glass Identification and Selection
+
+All five glasses in Example 1 are identified with high confidence against the HOYA catalog, which was the primary glass supplier for Pentax optical designs of this era.
+
+| Element | nd | νd | Glass (HOYA) | Cross-reference | Role |
+|---|---|---|---|---|---|
+| L1 | 1.65844 | 50.9 | BACD14 | S-BAL42 (OHARA), N-BASF2 (Schott) | Barium crown; positive SA generator |
+| L2 | 1.78472 | 25.7 | FD110 | S-TIH53 (OHARA), N-SF11 (Schott) | Dense flint; chromatic corrector |
+| L3 | 1.72825 | 28.5 | FD60 | S-TIH14 (OHARA), N-SF5 (Schott) | Dense flint; field flattener + chromatic |
+| L4 | 1.80440 | 39.6 | TAFD25 | S-LAH64 (OHARA), N-LAF33 (Schott) | Lanthanum flint; primary converger |
+| L5 | 1.51633 | 64.1 | BSC7 | S-BSL7 (OHARA), N-BK7 (Schott) | Borosilicate crown; field flattener/relay |
+
+All matches are exact to the catalog's published precision (Δnd < 0.00001, Δνd < 0.05). The HOYA attribution is preferred because Pentax historically sourced glass from HOYA for its domestic optical production.
+
+**Chromatic strategy.** The glass palette divides into two chromatic families: two dense flints (L2 at νd = 25.7, L3 at νd = 28.5) paired against a barium crown (L1 at νd = 50.9) and a BK7 crown (L5 at νd = 64.1). L4's lanthanum flint (νd = 39.6) straddles the boundary, contributing moderate positive chromatic aberration. The net chromatic balance is:
+
+$$\sum \frac{\phi_i}{\nu_i} = -0.000153$$
+
+This small negative residual indicates the system is slightly overcorrected chromatically — the flint elements slightly overcompensate the crowns. This is typical for soft focus designs, where a small amount of chromatic undercorrection would compound the SA-based softness in an unpleasant way (color fringing in the halo). The slight overcorrection keeps the soft halo essentially achromatic.
+
+---
+
+## Focus Mechanism
+
+The lens uses **front-group focusing**: the entire front group (L1–L4) translates forward as a rigid unit, while the rear group (L5) remains fixed relative to the film plane. This is a classic telephoto-focus scheme optimized for autofocus SLR use — the moving group is compact (4 elements, ≈ 300g total lens weight) and requires only modest extension.
+
+### Patent maximum extension (M ≈ −1/3)
+
+| Parameter | Infinity focus | Close focus (M ≈ −1/3) |
+|---|---|---|
+| d₇ (gap L4–L5) | 3.50 mm | 23.65 mm |
+| Extension | — | 20.15 mm |
+| Object distance (from S1) | ∞ | 311.7 mm |
+| Object distance (from film) | ∞ | 425 mm |
+| Magnification | 0 | −0.337 |
+
+*(All values at 85mm production scale.)*
+
+The patent states d₇ = 27.82 mm at close focus (at f = 100 scale), confirming a total extension of 23.70 mm (patent scale) or 20.15 mm (85mm scale). This is the full design extension corresponding to M = −0.337, or approximately 1:3 life-size.
+
+### Production mechanical limits
+
+The production lens limits the mechanical travel to a minimum focus distance of 0.50 m, yielding a maximum magnification of 0.23× (1:4.35). At MFD = 0.50 m, the paraxial model predicts d₇ ≈ 18.8 mm (85mm scale), corresponding to an extension of approximately 15.3 mm and a computed magnification of approximately 0.26×. The small discrepancy between the computed 0.26× and the manufacturer-specified 0.23× is expected: the paraxial model does not account for higher-order effects, and the manufacturer specification takes precedence for hard specifications.
+
+The patent's Condition (3), 0.7 < f_F/f < 0.92, governs the focus extension. With f_F/f = 0.839, the front group's focal length is 84% of the system focal length. A longer front group focal length (higher ratio) would require more extension to reach close focus, while a shorter one (lower ratio) increases the rear group's magnification of front-group aberrations.
+
+---
+
+## Soft Focus Mechanism
+
+The soft focus effect in this lens is entirely a consequence of **deliberate residual spherical aberration (SA)**. Unlike diffusion filters or Gaussian blur, SA-based soft focus preserves a sharp core image while overlaying a luminous halo — the effect is most visible on highlights and specular reflections, and it diminishes progressively as the aperture is stopped down.
+
+### The SA-generating surface
+
+The first surface of L1 (R₁ = 30.29 mm at 85mm scale) is the primary SA source. At f/2.8, the marginal ray arrives at this surface at a height of approximately 15.2 mm (85mm scale) and refracts through a barium crown glass (nd = 1.658) with a steep paraxial angle of incidence. At this angle, the difference between the paraxial and real (Snell's law) refraction produces significant positive transverse SA — the marginal rays converge to a shorter focal length than the paraxial rays, creating the characteristic "under-corrected" halo.
+
+### Aperture dependence
+
+The SA contribution scales roughly as the fourth power of the ray height. Stopping down from f/2.8 to f/5.6 (halving the marginal ray height) reduces the SA contribution by approximately 16×, which is why the soft effect fades rapidly between f/2.8 and f/5.6 and is essentially absent by f/8. The production lens's partially manual diaphragm exploits this: the f/2.8–f/5.6 range (stop-down mode) covers the full range of soft effects, while f/5.6–f/32 (automatic mode) produces conventionally sharp images.
+
+### Design balance
+
+The remaining elements do not fully correct the SA introduced by L1; they are designed to correct *other* aberrations (coma, astigmatism, chromatic aberration, field curvature) while leaving the SA partially intact. Specifically:
+
+- **L2** (cemented flint): corrects chromatic aberration from L1 without substantially reducing SA.
+- **L3** (negative meniscus): flattens the Petzval field and provides additional chromatic correction, with modest negative SA contribution.
+- **L4** (biconvex lanthanum): provides the converging power needed for image formation; its SA contribution is moderate and partially compensates L1's SA, but not completely.
+- **L5** (BK7 field flattener): very weak power, negligible SA contribution.
+
+The result is a system with approximately 8–10 mm of longitudinal SA at full aperture (estimated from the Fig. 2 aberration curve, which spans the −10 to +10 mm axis), compared to essentially zero SA for a well-corrected 85mm portrait lens. This is the optical signature of the soft focus effect.
+
+---
+
+## Petzval Sum and Field Curvature
+
+The surface-by-surface Petzval sum is:
+
+$$\Sigma_{\text{Petz}} = \sum_{i} \frac{\phi_i}{n_i \cdot n_i'} = +0.00450 \text{ mm}^{-1}$$
+
+This corresponds to a Petzval radius of −222.3 mm (at f = 100 scale) or −188.9 mm (at 85mm scale). The negative sign indicates **inward-curving** Petzval field (image surface curves toward the lens), which is typical for designs with more positive than negative power.
+
+A Petzval radius of −189 mm is moderate for an 85mm lens — not as flat as a double-Gauss design (which would target a Petzval radius of −300 to −500 mm), but acceptable for a portrait/soft-focus lens where the shallow depth of field at f/2.8 masks most field curvature effects. The soft focus halo itself also masks field curvature at the edge of the frame.
+
+---
+
+## Conditional Expressions
+
+The patent specifies five conditions governing the design space. Example 1 satisfies all of them:
+
+| Condition | Expression | Computed value | Range | Status |
+|---|---|---|---|---|
+| (1) | r₁/f | 0.356 | 0.25 – 0.50 | ✓ |
+| (2) | ν₁ − ν₂ | 25.2 | 10 – 30 | ✓ |
+| (3) | f_F/f | 0.839 | 0.70 – 0.92 | ✓ |
+| (4) | −f/f_R | 0.329 | 0.10 – 0.50 | ✓ |
+| (5) | ν₅ | 64.1 | > 55 | ✓ |
+
+---
+
+## Verification Summary
+
+All patent-stated values were independently verified via ABCD paraxial matrix ray trace (Python, 64-bit floating point):
+
+| Parameter | Patent | Computed | Δ |
+|---|---|---|---|
+| EFL | 100.00 mm | 100.003 mm | +0.003 mm |
+| BFD (f_B) | 58.80 mm | 58.813 mm | +0.013 mm |
+| f_F/f | 0.84 | 0.839 | −0.001 |
+| −f/f_R | 0.33 | 0.329 | −0.001 |
+| ν₁ − ν₂ | 25.20 | 25.2 | 0.0 |
+| M at d₇ = 27.82 | −0.337 | −0.337 | < 0.001 |
+
+All values agree within rounding tolerance, confirming the transcription is free of errors.
+
+**Scaling note.** The data file applies a uniform ×0.85 scale factor to all R, d, and sd values, yielding an EFL of 85.00 mm at production scale. The Petzval sum and all power-derived quantities scale inversely (e.g., Petzval radius scales from −222.3 mm to −188.9 mm). Element focal lengths scale linearly (e.g., L1: 57.9 → 49.2 mm).
+
+**Close-focus note.** The close-focus variable gap in the data file (d₇ = 18.815 mm at 85mm scale) is computed for the production MFD of 0.50 m, not the patent's maximum extension. The paraxial model at this MFD yields M ≈ −0.256, somewhat larger than the manufacturer-specified 0.23×. The manufacturer value is authoritative; the discrepancy reflects paraxial approximation limits and possible differences between the patent prescription and the final production design.
+
+---
+
+## Design Heritage and Context
+
+The smc PENTAX-F 85mm f/2.8 Soft is Pentax's second-generation 85mm soft focus lens, succeeding the manual-focus smc Pentax SOFT 85mm f/2.2 (1985). The earlier lens used a much simpler 2-element-in-1-group design (similar in concept to a Rodenstock Imagon) with a variable aperture disc system to control the soft effect. The f/2.8 Soft represents a complete redesign: it moved to a 5-element corrected optical system with autofocus compatibility, conventional 9-blade diaphragm-based softness control, and much improved close-focus capability.
+
+The lens was later updated cosmetically as the smc PENTAX-FA 85mm f/2.8 Soft (1995), with changes to improve compatibility with 1.4× teleconverters. The optical formula remained unchanged between the F and FA versions.
+
+Among soft focus lenses of this era, the Pentax design is distinguished by its simplicity — 5 elements is notably fewer than the Canon EF 135mm f/2.8 with Softfocus (7 elements in 6 groups) or the Minolta AF 100mm f/2.8 Soft Focus (7 elements in 7 groups). The Canon design uses a fundamentally different soft focus mechanism: a movable glass-molded aspherical element (the 4th element) that shifts to introduce variable spherical aberration, whereas the Pentax achieves its effect through fixed under-correction controlled solely by the aperture. The compact, lightweight design (300g, 60mm length) made the Pentax one of the most practical soft focus lenses for field use.
+
+---
+
+## Sources
+
+- US Patent 5,267,086 (Hirano / Asahi Kogaku Kogyo, 1993). Primary source for all optical prescription data, conditional expressions, and design rationale.
+- The K-Mount Page (kmp.pentaxians.eu), "F 85/2.8 Soft" and "K 85/2.2 Soft." Production specifications, catalog number, mechanical details, diaphragm behavior comparison between F and FA versions.
+- LENS-DB (lens-db.com), "smc Pentax-F 85mm F/2.8 Soft" and "smc Pentax-FA 85mm F/2.8 Soft." Element/group counts, magnification (1:4.35), introduction dates.
+- HOYA Optical Glass Catalog. Glass identification reference (BACD14, FD110, FD60, TAFD25, BSC7).
+- OHARA Optical Glass Catalog. Cross-reference glass identification (S-BAL42, S-TIH53, S-TIH14, S-LAH64, S-BSL7).
+- Schott Optical Glass Catalog. Cross-reference glass identification (N-BASF2, N-SF11, N-SF5, N-LAF33, N-BK7).

--- a/src/lens-data/pentax/PentaxF85mmf28Soft.data.ts
+++ b/src/lens-data/pentax/PentaxF85mmf28Soft.data.ts
@@ -1,0 +1,174 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — smc PENTAX-F 85mm f/2.8 Soft                 ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 5,267,086 Example 1 (Asahi Kogaku Kogyo / Hirano).║
+ * ║  Soft focus prime with deliberate residual spherical aberration.    ║
+ * ║  5 elements / 4 groups, 0 aspherical surfaces.                     ║
+ * ║  Focus: front-group unit focus (L1–L4 translate, L5 fixed).        ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent at f=100; all R, d, sd values scaled ×0.85 to f≈85 mm   ║
+ * ║    production focal length.                                        ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Estimated from paraxial marginal ray (f/2.8) + chief ray (60%   ║
+ * ║    field) with 8% mechanical clearance. Front element constrained  ║
+ * ║    by 52 mm filter thread (inner ≈ 49 mm, max SD ≈ 24.5 mm).      ║
+ * ║                                                                    ║
+ * ║  IMPORTANT: This file describes ONLY the optical design:           ║
+ * ║    ✓ Glass elements and surfaces (front element to image plane)    ║
+ * ║    ✓ Aperture stop and variable focus gap                          ║
+ * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts       ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "pentax-f-85-f28-soft",
+  maker: "Pentax",
+  name: "smc PENTAX-F 85mm f/2.8 Soft",
+  subtitle: "US 5,267,086 Example 1 — Asahi Kogaku Kogyo / Hirano",
+  specs: ["5 ELEMENTS / 4 GROUPS", "f ≈ 85.0 mm", "F/2.8", "2ω ≈ 28.4°", "ALL SPHERICAL"],
+
+  focalLengthMarketing: 85,
+  focalLengthDesign: 85.0,
+  apertureMarketing: 2.8,
+  patentYear: 1993,
+  elementCount: 5,
+  groupCount: 4,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.65844,
+      vd: 50.9,
+      fl: 49.2,
+      glass: "BACD14 (HOYA)",
+      apd: false,
+      cemented: "D1",
+      role: "Primary SA generator; strongly curved front surface (r₁/f = 0.36) produces the deliberate spherical aberration that creates the soft focus effect.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.78472,
+      vd: 25.7,
+      fl: -82.6,
+      glass: "FD110 (HOYA)",
+      apd: false,
+      cemented: "D1",
+      role: "Dense flint achromatizer cemented to L1; corrects chromatic aberration without reducing SA. Abbe difference ν₁−ν₂ = 25.2.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.72825,
+      vd: 28.5,
+      fl: -56.0,
+      glass: "FD60 (HOYA)",
+      apd: false,
+      role: "Strongest negative element; field-flattening diverger providing Petzval correction and secondary chromatic compensation.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.8044,
+      vd: 39.6,
+      fl: 43.6,
+      glass: "TAFD25 (HOYA)",
+      apd: false,
+      role: "Primary converging element; high-index lanthanum flint yields strong power from moderate curvatures, controlling higher-order aberrations.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.51633,
+      vd: 64.1,
+      fl: -258.7,
+      glass: "BSC7 (HOYA)",
+      apd: false,
+      role: "Fixed rear group; weak negative field flattener extending BFD for K-mount mirror clearance. Low-dispersion glass minimizes chromatic tracking error during focusing.",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Patent at f = 100 mm; all R, d, sd scaled ×0.85 for f ≈ 85 mm production.
+   *  Aperture stop inferred from Fig. 1 cross-section: mid-gap between L3 rear and L4 front.
+   *  STO splits patent d₅ = 4.32 mm (3.672 mm scaled) into two equal halves.
+   */
+  surfaces: [
+    // ── Group 1: Cemented doublet L1+L2 ──
+    { label: "1", R: 30.286, d: 9.851, nd: 1.65844, elemId: 1, sd: 22.5 }, // L1 front
+    { label: "2", R: 399.825, d: 3.995, nd: 1.78472, elemId: 2, sd: 18.7 }, // L1→L2 junction
+    { label: "3", R: 55.531, d: 12.232, nd: 1.0, elemId: 0, sd: 17.2 }, // L2 rear → air
+
+    // ── Group 2: L3 ──
+    { label: "4", R: 358.843, d: 2.108, nd: 1.72825, elemId: 3, sd: 12.1 }, // L3 front
+    { label: "5", R: 36.524, d: 1.836, nd: 1.0, elemId: 0, sd: 11.6 }, // L3 rear → air (first half of d₅)
+
+    // ── Aperture stop ──
+    // STO position inferred from Fig. 1 iris placement; d₅ split 50/50.
+    { label: "STO", R: 1e15, d: 1.836, nd: 1.0, elemId: 0, sd: 10.4 },
+
+    // ── Group 3: L4 ──
+    { label: "6", R: 54.276, d: 5.44, nd: 1.8044, elemId: 4, sd: 11.7 }, // L4 front
+    { label: "7", R: -94.959, d: 3.502, nd: 1.0, elemId: 0, sd: 12.0 }, // L4 rear → air (variable: focus)
+
+    // ── Group 4: L5 (fixed rear group) ──
+    { label: "8", R: 999.562, d: 2.499, nd: 1.51633, elemId: 5, sd: 11.9 }, // L5 front
+    { label: "9", R: 117.728, d: 49.98, nd: 1.0, elemId: 0, sd: 11.9 }, // L5 rear → BFD (49.98 mm)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (focus) ──
+   *  Front-group focus: L1–L4 translate forward as a rigid unit; L5 fixed.
+   *  Only the gap between L4 rear (surface "7") and L5 front changes.
+   *  Patent d₇ = 4.12 mm at ∞, 27.82 mm at M = −0.337 (×0.85 scale applied).
+   *  Close-focus value computed for production MFD = 0.50 m via paraxial conjugate.
+   */
+  var: {
+    "7": [3.502, 18.815],
+  },
+  varLabels: [["7", "D7"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT (FOCUS)", fromSurface: "1", toSurface: "7" },
+    { text: "REAR (FIXED)", fromSurface: "8", toSurface: "9" },
+  ],
+  doublets: [{ text: "D1", fromSurface: "1", toSurface: "3" }],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.5,
+  focusDescription:
+    "Front-group unit focus: L1–L4 translate forward as a rigid unit, L5 remains fixed relative to the film plane. AF via Pentax K-mount in-body motor.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.8,
+  apertureBlades: 9,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16, 22, 32],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.4,
+  maxFstop: 32,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/pentax/PentaxF85mmf28Soft.data.ts
+++ b/src/lens-data/pentax/PentaxF85mmf28Soft.data.ts
@@ -29,7 +29,7 @@ const LENS_DATA = {
   /* ── Identity ── */
   key: "pentax-f-85-f28-soft",
   maker: "Pentax",
-  name: "smc PENTAX-F 85mm f/2.8 Soft",
+  name: "PENTAX-F 85mm f/2.8 Soft",
   subtitle: "US 5,267,086 Example 1 — Asahi Kogaku Kogyo / Hirano",
   specs: ["5 ELEMENTS / 4 GROUPS", "f ≈ 85.0 mm", "F/2.8", "2ω ≈ 28.4°", "ALL SPHERICAL"],
 

--- a/src/optics/aberration/bokeh.ts
+++ b/src/optics/aberration/bokeh.ts
@@ -83,7 +83,7 @@ function computeBestFocusZFromLayout(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
-  _aberrationT = 0,
+  aberrationT = 0,
 ): number {
   const lastSurfZ = layout.z[L.N - 1];
   const imagePlaneZ = layout.imgZ;
@@ -99,6 +99,7 @@ function computeBestFocusZFromLayout(
       lastSurfZ,
       imagePlaneZ,
       fraction,
+      aberrationT,
     );
     const minusHit = computeRealRayHit(
       L,
@@ -110,6 +111,7 @@ function computeBestFocusZFromLayout(
       lastSurfZ,
       imagePlaneZ,
       -fraction,
+      aberrationT,
     );
     return [plusHit, minusHit].filter((h): h is NonNullable<typeof h> => h !== null);
   });
@@ -552,7 +554,6 @@ function computeBokehPreviewFromContext(
   currentEPSD: number,
   currentPhysStopSD: number,
   label: string,
-  _aberrationT = 0,
 ): BokehPreviewResult | null {
   const defocusDelta = sensorZ - context.layout.imgZ;
 

--- a/src/optics/aberration/coma.ts
+++ b/src/optics/aberration/coma.ts
@@ -45,6 +45,7 @@ const COMA_PREVIEW_FIELD_LABELS: Record<(typeof COMA_PREVIEW_FIELD_FRACTIONS)[nu
 };
 
 interface ComaTraceContext {
+  aberrationT: number;
   fieldGeometryState: FieldGeometryState;
   tangentialPupilSamples: OrthogonalPupilSample[];
   sagittalPupilSamples: OrthogonalPupilSample[];
@@ -111,9 +112,10 @@ interface FixedComaPointCloudPreviewFootprint {
   footprint: ComaPointCloudFieldFootprint | null;
 }
 
-function buildComaTraceContext(L: RuntimeLens, focusT: number, zoomT: number): ComaTraceContext {
+function buildComaTraceContext(L: RuntimeLens, focusT: number, zoomT: number, aberrationT = 0): ComaTraceContext {
   return {
-    fieldGeometryState: computeFieldGeometryAtState(focusT, zoomT, L),
+    aberrationT,
+    fieldGeometryState: computeFieldGeometryAtState(focusT, zoomT, L, aberrationT),
     tangentialPupilSamples: sampleOrthogonalPupilFan(MERIDIONAL_COMA_SAMPLE_COUNT, "tangential"),
     sagittalPupilSamples: sampleOrthogonalPupilFan(MERIDIONAL_COMA_SAMPLE_COUNT, "sagittal"),
     circularPupilSamples: sampleCircularPupil(COMA_PREVIEW_CIRCULAR_PUPIL_RING_SAMPLES),
@@ -183,10 +185,21 @@ function traceComaFieldBundle(
     zoomT,
     fieldFraction,
     traceContext.fieldGeometryState,
+    traceContext.aberrationT,
   );
   if (geometry === null) return null;
 
-  const bundle = traceOffAxisBundleFromSamples(samples, geometry, L, focusT, zoomT, currentEPSD, currentPhysStopSD);
+  const bundle = traceOffAxisBundleFromSamples(
+    samples,
+    geometry,
+    L,
+    focusT,
+    zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+    undefined,
+    traceContext.aberrationT,
+  );
   if (bundle === null) return null;
 
   return { geometry, bundle };
@@ -707,8 +720,9 @@ export function computeMeridionalComa(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): MeridionalComaResult | null {
-  const traceContext = buildComaTraceContext(L, focusT, zoomT);
+  const traceContext = buildComaTraceContext(L, focusT, zoomT, aberrationT);
   const footprint = computeMeridionalComaFieldFootprint(
     L,
     zPos,
@@ -744,6 +758,7 @@ export function computeComaPreview(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): ComaPreviewResult | null {
   return computeComaPreviewFromContext(
     L,
@@ -752,7 +767,7 @@ export function computeComaPreview(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
-    buildComaTraceContext(L, focusT, zoomT),
+    buildComaTraceContext(L, focusT, zoomT, aberrationT),
   );
 }
 
@@ -763,6 +778,7 @@ export function computeSagittalComa(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): SagittalComaResult | null {
   return computeSagittalComaResultAtField(
     L,
@@ -772,7 +788,7 @@ export function computeSagittalComa(
     currentEPSD,
     currentPhysStopSD,
     L.offAxisFieldFrac,
-    buildComaTraceContext(L, focusT, zoomT),
+    buildComaTraceContext(L, focusT, zoomT, aberrationT),
   );
 }
 
@@ -783,6 +799,7 @@ export function computeComaPointCloudPreview(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): ComaPointCloudPreviewResult | null {
   return computeComaPointCloudPreviewFromContext(
     L,
@@ -791,7 +808,7 @@ export function computeComaPointCloudPreview(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
-    buildComaTraceContext(L, focusT, zoomT),
+    buildComaTraceContext(L, focusT, zoomT, aberrationT),
   );
 }
 
@@ -802,8 +819,9 @@ export function computeComaAnalysis(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): ComaAnalysisResult {
-  const traceContext = buildComaTraceContext(L, focusT, zoomT);
+  const traceContext = buildComaTraceContext(L, focusT, zoomT, aberrationT);
   const meridionalFootprint = computeMeridionalComaFieldFootprint(
     L,
     zPos,

--- a/src/optics/aberration/fieldCurvature.ts
+++ b/src/optics/aberration/fieldCurvature.ts
@@ -5,12 +5,19 @@ import {
   FIELD_CURVATURE_FIELD_FRACTIONS,
   MERIDIONAL_COMA_SAMPLE_COUNT,
 } from "./types.js";
-import { traceChiefRelativeSkewRay, traceChiefRelativeSkewRayChromatic } from "../optics.js";
+import {
+  computeFieldGeometryAtState,
+  thick,
+  traceChiefRelativeSkewRay,
+  traceChiefRelativeSkewRayChromatic,
+  type FieldGeometryState,
+} from "../optics.js";
 import {
   bestFocusPlaneForDirection,
-  computeOffAxisFieldGeometry,
+  computeStateAwareOffAxisFieldGeometry,
   traceOffAxisChiefRay,
   traceOrthogonalOffAxisBundle,
+  type OffAxisFieldGeometry,
 } from "./offAxis.js";
 import { bestRelativeFocusPlane, type TransverseFocusHit } from "./shared.js";
 
@@ -140,14 +147,24 @@ function focusPlaneFromRelativeHits(
 
 function computeStandardizedFieldFocus(
   L: RuntimeLens,
-  geometry: ReturnType<typeof computeOffAxisFieldGeometry> & object,
+  geometry: OffAxisFieldGeometry,
   focusT: number,
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
   channel?: ChromaticChannel,
+  aberrationT = 0,
 ): StandardizedFieldFocus | null {
-  const chiefRay = traceOffAxisChiefRay(geometry, L, focusT, zoomT, currentEPSD, currentPhysStopSD, channel);
+  const chiefRay = traceOffAxisChiefRay(
+    geometry,
+    L,
+    focusT,
+    zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+    channel,
+    aberrationT,
+  );
   if (chiefRay === null) return null;
 
   const parabasalFraction = parabasalPupilFraction(currentEPSD);
@@ -167,6 +184,7 @@ function computeStandardizedFieldFocus(
           true,
           L,
           channel,
+          aberrationT,
         )
       : traceChiefRelativeSkewRay(
           xFraction,
@@ -179,6 +197,7 @@ function computeStandardizedFieldFocus(
           currentPhysStopSD,
           true,
           L,
+          aberrationT,
         );
     if (trace.clipped) return null;
 
@@ -221,11 +240,12 @@ function computeStandardizedFieldFocus(
 
 function computeDiagnosticFieldFocus(
   L: RuntimeLens,
-  geometry: ReturnType<typeof computeOffAxisFieldGeometry> & object,
+  geometry: OffAxisFieldGeometry,
   focusT: number,
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): DiagnosticFieldFocus | null {
   const tangentialBundle = traceOrthogonalOffAxisBundle(
     "tangential",
@@ -236,6 +256,8 @@ function computeDiagnosticFieldFocus(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
+    undefined,
+    aberrationT,
   );
   const sagittalBundle = traceOrthogonalOffAxisBundle(
     "sagittal",
@@ -246,6 +268,8 @@ function computeDiagnosticFieldFocus(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
+    undefined,
+    aberrationT,
   );
   if (tangentialBundle === null || sagittalBundle === null) return null;
   if (tangentialBundle.validSampleCount < 3 || sagittalBundle.validSampleCount < 3) return null;
@@ -272,11 +296,12 @@ function computeDiagnosticFieldFocus(
 
 function computeChromaticFieldShifts(
   L: RuntimeLens,
-  geometry: ReturnType<typeof computeOffAxisFieldGeometry> & object,
+  geometry: OffAxisFieldGeometry,
   focusT: number,
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): ChromaticFieldShift[] | null {
   const shifts: ChromaticFieldShift[] = [];
 
@@ -289,6 +314,7 @@ function computeChromaticFieldShifts(
       currentEPSD,
       currentPhysStopSD,
       channel,
+      aberrationT,
     );
     if (fieldFocus === null) return null;
 
@@ -311,10 +337,20 @@ function computeFieldCurvatureField(
   currentPhysStopSD: number,
   meta: FieldCurvatureFieldMeta,
   chromatic: boolean,
+  stateGeometry: FieldGeometryState,
+  aberrationT = 0,
 ): FieldCurvatureFieldResult {
   if (currentEPSD <= 0 || L.N < 1) return emptyFieldCurvatureFieldResult(meta);
 
-  const geometry = computeOffAxisFieldGeometry(L, zPos, zoomT, meta.fieldFraction);
+  const geometry = computeStateAwareOffAxisFieldGeometry(
+    L,
+    zPos,
+    focusT,
+    zoomT,
+    meta.fieldFraction,
+    stateGeometry,
+    aberrationT,
+  );
   if (geometry === null) return emptyFieldCurvatureFieldResult(meta);
 
   const standardizedFieldFocus = computeStandardizedFieldFocus(
@@ -324,10 +360,20 @@ function computeFieldCurvatureField(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
+    undefined,
+    aberrationT,
   );
   if (standardizedFieldFocus === null) return emptyFieldCurvatureFieldResult(meta);
 
-  const diagnosticFieldFocus = computeDiagnosticFieldFocus(L, geometry, focusT, zoomT, currentEPSD, currentPhysStopSD);
+  const diagnosticFieldFocus = computeDiagnosticFieldFocus(
+    L,
+    geometry,
+    focusT,
+    zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+    aberrationT,
+  );
   const chiefImageHeight = standardizedFieldFocus.chiefImageHeight;
   const petzvalShiftMm = petzvalShiftAtImageHeight(chiefImageHeight, L.petzvalSum) ?? 0;
   const petzvalBestFocusZ = geometry.imagePlaneZ + petzvalShiftMm;
@@ -355,7 +401,7 @@ function computeFieldCurvatureField(
     diagnosticAstigmaticDifferenceMm: diagnosticFieldFocus?.astigmaticDifferenceMm,
     diagnosticAstigmaticDifferenceUm: diagnosticFieldFocus?.astigmaticDifferenceUm,
     chromaticFieldShifts: chromatic
-      ? computeChromaticFieldShifts(L, geometry, focusT, zoomT, currentEPSD, currentPhysStopSD)
+      ? computeChromaticFieldShifts(L, geometry, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT)
       : null,
     usable: true,
   };
@@ -369,18 +415,42 @@ export function computeFieldCurvature(
   currentEPSD: number,
   currentPhysStopSD: number,
   chromatic = false,
+  aberrationT = 0,
 ): FieldCurvatureResult | null {
   if (currentEPSD <= 0 || L.N < 1) return null;
 
   const lastSurfZ = zPos[L.N - 1];
-  const imagePlaneZ = lastSurfZ + (L.S[L.N - 1]?.d ?? 0);
+  const imagePlaneZ = lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
   if (!isFinite(imagePlaneZ)) return null;
 
+  const stateGeometry = computeFieldGeometryAtState(focusT, zoomT, L, aberrationT);
   const fields = fieldCurvatureFieldMeta(FIELD_CURVATURE_FIELD_FRACTIONS).map((meta) =>
-    computeFieldCurvatureField(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, meta, chromatic),
+    computeFieldCurvatureField(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      meta,
+      chromatic,
+      stateGeometry,
+      aberrationT,
+    ),
   );
   const curveFields = fieldCurvatureFieldMeta(FIELD_CURVATURE_CURVE_FIELD_FRACTIONS).map((meta) =>
-    computeFieldCurvatureField(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, meta, chromatic),
+    computeFieldCurvatureField(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      meta,
+      chromatic,
+      stateGeometry,
+      aberrationT,
+    ),
   );
   const usableFields = fields.filter((field) => field.usable);
   const usableCurveFields = curveFields.filter((field) => field.usable);

--- a/src/optics/aberration/shared.ts
+++ b/src/optics/aberration/shared.ts
@@ -53,9 +53,10 @@ export function computeRealRayHit(
   lastSurfZ: number,
   imagePlaneZ: number,
   signedFraction: number,
+  aberrationT = 0,
 ): RealRayHit | null {
   const h = signedFraction * currentEPSD;
-  const ray = traceRay(h, 0, zPos, focusT, zoomT, currentPhysStopSD, true, L);
+  const ray = traceRay(h, 0, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT);
   if (ray.clipped) return null;
 
   const intercept = axialIntercept(ray.y, ray.u, lastSurfZ);
@@ -84,6 +85,7 @@ export function computeSymmetricRealSample(
   lastSurfZ: number,
   imagePlaneZ: number,
   fraction: number,
+  aberrationT = 0,
 ): SymmetricRealSample | null {
   const plusHit = computeRealRayHit(
     L,
@@ -95,6 +97,7 @@ export function computeSymmetricRealSample(
     lastSurfZ,
     imagePlaneZ,
     fraction,
+    aberrationT,
   );
   const minusHit = computeRealRayHit(
     L,
@@ -106,6 +109,7 @@ export function computeSymmetricRealSample(
     lastSurfZ,
     imagePlaneZ,
     -fraction,
+    aberrationT,
   );
   if (plusHit === null || minusHit === null) return null;
 

--- a/src/optics/aberration/spherical.ts
+++ b/src/optics/aberration/spherical.ts
@@ -1,4 +1,4 @@
-import { computeFieldGeometryAtState, sampleCircularPupil, skewImagePlaneIntercept } from "../optics.js";
+import { computeFieldGeometryAtState, sampleCircularPupil, skewImagePlaneIntercept, thick } from "../optics.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type {
   BokehPoint,
@@ -32,11 +32,12 @@ export function computeSphericalAberration(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): SphericalAberrationResult | null {
   if (currentEPSD <= 0 || L.N < 1) return null;
 
   const lastSurfZ = zPos[L.N - 1];
-  const imagePlaneZ = lastSurfZ + (L.S[L.N - 1]?.d ?? 0);
+  const imagePlaneZ = lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
   if (!isFinite(imagePlaneZ)) return null;
 
   const nearAxisSample = computeSymmetricRealSample(
@@ -49,6 +50,7 @@ export function computeSphericalAberration(
     lastSurfZ,
     imagePlaneZ,
     NEAR_AXIS_REAL_FRAC,
+    aberrationT,
   );
   if (nearAxisSample === null) return null;
 
@@ -64,6 +66,7 @@ export function computeSphericalAberration(
       lastSurfZ,
       imagePlaneZ,
       fraction,
+      aberrationT,
     );
     if (marginalSample !== null) break;
   }
@@ -80,6 +83,7 @@ export function computeSphericalAberration(
       lastSurfZ,
       imagePlaneZ,
       fraction,
+      aberrationT,
     );
     const minusHit = computeRealRayHit(
       L,
@@ -91,6 +95,7 @@ export function computeSphericalAberration(
       lastSurfZ,
       imagePlaneZ,
       -fraction,
+      aberrationT,
     );
     if (plusHit === null || minusHit === null) return [];
     return [plusHit, minusHit];
@@ -135,11 +140,12 @@ export function computeSAProfile(
   zoomT: number,
   currentEPSD: number,
   currentPhysStopSD: number,
+  aberrationT = 0,
 ): SAProfilePoint[] {
   if (currentEPSD <= 0 || L.N < 1) return [];
 
   const lastSurfZ = zPos[L.N - 1];
-  const imagePlaneZ = lastSurfZ + (L.S[L.N - 1]?.d ?? 0);
+  const imagePlaneZ = lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
   if (!isFinite(imagePlaneZ)) return [];
 
   const hits = PROFILE_FRACS.flatMap((fraction) => {
@@ -153,6 +159,7 @@ export function computeSAProfile(
       lastSurfZ,
       imagePlaneZ,
       fraction,
+      aberrationT,
     );
     const minusHit = computeRealRayHit(
       L,
@@ -164,6 +171,7 @@ export function computeSAProfile(
       lastSurfZ,
       imagePlaneZ,
       -fraction,
+      aberrationT,
     );
     if (plusHit === null || minusHit === null) return [];
     return [plusHit, minusHit];
@@ -255,17 +263,19 @@ export function computeSphericalAberrationBlurCharacter(
   currentEPSD: number,
   currentPhysStopSD: number,
   baseResult: Pick<SphericalAberrationResult, "bestFocusZ" | "longitudinalSaMm"> | null = null,
+  aberrationT = 0,
 ): SphericalAberrationBlurCharacterResult | null {
   if (currentEPSD <= 0 || L.N < 1) return null;
 
-  const resolvedBase = baseResult ?? computeSphericalAberration(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD);
+  const resolvedBase =
+    baseResult ?? computeSphericalAberration(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT);
   if (resolvedBase === null) return null;
 
   const defocusOffsetMm = Math.abs(resolvedBase.longitudinalSaMm) * SA_BLUR_CHARACTER_DEFOCUS_SCALE;
   if (!isFinite(defocusOffsetMm) || defocusOffsetMm < SA_BLUR_CHARACTER_MIN_LONGITUDINAL_MM) return null;
 
-  const geometryState = computeFieldGeometryAtState(focusT, zoomT, L);
-  const geometry = computeStateAwareOffAxisFieldGeometry(L, zPos, focusT, zoomT, 0, geometryState);
+  const geometryState = computeFieldGeometryAtState(focusT, zoomT, L, aberrationT);
+  const geometry = computeStateAwareOffAxisFieldGeometry(L, zPos, focusT, zoomT, 0, geometryState, aberrationT);
   if (geometry === null) return null;
 
   const bundle = traceOffAxisBundleFromSamples(
@@ -276,6 +286,8 @@ export function computeSphericalAberrationBlurCharacter(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
+    undefined,
+    aberrationT,
   );
   if (bundle === null || bundle.validSampleCount < SA_BLUR_CHARACTER_MIN_VALID_SAMPLES) return null;
 

--- a/src/optics/pupilAberration.ts
+++ b/src/optics/pupilAberration.ts
@@ -36,6 +36,8 @@ import {
   traceRay,
 } from "./optics.js";
 import type { FieldGeometryState } from "./optics.js";
+import { stateSurfaces } from "./layout.js";
+import { traceSurfacesReal } from "./internal/traceSurfaces.js";
 import type { RuntimeLens } from "../types/optics.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -136,6 +138,46 @@ export interface ExitPupilAberrationProfile {
 /** Default number of field samples (0° through halfField). */
 export const PUPIL_ABERRATION_SAMPLE_COUNT = 17;
 
+function computeStatePupilBaselines(
+  focusT: number,
+  zoomT: number,
+  L: RuntimeLens,
+  geometry: FieldGeometryState,
+  aberrationT = 0,
+): { paraxialEpZRelStop: number; paraxialXpZRelLastSurf: number } {
+  if (aberrationT <= 0) {
+    return {
+      paraxialEpZRelStop: epZRelStopAtZoom(zoomT, L),
+      paraxialXpZRelLastSurf: xpZRelLastSurfAtZoom(zoomT, L),
+    };
+  }
+
+  const S = stateSurfaces(focusT, zoomT, L, aberrationT);
+  const layout = doLayout(focusT, zoomT, L, aberrationT);
+  const delta = 1e-4;
+  const marginalStop = traceSurfacesReal(S, L.asphByIdx, delta, 0, { stopAt: L.stopIdx });
+  const chiefStop = traceSurfacesReal(S, L.asphByIdx, 0, delta, { stopAt: L.stopIdx });
+  const realYRatio = isFinite(marginalStop.y) ? marginalStop.y / delta : geometry.yRatio;
+  const realB = isFinite(chiefStop.y) ? chiefStop.y / delta : geometry.b;
+  const paraxialEpZRelStop =
+    Math.abs(realYRatio) > 1e-9 ? realB / realYRatio - layout.z[L.stopIdx] : epZRelStopAtZoom(zoomT, L);
+
+  const marginalFull = traceSurfacesReal(S, L.asphByIdx, delta, 0, { skipLastTransfer: true });
+  const chiefFull = traceSurfacesReal(S, L.asphByIdx, 0, delta, { skipLastTransfer: true });
+  let paraxialXpZRelLastSurf = xpZRelLastSurfAtZoom(zoomT, L);
+  if (isFinite(marginalFull.y) && isFinite(chiefFull.y)) {
+    const mY = marginalFull.y / delta;
+    const mU = marginalFull.u / delta;
+    const cY = chiefFull.y / delta;
+    const cU = chiefFull.u / delta;
+    const xpY = realYRatio * cY - realB * mY;
+    const xpU = realYRatio * cU - realB * mU;
+    paraxialXpZRelLastSurf = Math.abs(xpU) > 1e-9 ? -xpY / xpU : Infinity;
+  }
+
+  return { paraxialEpZRelStop, paraxialXpZRelLastSurf };
+}
+
 // ─── Entrance Pupil Aberration ────────────────────────────────────────────────
 
 /**
@@ -154,10 +196,11 @@ export function computePupilAberrationProfile(
   L: RuntimeLens,
   sampleCount = PUPIL_ABERRATION_SAMPLE_COUNT,
   geometry?: FieldGeometryState,
+  aberrationT = 0,
 ): PupilAberrationProfile {
-  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L);
+  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L, aberrationT);
   const { halfFieldDeg, epRatio } = geom;
-  const paraxialEpZRelStop = epZRelStopAtZoom(zoomT, L);
+  const { paraxialEpZRelStop } = computeStatePupilBaselines(focusT, zoomT, L, geom, aberrationT);
 
   const n = Math.max(sampleCount, 2);
   const samples: PupilAberrationSample[] = [];
@@ -173,7 +216,7 @@ export function computePupilAberrationProfile(
     // paraxialYChief = epRatio × tanTheta (mm).  Zero at fieldDeg = 0.
     const paraxialYChief = epRatio * tanTheta;
     if (Math.abs(paraxialYChief) > 1e-12) {
-      const solvedYChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom);
+      const solvedYChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT);
       chiefRayCorrection = isFinite(solvedYChief) ? solvedYChief / paraxialYChief : 1;
       epShiftMm = (chiefRayCorrection - 1) * epRatio;
     }
@@ -207,10 +250,11 @@ export function computeExitPupilAberrationProfile(
   L: RuntimeLens,
   sampleCount = PUPIL_ABERRATION_SAMPLE_COUNT,
   geometry?: FieldGeometryState,
+  aberrationT = 0,
 ): ExitPupilAberrationProfile {
-  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L);
+  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L, aberrationT);
   const { halfFieldDeg } = geom;
-  const paraxialXpZRelLastSurf = xpZRelLastSurfAtZoom(zoomT, L);
+  const { paraxialXpZRelLastSurf } = computeStatePupilBaselines(focusT, zoomT, L, geom, aberrationT);
 
   const n = Math.max(sampleCount, 2);
 
@@ -226,7 +270,7 @@ export function computeExitPupilAberrationProfile(
   }
 
   // zPos is required by traceRay for building visualization paths; compute once.
-  const { z: zPos } = doLayout(focusT, zoomT, L);
+  const { z: zPos } = doLayout(focusT, zoomT, L, aberrationT);
 
   const samples: ExitPupilAberrationSample[] = [];
 
@@ -241,8 +285,8 @@ export function computeExitPupilAberrationProfile(
     // At θ = 0, uField = 0 and the chief ray is the optical axis — no useful
     // back-projection is possible.  Use the paraxial baseline directly.
     if (Math.abs(fieldDeg) > 1e-9) {
-      const yChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom);
-      const result = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L);
+      const yChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT);
+      const result = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT);
 
       // Back-project: XP z = −y_last / u_last (relative to last surface).
       // Guard against near-zero exit slope (XP at infinity).
@@ -287,11 +331,17 @@ export function computeBothPupilAberrationProfiles(
   L: RuntimeLens,
   sampleCount = PUPIL_ABERRATION_SAMPLE_COUNT,
   geometry?: FieldGeometryState,
+  aberrationT = 0,
 ): BothPupilAberrationProfiles {
-  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L);
+  const geom = geometry ?? computeFieldGeometryAtState(focusT, zoomT, L, aberrationT);
   const { halfFieldDeg, epRatio } = geom;
-  const paraxialEpZRelStop = epZRelStopAtZoom(zoomT, L);
-  const paraxialXpZRelLastSurf = xpZRelLastSurfAtZoom(zoomT, L);
+  const { paraxialEpZRelStop, paraxialXpZRelLastSurf } = computeStatePupilBaselines(
+    focusT,
+    zoomT,
+    L,
+    geom,
+    aberrationT,
+  );
 
   const n = Math.max(sampleCount, 2);
 
@@ -307,7 +357,7 @@ export function computeBothPupilAberrationProfiles(
         let chiefRayCorrection = 1;
         let epShiftMm = 0;
         if (Math.abs(paraxialYChief) > 1e-12) {
-          const solvedYChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom);
+          const solvedYChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT);
           chiefRayCorrection = isFinite(solvedYChief) ? solvedYChief / paraxialYChief : 1;
           epShiftMm = (chiefRayCorrection - 1) * epRatio;
         }
@@ -333,7 +383,7 @@ export function computeBothPupilAberrationProfiles(
     return { ep, xp, halfFieldDeg, maxAbsEpShiftMm: ep.maxAbsShiftMm, maxAbsXpShiftMm: 0 };
   }
 
-  const { z: zPos } = doLayout(focusT, zoomT, L);
+  const { z: zPos } = doLayout(focusT, zoomT, L, aberrationT);
 
   const epSamples: PupilAberrationSample[] = [];
   const xpSamples: ExitPupilAberrationSample[] = [];
@@ -352,7 +402,7 @@ export function computeBothPupilAberrationProfiles(
     const paraxialYChief = epRatio * tanTheta;
 
     if (Math.abs(fieldDeg) > 1e-9) {
-      const yChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom);
+      const yChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT);
 
       // EP fields
       if (Math.abs(paraxialYChief) > 1e-12) {
@@ -361,7 +411,7 @@ export function computeBothPupilAberrationProfiles(
       }
 
       // XP fields — trace the same solved chief ray through the full system
-      const result = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L);
+      const result = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT);
       if (isFinite(result.y) && isFinite(result.u) && Math.abs(result.u) > 1e-9) {
         xpZRelLastSurf = -result.y / result.u;
         xpShiftMm = xpZRelLastSurf - paraxialXpZRelLastSurf;

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -23,6 +23,11 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-05-06",
     type: "lens",
+    summary: "Added three Pentax lenses: DA 16-50mm f/2.8, DA 50-135mm f/2.8, and F 85mm f/2.8 Soft",
+  },
+  {
+    date: "2026-05-06",
+    type: "lens",
     summary:
       "Added Sigma 40mm f/1.4 DG DN Art, Voigtlander Macro Apo-Lanthar 125mm f/2.5, and Apo-Lanthar 180mm f/4 SL Close Focus",
   },

--- a/src/utils/changelogData.ts
+++ b/src/utils/changelogData.ts
@@ -22,6 +22,11 @@ export const CHANGELOG: ChangelogEntry[] = [
   // ── 2026-05-06 ──────────────────────────────────────────────────────────
   {
     date: "2026-05-06",
+    type: "fix",
+    summary: "Fixed soft-focus control in aberration, bokeh, pupil, and LCA views",
+  },
+  {
+    date: "2026-05-06",
     type: "lens",
     summary: "Added three Pentax lenses: DA 16-50mm f/2.8, DA 50-135mm f/2.8, and F 85mm f/2.8 Soft",
   },


### PR DESCRIPTION
## Summary
- Threaded the Minolta Varisoft soft-focus control through spherical aberration, field curvature, coma, bokeh, pupil aberration, and related chromatic/LCA analysis paths.
- Added regression and forwarding coverage for the variable soft-focus calculations and analysis drawer plumbing.
- Added a changelog entry for the user-facing fix.

## Verification
- npm run typecheck
- npm run format:check
- npm run lint
- npm run test