### PR TITLE
Make lens library sort/filter controls wrap on mobile

### DIFF
--- a/src/pages/LensIndexPage.tsx
+++ b/src/pages/LensIndexPage.tsx
@@ -130,7 +130,15 @@ export default function LensIndexPage() {
             Showing {filteredEntries.length} of {totalLenses} interactive optical cross-section diagrams built from
             patent data.
           </p>
-          <div style={{ display: "flex", gap: "0.375rem", flexShrink: 0, flexWrap: "wrap" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: "0.375rem",
+              flexWrap: "wrap",
+              width: "100%",
+              justifyContent: "flex-start",
+            }}
+          >
             <button
               type="button"
               style={toggleButtonStyle(groupMode === "maker")}


### PR DESCRIPTION
### Motivation
- Prevent horizontal overflow of the sort/filter control buttons on small screens by allowing them to break onto additional lines and remain left-aligned.

### Description
- Adjusted the control button container in `src/pages/LensIndexPage.tsx` to use a wrapping flex layout (`flexWrap: "wrap"`, `width: "100%"`, `justifyContent: "flex-start"`) instead of the previous `flexShrink: 0`, enabling multi-line flow and removing forced horizontal overflow.

### Testing
- Ran formatting (`npm run format`), metadata generation (`npm run generate:metadata`), linting (`npm run lint`), typecheck (`npm run typecheck`), and the test suite (`npm test`), and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a012330a07483268e8cdf6baf4bd207)