### PR TITLE
[codex] Normalize lens patent metadata blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 
 ## Current Scope
 
-- `208` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
+- `210` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Canon, Carl Zeiss Jena, Carl Zeiss Oberkochen, Fujifilm, Leica,
   Nikon, Olympus, Ricoh, Sony, Vivitar, and Voigtländer
 - Lens pages pair interactive diagrams with long-form optical analysis markdown

--- a/agent_docs/catalog-mismatches.generated.md
+++ b/agent_docs/catalog-mismatches.generated.md
@@ -13,11 +13,11 @@ with words like "probable" or "approx").
 
 ## Summary
 
-- **209** lenses scanned
-- **2426** glass surfaces examined
-- **2420** surfaces with non-empty `glass` strings
-- **1692** of those resolved to a catalog entry
-- **371** mismatches found (21.9% of resolved surfaces)
+- **211** lenses scanned
+- **2442** glass surfaces examined
+- **2436** surfaces with non-empty `glass` strings
+- **1705** of those resolved to a catalog entry
+- **371** mismatches found (21.8% of resolved surfaces)
 - **119** distinct lens files affected
 
 ## Most-frequent mismatched catalog targets

--- a/agent_docs/records/patent-metadata-backfill.md
+++ b/agent_docs/records/patent-metadata-backfill.md
@@ -8,12 +8,12 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 
 | Status | Count | Notes |
 |---|---:|---|
-| Total analysis files | 209 | `find src/lens-data -name '*.analysis.md'` |
+| Total analysis files | 211 | `find src/lens-data -name '*.analysis.md'` |
 | Robust bold blocks before this standardization | 103 | Approximate scan: patent + inventor/applicant/assignee + date |
 | Missing robust bold block before this standardization | 106 | Grouped by maker below |
 | Completed so far | 106 | All initially missing analyses |
-| Current robust count | 209 | Latest scan after final backfill batch |
-| Current missing count | 0 | Latest scan after final backfill batch |
+| Current robust count | 211 | Latest scan after Olympus new-analysis check |
+| Current missing count | 0 | Latest scan after Olympus new-analysis check |
 
 ## Initial Missing Robust Count by Maker
 
@@ -41,6 +41,9 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 
 ### Done
 
+- Olympus new-analysis check complete: the newly added Zuiko 16mm f/3.5 Fisheye and XA F.Zuiko 35mm f/2.8 analyses satisfy the robust-block scan.
+- `src/lens-data/olympus/OlympusZuiko16mmf35.analysis.md`
+- `src/lens-data/olympus/OlympusXAZuiko35mmf28.analysis.md`
 - Final backfill batch complete: Carl Zeiss Oberkochen, Carl Zeiss Jena, Schneider-Kreuznach, Ricoh, Laowa, Sigma, Leica, Hasselblad, Vivitar, and Pentax pending analyses now satisfy the robust-block scan.
 - `src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.analysis.md`
 - `src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.analysis.md`

--- a/agent_docs/records/patent-metadata-backfill.md
+++ b/agent_docs/records/patent-metadata-backfill.md
@@ -11,9 +11,9 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 | Total analysis files | 209 | `find src/lens-data -name '*.analysis.md'` |
 | Robust bold blocks before this standardization | 103 | Approximate scan: patent + inventor/applicant/assignee + date |
 | Missing robust bold block before this standardization | 106 | Grouped by maker below |
-| Completed so far | 58 | Voigtländer, Canon, and Nikon analyses |
-| Current robust count | 161 | Latest scan after Nikon batch |
-| Current missing count | 48 | Latest scan after Nikon batch |
+| Completed so far | 82 | Voigtländer, Canon, Nikon, Olympus, Fujifilm, Sony, and Minolta batches |
+| Current robust count | 185 | Latest scan after Olympus/Fujifilm/Sony/Minolta batch |
+| Current missing count | 24 | Latest scan after Olympus/Fujifilm/Sony/Minolta batch |
 
 ## Initial Missing Robust Count by Maker
 
@@ -41,6 +41,36 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 
 ### Done
 
+- Olympus, Fujifilm, Sony, and Minolta batch complete: all analysis files in those four maker folders now satisfy the robust-block scan.
+- `src/lens-data/olympus/OlympusMZuiko12100mmf4ISPRO.analysis.md`
+- `src/lens-data/olympus/OlympusMZuiko17mmf18.analysis.md`
+- `src/lens-data/olympus/OlympusZuiko135mmf35.analysis.md`
+- `src/lens-data/olympus/OlympusZuiko24mmf2J.analysis.md`
+- `src/lens-data/olympus/OlympusZuiko85mmf2.analysis.md`
+- `src/lens-data/olympus/OlympusZuikoAuto21mmf2.analysis.md`
+- `src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.analysis.md`
+- `src/lens-data/olympus/OlympusZuikoAutoS50mmf12.analysis.md`
+- `src/lens-data/olympus/OlympusZuikoAutoS55mmf12.analysis.md`
+- `src/lens-data/fujifilm/FujifilmGF80mmf17R.analysis.md`
+- `src/lens-data/fujifilm/FujifilmXF1680mmf4.analysis.md`
+- `src/lens-data/fujifilm/FujifilmXF1655mmf28R.analysis.md`
+- `src/lens-data/fujifilm/FujifilmXF200mmf2R.analysis.md`
+- `src/lens-data/fujifilm/FujifilmXF35mmf14R.analysis.md`
+- `src/lens-data/fujifilm/FujifilmXF50140mmf28R.analysis.md`
+- `src/lens-data/fujifilm/FujifilmXF60mmf24R.analysis.md`
+- `src/lens-data/sony/SonyFE135mmf18GM.analysis.md`
+- `src/lens-data/sony/SonyFE2070mmf4G.analysis.md`
+- `src/lens-data/sony/SonyFE2470mmf28GMII.analysis.md`
+- `src/lens-data/sony/SonyFE2870mmf2GM.analysis.md`
+- `src/lens-data/sony/SonyFE85mmf14GMII.analysis.md`
+- `src/lens-data/sony/SonyFE90mmf28.analysis.md`
+- `src/lens-data/sony/SonyPlanarFE50mmf14ZA.analysis.md`
+- `src/lens-data/sony/SonyPlanarT50mmf14ZA.analysis.md`
+- `src/lens-data/minolta/MinoltaAF100mmf28Macro.analysis.md`
+- `src/lens-data/minolta/MinoltaAF35105mmf3545v2.analysis.md`
+- `src/lens-data/minolta/MinoltaAF70200mmf28APO.analysis.md`
+- `src/lens-data/minolta/MinoltaRokkor45mmf2MD.analysis.md`
+- `src/lens-data/minolta/MinoltaRokkor50mmf14MD.analysis.md`
 - Nikon batch complete: all 54 Nikon analysis files now satisfy the robust-block scan.
 - `src/lens-data/nikon/Nikon28Ti28mmf28.analysis.md`
 - `src/lens-data/nikon/Nikon35Ti35mmf28.analysis.md`

--- a/agent_docs/records/patent-metadata-backfill.md
+++ b/agent_docs/records/patent-metadata-backfill.md
@@ -1,0 +1,76 @@
+# Patent Metadata Backfill
+
+Scan date: 2026-05-17
+
+Target format: each `*.analysis.md` file should begin its patent/design-identification section with a robust bold-label metadata block. The block should include the patent reference, inventor/applicant or assignee, at least one filing/publication/grant date, and the selected embodiment when known. Optional fields such as application number, priority date, title, classification, claim count, and worked-example count should be included only when readily verified.
+
+## Corpus Status
+
+| Status | Count | Notes |
+|---|---:|---|
+| Total analysis files | 209 | `find src/lens-data -name '*.analysis.md'` |
+| Robust bold blocks before this standardization | 103 | Approximate scan: patent + inventor/applicant/assignee + date |
+| Missing robust bold block before this standardization | 106 | Grouped by maker below |
+| Completed in this pass | 9 | Voigtländer analyses |
+
+## Initial Missing Robust Count by Maker
+
+| Maker folder | Missing files |
+|---|---:|
+| nikon | 34 |
+| canon | 15 |
+| voigtlander | 9 |
+| olympus | 7 |
+| fujifilm | 6 |
+| sony | 6 |
+| minolta | 5 |
+| carl-zeiss-jena | 3 |
+| hasselblad | 3 |
+| laowa | 3 |
+| leica | 3 |
+| sigma | 3 |
+| carl-zeiss-oberkochen | 2 |
+| ricoh | 2 |
+| schneider-kreuznach | 2 |
+| vivitar | 2 |
+| pentax | 1 |
+
+## Status Buckets
+
+### Done
+
+- `src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderApoLanthar180mmf4.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderHeliar.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderNokton35mmf12.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderNokton50f1.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderNoktonX50mmf12.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderUltron28f2.analysis.md`
+- `src/lens-data/voigtlander/VoigtlanderUltron50f2.analysis.md`
+
+### Ready From Existing Prose
+
+- Analyses with patent metadata in prose, title lines, or source sections that can be lifted into the robust block without external research.
+- Good candidates: Sony, Olympus, Canon, Nikon modern patent files.
+
+### Has Partial Block
+
+- Analyses that already have `**Patent:**` but are missing inventor/applicant/assignee, a date, or embodiment.
+- Normalize by adding missing known rows from existing prose and avoiding duplicate one-off headings.
+
+### Needs Patent Lookup
+
+- Files whose core patent metadata is not available near the top of the analysis or source section.
+- Do not add placeholder rows; leave these queued until the source patent is checked.
+
+### Multi-Patent / Special Case
+
+- Historical-lineage analyses and files comparing multiple embodiments or patent families.
+- Use the robust block for the primary transcribed prescription and keep context patents in prose unless multiple prescriptions are directly transcribed.
+
+## Scan Command
+
+```bash
+node -e 'const fs=require("fs"); const cp=require("child_process"); const files=cp.execFileSync("find",["src/lens-data","-name","*.analysis.md"],{encoding:"utf8"}).trim().split("\n").filter(Boolean); const patent=/^\*\*Patent(s)?\s*:?\*\*/mi; const owner=/^\*\*(Inventor(s)?|Applicant(s)?|Assignee)\s*:?\*\*/mi; const date=/^\*\*(Filed|Published|Granted|Filing Date|Publication Date)\s*:?\*\*/mi; const missing=files.filter(f=>{const s=fs.readFileSync(f,"utf8"); return !(patent.test(s)&&owner.test(s)&&date.test(s));}); const by={}; for(const f of missing){const maker=f.split("/")[2]; by[maker]=(by[maker]||0)+1;} console.log("missing robust bold block:",missing.length,"of",files.length); console.log(Object.entries(by).sort((a,b)=>b[1]-a[1]||a[0].localeCompare(b[0])).map(([k,v])=>`${k}: ${v}`).join("\n"));'
+```

--- a/agent_docs/records/patent-metadata-backfill.md
+++ b/agent_docs/records/patent-metadata-backfill.md
@@ -11,9 +11,9 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 | Total analysis files | 209 | `find src/lens-data -name '*.analysis.md'` |
 | Robust bold blocks before this standardization | 103 | Approximate scan: patent + inventor/applicant/assignee + date |
 | Missing robust bold block before this standardization | 106 | Grouped by maker below |
-| Completed so far | 82 | Voigtländer, Canon, Nikon, Olympus, Fujifilm, Sony, and Minolta batches |
-| Current robust count | 185 | Latest scan after Olympus/Fujifilm/Sony/Minolta batch |
-| Current missing count | 24 | Latest scan after Olympus/Fujifilm/Sony/Minolta batch |
+| Completed so far | 106 | All initially missing analyses |
+| Current robust count | 209 | Latest scan after final backfill batch |
+| Current missing count | 0 | Latest scan after final backfill batch |
 
 ## Initial Missing Robust Count by Maker
 
@@ -41,6 +41,31 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 
 ### Done
 
+- Final backfill batch complete: Carl Zeiss Oberkochen, Carl Zeiss Jena, Schneider-Kreuznach, Ricoh, Laowa, Sigma, Leica, Hasselblad, Vivitar, and Pentax pending analyses now satisfy the robust-block scan.
+- `src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.analysis.md`
+- `src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.analysis.md`
+- `src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.analysis.md`
+- `src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.analysis.md`
+- `src/lens-data/carl-zeiss-jena/ZeissTessar144f55.analysis.md`
+- `src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.analysis.md`
+- `src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.analysis.md`
+- `src/lens-data/ricoh/RicohGR218mmf28.analysis.md`
+- `src/lens-data/ricoh/RicohGXRA1218mmf25.analysis.md`
+- `src/lens-data/laowa/Laowa15mmf2ZeroD.analysis.md`
+- `src/lens-data/laowa/Laowa12mmf28ZeroD.analysis.md`
+- `src/lens-data/laowa/Laowa24mmf14Probe.analysis.md`
+- `src/lens-data/sigma/SigmaDGDNA35mmf14.analysis.md`
+- `src/lens-data/sigma/SigmaDP3M50mmf28.analysis.md`
+- `src/lens-data/sigma/SigmaDGDNA85mmf14.analysis.md`
+- `src/lens-data/leica/LeicaAPO43mmf2.analysis.md`
+- `src/lens-data/leica/LeicaAPO35mmf2.analysis.md`
+- `src/lens-data/leica/Leica28mmf17.analysis.md`
+- `src/lens-data/hasselblad/HasselbladHC150mmf32.analysis.md`
+- `src/lens-data/hasselblad/HasselbladXCD120mmf35Macro.analysis.md`
+- `src/lens-data/hasselblad/HasselbladXCD65mmf28.analysis.md`
+- `src/lens-data/vivitar/VivitarSeries1200mmf3.analysis.md`
+- `src/lens-data/vivitar/VivitarSeries13585mmf28.analysis.md`
+- `src/lens-data/pentax/Pentax11024mmf28.analysis.md`
 - Olympus, Fujifilm, Sony, and Minolta batch complete: all analysis files in those four maker folders now satisfy the robust-block scan.
 - `src/lens-data/olympus/OlympusMZuiko12100mmf4ISPRO.analysis.md`
 - `src/lens-data/olympus/OlympusMZuiko17mmf18.analysis.md`
@@ -134,23 +159,19 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 
 ### Ready From Existing Prose
 
-- Analyses with patent metadata in prose, title lines, or source sections that can be lifted into the robust block without external research.
-- Good candidates: Sony, Olympus, and Nikon modern patent files.
+- Complete. No files remain in this bucket after the final backfill scan.
 
 ### Has Partial Block
 
-- Analyses that already have `**Patent:**` but are missing inventor/applicant/assignee, a date, or embodiment.
-- Normalize by adding missing known rows from existing prose and avoiding duplicate one-off headings.
+- Complete. No files remain in this bucket after the final backfill scan.
 
 ### Needs Patent Lookup
 
-- Files whose core patent metadata is not available near the top of the analysis or source section.
-- Do not add placeholder rows; leave these queued until the source patent is checked.
+- None currently identified by the robust-block scan.
 
 ### Multi-Patent / Special Case
 
-- Historical-lineage analyses and files comparing multiple embodiments or patent families.
-- Use the robust block for the primary transcribed prescription and keep context patents in prose unless multiple prescriptions are directly transcribed.
+- Complete for this pass. Multi-patent and historical-lineage files now carry a robust block for the primary transcribed prescription.
 
 ## Scan Command
 

--- a/agent_docs/records/patent-metadata-backfill.md
+++ b/agent_docs/records/patent-metadata-backfill.md
@@ -11,7 +11,9 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 | Total analysis files | 209 | `find src/lens-data -name '*.analysis.md'` |
 | Robust bold blocks before this standardization | 103 | Approximate scan: patent + inventor/applicant/assignee + date |
 | Missing robust bold block before this standardization | 106 | Grouped by maker below |
-| Completed in this pass | 9 | Voigtländer analyses |
+| Completed so far | 24 | Voigtländer and Canon analyses |
+| Current robust count | 127 | Latest scan after Canon batch |
+| Current missing count | 82 | Latest scan after Canon batch |
 
 ## Initial Missing Robust Count by Maker
 
@@ -39,6 +41,22 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 
 ### Done
 
+- Canon batch complete: all 30 Canon analysis files now satisfy the robust-block scan.
+- `src/lens-data/canon/CanonEFM22mmf2STM.analysis.md`
+- `src/lens-data/canon/CanonEFM28mmf34MacroISSTM.analysis.md`
+- `src/lens-data/canon/CanonEFM32mmf14STM.analysis.md`
+- `src/lens-data/canon/CanonFD35mmf2.analysis.md`
+- `src/lens-data/canon/CanonFD50mmf12L.analysis.md`
+- `src/lens-data/canon/CanonFDn50f12.analysis.md`
+- `src/lens-data/canon/CanonRF1535f28.analysis.md`
+- `src/lens-data/canon/CanonRF24105mmf28Z.analysis.md`
+- `src/lens-data/canon/CanonRF24105mmf4L.analysis.md`
+- `src/lens-data/canon/CanonRF24240mmf463.analysis.md`
+- `src/lens-data/canon/CanonRF2870mmf28.analysis.md`
+- `src/lens-data/canon/CanonRF85mmf2Macro.analysis.md`
+- `src/lens-data/canon/CanonSerenar35mmf32.analysis.md`
+- `src/lens-data/canon/CanonSerenar50mmf18.analysis.md`
+- `src/lens-data/canon/CanonSerenar85mmf15.analysis.md`
 - `src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.analysis.md`
 - `src/lens-data/voigtlander/VoigtlanderApoLanthar180mmf4.analysis.md`
 - `src/lens-data/voigtlander/VoigtlanderHeliar.analysis.md`
@@ -52,7 +70,7 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 ### Ready From Existing Prose
 
 - Analyses with patent metadata in prose, title lines, or source sections that can be lifted into the robust block without external research.
-- Good candidates: Sony, Olympus, Canon, Nikon modern patent files.
+- Good candidates: Sony, Olympus, and Nikon modern patent files.
 
 ### Has Partial Block
 

--- a/agent_docs/records/patent-metadata-backfill.md
+++ b/agent_docs/records/patent-metadata-backfill.md
@@ -11,9 +11,9 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 | Total analysis files | 209 | `find src/lens-data -name '*.analysis.md'` |
 | Robust bold blocks before this standardization | 103 | Approximate scan: patent + inventor/applicant/assignee + date |
 | Missing robust bold block before this standardization | 106 | Grouped by maker below |
-| Completed so far | 24 | Voigtländer and Canon analyses |
-| Current robust count | 127 | Latest scan after Canon batch |
-| Current missing count | 82 | Latest scan after Canon batch |
+| Completed so far | 58 | Voigtländer, Canon, and Nikon analyses |
+| Current robust count | 161 | Latest scan after Nikon batch |
+| Current missing count | 48 | Latest scan after Nikon batch |
 
 ## Initial Missing Robust Count by Maker
 
@@ -41,6 +41,41 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 
 ### Done
 
+- Nikon batch complete: all 54 Nikon analysis files now satisfy the robust-block scan.
+- `src/lens-data/nikon/Nikon28Ti28mmf28.analysis.md`
+- `src/lens-data/nikon/Nikon35Ti35mmf28.analysis.md`
+- `src/lens-data/nikon/Nikon58f14GDesignCandidate.analysis.md`
+- `src/lens-data/nikon/Nikon85f14D.analysis.md`
+- `src/lens-data/nikon/NikonAF28f14D.analysis.md`
+- `src/lens-data/nikon/NikonAFPDX1020mmf4556G.analysis.md`
+- `src/lens-data/nikon/NikonAFPDX70300mmf4563G.analysis.md`
+- `src/lens-data/nikon/NikonAFP70300mmf4556E.analysis.md`
+- `src/lens-data/nikon/NikonAI135mmf2.analysis.md`
+- `src/lens-data/nikon/NikonAI135mmf28.analysis.md`
+- `src/lens-data/nikon/NikonL35AF35mmf28.analysis.md`
+- `src/lens-data/nikon/NikonNikkorAFS120300mmf28.analysis.md`
+- `src/lens-data/nikon/NikonNikkorAFS1424mmf28.analysis.md`
+- `src/lens-data/nikon/NikonNikkorAFS200500mmf56.analysis.md`
+- `src/lens-data/nikon/NikonNikkorAFS2470mmf28E.analysis.md`
+- `src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.analysis.md`
+- `src/lens-data/nikon/NikonNikkorN28mmf2.analysis.md`
+- `src/lens-data/nikon/NikonNikkorPCE19mmf4E.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ100400f4556.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ1430mmf4S.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ24200mmf463VR.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ2450mmf463.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ35mmf12S.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ40mmf2.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ50f18S.analysis.md`
+- `src/lens-data/nikon/NikonNikkorZ70200f28.analysis.md`
+- `src/lens-data/nikon/NikonPCENikkor24mmf35DED.analysis.md`
+- `src/lens-data/nikon/NikonZ1424f28S.analysis.md`
+- `src/lens-data/nikon/NikonZ2470f28.analysis.md`
+- `src/lens-data/nikon/NikonZ28f28.analysis.md`
+- `src/lens-data/nikon/NikonZ35f18S.analysis.md`
+- `src/lens-data/nikon/NikonZ85f18S.analysis.md`
+- `src/lens-data/nikon/NikonZDX18140mmf3563VR.analysis.md`
+- `src/lens-data/nikon/NikonZDX50250mmf4564VR.analysis.md`
 - Canon batch complete: all 30 Canon analysis files now satisfy the robust-block scan.
 - `src/lens-data/canon/CanonEFM22mmf2STM.analysis.md`
 - `src/lens-data/canon/CanonEFM28mmf34MacroISSTM.analysis.md`
@@ -90,5 +125,5 @@ Target format: each `*.analysis.md` file should begin its patent/design-identifi
 ## Scan Command
 
 ```bash
-node -e 'const fs=require("fs"); const cp=require("child_process"); const files=cp.execFileSync("find",["src/lens-data","-name","*.analysis.md"],{encoding:"utf8"}).trim().split("\n").filter(Boolean); const patent=/^\*\*Patent(s)?\s*:?\*\*/mi; const owner=/^\*\*(Inventor(s)?|Applicant(s)?|Assignee)\s*:?\*\*/mi; const date=/^\*\*(Filed|Published|Granted|Filing Date|Publication Date)\s*:?\*\*/mi; const missing=files.filter(f=>{const s=fs.readFileSync(f,"utf8"); return !(patent.test(s)&&owner.test(s)&&date.test(s));}); const by={}; for(const f of missing){const maker=f.split("/")[2]; by[maker]=(by[maker]||0)+1;} console.log("missing robust bold block:",missing.length,"of",files.length); console.log(Object.entries(by).sort((a,b)=>b[1]-a[1]||a[0].localeCompare(b[0])).map(([k,v])=>`${k}: ${v}`).join("\n"));'
+node -e 'const fs=require("fs"); const cp=require("child_process"); const files=cp.execFileSync("find",["src/lens-data","-name","*.analysis.md"],{encoding:"utf8"}).trim().split("\n").filter(Boolean); const patent=/^\*\*Patent(s)?\s*:?\*\*/mi; const owner=/^\*\*(Inventor(s)?|Applicant(s)?|Applicants|Assignee)\s*:?\*\*/mi; const date=/^\*\*(Filed|Published|Granted|Filing Date|Publication Date)\s*:?\*\*/mi; const missing=files.filter(f=>{const s=fs.readFileSync(f,"utf8"); return !(patent.test(s)&&owner.test(s)&&date.test(s));}); const by={}; for(const f of missing){const maker=f.split("/")[2]; by[maker]=(by[maker]||0)+1;} console.log("missing robust bold block:",missing.length,"of",files.length); console.log(Object.entries(by).sort((a,b)=>b[1]-a[1]||a[0].localeCompare(b[0])).map(([k,v])=>`${k}: ${v}`).join("\n"));'
 ```

--- a/agent_docs/unresolved-glass.generated.md
+++ b/agent_docs/unresolved-glass.generated.md
@@ -8,11 +8,11 @@ or per-lens patent backfills.
 
 ## Summary
 
-- **209** lenses scanned
-- **2426** non-air surfaces examined
-- **2420** element glass declarations examined
-- **635** non-explicit-unmatched annotations did not resolve
-- **192** distinct unresolved glass-like tokens found
+- **211** lenses scanned
+- **2442** non-air surfaces examined
+- **2436** element glass declarations examined
+- **638** non-explicit-unmatched annotations did not resolve
+- **193** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency
 
@@ -57,10 +57,12 @@ or per-lens patent backfills.
 | N-BALF5 | 2 | 1 | |
 | N-F2 | 2 | 2 | |
 | NBFD13 | 2 | 2 | |
+| S-APL1 | 2 | 1 | |
 | S-BAH11 | 2 | 2 | |
 | S-BAL41 | 2 | 1 | |
 | S-LAH52Q | 2 | 2 | |
 | S-LAL7 | 2 | 2 | |
+| S-LAM61 | 2 | 2 | |
 | S-LAM73 | 2 | 1 | |
 | S-PHM52Q | 2 | 2 | |
 | S-TIL26 | 2 | 2 | |
@@ -181,7 +183,6 @@ or per-lens patent backfills.
 | S-LAL12 | 1 | 1 | |
 | S-LAL52 | 1 | 1 | |
 | S-LAL61 | 1 | 1 | |
-| S-LAM61 | 1 | 1 | |
 | S-LAM7 | 1 | 1 | |
 | S-NBF1 | 1 | 1 | |
 | S-NBH53 | 1 | 1 | |
@@ -441,6 +442,11 @@ or per-lens patent backfills.
 - [CANON EF-S 17-55mm f/2.8 IS USM](../src/lens-data/canon/CanonEFS1755mmf28IS.data.ts) 34: `NBFD13 (HOYA)`
 - [Laowa 15mm f/2 Zero-D](../src/lens-data/laowa/Laowa15mmf2ZeroD.data.ts) 3A: `M-NBFD130 / NBFD13 class (806-407)`
 
+### S-APL1 — 2 occurrences
+
+- [OLYMPUS OM Zuiko 16mm f/3.5 Fisheye](../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) 13: `S-APL1 (OHARA)`
+- [OLYMPUS OM Zuiko 16mm f/3.5 Fisheye](../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) 16: `S-APL1 (OHARA)`
+
 ### S-BAH11 — 2 occurrences
 
 - [NIKON AF-S NIKKOR 14-24mm f/2.8G ED](../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.ts) 3: `S-BAH11 (OHARA)`
@@ -460,6 +466,11 @@ or per-lens patent backfills.
 
 - [CANON FD 35mm f/2 S.S.C. (I)](../src/lens-data/canon/CanonFD35mmf2.data.ts) 7: `LaK (700480, S-LAL7 family)`
 - [SIGMA DP2X 24mm f/2.8](../src/lens-data/sigma/SigmaDP2X24mmf28.data.ts) 1: `S-LAL7 / LACL5 (OHARA / HOYA)`
+
+### S-LAM61 — 2 occurrences
+
+- [OLYMPUS XA F.ZUIKO 35mm f/2.8](../src/lens-data/olympus/OlympusXAZuiko35mmf28.data.ts) 6: `S-LAM61 class (720/460)`
+- [SONY FE 90 mm F2.8 Macro G OSS](../src/lens-data/sony/SonyFE90mmf28.data.ts) 6: `S-LAM61 (OHARA)`
 
 ### S-LAM73 — 2 occurrences
 
@@ -946,10 +957,6 @@ or per-lens patent backfills.
 ### S-LAL61 — 1 occurrence
 
 - [NIKON AF-S NIKKOR 28mm f/1.4E ED](../src/lens-data/nikon/NikonAFS28f14E.data.ts) 15: `S-LAL61 (OHARA)`
-
-### S-LAM61 — 1 occurrence
-
-- [SONY FE 90 mm F2.8 Macro G OSS](../src/lens-data/sony/SonyFE90mmf28.data.ts) 6: `S-LAM61 (OHARA)`
 
 ### S-LAM7 — 1 occurrence
 

--- a/src/lens-data/LENS_ANALYSIS_SPEC.md
+++ b/src/lens-data/LENS_ANALYSIS_SPEC.md
@@ -28,10 +28,25 @@ Every analysis file should contain the following H2 sections in this order. Sect
 
 Opens the file. Contains:
 
-- Patent number (with publication country prefix), title, applicant, inventor(s).
+- Patent number (with publication country prefix), title when known, applicant or assignee, inventor(s).
 - Filing and publication or grant dates. Priority date when relevant.
 - The specific embodiment (`Example N`, `第N実施例`, `Numerical Example N`) used.
 - The convergent evidence linking the embodiment to the production lens. Use a numbered list when multiple criteria converge — element/group count, special-element count (ED, asph), focal length, aperture, image-circle diameter, focus mechanism, IS configuration, MFD, and patent timing.
+
+Begin this section with a robust bold-label metadata block before the identification prose. When backfilling an existing analysis, normalize older one-off tables, title-only summaries, or partial metadata lines into this block rather than duplicating the same facts in multiple formats.
+
+```md
+**Patent:** ...
+**Application Number:** ... <!-- optional -->
+**Filed:** ...
+**Published:** ... <!-- or Granted -->
+**Inventor:** ...
+**Applicant:** ... <!-- or Assignee -->
+**Title:** ... <!-- optional but preferred -->
+**Embodiment analyzed:** ...
+```
+
+Use the block adaptively. A robust block has, at minimum, `**Patent:**`, one ownership/authorship line (`**Inventor:**`, `**Inventors:**`, `**Applicant:**`, or `**Assignee:**`), one date line (`**Filed:**`, `**Published:**`, or `**Granted:**`), and the selected embodiment when the source provides one. Include optional rows such as application number, priority date, title, classification, total claims, or worked-example count only when known or readily verified; omit optional unknowns rather than inventing values. For older granted patents, `**Granted:**` can replace `**Published:**` when the grant is the meaningful public event. For multi-patent analyses, use the block for the primary transcribed patent and describe secondary or context patents in the prose unless multiple patents directly supply prescriptions; in that case, use one block per primary prescription source.
 
 A reader who knows the lens but not the patent should be able to verify the identification from this section alone.
 

--- a/src/lens-data/canon/CanonEF100mmf28LMacroIS.analysis.md
+++ b/src/lens-data/canon/CanonEF100mmf28LMacroIS.analysis.md
@@ -8,7 +8,7 @@
 **Filed:** December 16, 2009 (US); **Priority:** December 19, 2008 (JP 2008-324167)
 **Granted:** January 4, 2011
 
-**Embodiment used:** First Numerical Example (FIGS. 1A–1B, 2A–2B, 3A–3B).
+**Embodiment analyzed:** First Numerical Example (FIGS. 1A–1B, 2A–2B, 3A–3B).
 
 The identification of this embodiment with the Canon EF 100mm f/2.8L Macro IS USM (marketed October 2009) rests on the following convergent evidence:
 

--- a/src/lens-data/canon/CanonEF40mmf28.analysis.md
+++ b/src/lens-data/canon/CanonEF40mmf28.analysis.md
@@ -7,7 +7,7 @@
 **Inventor:** Satoshi Maetaki, Utsunomiya (JP)
 **Filed:** December 19, 2012 (US); priority JP 2011-288116, December 28, 2011
 **Granted:** March 3, 2015
-**Embodiment used:** Numerical Example 2
+**Embodiment analyzed:** Numerical Example 2
 
 The prescription transcribed here corresponds to Numerical Example 2 of the patent. The following convergent evidence links this embodiment to the Canon EF 40mm f/2.8 STM production lens:
 

--- a/src/lens-data/canon/CanonEFM22mmf2STM.analysis.md
+++ b/src/lens-data/canon/CanonEFM22mmf2STM.analysis.md
@@ -2,6 +2,16 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 8,854,747 B2; US 2013/0242414 A1
+**Inventor:** Shunji Iwamoto
+**Applicant:** Canon Kabushiki Kaisha
+**Priority:** JP priority, March 15, 2012
+**Filed:** March 11, 2013
+**Published:** September 19, 2013
+**Granted:** October 7, 2014
+**Title:** Optical System and Image Pickup Apparatus Including the Same
+**Embodiment analyzed:** Example 1 / First Numerical Example
+
 The prescription analyzed here is **Example 1 / First Numerical Example** of Canon U.S. Patent **US 8,854,747 B2**, *Optical System and Image Pickup Apparatus Including the Same*. The applicant and assignee are Canon Kabushiki Kaisha, the inventor is Shunji Iwamoto, the Japanese priority date is 15 March 2012, the U.S. filing date is 11 March 2013, the U.S. publication is US 2013/0242414 A1 on 19 September 2013, and the grant date is 7 October 2014.
 
 The patent does not name the retail lens. The correspondence to the **Canon EF-M 22mm f/2 STM** is nevertheless strong enough to treat Example 1 as the production-related prescription, with the normal qualification that the patent is a generic optical-system filing rather than a retail service drawing.

--- a/src/lens-data/canon/CanonEFM28mmf34MacroISSTM.analysis.md
+++ b/src/lens-data/canon/CanonEFM28mmf34MacroISSTM.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 2016/0313535 A1
+**Inventor:** Makoto Nakahara
+**Applicant:** Canon Kabushiki Kaisha
+**Priority:** JP 2015-089582, April 24, 2015
+**Filed:** April 19, 2016
+**Published:** October 27, 2016
+**Title:** Optical System and Imaging Apparatus Including the Same
+**Embodiment analyzed:** Numerical Example 1, first embodiment, FIGS. 1A–1D / 2A–2D
+
 This analysis concerns Canon patent publication **US 2016/0313535 A1**, “Optical System and Imaging Apparatus Including the Same,” filed by **Canon Kabushiki Kaisha**, inventor **Makoto Nakahara**, filed 19 April 2016, published 27 October 2016, and claiming priority from Japanese application JP 2015-089582 of 24 April 2015. The prescription transcribed here is **Numerical Example 1**, corresponding to the patent's first embodiment and FIGS. 1A–1D / 2A–2D.
 
 The first embodiment remains the closest patent match for the production **Canon EF-M 28mm f/3.5 Macro IS STM**. Canon's first-party specifications give a 28 mm f/3.5 EF-M APS-C macro lens, 11 elements in 10 groups, 51°55′ diagonal angle of view, 0.097 m normal-mode minimum focus, 0.093 m Super Macro minimum focus, 1.0× normal magnification, 1.2× Super Macro magnification, Hybrid IS, and STM autofocus. Numerical Example 1 gives a 27.74 mm infinity-state focal length, F-number 3.61, 13.66 mm image height, first-mode focusing to 1.0×, and a second focusing mode reaching 1.2×. The patent was filed in April 2016 and published in October 2016; Canon's Camera Museum lists the lens as marketed in June 2016.

--- a/src/lens-data/canon/CanonEFM32mmf14STM.analysis.md
+++ b/src/lens-data/canon/CanonEFM32mmf14STM.analysis.md
@@ -2,6 +2,13 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** JP 2018-180366 A
+**Filed:** April 17, 2017
+**Published:** November 2018
+**Assignee:** Canon Inc.
+**Title:** Imaging Optical System and Imaging Apparatus
+**Embodiment analyzed:** Numerical Data 1 / Example 1
+
 The relevant patent is Japanese published application **JP 2018-180366 A**, titled *Imaging Optical System and Imaging Apparatus*, assigned to Canon Inc. and filed on 17 April 2017. The implemented prescription is **Numerical Data 1 / Example 1**.
 
 The production lens is the **Canon EF-M 32mm f/1.4 STM**, marketed for the EOS M / EF-M APS-C system. Canon's published product specifications give a 32 mm focal length, f/1.4 maximum aperture, 14 elements in 8 groups, one high-precision glass-molded aspherical lens, 7 aperture blades, a 0.23 m closest focusing distance, and 0.25× maximum magnification. The patent example gives f = 32.34 mm, Fno = 1.45, half-field angle ω = 22.90°, 14 powered lens elements in 8 air-separated optical groups, and a plane-parallel GB block before the image plane.

--- a/src/lens-data/canon/CanonEFS1018mmf4.analysis.md
+++ b/src/lens-data/canon/CanonEFS1018mmf4.analysis.md
@@ -5,9 +5,9 @@
 **Patent:** JP 2015-31869 A, "ズームレンズ及びそれを有する撮像装置" (Zoom Lens and Imaging Apparatus Having the Same).
 **Applicant:** Canon Inc. (キヤノン株式会社), Tokyo, Japan.
 **Inventor:** Makoto Nakahara (中原 誠).
-**Filing date:** 5 August 2013 (Priority: 特願2013-162437).
-**Publication date:** 16 February 2015.
-**Embodiment used:** Numerical Example 1 (数値実施例１), corresponding to the lens cross-section in Figure 1.
+**Filed:** 5 August 2013 (Priority: 特願2013-162437).
+**Published:** 16 February 2015.
+**Embodiment analyzed:** Numerical Example 1 (数値実施例１), corresponding to the lens cross-section in Figure 1.
 
 ### Production Lens Identification
 

--- a/src/lens-data/canon/CanonEFS1755mmf28IS.analysis.md
+++ b/src/lens-data/canon/CanonEFS1755mmf28IS.analysis.md
@@ -6,7 +6,7 @@
 **Applicant:** Canon Inc. (Tokyo, Japan).
 **Inventor:** Endo Hiroshi (遠藤 宏志).
 **Filed:** October 13, 2005 (特願 2005-298895). **Published:** April 26, 2007.
-**Embodiment used:** Numerical Example 1 (数値実施例 1).
+**Embodiment analyzed:** Numerical Example 1 (数値実施例 1).
 
 The identification of Example 1 with the production Canon EF-S 17-55mm f/2.8 IS USM rests on the following convergent evidence:
 

--- a/src/lens-data/canon/CanonEFS24mmf28STM.analysis.md
+++ b/src/lens-data/canon/CanonEFS24mmf28STM.analysis.md
@@ -8,7 +8,7 @@
 **Filed:** December 6, 2013 (Priority: 特願2013-252979)
 **Published:** June 18, 2015
 
-**Embodiment used:** Numerical Example 1 (数値実施例１, ¶0066)
+**Embodiment analyzed:** Numerical Example 1 (数値実施例１, ¶0066)
 
 The following convergent evidence identifies Example 1 as the production Canon EF-S 24mm f/2.8 STM (released November 2014):
 

--- a/src/lens-data/canon/CanonFD35mmf2.analysis.md
+++ b/src/lens-data/canon/CanonFD35mmf2.analysis.md
@@ -2,13 +2,13 @@
 
 ## Patent Identification
 
-**US Patent 3,748,022** — *Reverse Telephoto Type Lens Prevented from the Deterioration of Image at the Time of Close Shot*
-
-- **Inventor:** Akira Tajima (Kawasaki, Japan)
-- **Assignee:** Canon Kabushiki Kaisha (Tokyo, Japan)
-- **Filed:** March 3, 1972 (JP priority March 11, 1971, No. 46/12786)
-- **Granted:** July 24, 1973
-- **Classification:** US 350/214; Int. Cl. G02b 9/64
+**Patent:** US 3,748,022 — *Reverse Telephoto Type Lens Prevented from the Deterioration of Image at the Time of Close Shot*
+**Inventor:** Akira Tajima (Kawasaki, Japan)
+**Assignee:** Canon Kabushiki Kaisha (Tokyo, Japan)
+**Filed:** March 3, 1972 (JP priority March 11, 1971, No. 46/12786)
+**Granted:** July 24, 1973
+**Classification:** US 350/214; Int. Cl. G02b 9/64
+**Embodiment analyzed:** Single numerical embodiment
 
 This patent discloses the optical formula for the **Canon FD 35mm f/2 S.S.C. (I)** — the first version of Canon's professional-grade 35mm wide-angle lens for the FD-mount system, and the first Canon wide-angle interchangeable lens to incorporate what Canon calls a "floating mechanism." This version is identified by its distinctive **concave front element** (R₁ < 0) and is known to employ **thoriated glass elements**, which produce the characteristic yellowing observed in aged examples. The single numerical embodiment given in the patent is the production design.
 

--- a/src/lens-data/canon/CanonFD50mmf12L.analysis.md
+++ b/src/lens-data/canon/CanonFD50mmf12L.analysis.md
@@ -2,8 +2,11 @@
 
 **Patent:** US 4,364,644 — "Gauss Type Large Aperture Photographic Objective"  
 **Inventor:** Keiji Ikemori, Canon Kabushiki Kaisha  
-**JP Priority:** 27 November 1979 (JP 54-153258) · **US Filed:** 24 November 1980 · **US Granted:** 21 December 1982  
-**Implemented example:** Example 1 — normalised to f = 100 mm (production scale k = 0.500 → f = 50 mm)  
+**Assignee:** Canon Kabushiki Kaisha  
+**JP Priority:** November 27, 1979 (JP 54-153258)  
+**Filed:** November 24, 1980  
+**Granted:** December 21, 1982  
+**Embodiment analyzed:** Example 1 — normalised to f = 100 mm (production scale k = 0.500 → f = 50 mm)  
 **Lens construction:** 8 elements / 6 groups, 1 aspherical surface  
 **Optical class:** Modified Double-Gauss with aspherical correction
 

--- a/src/lens-data/canon/CanonFDn50f12.analysis.md
+++ b/src/lens-data/canon/CanonFDn50f12.analysis.md
@@ -1,8 +1,12 @@
 # Canon New FD 50mm f/1.2 — Optical Analysis
 
-**Patent:** US 4,364,643 (Momiyama, assigned to Canon K.K.), filed May 28, 1980, granted December 21, 1982
-**Design basis:** Embodiment 3 (7 elements in 6 groups, all spherical)
+**Patent:** US 4,364,643
+**Inventor:** Momiyama
+**Assignee:** Canon K.K.
 **Japanese priority:** JP 54-67047, May 30, 1979
+**Filed:** May 28, 1980
+**Granted:** December 21, 1982
+**Embodiment analyzed:** Embodiment 3 (7 elements in 6 groups, all spherical)
 
 ---
 

--- a/src/lens-data/canon/CanonRF1535f28.analysis.md
+++ b/src/lens-data/canon/CanonRF1535f28.analysis.md
@@ -1,8 +1,11 @@
 # Canon RF 15-35mm f/2.8 L IS USM — Optical Analysis
 
 **Patent:** US 2020/0257181 A1 (Gyoda, Canon Kabushiki Kaisha)
-**Published:** August 13, 2020 · **Priority:** JP 2019-021356, February 8, 2019
-**Embodiment:** Numerical Example 1 (FIGS. 1A/1B, aberration plots FIGS. 2A/2B)
+**Inventor:** Yuichi Gyoda
+**Assignee:** Canon Kabushiki Kaisha
+**Priority:** JP 2019-021356, February 8, 2019
+**Published:** August 13, 2020
+**Embodiment analyzed:** Numerical Example 1 (FIGS. 1A/1B, aberration plots FIGS. 2A/2B)
 
 ---
 

--- a/src/lens-data/canon/CanonRF24105mmf28Z.analysis.md
+++ b/src/lens-data/canon/CanonRF24105mmf28Z.analysis.md
@@ -2,7 +2,10 @@
 
 **Patent:** US 2024/0192474 A1 (Pub. Jun. 13, 2024), Numerical Example 4
 **Inventor:** Shunji Iwamoto (Canon Kabushiki Kaisha)
+**Assignee:** Canon Kabushiki Kaisha
 **JP Priority:** 2022-192641 (Dec. 1, 2022)
+**Published:** June 13, 2024
+**Embodiment analyzed:** Numerical Example 4
 **Production lens:** Canon RF24-105mm F2.8 L IS USM Z (announced Nov. 3, 2023)
 
 ---

--- a/src/lens-data/canon/CanonRF24105mmf4L.analysis.md
+++ b/src/lens-data/canon/CanonRF24105mmf4L.analysis.md
@@ -1,9 +1,11 @@
 # Canon RF 24-105mm f/4 L IS USM — Optical Design Analysis
 
 **Patent:** US 2019/0278068 A1 (Hatada, Canon Kabushiki Kaisha)
-**Example:** Numerical Example 2 (Fig. 3)
+**Inventor:** Takahiro Hatada
+**Assignee:** Canon Kabushiki Kaisha
 **Published:** September 12, 2019
 **Priority:** JP 2018-042214, filed March 8, 2018
+**Embodiment analyzed:** Numerical Example 2 (Fig. 3)
 
 ---
 

--- a/src/lens-data/canon/CanonRF24240mmf463.analysis.md
+++ b/src/lens-data/canon/CanonRF24240mmf463.analysis.md
@@ -2,8 +2,10 @@
 
 **Patent:** US 2020/0142167 A1 (Pub. May 7, 2020)
 **Inventor:** Shohei Kikuchi (Canon Kabushiki Kaisha)
+**Assignee:** Canon Kabushiki Kaisha
 **Priority:** JP 2018-207200, filed November 2, 2018
-**Numerical Example:** 1 (of 5 examples in the patent)
+**Published:** May 7, 2020
+**Embodiment analyzed:** Numerical Example 1 (of 5 examples in the patent)
 **Production Lens:** Canon RF24-240mm F4-6.3 IS USM (Canon RF mount, released 2019)
 
 ---

--- a/src/lens-data/canon/CanonRF2870mmf28.analysis.md
+++ b/src/lens-data/canon/CanonRF2870mmf28.analysis.md
@@ -2,7 +2,9 @@
 
 **Patent:** US 2024/0329367 A1 (Pub. Oct 3, 2024)
 **Inventor:** Yasuaki Hagiwara (Canon Kabushiki Kaisha)
+**Assignee:** Canon Kabushiki Kaisha
 **Priority:** JP 2023-051695 (Mar 28, 2023)
+**Published:** October 3, 2024
 **Embodiment analyzed:** First Numerical Example (§0083)
 
 ---

--- a/src/lens-data/canon/CanonRF2870mmf2L.analysis.md
+++ b/src/lens-data/canon/CanonRF2870mmf2L.analysis.md
@@ -2,7 +2,7 @@
 
 **Patent:** JP 2020-118807 A (Published 2020-08-06), Example A Main Optical System  
 **Inventor:** Kohei Kimura (木村 公平), Canon Inc.  
-**Filing date:** 2019-01-22  
+**Filed:** 2019-01-22  
 **Manufacturer specification:** 19 elements in 13 groups, f/2 constant aperture, 28–70 mm zoom  
 
 ---

--- a/src/lens-data/canon/CanonRF85mmf2Macro.analysis.md
+++ b/src/lens-data/canon/CanonRF85mmf2Macro.analysis.md
@@ -1,8 +1,11 @@
 # Canon RF 85mm f/2 Macro IS STM — Optical Analysis
 
 **Patent:** US 2021/0072505 A1, First Numerical Example (Kobayashi, Canon Kabushiki Kaisha)  
-**Priority:** JP 2019-161981, September 5, 2019 · **Published:** March 11, 2021  
 **Inventor:** Kana Kobayashi, Utsunomiya-shi, Japan
+**Assignee:** Canon Kabushiki Kaisha
+**Priority:** JP 2019-161981, September 5, 2019
+**Published:** March 11, 2021
+**Embodiment analyzed:** First Numerical Example
 
 ---
 

--- a/src/lens-data/canon/CanonSerenar35mmf32.analysis.md
+++ b/src/lens-data/canon/CanonSerenar35mmf32.analysis.md
@@ -1,9 +1,12 @@
 # Canon Serenar 35mm f/3.2 — Optical Analysis
 
-**Patent:** US 2,645,975 — Hiroshi Ito, assigned to Canon Camera Company, Ltd.
+**Patent:** US 2,645,975
+**Inventor:** Hiroshi Ito
+**Assignee:** Canon Camera Company, Ltd.
 **Filed:** June 29, 1951 (priority: Japan, July 14, 1950)
 **Granted:** July 21, 1953
 **Marketed:** June 1951
+**Embodiment analyzed:** Example 1
 **Design type:** Modified double-Gauss (four-component, six-element)
 
 ---

--- a/src/lens-data/canon/CanonSerenar50mmf18.analysis.md
+++ b/src/lens-data/canon/CanonSerenar50mmf18.analysis.md
@@ -1,8 +1,11 @@
 # Canon Serenar 50mm f/1.8 — Optical Analysis
 
-**Patent:** US 2,681,594 · Hiroshi Ito, assignor to Canon Camera Company, Ltd.  
+**Patent:** US 2,681,594  
+**Inventor:** Hiroshi Ito  
+**Assignee:** Canon Camera Company, Ltd.  
 **Filed:** June 29, 1951 (priority: Japan, November 7, 1950)  
 **Granted:** June 22, 1954  
+**Embodiment analyzed:** Example 1, Claim 3  
 **Marketed:** November 1951 (Canon Camera Museum)
 
 ---

--- a/src/lens-data/canon/CanonSerenar85mmf15.analysis.md
+++ b/src/lens-data/canon/CanonSerenar85mmf15.analysis.md
@@ -1,6 +1,8 @@
 # Canon Serenar 85mm f/1.5 — Optical Analysis
 
-**Patent:** US 2,645,973 · Hiroshi Ito · Canon Camera Company, Ltd.
+**Patent:** US 2,645,973
+**Inventor:** Hiroshi Ito
+**Assignee:** Canon Camera Company, Ltd.
 **Filed:** June 29, 1951 (Japanese priority: January 31, 1951)
 **Granted:** July 21, 1953
 **Embodiment analyzed:** Example 1 (Figure 1) — 7 elements / 4 groups, f/1.5, 30° including field

--- a/src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.analysis.md
+++ b/src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.analysis.md
@@ -1,9 +1,12 @@
 # Carl Zeiss Jena Pancolar 50mm f/2 — Patent Analysis
 
-**Patent:** GB 850,117 (filed 28 March 1958, published 28 September 1960)
+**Patent:** GB 850,117
 **Inventors:** Eduard Hubert and Harry Zöllner, VEB Carl Zeiss Jena
+**Applicant:** VEB Carl Zeiss Jena
+**Filed:** 28 March 1958
+**Published:** 28 September 1960
 **Design:** Gauss-type (double-Gauss), 6 elements in 4 groups
-**Numerical Example:** Claim 2 — f = 100, relative aperture 1:2, S′ = 72.4
+**Embodiment analyzed:** Claim 2 — f = 100, relative aperture 1:2, S′ = 72.4
 
 ---
 

--- a/src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.analysis.md
+++ b/src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.analysis.md
@@ -6,6 +6,14 @@
 
 ## 1. Patent provenance
 
+**Patent:** FR 1.066.698
+**Applicant:** VEB Optik Carl Zeiss Jena (East Germany)
+**Filed:** 19 November 1952, 16 h 46 min, Paris
+**Granted:** 20 January 1954
+**Published:** 9 June 1954
+**Title:** Objectif à correction sphérique, chromatique et astigmatique
+**Embodiment analyzed:** Example 1
+
 | Field | Value |
 |---|---|
 | Patent number | FR 1.066.698 |

--- a/src/lens-data/carl-zeiss-jena/ZeissTessar144f55.analysis.md
+++ b/src/lens-data/carl-zeiss-jena/ZeissTessar144f55.analysis.md
@@ -2,6 +2,14 @@
 
 **Paul Rudolph · Carl Zeiss, Jena · Filed July 15, 1902 · Patented February 24, 1903**
 
+**Patent:** US 721,240
+**Inventor:** Paul Rudolph
+**Assignee:** Carl Zeiss, Jena
+**Filed:** July 15, 1902
+**Granted:** February 24, 1903
+**Title:** Photographic Objective
+**Embodiment analyzed:** Single worked example
+
 ---
 
 ## 1. Introduction

--- a/src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.analysis.md
+++ b/src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.analysis.md
@@ -2,11 +2,14 @@
 
 ## Patent Attribution
 
-**US Patent 3,874,771** — *Photographic Objective of the Extended Gauss Type*
-Filed: June 25, 1973 (German priority DE 2232101, June 30, 1972)
-Granted: April 1, 1975
-Inventors: Karl-Heinrich Behrens, Erhard Glatzel
-Assignee: Carl Zeiss Stiftung d/b/a Carl Zeiss, Oberkochen, Germany
+**Patent:** US 3,874,771
+**Inventors:** Karl-Heinrich Behrens, Erhard Glatzel
+**Assignee:** Carl Zeiss Stiftung d/b/a Carl Zeiss, Oberkochen, Germany
+**Priority:** DE 2232101, June 30, 1972
+**Filed:** June 25, 1973
+**Granted:** April 1, 1975
+**Title:** Photographic Objective of the Extended Gauss Type
+**Embodiment analyzed:** Example 5 (Table 5)
 
 This analysis is based on **Example 5** (Table 5) of the patent, one of two "fine-corrected" embodiments designed for color photography at f/1.4. The patent provides five examples; Examples 1–3 are monochromatic rough forms at f/1.5, while Examples 4 and 5 are fully achromatized designs at f/1.4 with glass dispersion data (Abbe numbers). Both Examples 4 and 5 use identical glass types and share the 7-element/6-group configuration of the production lens; without direct confirmation from Zeiss, either (or a closely related derivative) could be the basis of the production design. Example 5 is analyzed here as the more likely candidate, being the final and presumably most refined example in the patent sequence.
 

--- a/src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.analysis.md
+++ b/src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.analysis.md
@@ -1,10 +1,12 @@
 # Carl Zeiss Tessar 50 mm f/3.5 — A Detailed Analysis of Swiss Patent CH 314381 (Example 1)
 
+**Patent:** CH 314381
 **Inventors:** Dr. Günther Lange (Königsbronn) & Dr. phil. Robert Richter (Aalen)
 **Assignee:** Firma Carl Zeiss, Heidenheim a.d. Brenz
 **Priority:** Germany, 21 July 1952
 **Filed (Switzerland):** 24 June 1953
 **Published:** 31 July 1956
+**Embodiment analyzed:** Example 1
 
 ---
 

--- a/src/lens-data/fujifilm/FujifilmGF110mmf2RLM.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmGF110mmf2RLM.analysis.md
@@ -9,7 +9,7 @@
 **Published:** April 12, 2018
 **Priority:** JP 2016-197954 (October 6, 2016)
 
-**Embodiment used:** Example 1 (Tables 1–3; Figs. 1, 2, 12)
+**Embodiment analyzed:** Example 1 (Tables 1–3; Figs. 1, 2, 12)
 
 The prescription is identified as the basis for the production Fujinon GF110mmF2 R LM WR by the following convergent evidence:
 

--- a/src/lens-data/fujifilm/FujifilmGF120mmf4RLM.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmGF120mmf4RLM.analysis.md
@@ -7,7 +7,7 @@
 **Inventor:** Taiga Noda, Saitama (JP).
 **Filed:** June 13, 2017. **Published:** March 1, 2018.
 **Priority:** Japanese Patent Application No. 2016-162462, filed August 23, 2016.
-**Embodiment used:** Example 1 (Tables 1–3, FIGS. 1, 6–7).
+**Embodiment analyzed:** Example 1 (Tables 1–3, FIGS. 1, 6–7).
 
 The identification of Example 1 as the production Fujinon GF120mmF4 R LM OIS WR Macro rests on convergent evidence across multiple independent criteria:
 

--- a/src/lens-data/fujifilm/FujifilmGF80mmf17R.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmGF80mmf17R.analysis.md
@@ -1,10 +1,13 @@
 ## Patent Reference and Design Identification
 
-**US 2021/0294073 A1**, "Imaging Lens and Imaging Apparatus."
-Applicant: FUJIFILM Corporation, Tokyo, Japan.
-Inventor: Masato Kondo (Saitama, JP).
-Filed: March 4, 2021. Priority: JP 2020-047018, March 17, 2020.
-Published: September 23, 2021.
+**Patent:** US 2021/0294073 A1
+**Inventor:** Masato Kondo (Saitama, JP)
+**Applicant:** FUJIFILM Corporation, Tokyo, Japan
+**Priority:** JP 2020-047018, March 17, 2020
+**Filed:** March 4, 2021
+**Published:** September 23, 2021
+**Title:** Imaging Lens and Imaging Apparatus
+**Embodiment analyzed:** Example 1 (Tables 1-4, FIG. 2, FIG. 3)
 
 The prescription transcribed here is **Example 1** (Tables 1–4, FIG. 2, FIG. 3). Convergent evidence linking this embodiment to the production FUJINON GF80mmF1.7 R WR:
 

--- a/src/lens-data/fujifilm/FujifilmXF1655mmf28R.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmXF1655mmf28R.analysis.md
@@ -8,13 +8,12 @@
 
 The lens under analysis is the **Fujinon XF 16-55mm F2.8 R LM WR**, Fujifilm's weather-sealed standard zoom for the APS-C X mount, first announced in January 2015. The published patent filing most closely aligned with this product is:
 
-| | |
-|---|---|
-| Application | US 2016/0154221 A1 |
-| Priority | JP 2014-243845, filed 2 December 2014 |
-| Applicant | FUJIFILM Corporation |
-| Inventors | Taiga Noda; Michio Cho |
-| Examples in filing | 3 numerical examples; this document analyses **Example 1** |
+**Patent:** US 2016/0154221 A1
+**Inventors:** Taiga Noda; Michio Cho
+**Applicant:** FUJIFILM Corporation
+**Priority:** JP 2014-243845, December 2, 2014
+**Published:** June 2, 2016
+**Embodiment analyzed:** Example 1
 
 The patent discloses three closely related numerical examples of a five-group standard zoom; all three meet the stated design targets (small F-number across the full zoom range, aberration-corrected at high pixel counts). Example 1 is the variant whose paraxial specifications (EFL range 16.49–53.44 mm, F/2.88–2.89, image heights consistent with APS-C) match Fujifilm's marketed XF 16-55mm product most closely. Examples 2 and 3 are design-space alternatives with modified Conditional Formula values; they were not commercialised. The analysis below is confined to Example 1.
 

--- a/src/lens-data/fujifilm/FujifilmXF1680mmf4.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmXF1680mmf4.analysis.md
@@ -1,6 +1,14 @@
 # Fujifilm Fujinon XF 16–80 mm f/4 R OIS WR — Optical Analysis
 
-**Patent embodiment:** US 2020/0166735 A1, Example 11 (Kawamura & Noda, assigned to FUJIFILM Corporation; filed 20 Nov 2019; priority JP 2018‑221597, 27 Nov 2018; published 28 May 2020). Example 11 is the uniquely matching embodiment among the eleven in the application: it contains 16 elements in 12 groups, four elements with aspherical surfaces (one of which is also the ED element), a constant f/4 aperture across the zoom range (FNo 4.12 at wide, 4.13 at tele), a focal range of 16.497–77.751 mm that maps cleanly to the marketed 16–80 mm, and the positive‑negative‑positive‑negative‑positive five‑group topology Fujifilm's product documentation attributes to the shipping lens.
+**Patent:** US 2020/0166735 A1
+**Inventors:** Kawamura, Noda
+**Assignee:** FUJIFILM Corporation
+**Priority:** JP 2018-221597, November 27, 2018
+**Filed:** November 20, 2019
+**Published:** May 28, 2020
+**Embodiment analyzed:** Example 11
+
+Example 11 is the uniquely matching embodiment among the eleven in the application: it contains 16 elements in 12 groups, four elements with aspherical surfaces (one of which is also the ED element), a constant f/4 aperture across the zoom range (FNo 4.12 at wide, 4.13 at tele), a focal range of 16.497–77.751 mm that maps cleanly to the marketed 16–80 mm, and the positive‑negative‑positive‑negative‑positive five‑group topology Fujifilm's product documentation attributes to the shipping lens.
 
 This analysis is derived from the patent prescription alone, cross‑referenced with Fujifilm's published product specifications. All quantitative claims have been independently verified via paraxial ray trace using ABCD matrix methods (the Python verification reproduces the patent's stated EFLs at all three zoom positions to within 0.001 mm and matches eighteen of the nineteen Table 34 conditional expressions that the patent lists for Example 11; the single discrepancy — Expression 11 — is identified in § 10 as a transcription error in the patent's printed table).
 

--- a/src/lens-data/fujifilm/FujifilmXF18mmf2.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmXF18mmf2.analysis.md
@@ -2,7 +2,7 @@
 
 **Patent:** US 2014/0240851 A1, Example 4  
 **Inventor:** Daiki Kawamura (Fujifilm Corporation)  
-**Priority date:** November 9, 2011 (JP 2011-245310)  
+**Priority:** November 9, 2011 (JP 2011-245310)  
 **Published:** August 28, 2014  
 **Production lens:** Fujinon XF18mmF2 R (launched March 2012 with X-Pro1)
 

--- a/src/lens-data/fujifilm/FujifilmXF200mmf2R.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmXF200mmf2R.analysis.md
@@ -1,6 +1,11 @@
 # Fujifilm Fujinon XF 200 mm f/2 R LM OIS WR — Optical Analysis
 
-**Patent:** US 2019/0265504 A1 · Example 1 · Applicant FUJIFILM Corporation · Inventor Hiroki Saito · Priority JP 2018‑035614 (28 Feb 2018) · Published 29 Aug 2019
+**Patent:** US 2019/0265504 A1
+**Inventor:** Hiroki Saito
+**Applicant:** FUJIFILM Corporation
+**Priority:** JP 2018-035614, February 28, 2018
+**Published:** August 29, 2019
+**Embodiment analyzed:** Example 1
 
 **Production lens:** Fujinon XF 200 mm F2 R LM OIS WR · Fujifilm X‑mount · Announced September 2018; shipping since November 2018
 

--- a/src/lens-data/fujifilm/FujifilmXF35mmf14R.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmXF35mmf14R.analysis.md
@@ -2,8 +2,10 @@
 
 **Patent:** US 2014/0285903 A1 — Example 1
 **Inventor:** Takashi Suzuki (Fujifilm Corporation)
-**Priority date:** December 16, 2011 (JP 2011-275177)
-**Publication date:** September 25, 2014
+**Applicant:** Fujifilm Corporation
+**Priority:** December 16, 2011 (JP 2011-275177)
+**Published:** September 25, 2014
+**Embodiment analyzed:** Example 1
 
 *Note on patent title:* The US publication is titled "Imaging Zoom Lens and Imaging Apparatus Including the Same," but the patent describes fixed focal length (prime) lens designs exclusively. None of the three numerical examples include variable magnification or zoom mechanisms. The title is likely an artifact of broad PCT filing language or a translation convention from the original Japanese application.
 

--- a/src/lens-data/fujifilm/FujifilmXF50140mmf28R.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmXF50140mmf28R.analysis.md
@@ -1,5 +1,13 @@
 # FUJIFILM FUJINON XF 50–140mm F2.8 R LM OIS WR — Optical Analysis
 
+**Patent:** US 2017/0090163 A1
+**Inventor:** T. Ori
+**Applicant:** FUJIFILM Corporation
+**Priority:** JP 2015-186957, September 24, 2015
+**Filed:** August 26, 2016
+**Title:** Rear Convertor Lens and Imaging Apparatus
+**Embodiment analyzed:** Master lens prescription with Example 1 rear converter
+
 **Primary source:** US 2017/0090163 A1 (Fujifilm Corporation, inventor T. Ori; filed 26 August 2016; priority JP 2015‑186957, 24 September 2015). The patent is titled *"Rear Convertor Lens and Imaging Apparatus"*; the XF 50‑140mm prescription appears as the **master lens** against which the claimed rear converter is demonstrated.
 
 **Verification methodology.** Every quantitative claim in this document was cross‑checked by an independent paraxial ray trace (y‑u method; geometric angles; n·u conserved at refractions) executed against a fresh transcription of the patent prescription. The final section, **§12 — Numerical Verification**, documents the residual agreement between computed and patent‑stated quantities.

--- a/src/lens-data/fujifilm/FujifilmXF60mmf24R.analysis.md
+++ b/src/lens-data/fujifilm/FujifilmXF60mmf24R.analysis.md
@@ -1,8 +1,11 @@
 # FUJINON XF60mmF2.4 R Macro — Optical Analysis
 
 **Patent:** US 2014/0247506 A1, Example 1 (Tetsuya Ori / FUJIFILM Corporation)
+**Inventor:** Tetsuya Ori
+**Applicant:** FUJIFILM Corporation
 **Priority:** November 14, 2011 (JP 2011-248180)
 **Published:** September 4, 2014
+**Embodiment analyzed:** Example 1
 **Design:** 10 elements / 8 groups, 2 aspherical surfaces, 1 ED element
 **Design EFL:** 61.06 mm | **FNO:** 2.48 | **2ω:** 25.4°
 

--- a/src/lens-data/hasselblad/HasselbladHC120mmf4Macro.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladHC120mmf4Macro.analysis.md
@@ -6,7 +6,7 @@
 **Applicant:** Fuji Photo Optical Co., Ltd. (富士写真光機株式会社), Saitama, Japan.
 **Inventor:** Kazunori Ohno (大野 和則).
 **Filed:** 31 March 2003 (Heisei 15). **Published:** 28 October 2004 (Heisei 16).
-**Embodiment used:** Example 4 (第4実施例, Table 4).
+**Embodiment analyzed:** Example 4 (第4実施例, Table 4).
 
 The prescription data in the patent is normalised to $f = 100\text{ mm}$. The production lens scales all linear dimensions by a factor of approximately 1.187 to reach the actual focal length of 118.7 mm.
 

--- a/src/lens-data/hasselblad/HasselbladHC150mmf32.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladHC150mmf32.analysis.md
@@ -2,6 +2,14 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 2002/0075570 A1
+**Inventor:** Hiromitsu Yamakawa
+**Priority:** JP 2000-293710, September 27, 2000
+**Filed:** September 13, 2001
+**Published:** June 20, 2002
+**Title:** Inner-Focus-Type Lens
+**Embodiment analyzed:** Embodiment 1 (Table 1, FIG. 1)
+
 **US 2002/0075570 A1**, "Inner-Focus-Type Lens." Inventor: Hiromitsu Yamakawa (Saitama City, Japan). Filed September 13, 2001; published June 20, 2002. Priority: JP 2000-293710, filed September 27, 2000. The prescription used is **Embodiment 1** (Table 1, FIG. 1, aberration plots FIGS. 3A–3H).
 
 The patent was filed by Yamakawa through the correspondence firm Arnold International. Yamakawa is a prolific optical designer whose subsequent patents — covering wide-angle, imaging, and ultra-wide-angle lenses — were assigned to Fujinon Corporation and later Fujifilm Corporation. The Hasselblad H-system lenses were jointly developed with Fujifilm and manufactured by Fujinon; the HC lenses were also sold under Fujinon branding for the Fujifilm GX645AF platform. This patent therefore represents a Fujinon-designed lens produced for the Hasselblad H system.

--- a/src/lens-data/hasselblad/HasselbladHC210mmf4.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladHC210mmf4.analysis.md
@@ -5,8 +5,8 @@
 **Patent:** US 6,445,511 B1, "Inner-Focus-Type Lens," granted September 3, 2002.
 **Applicant:** Fuji Photo Optical Co., Ltd., Saitama (JP).
 **Inventor:** You Kitahara.
-**Filing date:** January 31, 2002; priority date March 15, 2001 (JP 2001-075010).
-**Embodiment used:** Example 3, corresponding to Figure 3 and Table 3.
+**Filed:** January 31, 2002; priority date March 15, 2001 (JP 2001-075010).
+**Embodiment analyzed:** Example 3, corresponding to Figure 3 and Table 3.
 
 The prescription is normalized to $f = 1.0$. All radii, thicknesses, and spacings were scaled by a factor of $\times 210.07$ to match the marketed 210 mm focal length.
 

--- a/src/lens-data/hasselblad/HasselbladHC300mmf45.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladHC300mmf45.analysis.md
@@ -8,7 +8,7 @@
 **Filed:** March 6, 2006
 **Published:** September 21, 2006
 **Priority:** JP P.2005-062459, March 7, 2005
-**Embodiment used:** Example 1 (Table 1, corresponding to FIG. 1)
+**Embodiment analyzed:** Example 1 (Table 1, corresponding to FIG. 1)
 
 The identification of Example 1 with the production Hasselblad HC 4.5/300 rests on the following convergent evidence:
 

--- a/src/lens-data/hasselblad/HasselbladHC50mmf4.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladHC50mmf4.analysis.md
@@ -11,7 +11,7 @@
 **Inventor:** Masao Mori
 **Filed:** July 11, 2002 (US); priority July 12, 2001 (JP 2001-211937)
 **Published:** January 16, 2003
-**Embodiment used:** Example 4 (Numerical Example 4, FIG. 4 / FIG. 8)
+**Embodiment analyzed:** Example 4 (Numerical Example 4, FIG. 4 / FIG. 8)
 
 ### Production Identification
 

--- a/src/lens-data/hasselblad/HasselbladHC80mmf28.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladHC80mmf28.analysis.md
@@ -6,7 +6,7 @@
 **Inventor:** Kazunori Ohno (Omiya City, Japan).
 **Filed:** March 8, 2001 (US). **Priority:** March 28, 2000 (JP 2000-089202).
 **Published:** December 13, 2001.
-**Embodiment used:** Embodiment 3 (Table 3, Figs. 4A–4C).
+**Embodiment analyzed:** Embodiment 3 (Table 3, Figs. 4A–4C).
 
 The patent is not assigned to a corporate entity, but Kazunori Ohno is a career lens designer at Fuji Photo Optical Co., Ltd. (later Fujinon Corporation, now a division of Fujifilm). His name appears on multiple Fujifilm-assigned patents spanning zoom lenses, viewfinder optics, and imaging objectives (e.g., US 5,179,472 assigned to Fuji Photo Optical; US 8,514,504 assigned to Fujifilm Corporation). A Fujifilm corporate blog identifies "Kazunori Oono" (alternate romanization of 大野) as a former Senior Manager of the Optical Device Division. The Hasselblad H-system lenses are manufactured by Fujifilm under the SUPER-EBC Fujinon designation.
 

--- a/src/lens-data/hasselblad/HasselbladXCD120mmf35Macro.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladXCD120mmf35Macro.analysis.md
@@ -5,10 +5,10 @@
 **Patent:** US 2020/0192060 A1, "Optical System for Image Pickup, and Image Pickup Device"
 **Applicant / Assignee:** Nittoh Inc., Suwa-shi, Nagano, Japan
 **Inventor:** Akira Sawamoto
-**PCT Filed:** May 25, 2018 (PCT/JP2018/020089)
+**Filed:** May 25, 2018 (PCT/JP2018/020089)
 **Priority Date:** May 26, 2017 (JP 2017-104151)
-**US Publication Date:** June 18, 2020
-**Embodiment used:** Example 2 (Figs. 5–8)
+**Published:** June 18, 2020
+**Embodiment analyzed:** Example 2 (Figs. 5–8)
 
 The prescription in Example 2 of this patent corresponds to the production Hasselblad XCD 3,5/120mm Macro lens. The identification rests on the following convergent evidence:
 

--- a/src/lens-data/hasselblad/HasselbladXCD120mmf35Macro.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladXCD120mmf35Macro.analysis.md
@@ -6,7 +6,7 @@
 **Applicant / Assignee:** Nittoh Inc., Suwa-shi, Nagano, Japan
 **Inventor:** Akira Sawamoto
 **Filed:** May 25, 2018 (PCT/JP2018/020089)
-**Priority Date:** May 26, 2017 (JP 2017-104151)
+**Priority:** May 26, 2017 (JP 2017-104151)
 **Published:** June 18, 2020
 **Embodiment analyzed:** Example 2 (Figs. 5–8)
 

--- a/src/lens-data/hasselblad/HasselbladXCD65mmf28.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladXCD65mmf28.analysis.md
@@ -7,7 +7,7 @@
 **Inventor:** Takuya Yazaki
 **Filed:** December 26, 2018 (PCT/JP2018/047819)
 **Published:** October 8, 2020
-**Priority Dates:** December 28, 2017 (JP 2017-254496, 2017-254497, 2017-254498)
+**Priority:** December 28, 2017 (JP 2017-254496, 2017-254497, 2017-254498)
 **Embodiment analyzed:** Example 1 (Figs. 1–6)
 
 The patent was filed by Nittoh Inc., a Suwa-based optical manufacturer known to design and produce lenses for Hasselblad's X-system. Example 1 of this patent is identified as the production design for the **Hasselblad XCD 2,8/65** based on the following convergent evidence:

--- a/src/lens-data/hasselblad/HasselbladXCD65mmf28.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladXCD65mmf28.analysis.md
@@ -5,10 +5,10 @@
 **Patent:** US 2020/0319427 A1, "Lens System and Image Pickup Apparatus"
 **Applicant:** Nittoh Inc., Suwa-shi, Nagano (JP)
 **Inventor:** Takuya Yazaki
-**PCT Filed:** December 26, 2018 (PCT/JP2018/047819)
-**US Publication Date:** October 8, 2020
+**Filed:** December 26, 2018 (PCT/JP2018/047819)
+**Published:** October 8, 2020
 **Priority Dates:** December 28, 2017 (JP 2017-254496, 2017-254497, 2017-254498)
-**Embodiment used:** Example 1 (Figs. 1–6)
+**Embodiment analyzed:** Example 1 (Figs. 1–6)
 
 The patent was filed by Nittoh Inc., a Suwa-based optical manufacturer known to design and produce lenses for Hasselblad's X-system. Example 1 of this patent is identified as the production design for the **Hasselblad XCD 2,8/65** based on the following convergent evidence:
 

--- a/src/lens-data/hasselblad/HasselbladXCD90mmf25V.analysis.md
+++ b/src/lens-data/hasselblad/HasselbladXCD90mmf25V.analysis.md
@@ -7,9 +7,9 @@
 ("Imaging optical system, and imaging device and camera system using imaging optical system")
 **Applicant:** Panasonic IP Management Co., Ltd.
 **Inventor:** Nishioka Takehiro (西岡 毅洋)
-**Filing date:** 23 December 2020
-**Publication date:** 5 July 2022
-**Embodiment used:** 数値実施例１ (Numerical Example 1), corresponding to 実施の形態１ (Embodiment 1)
+**Filed:** 23 December 2020
+**Published:** 5 July 2022
+**Embodiment analyzed:** 数値実施例１ (Numerical Example 1), corresponding to 実施の形態１ (Embodiment 1)
 
 ### Patent-to-Production Matching
 

--- a/src/lens-data/laowa/Laowa12mmf28ZeroD.analysis.md
+++ b/src/lens-data/laowa/Laowa12mmf28ZeroD.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** CN205720849U
+**Inventor:** Zhang Xiaohua
+**Assignee:** Anhui Changgeng Optical Technology Co., Ltd.
+**Filed:** April 12, 2016
+**Published:** November 23, 2016
+**Granted:** November 23, 2016
+**Title:** 一种大光圈广角微距镜头 / Large-aperture wide-angle macro lens
+**Embodiment analyzed:** Example 2 / 第二实施例
+
 The relevant filing is **CN205720849U**, *一种大光圈广角微距镜头* / “large-aperture wide-angle macro lens,” assigned to **Anhui Changgeng Optical Technology Co., Ltd.** and naming **Zhang Xiaohua** as inventor. The Chinese utility-model application was filed on 2016-04-12 and published/granted on 2016-11-23. The same optical disclosure is also present in **WO2017177665A1**, *一种超广角大光圈镜头*, which is text-searchable and was used as a cross-check against the image-only CN scan.
 
 This analysis uses **Example 2 / 第二实施例**. In the attached CN document, Example 2 is the design drawn in Figure 3, with its aberration plots in Figure 4. The numerical example gives **f = 12.5 mm**, **Fno = 2.87**, and **half-field angle ω = 60.1°**. Independent reduced-angle paraxial tracing of the transcribed prescription gives **EFL = 12.49993 mm** and **back focal distance = 38.83061 mm**, matching the patent’s stated focal length and the infinity **LB = 38.8325 mm** spacing within transcription precision.

--- a/src/lens-data/laowa/Laowa15mmf2ZeroD.analysis.md
+++ b/src/lens-data/laowa/Laowa15mmf2ZeroD.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 2018/0149842 A1
+**Inventor:** Xiaohua Zhang
+**Assignee:** Anhui Changgeng Optics Technology Co., Ltd.
+**Priority:** CN 201611050404.7, November 25, 2016
+**Filed:** May 5, 2017
+**Published:** May 31, 2018
+**Title:** Mirrorless Large-Aperture Ultra Wide-Angle Lens
+**Embodiment analyzed:** Example 1
+
 The relevant patent is **US 2018/0149842 A1**, titled **"Mirrorless Large-Aperture Ultra Wide-Angle Lens"**, assigned to **Anhui Changgeng Optics Technology Co., Ltd.** with **Xiaohua Zhang** as inventor. The U.S. application was filed on 2017-05-05, published on 2018-05-31, and claims Chinese priority **CN 201611050404.7** from 2016-11-25.[^patent]
 
 This prescription uses **Example 1**, not Example 2. The identification is based on convergence between the patent prescription and production specifications:

--- a/src/lens-data/laowa/Laowa15mmf4Macro.analysis.md
+++ b/src/lens-data/laowa/Laowa15mmf4Macro.analysis.md
@@ -5,7 +5,7 @@
 **Patent:** CN 205427291 U (Chinese Utility Model), "超广角微距镜头" (Ultra Wide-Angle Macro Lens).
 **Applicant:** 安徽长庚光学科技有限公司 (Anhui ChangGeng Optical Technology Co., Ltd.) — the parent company of the Venus Optics / Laowa brand.
 **Inventor:** 张小华 (Zhang Xiaohua).
-**Filing date:** 2015-04-08. **Grant date:** 2016-08-03.
+**Filed:** 2015-04-08. **Granted:** 2016-08-03.
 
 The patent presents three numerical embodiments. **Example 2** (第二实施例, ¶0053–0065) is the embodiment analyzed here, identified as the basis for the production Laowa 15mm f/4 Wide Angle 1:1 Macro by the following convergent evidence:
 

--- a/src/lens-data/laowa/Laowa24mmf14Probe.analysis.md
+++ b/src/lens-data/laowa/Laowa24mmf14Probe.analysis.md
@@ -6,6 +6,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** CN 210573001 U
+**Inventor:** Li Dayong (李大勇)
+**Applicant:** Anhui ChangGeng Optical Technology Co., Ltd.
+**Filed:** August 29, 2019
+**Published:** May 19, 2020
+**Granted:** May 19, 2020
+**Title:** 一种细长微距镜头 / A Slender Macro Lens
+**Embodiment analyzed:** Example 1 (实施例1)
+
 Chinese Utility Model patent CN 210573001 U, titled "一种细长微距镜头" ("A Slender Macro Lens"), was filed on 2019-08-29 by 安徽长庚光学科技有限公司 (Anhui ChangGeng Optical Technology Co., Ltd. — the corporate entity behind the Laowa brand). The named inventor is 李大勇 (Li Dayong). The patent was granted and published on 2020-05-19. A companion invention patent application was filed on the same date.
 
 **Example 1** (实施例1, described beginning at ¶0043) represents the straight-through ("direct-view") optical configuration in which all prisms are unfolded and no mirrors are inserted. This is the configuration that corresponds to the production Laowa 24mm f/14 2× Macro Probe lens, based on the following convergent evidence:

--- a/src/lens-data/laowa/Laowa58mmf28MacroAPO.analysis.md
+++ b/src/lens-data/laowa/Laowa58mmf28MacroAPO.analysis.md
@@ -5,9 +5,9 @@
 **Patent:** CN 116520542 A, "一种高倍率微距镜头" (*A High-Magnification Macro Lens*)
 **Applicant:** 安徽长庚光学科技有限公司 (Anhui ChangGeng Optical Technology Co., Ltd. — Laowa)
 **Inventor:** 李大勇 (Li Dayong)
-**Filing date:** 2023-02-16
-**Publication date:** 2023-08-01
-**Embodiment used:** Example 2 (实施例2, ¶0051–0064)
+**Filed:** 2023-02-16
+**Published:** 2023-08-01
+**Embodiment analyzed:** Example 2 (实施例2, ¶0051–0064)
 
 The patent discloses two numerical examples. Example 1 is a longer-focal-length variant ($f = 87.1$ mm) that does not correspond to any known production lens. Example 2 is identified as the production Laowa 58 mm f/2.8 2× Ultra-Macro APO by the following convergent evidence:
 

--- a/src/lens-data/leica/Leica28mmf17.analysis.md
+++ b/src/lens-data/leica/Leica28mmf17.analysis.md
@@ -2,11 +2,14 @@
 
 ## Patent Identification
 
-**US 2016/0266350 A1**, "Lens System and Imaging Device"
-Filed by Panasonic Intellectual Property Management Co., Ltd., Osaka, Japan.
-Inventors: Tomoko Iiyama (Osaka), Masafumi Sueyoshi (Kanagawa).
-Japanese priority: JP 2014-195434, filed September 25, 2014.
-US continuation filed May 20, 2016; published September 15, 2016.
+**Patent:** US 2016/0266350 A1
+**Inventors:** Tomoko Iiyama (Osaka), Masafumi Sueyoshi (Kanagawa)
+**Applicant:** Panasonic Intellectual Property Management Co., Ltd., Osaka, Japan
+**Priority:** JP 2014-195434, September 25, 2014
+**Filed:** May 20, 2016
+**Published:** September 15, 2016
+**Title:** Lens System and Imaging Device
+**Embodiment analyzed:** Example 1 (Numerical Example 1)
 
 **Production lens:** Leica Summilux 28 mm f/1.7 ASPH, the fixed lens of the Leica Q (Typ 116), Q2, and Q3 compact cameras. Designed by Peter Karbe (head of optics at Leica Camera AG), manufactured by Panasonic, which produces the Q-series hardware. This patent covers the optical prescription used in the production lens, with Example 1 (Numerical Example 1) being the implemented embodiment.
 

--- a/src/lens-data/leica/LeicaAPO35mmf2.analysis.md
+++ b/src/lens-data/leica/LeicaAPO35mmf2.analysis.md
@@ -2,7 +2,8 @@
 
 **Patent:** US 2022/0066176 A1 (published March 3, 2022)  
 **Priority:** DE 10 2018 132 472.3 (December 17, 2018)  
-**PCT Filing:** PCT/EP2019/085673 (December 17, 2019)  
+**Filed:** PCT/EP2019/085673 (December 17, 2019)  
+**Published:** March 3, 2022  
 **Inventors:** Stefan Roth, Kathrin Keller (Lahnau, Germany)  
 **Applicant:** Leica Camera AG, Wetzlar  
 **Embodiment analyzed:** Example 1 (the sole worked example; FIGS. 1–3)

--- a/src/lens-data/leica/LeicaAPO43mmf2.analysis.md
+++ b/src/lens-data/leica/LeicaAPO43mmf2.analysis.md
@@ -3,7 +3,9 @@
 **Patent:** US 2024/0241349 A1, Example 1 (First Embodiment)
 **Applicant:** Panasonic Intellectual Property Management Co., Ltd.
 **Inventors:** Takehiro Nishioka, Yoshiaki Kurioka
-**Priority:** JP 2022-142614 (Sep. 8, 2022) · Published Jul. 18, 2024
+**Priority:** JP 2022-142614 (Sep. 8, 2022)
+**Published:** Jul. 18, 2024
+**Embodiment analyzed:** Example 1 (First Embodiment)
 **Production lens:** Leica APO-Summicron 43mm f/2 ASPH. (fixed to the Leica Q3 43)
 
 ---

--- a/src/lens-data/leica/LeicaAPOMacroElmaritTL60mmf28.analysis.md
+++ b/src/lens-data/leica/LeicaAPOMacroElmaritTL60mmf28.analysis.md
@@ -7,7 +7,7 @@
 **Inventor:** Hiroaki Tanaka (田中 宏明).
 **Filed:** 31 October 2014 (特願 2014-223123).
 **Published:** 23 May 2016.
-**Embodiment used:** Example 9 (第9実施例), §0054, §0110–§0116.
+**Embodiment analyzed:** Example 9 (第9実施例), §0054, §0110–§0116.
 
 The following convergent evidence links Example 9 to the production Leica APO-Macro-Elmarit-TL 60 mm f/2.8 ASPH (order numbers 11086/11087):
 

--- a/src/lens-data/leica/LeicaAPOVarioElmaritSL90280mmf284.analysis.md
+++ b/src/lens-data/leica/LeicaAPOVarioElmaritSL90280mmf284.analysis.md
@@ -7,7 +7,7 @@
 **Inventor:** Imaoka Takuya (今岡 卓也).
 **Filed:** 2015-12-22 (priority: 2015-01-21, JP 2015-9845).
 **Published:** 2016-08-04.
-**Embodiment used:** Numerical Example 1 (数値実施例1), corresponding to Embodiment 1 (実施の形態1).
+**Embodiment analyzed:** Numerical Example 1 (数値実施例1), corresponding to Embodiment 1 (実施の形態1).
 
 The prescription is identified with the production Leica APO-Vario-Elmarit-SL 90–280 mm f/2.8–4 (order number 11 175) by the following convergent evidence:
 

--- a/src/lens-data/minolta/MinoltaAF100mmf28Macro.analysis.md
+++ b/src/lens-data/minolta/MinoltaAF100mmf28Macro.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 4,764,000
+**Inventor:** Hisashi Tokumaru
+**Assignee:** Minolta Camera Kabushiki Kaisha
+**Priority:** JP May 20, 1985 and JP September 27, 1985
+**Filed:** May 19, 1986
+**Granted:** August 16, 1988
+**Title:** Telephoto Lens System with Three Relatively Shiftable Lens Groups
+**Embodiment analyzed:** Embodiment 8 / Example 8
+
 United States Patent **US 4,764,000**, **“Telephoto Lens System with Three Relatively Shiftable Lens Groups,”** was filed by Hisashi Tokumaru for Minolta Camera Kabushiki Kaisha on 19 May 1986. It claims Japanese priorities of 20 May 1985 and 27 September 1985 and was granted on 16 August 1988.[^patent]
 
 This file transcribes and interprets **Embodiment 8 / Example 8**, which is also repeated numerically in claim 9. The patent table gives a normalized **f = 100 mm**, **F.No. = 2.83** 35 mm SLR macro design with three tabulated focus states: infinity, β = −0.5, and β = −1.0.[^patent]

--- a/src/lens-data/minolta/MinoltaAF35105mmf3545v2.analysis.md
+++ b/src/lens-data/minolta/MinoltaAF35105mmf3545v2.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 4,871,239
+**Inventors:** Hisayuki Masumoto, Akira Fukushima
+**Assignee:** Minolta Camera Kabushiki Kaisha
+**Priority:** JP September 9, 1986 and JP October 29, 1986
+**Filed:** September 9, 1987
+**Granted:** October 3, 1989
+**Title:** Zoom Lens System for Minimal Lens System Length and Minimal Aberrations
+**Embodiment analyzed:** Example 3 / Embodiment 3
+
 The relevant first-party technical source is US Patent 4,871,239, **"Zoom Lens System for Minimal Lens System Length and Minimal Aberrations"**, assigned to Minolta Camera Kabushiki Kaisha. The named inventors are Hisayuki Masumoto and Akira Fukushima. The US application was filed on 9 September 1987, with Japanese priorities of 9 September 1986 and 29 October 1986, and the patent issued on 3 October 1989.
 
 This document analyzes **Example 3 / Embodiment 3**, which appears as Table 3 in the specification and again as claim 29. Claim 29 gives the design as **f = 36.0-60.0-102.0 mm**, **FNo = 3.6-4.2-4.65**, and **2ω = 61.93°-39.60°-23.91°**. Those values are the patent-scale counterpart of the marketed **Minolta AF 35-105mm f/3.5-4.5 New / RS / v2** normal zoom. The later Certificate of Correction removes several other embodiments and makes text/table corrections elsewhere, but it does not supply a corrected printed value for the Example 3 wide-angle d13 entry; the d13 correction used here is therefore a numerical reconstruction rather than an issued textual correction.

--- a/src/lens-data/minolta/MinoltaAF70200mmf28APO.analysis.md
+++ b/src/lens-data/minolta/MinoltaAF70200mmf28APO.analysis.md
@@ -2,6 +2,14 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** JP 2004-109559 A
+**Inventors:** Hiroyuki Matsumoto (松本博之), Mamoru Terada (寺田守)
+**Applicant:** Minolta Co., Ltd.
+**Filed:** September 19, 2002
+**Published:** April 8, 2004
+**Title:** Zoom Lens System (ズームレンズ系)
+**Embodiment analyzed:** Example 1 (実施例1), Fig. 1
+
 JP 2004-109559 A, *Zoom Lens System* (`ズームレンズ系`), was filed by Minolta Co., Ltd. on 2002-09-19 and published on 2004-04-08. The publication front page names Hiroyuki Matsumoto (`松本博之`) and Mamoru Terada (`寺田守`) as inventors. The reviewed prescription is Example 1 (`実施例1`), corresponding to Fig. 1.
 
 Example 1 gives a constant-aperture zoom with patent focal lengths $f = 71.8, 105.0, 195.0$ mm and $F_{no} = 2.88$ at the wide, middle, and telephoto positions. A fresh paraxial trace of the numerical prescription gives $71.756668$, $105.008403$, and $195.006309$ mm, so the Example 1 transcription is internally consistent with the patent's rounded focal lengths.

--- a/src/lens-data/minolta/MinoltaRokkor45mmf2MD.analysis.md
+++ b/src/lens-data/minolta/MinoltaRokkor45mmf2MD.analysis.md
@@ -2,9 +2,14 @@
 
 ## Patent Reference and Design Identification
 
-**US 4,277,149** — "Modified Gauss Type Lens System"
-Inventor: Kunihiko Konoma. Assignee: Minolta Camera Kabushiki Kaisha, Osaka, Japan.
-Filed: September 5, 1978. Granted: July 7, 1981. Priority: JP 52/108249, September 7, 1977.
+**Patent:** US 4,277,149
+**Inventor:** Kunihiko Konoma
+**Assignee:** Minolta Camera Kabushiki Kaisha, Osaka, Japan
+**Priority:** JP 52/108249, September 7, 1977
+**Filed:** September 5, 1978
+**Granted:** July 7, 1981
+**Title:** Modified Gauss Type Lens System
+**Embodiment analyzed:** Embodiment 7 (Table 7)
 
 The prescription used is **Embodiment 7** (Table 7), the final and most refined example in the patent. The identification with the production Minolta MD Rokkor 45mm f/2 rests on the following convergent evidence:
 

--- a/src/lens-data/minolta/MinoltaRokkor50mmf14MD.analysis.md
+++ b/src/lens-data/minolta/MinoltaRokkor50mmf14MD.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 4,182,550
+**Inventor:** Tamikazu Yamaguchi
+**Assignee:** Minolta Camera Kabushiki Kaisha, Osaka, Japan
+**Priority:** JP 52-32728, March 23, 1977
+**Filed:** March 15, 1978
+**Granted:** January 8, 1980
+**Title:** Modified Gauss Type Lens System
+**Embodiment analyzed:** Embodiment 2 (Table 2)
+
 **US Patent 4,182,550**, "Modified Gauss Type Lens System." Inventor: Tamikazu Yamaguchi. Assignee: Minolta Camera Kabushiki Kaisha, Osaka, Japan. Filed March 15, 1978; granted January 8, 1980. Japanese priority date: March 23, 1977 (JP 52-32728). A Certificate of Correction was issued July 15, 1980, correcting condition (5) from $N_3 < 1.67, N_4 < 1.67$ to $N_3 > 1.67, N_4 > 1.67$.
 
 The prescription used here is **Embodiment 2** (Table 2), the f/1.4 variant. The patent discloses three embodiments: Embodiment 1 at f/1.2 with 2ω = 46°, Embodiment 2 at f/1.4 with 2ω = 46°, and Embodiment 3 at f/1.8 with 2ω = 52°. Embodiment 2 is identified as the design corresponding to the production Minolta MD 50mm f/1.4 lens based on the following convergent evidence:

--- a/src/lens-data/minolta/MinoltaVarisoft85mmf28.analysis.md
+++ b/src/lens-data/minolta/MinoltaVarisoft85mmf28.analysis.md
@@ -6,7 +6,7 @@
 **Assignee:** Minolta Camera Kabushiki Kaisha, Japan.
 **Inventors:** Yukio Okano, Akiyoshi Nakamura, Toshinobu Ogura.
 **Filed:** December 15, 1976. **Priority:** JP 50/154540 (December 22, 1975), JP 51/109281 (September 10, 1976).
-**Embodiment used:** Embodiment 3 (Table 6, FIG. 8).
+**Embodiment analyzed:** Embodiment 3 (Table 6, FIG. 8).
 
 A second related patent, US 4,214,814A (Ogino, Ogura, Okano, Nakamura, 1977), covers an alternative variable soft focus mechanism using the same optical concept. Minolta marketing literature and a published lens diagram confirm that the production Varisoft Rokkor is based on the first patent, with the rearmost element moved to control spherical aberration.
 

--- a/src/lens-data/nikon/Nikon28Ti28mmf28.analysis.md
+++ b/src/lens-data/nikon/Nikon28Ti28mmf28.analysis.md
@@ -6,6 +6,8 @@
 **Inventors:** Motoyuki Ohtake, Motohisa Mori
 **Assignee:** Nikon Corporation
 **Priority dates:** November 13, 1991 (JP 3-297444); May 13, 1993 (JP 5-111289)
+**Granted:** June 18, 1996
+**Embodiment analyzed:** Embodiment 3
 
 ---
 

--- a/src/lens-data/nikon/Nikon35Ti35mmf28.analysis.md
+++ b/src/lens-data/nikon/Nikon35Ti35mmf28.analysis.md
@@ -1,6 +1,11 @@
 # Nikon Nikkor 35 mm f/2.8 — Nikon 35Ti  
-### US Patent 5,243,468 · Fifth Embodiment (Table 5 / Claim 9)  
-*Motoyuki Ohtake, Nikon Corporation — Filed 1 December 1992 · Granted 7 September 1993*
+
+**Patent:** US 5,243,468
+**Inventor:** Motoyuki Ohtake
+**Assignee:** Nikon Corporation
+**Filed:** December 1, 1992
+**Granted:** September 7, 1993
+**Embodiment analyzed:** Fifth Embodiment (Table 5 / Claim 9)
 
 ---
 

--- a/src/lens-data/nikon/Nikon58f14GDesignCandidate.analysis.md
+++ b/src/lens-data/nikon/Nikon58f14GDesignCandidate.analysis.md
@@ -1,7 +1,11 @@
 # Nikon AF-S NIKKOR 58mm f/1.4G — Patent Analysis
 
-**Patent:** JP 2013-019993 A (published 2013.01.31, filed 2011.07.08)
+**Patent:** JP 2013-019993 A
 **Inventor:** Haruo Sato (佐藤治夫), Nikon Corporation
+**Assignee:** Nikon Corporation
+**Filed:** July 8, 2011
+**Published:** January 31, 2013
+**Embodiment analyzed:** Example 2 (OS2)
 **Production Lens:** AF-S NIKKOR 58mm f/1.4G, announced October 2013
 
 ---

--- a/src/lens-data/nikon/Nikon85f14D.analysis.md
+++ b/src/lens-data/nikon/Nikon85f14D.analysis.md
@@ -2,10 +2,13 @@
 
 ## US Patent 5,640,277 · Example 2 (Production Design)
 
-**Patent:** US 5,640,277 · Filed Dec 27, 1994 · Granted Jun 17, 1997
+**Patent:** US 5,640,277
+**Filed:** December 27, 1994
+**Granted:** June 17, 1997
 **Inventor:** Koichi Ohshita (大下浩一)
 **Assignee:** Nikon Corporation, Tokyo, Japan
 **Japanese Priority:** JP 5-353455, filed Dec 28, 1993
+**Embodiment analyzed:** Example 2
 **Production Lens:** Nikon AF Nikkor 85mm f/1.4D IF (released December 1995, in production 1995–2010)
 
 ---

--- a/src/lens-data/nikon/NikonAF28f14D.analysis.md
+++ b/src/lens-data/nikon/NikonAF28f14D.analysis.md
@@ -2,9 +2,11 @@
 
 **Patent:** US 5,315,441 · *Inverse Telephoto Large Aperture Wide Angle Lens*
 **Inventors:** Kenji Hori, Wataru Tatsuno (Nikon Corporation)
+**Assignee:** Nikon Corporation
 **Priority:** January 16, 1992 (JP 4-005862)
-**Filed (US):** September 13, 1993 · **Granted:** May 24, 1994
-**Production embodiment:** Embodiment 1 (Table 1)
+**Filed:** September 13, 1993
+**Granted:** May 24, 1994
+**Embodiment analyzed:** Embodiment 1 (Table 1)
 
 ---
 

--- a/src/lens-data/nikon/NikonAFP70300mmf4556E.analysis.md
+++ b/src/lens-data/nikon/NikonAFP70300mmf4556E.analysis.md
@@ -2,6 +2,14 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 2019/0353880 A1
+**Inventor:** Kosuke Machida
+**Applicant:** Nikon Corporation
+**Filed:** November 21, 2016 (PCT filing)
+**Published:** November 21, 2019
+**Title:** Zoom optical system, optical apparatus, imaging apparatus and method for manufacturing the zoom optical system
+**Embodiment analyzed:** First Example / Example 1, Fig. 1 and Table 1
+
 The working patent is **US 2019/0353880 A1**, "Zoom optical system, optical apparatus, imaging apparatus and method for manufacturing the zoom optical system." The applicant is Nikon Corporation and the named inventor is Kosuke Machida. The PCT filing date is 21 November 2016, and the United States publication date is 21 November 2019. The numerical embodiment transcribed here is **First Example / Example 1**, shown in Fig. 1 and Table 1 of the patent.
 
 The production lens identified with this embodiment is the **AF-P NIKKOR 70-300mm f/4.5-5.6E ED VR**, announced by Nikon on 11 July 2017. The identification rests on convergent evidence rather than a single matching parameter:

--- a/src/lens-data/nikon/NikonAFPDX1020mmf4556G.analysis.md
+++ b/src/lens-data/nikon/NikonAFPDX1020mmf4556G.analysis.md
@@ -2,6 +2,11 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** WO2021039813A1; US20220269056A1
+**Applicant:** Nikon Corporation
+**Published:** March 4, 2021 (WO); August 25, 2022 (US)
+**Embodiment analyzed:** Example 2 / LS(2), Table 2
+
 The prescription transcribed here is **Example 2** of Nikon's WO2021039813A1 family, with the same numerical data available in the English Google Patents text of **US20220269056A1**. The applicant is Nikon Corporation. The relevant embodiment is the zoom optical system **LS(2)**, and its numerical prescription is **Table 2**. The uploaded WO pamphlet scan contains the publication front matter and early description pages; the full Table 2 numerical data used for this review was therefore cross-checked against the text-searchable equivalent publication.
 
 The production lens identified with this embodiment is the **Nikon AF-P DX NIKKOR 10-20mm f/4.5-5.6G VR**. Nikon's official specifications give a 10-20 mm DX-format zoom, maximum aperture f/4.5-5.6, 14 elements in 11 groups, three aspherical lens elements, vibration reduction, internal focusing, closest focus distance 0.22 m from the focal plane, and maximum reproduction ratio 0.17x. The patent example gives a 10.310-19.394 mm design focal-length range, 14 production lens elements in 11 air-separated groups, three aspherical surfaces on three elements, an internal focusing G3 group, and an L23 vibration-reduction sub-group.

--- a/src/lens-data/nikon/NikonAFPDX70300mmf4563G.analysis.md
+++ b/src/lens-data/nikon/NikonAFPDX70300mmf4563G.analysis.md
@@ -2,6 +2,13 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 2021/0026133 A1
+**Applicant:** Nikon Corporation
+**Filed:** December 15, 2017 (PCT/JP2017/045187)
+**Published:** January 28, 2021
+**Title:** Optical System, Optical Apparatus, and Method of Manufacturing Optical System
+**Embodiment analyzed:** Example 4, Table 4 / FIG. 7
+
 The relevant patent filing is **US 2021/0026133 A1, “Optical System, Optical Apparatus, and Method of Manufacturing Optical System,”** assigned to Nikon Corporation and published on 2021-01-28 from PCT/JP2017/045187, filed 2017-12-15. The numerical embodiment transcribed here is **Example 4**, corresponding to Table 4 and the sectional diagram of FIG. 7.
 
 The production lens matched to this embodiment is the **AF-P DX NIKKOR 70-300mm f/4.5-6.3G ED VR**. Nikon’s product documentation describes a Nikon F-mount DX telephoto zoom covering 70-300 mm, with VR, AF-P pulse-motor autofocus, 14 elements in 10 groups, one ED element, and a 1.1 m minimum focusing distance. The patent example is not an exact production specification table, but the match is strong:

--- a/src/lens-data/nikon/NikonAI135mmf2.analysis.md
+++ b/src/lens-data/nikon/NikonAI135mmf2.analysis.md
@@ -1,7 +1,11 @@
 # Nikon AI Nikkor 135mm f/2 — Optical Analysis
 
-**Patent:** US 4,062,630 · Sei Matsui · Nippon Kogaku K.K. · Filed March 11, 1976 · Granted December 13, 1977  
-**Embodiment:** Example V (conventionally identified as the production design; see §11)  
+**Patent:** US 4,062,630  
+**Inventor:** Sei Matsui  
+**Assignee:** Nippon Kogaku K.K.  
+**Filed:** March 11, 1976  
+**Granted:** December 13, 1977  
+**Embodiment analyzed:** Example V (conventionally identified as the production design; see §11)  
 **Production lens:** NEW Nikkor 135mm f/2 (1976–1977) → Ai Nikkor 135mm f/2 (1977–1981) → Ai-S Nikkor 135mm f/2 (1981–2005)
 
 ---

--- a/src/lens-data/nikon/NikonAI135mmf28.analysis.md
+++ b/src/lens-data/nikon/NikonAI135mmf28.analysis.md
@@ -2,6 +2,14 @@
 
 ## Patent and Production Identification
 
+**Patent:** US 4,057,330
+**Inventor:** Sei Matui (松井 清, commonly romanized as Matsui)
+**Assignee:** Nippon Kogaku K.K.
+**Filed:** October 3, 1974
+**Granted:** November 8, 1977
+**Title:** Lens System Having Large Relative Aperture and Long Focus
+**Embodiment analyzed:** Example 2
+
 US Patent 4,057,330, "Lens System Having Large Relative Aperture and Long Focus," was filed on October 3, 1974, by inventor Sei Matui (松井 清, commonly romanized as Matsui) and assigned to Nippon Kogaku K.K. (the corporate name Nikon used until 1988). The patent was granted November 8, 1977. It presents three numerical examples, all specified at a normalized composite focal length of f = 100 mm, a relative aperture of 1:2.8, and a half-angle of view of 9.05° (full angle 18.1°).
 
 The patent's 5-element, 4-group Ernostar-variant layout matches the production AI Nikkor 135mm f/2.8 specification exactly. The "New K" version of this lens was introduced in 1976 with the revised 5/4 formula and carried forward through the AI (1977) and AI-S (1981–2005) versions without optical change. The earlier Nikkor-Q 135mm f/2.8 (1965–1976) used a simpler 4-element, 4-group construction; the patent design replaced it with the addition of a fifth element (L2) to improve correction of spherical aberration and coma at the f/2.8 aperture.

--- a/src/lens-data/nikon/NikonL35AF35mmf28.analysis.md
+++ b/src/lens-data/nikon/NikonL35AF35mmf28.analysis.md
@@ -2,6 +2,13 @@
 
 ## US 4,457,596 · Embodiment 1 · Koichi Wakamiya / Nippon Kogaku K.K.
 
+**Patent:** US 4,457,596
+**Inventor:** Koichi Wakamiya
+**Assignee:** Nippon Kogaku K.K.
+**Filed:** September 27, 1982
+**Granted:** July 3, 1984
+**Embodiment analyzed:** Embodiment 1
+
 ---
 
 ## 1. Historical Context

--- a/src/lens-data/nikon/NikonNikkor105f14E.analysis.md
+++ b/src/lens-data/nikon/NikonNikkor105f14E.analysis.md
@@ -3,7 +3,7 @@
 **Patent:** WO2019/116563 A1 — Example 3 (第3実施例)  
 **Japanese national phase:** JPWO2019116563A1  
 **Title:** 光学系、光学機器、および光学系の製造方法 (Optical System, Optical Apparatus, and Manufacturing Method of Optical System)  
-**Filing date:** 15 December 2017 (PCT/JP2017/045183)  
+**Filed:** 15 December 2017 (PCT/JP2017/045183)  
 **Published:** 20 June 2019  
 **Applicant:** Nikon Corporation (株式会社ニコン)  
 **Inventors:** Masashi Yamashita (山下 雅史), Tomoki Ito (伊藤 智希), Hiroshi Yabumoto, Hiroshi Yamamoto, Tetsushi Miwa, Keisuke Tsubonoya, Ayumu Makita, Takeshi Uehara

--- a/src/lens-data/nikon/NikonNikkorAFS120300mmf28.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorAFS120300mmf28.analysis.md
@@ -1,8 +1,11 @@
 # Nikon AF-S NIKKOR 120-300mm f/2.8E FL ED SR VR — Optical Analysis
 
-**Patent:** JP 2020-177057 A (filed 2019-04-16, published 2020-10-29)  
+**Patent:** JP 2020-177057 A  
 **Inventors:** Masashi Yamashita, Toshinori Take (Nikon Corporation)  
-**Embodiment analysed:** Example 1 (Table 1)  
+**Applicant:** Nikon Corporation  
+**Filed:** April 16, 2019  
+**Published:** October 29, 2020  
+**Embodiment analyzed:** Example 1 (Table 1)  
 **Production lens:** AF-S NIKKOR 120-300mm f/2.8E FL ED SR VR (released January 2020)
 
 ---

--- a/src/lens-data/nikon/NikonNikkorAFS1424mmf28.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorAFS1424mmf28.analysis.md
@@ -2,9 +2,13 @@
 
 ## US 7,359,125 B2 — Example 1 (Kimura & Sato, Nikon Corporation)
 
-**Patent filed:** September 7, 2006 · **Granted:** April 15, 2008
+**Patent:** US 7,359,125 B2
+**Filed:** September 7, 2006
+**Granted:** April 15, 2008
 **Priority:** JP 2005-285398 (September 29, 2005)
 **Inventors:** Yoko Kimura, Haruo Sato
+**Assignee:** Nikon Corporation
+**Embodiment analyzed:** Example 1
 **Production lens:** AF-S Nikkor 14-24mm f/2.8G ED (released August 2007)
 
 ---

--- a/src/lens-data/nikon/NikonNikkorAFS200500mmf56.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorAFS200500mmf56.analysis.md
@@ -3,7 +3,8 @@
 **Patent:** JP 2014-209144 A (Published 2014-11-06)  
 **Applicants:** Nikon Corporation / Tamron Co., Ltd.  
 **Inventors:** Matsuo Taku, Suzuki Tsuyoshi, Sato Haruo (Nikon); Yamanaka Hisayuki (Tamron)  
-**Production embodiment:** Example 2 (第2実施形態)  
+**Published:** November 6, 2014  
+**Embodiment analyzed:** Example 2 (第2実施形態)  
 **Lens released:** August 2015
 
 ---

--- a/src/lens-data/nikon/NikonNikkorAFS2470mmf28E.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorAFS2470mmf28E.analysis.md
@@ -2,6 +2,14 @@
 
 ## US 2020/0142168 A1 · Example 1 · Inventor: Hiroki Harada · Nikon Corporation
 
+**Patent:** US 2020/0142168 A1
+**Inventor:** Hiroki Harada
+**Applicant:** Nikon Corporation
+**Priority:** JP 2015-017916, January 30, 2015
+**Filed:** January 29, 2016 (PCT/JP2016/052683)
+**Published:** May 7, 2020
+**Embodiment analyzed:** Example 1
+
 ---
 
 ## 1. Identification and Provenance

--- a/src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.analysis.md
@@ -2,6 +2,14 @@
 
 ## US 2020/0049962 A1 · Example 1 (ZL1) · Inventor: Tomoki Ito · Nikon Corporation
 
+**Patent:** US 2020/0049962 A1
+**Inventor:** Tomoki Ito
+**Applicant:** Nikon Corporation
+**Priority:** JP 2013-012752 through JP 2013-012758, January 28, 2013
+**Filed:** January 27, 2014 (PCT/JP2014/000396)
+**Published:** February 13, 2020
+**Embodiment analyzed:** Example 1 (ZL1)
+
 ---
 
 ## 1. Identification and Provenance

--- a/src/lens-data/nikon/NikonNikkorN28mmf2.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorN28mmf2.analysis.md
@@ -1,8 +1,12 @@
 # Nikon Nikkor-N Auto 28mm f/2 — Patent Analysis
 
-**Patent:** US 3,736,049 · Filed September 29, 1971 · Granted May 29, 1973
-**Inventor:** Yoshiyuki Shimizu · **Assignee:** Nippon Kogaku K.K. (Nikon)
+**Patent:** US 3,736,049
+**Filed:** September 29, 1971
+**Granted:** May 29, 1973
+**Inventor:** Yoshiyuki Shimizu
+**Assignee:** Nippon Kogaku K.K. (Nikon)
 **Japanese Priority:** JP 45/85417, September 30, 1970
+**Embodiment analyzed:** Single worked numerical example
 **Production lens:** Nikkor-N Auto 28mm f/2 (1970–1977), AI Nikkor 28mm f/2 (1977–1981), AI-S Nikkor 28mm f/2S (1981–2005)
 
 ---

--- a/src/lens-data/nikon/NikonNikkorPCE19mmf4E.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorPCE19mmf4E.analysis.md
@@ -3,7 +3,8 @@
 **Patent:** JP 2017-161685 A (published 2017.09.14)
 **Applicants:** Konica Minolta, Inc. & Nikon Corporation
 **Inventors:** Ryosuke Imashima, Taisei Fukuda (Konica Minolta); Toshinori Take, Takayuki Sensui (Nikon)
-**Examined Example:** Example 1 (EX1)
+**Published:** September 14, 2017
+**Embodiment analyzed:** Example 1 (EX1)
 **Lens type:** Retrofocus ultra-wide-angle perspective control (tilt-shift) prime
 
 ---

--- a/src/lens-data/nikon/NikonNikkorZ100400f4556.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ100400f4556.analysis.md
@@ -4,16 +4,15 @@
 
 ## Patent Overview
 
-| Field | Value |
-|---|---|
-| **Patent number** | JP2022-92388A (Kokai / Unexamined) |
-| **Filed** | 10 December 2020 |
-| **Published** | 22 June 2022 |
-| **Applicant** | Nikon Corporation (株式会社ニコン) |
-| **Inventor** | Hiroshi Yabumoto (籔本 洋) |
-| **Title** | Optical System, Optical Apparatus, and Method for Manufacturing Optical System |
-| **IPC** | G02B 15/22, G02B 13/02, G02B 15/20 |
-| **Prior art** | WO2013/027364 |
+**Patent:** JP2022-92388A (Kokai / Unexamined)
+**Filed:** December 10, 2020
+**Published:** June 22, 2022
+**Applicant:** Nikon Corporation (株式会社ニコン)
+**Inventor:** Hiroshi Yabumoto (籔本 洋)
+**Title:** Optical System, Optical Apparatus, and Method for Manufacturing Optical System
+**IPC:** G02B 15/22, G02B 13/02, G02B 15/20
+**Prior art:** WO2013/027364
+**Embodiment analyzed:** Example 1
 
 This patent discloses a zoom optical system with multiple focusing groups that move along different trajectories during focus, optimized for telephoto zoom lenses covering the super-telephoto range. Four numerical examples are provided. **Example 1** is the principal subject of this analysis and is a strong candidate for the production NIKKOR Z 100-400mm f/4.5-5.6 VR S, as demonstrated by the convergent evidence below.
 

--- a/src/lens-data/nikon/NikonNikkorZ1430mmf4S.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ1430mmf4S.analysis.md
@@ -1,8 +1,11 @@
 # Nikon NIKKOR Z 14-30mm f/4 S — Optical Design Analysis
 
-**Patent:** JP 2019-008031 A (filed 2017-06-21, published 2019-01-17)
+**Patent:** JP 2019-008031 A
 **Inventor:** Uehara Ken (上原 健), Nikon Corporation
-**Design Example:** Example 1 (第1実施例), Table 1
+**Assignee:** Nikon Corporation
+**Filed:** June 21, 2017
+**Published:** January 17, 2019
+**Embodiment analyzed:** Example 1 (第1実施例), Table 1
 **Production Lens:** NIKKOR Z 14-30mm f/4 S (announced January 8, 2019)
 
 ---

--- a/src/lens-data/nikon/NikonNikkorZ24200mmf463VR.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ24200mmf463VR.analysis.md
@@ -2,8 +2,10 @@
 
 **Patent:** JPWO2020/157904 A1, Example 1 (Table 1)
 **Inventors:** Makita Ayumu (槇田 歩), Itō Tomoki (伊藤 智希), Miwa Tetsushi (三輪 哲史) — Nikon Corporation
-**International Filing Date:** January 31, 2019
-**International Publication Date:** August 6, 2020
+**Applicant:** Nikon Corporation
+**Filed:** January 31, 2019
+**Published:** August 6, 2020
+**Embodiment analyzed:** Example 1 (Table 1)
 
 ---
 

--- a/src/lens-data/nikon/NikonNikkorZ2450mmf463.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ2450mmf463.analysis.md
@@ -3,7 +3,8 @@
 **Patent:** JP 2021-189377 A (published 2021-12-13)
 **Applicants:** Konica Minolta / Nikon Corporation
 **Inventors:** Hirose Takumo, Yamada Keiko, Yamamoto Yasushi, Yamamoto Hiroshi
-**Example:** No. 1 (corresponding to the First Embodiment, Figure 1)
+**Published:** December 13, 2021
+**Embodiment analyzed:** Example No. 1 (corresponding to the First Embodiment, Figure 1)
 
 ---
 

--- a/src/lens-data/nikon/NikonNikkorZ35mmf12S.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ35mmf12S.analysis.md
@@ -1,8 +1,11 @@
 # Nikon NIKKOR Z 35mm f/1.2 S — Optical Analysis
 
-**Patent:** JP 2025-52870A (filed 2023-09-26, published 2025-04-07)
-**Numerical Example:** 1 (Table 1)
+**Patent:** JP 2025-52870A
+**Filed:** September 26, 2023
+**Published:** April 7, 2025
 **Inventors:** Sōki Harada, Toshiyuki Shimada (Nikon Corporation)
+**Applicant:** Nikon Corporation
+**Embodiment analyzed:** Numerical Example 1 (Table 1)
 
 ---
 

--- a/src/lens-data/nikon/NikonNikkorZ40mmf2.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ40mmf2.analysis.md
@@ -1,7 +1,11 @@
 # Nikon NIKKOR Z 40mm f/2 — Optical Analysis
 
-**Patent:** JP 2021-189351A, Example 4 (Furuida Keigo, assignee: Nikon Corporation)  
-**Filed:** June 2, 2020 &nbsp;|&nbsp; **Published:** December 13, 2021  
+**Patent:** JP 2021-189351A
+**Inventor:** Furuida Keigo
+**Assignee:** Nikon Corporation
+**Filed:** June 2, 2020
+**Published:** December 13, 2021
+**Embodiment analyzed:** Example 4
 **Production lens:** NIKKOR Z 40mm f/2 (released September 2021); also sold as the NIKKOR Z 40mm f/2 (SE)
 
 ---

--- a/src/lens-data/nikon/NikonNikkorZ50f18S.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ50f18S.analysis.md
@@ -2,6 +2,13 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** JP WO2019/220618 A1
+**Inventors:** Saburo Masugi, Tomoyuki Koshima
+**Applicant:** Nikon Corporation
+**Filed:** May 18, 2018 (PCT/JP2018/019269)
+**Title:** Optical System, Optical Apparatus, and Method of Manufacturing Optical System
+**Embodiment analyzed:** Example 9 (第9実施例)
+
 This analysis is based on **Example 9 (第9実施例)** of Japanese patent publication **JP WO2019/220618 A1**, filed by Nikon Corporation on May 18, 2018 (PCT/JP2018/019269), with inventors Saburo Masugi and Tomoyuki Koshima. The patent covers an optical system, optical apparatus, and method of manufacturing the optical system, classified under IPC G02B 13/00 and G02B 13/18.
 
 Example 9 corresponds to the production NIKKOR Z 50mm f/1.8 S based on the following confirmation criteria:

--- a/src/lens-data/nikon/NikonNikkorZ70200f28.analysis.md
+++ b/src/lens-data/nikon/NikonNikkorZ70200f28.analysis.md
@@ -1,10 +1,11 @@
 # Optical Analysis: NIKKOR Z 70-200mm f/2.8 VR S
 
-**Patent WO2020/105104 A1 — Example 1 (Nikon Corporation)**
-
+**Patent:** WO2020/105104 A1
 **Inventor:** Ken Uehara  
+**Applicant:** Nikon Corporation  
 **Filed:** November 20, 2018 (PCT/JP2018/042763)  
 **Published:** May 28, 2020  
+**Embodiment analyzed:** Example 1
 
 ---
 

--- a/src/lens-data/nikon/NikonPCENikkor24mmf35DED.analysis.md
+++ b/src/lens-data/nikon/NikonPCENikkor24mmf35DED.analysis.md
@@ -1,7 +1,11 @@
 # Nikon PC-E Nikkor 24mm f/3.5D ED — Optical Design Analysis
 
 **Patent:** JP 2008-151949A, Example 2 (Nikon Corporation / Takayuki Sensui)
-**Filed:** December 15, 2006 · **Published:** July 3, 2008
+**Inventor:** Takayuki Sensui
+**Applicant:** Nikon Corporation
+**Filed:** December 15, 2006
+**Published:** July 3, 2008
+**Embodiment analyzed:** Example 2
 **Production lens:** PC-E NIKKOR 24mm f/3.5D ED (Nikon product code 2168)
 
 ---

--- a/src/lens-data/nikon/NikonZ1424f28S.analysis.md
+++ b/src/lens-data/nikon/NikonZ1424f28S.analysis.md
@@ -4,7 +4,9 @@
 
 **Patent:** WO 2021/117563 A1 (PCT/JP2020/044761), published 17 June 2021
 **Inventors:** Ohtake Fumiaki, Nonaka Azuna, Yuasa Yoshiharu, Umeda Takeshi (Nikon Corporation)
+**Applicant:** Nikon Corporation
 **Priority:** JP 2019-223165 / JP 2019-223166, filed 10 December 2019
+**Published:** June 17, 2021
 **Embodiment analyzed:** Example 4 (Table 4, Figures 10–12)
 **Production lens:** NIKKOR Z 14-24mm f/2.8 S (released November 2020)
 

--- a/src/lens-data/nikon/NikonZ2470f28.analysis.md
+++ b/src/lens-data/nikon/NikonZ2470f28.analysis.md
@@ -2,11 +2,14 @@
 
 ## Patent WO2020/136749 A1, Example 1
 
+**Patent:** WO2020/136749 A1
 **Applicant:** Nikon Corporation (Tokyo, Japan)
 **Inventors:** Machida Kōsuke (町田 幸介), Gomibuchi Osamu (五味渕 治)
-**International Filing Date:** December 26, 2018
+**Filed:** December 26, 2018
 **PCT Number:** PCT/JP2018/047781
-**Japanese Publication:** JP WO2020/136749 A1, published July 2, 2020
+**Published:** July 2, 2020
+**Japanese Publication:** JP WO2020/136749 A1
+**Embodiment analyzed:** Example 1
 
 ---
 

--- a/src/lens-data/nikon/NikonZ28f28.analysis.md
+++ b/src/lens-data/nikon/NikonZ28f28.analysis.md
@@ -2,8 +2,10 @@
 
 **Patent:** WO 2022/071249 A1 — Example 2 (Table 2)
 **Priority:** JP 2020-164402 (30 September 2020)
+**Published:** April 7, 2022
 **Inventor:** SHIMADA, Toshiyuki (嶋田 俊之)
 **Applicant:** Nikon Corporation
+**Embodiment analyzed:** Example 2 (Table 2)
 **Production Design Identification:** Confirmed — see §1 below
 
 ---

--- a/src/lens-data/nikon/NikonZ35f18S.analysis.md
+++ b/src/lens-data/nikon/NikonZ35f18S.analysis.md
@@ -1,9 +1,10 @@
 # Nikon NIKKOR Z 35mm f/1.8 S — Optical Design Analysis
 
-**Patent:** JP 2019-090947A (Published 2019-06-13)  
+**Patent:** JP 2019-090947A  
 **Applicants:** Konica Minolta Inc. / Nikon Corporation  
 **Inventors:** Yamada Keiko, Imashima Ryosuke, Tatsuno Wataru, Sato Haruo  
-**Embodiment:** Example 4 (EX4)  
+**Published:** June 13, 2019  
+**Embodiment analyzed:** Example 4 (EX4)  
 **Production match confidence:** High — convergent evidence across element count (11), group count (9), aspherical element count (3), ED element count (2), field angle (64.9° patent vs 63° Nikon spec), f-number (f/1.85 patent vs f/1.8 marketed), MFD (≈0.257 m scaled vs 0.25 m Nikon spec), and floating focus mechanism with three variable gaps. Note: EX1 shares the same EFL, f-number, and field angle as EX4, but has only 1 aspherical element (L23, 2 aspherical surfaces) versus EX4's 3 aspherical elements (L17, L23, L31, 6 aspherical surfaces). Nikon specifies 3 aspherical elements, uniquely matching EX4.
 
 ---

--- a/src/lens-data/nikon/NikonZ58f095SNoct.analysis.md
+++ b/src/lens-data/nikon/NikonZ58f095SNoct.analysis.md
@@ -1,7 +1,7 @@
 # NIKON NIKKOR Z 58mm f/0.95 S Noct — Optical Design Analysis
 
 **Patent:** WO2019/229849 A1 (JPWO2019229849A1)  
-**PCT Filed:** 29 May 2018 (PCT/JP2018/020552)  
+**Filed:** 29 May 2018 (PCT/JP2018/020552)  
 **Published:** 5 December 2019  
 **Applicant:** Nikon Corporation  
 **Inventors:** Keisuke Tsubonoya, Sōki Harada, Toshinori Take  

--- a/src/lens-data/nikon/NikonZ85f18S.analysis.md
+++ b/src/lens-data/nikon/NikonZ85f18S.analysis.md
@@ -1,9 +1,11 @@
 # NIKKOR Z 85mm f/1.8 S — Patent Design Analysis
 
-**Patent:** JP2020-173366A (filed April 11, 2019; published October 22, 2020)  
+**Patent:** JP2020-173366A  
 **Applicants:** Konica Minolta Co., Ltd. & Nikon Corporation (joint filing)  
 **Inventors:** Imashima Ryōsuke (今嶋 亮介), Hirose Takuma (廣瀬 卓万), Tanahashi Daisuke (棚橋 大輔) — Konica Minolta; Yamamoto Yasushi (山本 康), Muratani Mami (村谷 真美) — Nikon  
-**Production design:** Example 3 (EX3)  
+**Filed:** April 11, 2019  
+**Published:** October 22, 2020  
+**Embodiment analyzed:** Example 3 (EX3)  
 **Numerical example:** f = 83.0 mm, F/1.85, 2ω = 29.26°  
 
 ---

--- a/src/lens-data/nikon/NikonZDX1650mmf3563VR.analysis.md
+++ b/src/lens-data/nikon/NikonZDX1650mmf3563VR.analysis.md
@@ -6,9 +6,9 @@
 **Title:** 変倍光学系、光学機器、および変倍光学系の製造方法 (Variable magnification optical system, optical apparatus, and method for manufacturing variable magnification optical system).
 **Applicant:** Nikon Corporation, Tokyo.
 **Inventors:** Yoko Komatsubara (小松原陽子), Takeshi Umeda (梅田武).
-**Filing date:** 13 July 2018 (priority, as PCT/JP2018/026486).
-**Publication date:** 16 January 2020 (international), 10 June 2021 (Japanese re-publication).
-**Embodiment used:** Numerical Example 8 (第8実施例), Table 8 (¶0168).
+**Filed:** 13 July 2018 (priority, as PCT/JP2018/026486).
+**Published:** 16 January 2020 (international), 10 June 2021 (Japanese re-publication).
+**Embodiment analyzed:** Numerical Example 8 (第8実施例), Table 8 (¶0168).
 
 The identification of Example 8 as the production NIKKOR Z DX 16-50mm f/3.5-6.3 VR rests on the following convergent evidence:
 

--- a/src/lens-data/nikon/NikonZDX18140mmf3563VR.analysis.md
+++ b/src/lens-data/nikon/NikonZDX18140mmf3563VR.analysis.md
@@ -6,6 +6,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** WO 2022/264542 A1
+**Applicant:** Nikon Corporation
+**Inventors:** Tomoyuki Sashima, Norikazu Yokoi, Takahiro Ishikawa
+**Priority:** JP 2021-099589, June 15, 2021
+**Filed:** March 4, 2022 (PCT/JP2022/009426)
+**Published:** December 22, 2022
+**Title:** Variable-Magnification Optical System, Optical Apparatus, and Method for Manufacturing Variable-Magnification Optical System
+**Embodiment analyzed:** Example 1 (第1実施例, Table 1)
+
 Patent WO 2022/264542 A1, "Variable-Magnification Optical System, Optical Apparatus, and Method for Manufacturing Variable-Magnification Optical System," was filed by Nikon Corporation on 4 March 2022 (PCT/JP2022/009426) with a priority date of 15 June 2021 (JP 2021-099589). The patent was published on 22 December 2022. Inventors are Tomoyuki Sashima, Norikazu Yokoi, and Takahiro Ishikawa.
 
 The analysis that follows is based on Example 1 (第1実施例, Table 1), which corresponds to the production Nikon NIKKOR Z DX 18-140mm f/3.5-6.3 VR (Nikon product code 20104). The identification is supported by convergent evidence across multiple specifications:

--- a/src/lens-data/nikon/NikonZDX50250mmf4564VR.analysis.md
+++ b/src/lens-data/nikon/NikonZDX50250mmf4564VR.analysis.md
@@ -2,6 +2,14 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** JP WO2020/105107 A1; WO2020/105107
+**Inventors:** Takahiro Ishikawa, Norikazu Yokoi
+**Applicant:** Nikon Corporation
+**Filed:** November 20, 2018 (PCT/JP2018/042790)
+**Published:** May 28, 2020 (WO); September 27, 2021 (JPO republication)
+**Title:** Variable-magnification optical system, optical apparatus, and method for manufacturing a variable-magnification optical system
+**Embodiment analyzed:** Example 1 / 第1実施例
+
 The prescription analyzed here is **Example 1 / 第1実施例** of **JP WO2020/105107 A1**, the Japanese republication of international publication **WO2020/105107**, titled **“Variable-magnification optical system, optical apparatus, and method for manufacturing a variable-magnification optical system”**. The applicant is **Nikon Corporation**. The listed inventors are **Takahiro Ishikawa** and **Norikazu Yokoi**. The international application **PCT/JP2018/042790** was filed on **2018-11-20** and published on **2020-05-28**; the JPO republication issue date is **2021-09-27**.
 
 Example 1 is the strongest embodiment for comparison with the production **NIKKOR Z DX 50-250mm f/4.5-6.3 VR**. The patent's camera embodiment states that the illustrated mirrorless interchangeable-lens camera uses the variable-magnification optical system of Example 1 as its photographic lens (¶0200). The patent does not name the retail product, so the identification rests on convergent evidence:

--- a/src/lens-data/olympus/OlympusMZuiko12100mmf4ISPRO.analysis.md
+++ b/src/lens-data/olympus/OlympusMZuiko12100mmf4ISPRO.analysis.md
@@ -5,9 +5,9 @@
 **Patent:** JP2017-090535A, "ズームレンズ及びそれを備えた撮像装置" (Zoom Lens and Imaging Device Equipped with Same)  
 **Applicant:** Olympus Corporation  
 **Inventors:** Tetsuya Yanai, Tokinori Ima, Daichi Murakami, and Yuki Kubota  
-**Filing date:** November 4, 2015  
-**Publication date:** May 25, 2017  
-**Embodiment used:** Numerical Example 1 (数値実施例1)
+**Filed:** November 4, 2015  
+**Published:** May 25, 2017  
+**Embodiment analyzed:** Numerical Example 1 (数値実施例1)
 
 Numerical Example 1 remains the strongest match to the production **M.Zuiko Digital ED 12-100mm f/4.0 IS PRO**. The patent example gives $f = 12.36, 34.62, 97.98$ mm and constant FNO = 4.08 at the wide, middle, and tele positions, while Olympus/OM System publishes the production lens as a 12-100 mm constant-f/4 Micro Four Thirds zoom. The patent half-to-full field value, $2\omega = 83.05^\circ$ at the wide end, also tracks the production 84° wide-angle specification.
 

--- a/src/lens-data/olympus/OlympusMZuiko1240mmf28PRO.analysis.md
+++ b/src/lens-data/olympus/OlympusMZuiko1240mmf28PRO.analysis.md
@@ -7,7 +7,7 @@
 **Inventors:** Yasuji Ogata, Yasuharu Yamada, Akiyoshi Tochigi, Keitaro Yokoyama
 **Filed:** October 2, 2013 — **Published:** May 22, 2014
 **Priority:** JP 2012-256607, filed November 22, 2012
-**Embodiment used:** Example 5 (Numerical Example 5, ¶0259)
+**Embodiment analyzed:** Example 5 (Numerical Example 5, ¶0259)
 
 The identification of Example 5 as the production optical formula for the M.Zuiko Digital ED 12–40 mm f/2.8 PRO rests on the convergence of eight independent criteria:
 

--- a/src/lens-data/olympus/OlympusMZuiko17mmf18.analysis.md
+++ b/src/lens-data/olympus/OlympusMZuiko17mmf18.analysis.md
@@ -8,9 +8,11 @@
 
 **Inventors:** Yamada Yasuharu (山田 康晴), Murakami Daichi (村上 大地), Kubota Yuki (窪田 勇樹).
 
-**Filing date:** 2012-03-12 (Japanese application 特願2012-54267).
+**Filed:** 2012-03-12 (Japanese application 特願2012-54267).
 
-**Embodiment used:** Numerical Example 3 (数値実施例3, ¶0080).
+**Published:** 2013-09-19.
+
+**Embodiment analyzed:** Numerical Example 3 (数値実施例3, ¶0080).
 
 Example 3 is the best match to the production Olympus M.Zuiko Digital 17mm f/1.8. The identification is convergent rather than explicit: the patent does not name the retail product. The matching evidence is as follows.
 

--- a/src/lens-data/olympus/OlympusMZuiko40150mmf28PRO.analysis.md
+++ b/src/lens-data/olympus/OlympusMZuiko40150mmf28PRO.analysis.md
@@ -7,7 +7,7 @@
 **Inventor:** Yasuji Ogata
 **Filed:** December 16, 2014 (US); **Priority:** JP 2013-259561, December 16, 2013
 **Published:** June 18, 2015
-**Embodiment used:** Example 4 (Numerical Example 4, ¶0316)
+**Embodiment analyzed:** Example 4 (Numerical Example 4, ¶0316)
 
 The following evidence converges to identify Example 4 as the prescription underlying the production Olympus M.Zuiko Digital ED 40-150mm f/2.8 PRO:
 

--- a/src/lens-data/olympus/OlympusXAZuiko35mmf28.analysis.md
+++ b/src/lens-data/olympus/OlympusXAZuiko35mmf28.analysis.md
@@ -1,0 +1,134 @@
+# Olympus XA F.Zuiko 35mm f/2.8 — Patent Analysis
+
+## Patent Reference and Design Identification
+
+**Patent:** US 4,235,521
+**Inventor:** Toshihiro Imai
+**Applicant:** Olympus Optical Co., Ltd.
+**Priority:** JP 52-142167, November 29, 1977
+**Filed:** November 24, 1978
+**Granted:** November 25, 1980
+**Title:** Photographic Lens System
+**Embodiment analyzed:** Embodiment 1 (Fig. 2, Fig. 5)
+
+US 4,235,521, **Photographic Lens System**, was filed by Olympus Optical Co., Ltd. with Toshihiro Imai as inventor. The U.S. filing date is November 24, 1978, the Japanese priority date is November 29, 1977 (JP 52-142167), and the U.S. grant date is November 25, 1980. The analysis and data file use **Embodiment 1**, shown schematically in Fig. 2 and paired with the aberration plots in Fig. 5.
+
+The patent does not name the Olympus XA directly. The production association is therefore an identification by convergence rather than a literal statement in the patent text. The match rests on several mutually reinforcing points:
+
+1. Embodiment 1 is a six-element, five-group, all-spherical 35 mm-format lens with a relative aperture of F/2.8 and a field angle of $2\omega = 63°$.
+2. The Olympus XA instructions identify the production camera as a 35 mm rangefinder using a 24 × 36 mm frame and an F.Zuiko 35 mm f/2.8 lens of six elements in five groups.
+3. The third component is a cemented positive pair — the only form among the patent's four embodiments that yields the six-element count. Embodiment 2 uses a single (non-cemented) positive third component and has five elements.
+4. The patent's stated design objective — a compact-camera lens for 35 mm film with a 60–70° angular field, F/2.8 aperture ratio, and a first-surface-to-film length nearly as short as the focal length — matches the engineering problem solved by the Olympus XA body, whose concept required a fixed, compact lens inside a pocketable 35 mm camera.
+5. The patent assignee (Olympus Optical Co., Ltd.) and the filing date (1978) are consistent with the XA's 1979 market introduction.
+
+## Optical Architecture
+
+The design is a compact **telephoto-type wide-angle lens**. It is not a retrofocus. Its first-order structure is a convergent front group followed by a dispersive rear group, so the rear principal plane is displaced forward and the first-surface-to-film track becomes slightly shorter than the focal length.
+
+The front group consists of L1, L2, and the cemented L3a/L3b component. Its patent-stated composite focal length is $f_{123} = 62.1$ at the normalized $f = 100$ scale, giving $f/f_{123} = 1.61$. The rear group consists of L4 and L5, with patent-stated $f_{45} = -90.9$, giving $f/f_{45} = -1.10$. The cemented third component has axial thickness $D_5 = d_5 + d_5' = 3.39 + 10.80 = 14.19$, so $D_5/f = 0.1419$. The air interval between the third and fourth components is $d_6 = 16.56$, so $d_6/f = 0.1656$.
+
+These four values satisfy the patent's broad design conditions (column 1, lines 55–65): $1.2 < f/f_{123} < 1.8$, $-1.3 < f/f_{45} < -0.35$, $0.1 < D_5/f < 0.17$, and $0.13 < d_6/f < 0.25$. They also satisfy the narrower claimed ranges of claim 1: $1.3 < f/f_{123} < 1.7$, $-1.2 < f/f_{45} < -0.4$, $0.11 < D_5/f < 0.16$, $0.16 < d_6/f < 0.23$.
+
+Independent paraxial tracing of the transcribed prescription gives $f = 100.013$ and $f_B = 38.862$ at the normalized scale, matching the patent's $f = 100$ and $f_B = 38.85$ within rounding. With the production scale factor of 0.35, the effective focal length is 35.005 mm, the back focal distance is 13.602 mm, and the first-surface-to-image track is 34.43 mm. The resulting telephoto ratio is approximately 0.984.
+
+The surface-by-surface Petzval sum, computed as $\sum \phi_i / (n_i \cdot n_i')$, is $+0.001640$ at the normalized scale. This corresponds to a Petzval radius of approximately 610 normalized units, or 213 mm after scaling — a small residual Petzval curvature for a 63° all-spherical compact lens.
+
+## Element-by-Element Analysis
+
+### L1 — Positive meniscus, convex to object
+
+$n_d = 1.78800$, $\nu_d = 47.43$. Glass: S-LAH64 / N-LAF21 / TAF4 class (788/474). $f = +22.3$ mm.
+
+L1 is the high-index front collector. Its meniscus bending puts both centers of curvature to the image side, with the front surface more strongly curved than the rear. This lets the design obtain positive front-group power without requiring very short radii on the external surface. The high refractive index also reduces the Petzval burden for a given positive power contribution, consistent with the patent's recommendation that positive-element indices exceed 1.7 (column 3, lines 50–55).
+
+### L2 — Biconcave negative
+
+$n_d = 1.78472$, $\nu_d = 25.71$. Glass: FD110 (HOYA) / S-TIH11 class (785/257). $f = -20.2$ mm.
+
+L2 is the strong dispersive member of the front group. Its very low Abbe number supplies the main first-order chromatic correction against the more moderate-dispersion high-index positive elements. It also subtracts positive power from L1 and L3, helping to flatten the field and control front-group spherical aberration.
+
+The element is highly asymmetric: the object-side surface ($r_3 = -277.4$) is weakly concave, while the image-side surface ($r_4 = 54.2$) carries most of the negative power. This bending keeps the element useful as both a chromatic corrector and a monochromatic balancing element without making the front group excessively thick.
+
+### L3a / L3b — Cemented positive component (C1)
+
+**L3a:** $n_d = 1.80440$, $\nu_d = 39.62$. Glass: S-LAH63 / NBFD3 class (804/396). Standalone $f = -32.5$ mm.
+
+**L3b:** $n_d = 1.72000$, $\nu_d = 46.03$. Glass: S-LAM61 class (720/460). Standalone $f = +11.8$ mm.
+
+Together, L3a and L3b form the thick positive third component with a combined cemented focal length of $+19.3$ mm. This component is the main positive-power contributor in the front group, and its thickness is not incidental: the patent explicitly uses $D_5/f$ as a condition for controlling astigmatic difference across the wide field while preserving compactness and marginal illumination (column 3, lines 57–65).
+
+The strongly curved cemented interface ($r_5' = 27.309$) between L3a and L3b is the most important internal correction surface in the front half of the lens. L3a is individually negative in air, while L3b is strongly positive; their cemented combination gives positive power with chromatic and spherical-aberration correction that a single high-power positive element would not provide.
+
+### L4 — Negative meniscus, convex to image
+
+$n_d = 1.80400$, $\nu_d = 46.57$. Glass: S-LAH65 / TAF3 class (804/466). $f = -20.6$ mm.
+
+L4 is the principal rear dispersive element and the main source of the telephoto shortening. It sits after the stop in a converging beam and bends the beam outward, moving the rear principal plane forward. Its object-side radius ($r_7 = -18.491$ at patent scale) is short, making the surface optically aggressive even though the element itself is thin.
+
+The patent notes (column 4, lines 5–15) that making the rear group too strong worsens axial spherical aberration because the object-side radius of the fourth component becomes too small. The chosen $f/f_{45} = -1.10$ sits inside the allowed range and is near the strong end of the telephoto compromise without crossing the stated limit of $-1.3$.
+
+### L5 — Positive meniscus, convex to image
+
+$n_d = 1.74950$, $\nu_d = 35.27$. Glass: S-LAM7 / S-NBH51 class (750/353). $f = +70.3$ mm.
+
+L5 is a weak positive meniscus at the rear of the system. Its role is not to dominate the focal length; it moderates the distortion and lateral-color burden created by the strong negative L4. The patent states (column 4, lines 20–30) that the positive meniscus in the rear group reduces the positive distortion that otherwise follows from using a high-power dispersive rear group over a field wider than 60°.
+
+## Glass Identification and Selection
+
+The patent does not provide trade names for the glasses. The identifications below are catalog-class matches based on the published $n_d$ and $\nu_d$ pairs, not evidence of a specific melt used in XA production. Six-digit glass codes encode $n_d \times 1000$ (first three digits) and $\nu_d \times 10$ (last three digits).
+
+| Element | Patent $n_d$ | Patent $\nu_d$ | Code | Catalog-class identification | Function |
+|---|---:|---:|---|---|---|
+| L1 | 1.78800 | 47.43 | 788/474 | S-LAH64 / N-LAF21 / TAF4 class | High-index positive collector |
+| L2 | 1.78472 | 25.71 | 785/257 | FD110 (HOYA) / S-TIH11 class | Strong dispersive front negative |
+| L3a | 1.80440 | 39.62 | 804/396 | S-LAH63 / NBFD3 class | Negative cemented member |
+| L3b | 1.72000 | 46.03 | 720/460 | S-LAM61 class | Strong positive cemented member |
+| L4 | 1.80400 | 46.57 | 804/466 | S-LAH65 / TAF3 class | Rear negative telephoto member |
+| L5 | 1.74950 | 35.27 | 750/353 | S-LAM7 / S-NBH51 class | Rear distortion and color balance |
+
+The design uses no true crown glass by the usual Abbe-number convention ($\nu_d > 50$). Even the least dispersive members remain in high-index lanthanum-flint territory. This is consistent with the patent's preference for positive components with refractive indices greater than 1.7 in order to control field curvature.
+
+Several glass identifications were corrected from an earlier draft during independent cross-referencing. L1 was previously misidentified as HOYA TAFD25 (904/313 class — inconsistent with the 788/474 patent pair). L3a was previously labeled as HOYA TAF3, which is the 804/465 class, not the 804/396 class of the patent pair. L3b was previously identified as S-LAM51 (700/481 class), which does not match the 720/460 patent value. L5 was previously labeled NBFD11 (786/439 class), which also does not match the 750/353 patent pair. All four identifications were corrected to the nearest-matching catalog-class entries listed in the table above.
+
+## Focus Mechanism
+
+The production Olympus XA focuses from 0.85 m to infinity by a coupled rangefinder mechanism. US 4,235,521 does not publish close-focus prescriptions, variable spacings, or a table of finite-distance examples. The specific moving element or group therefore cannot be established from the patent alone.
+
+The prescription is encoded at infinity only. The `closeFocusM` field is set to 0.85 m from the Olympus XA camera instructions, but `var` is intentionally empty because there is no patent-grounded spacing model. Any future finite-focus model would need a service manual, a measured mechanism, or another first-party source identifying the moving group and travel.
+
+## Aspherical Surfaces
+
+There are no aspherical surfaces in Embodiment 1. The patent prescription lists only spherical radii, with no conic constants or polynomial aspheric coefficients. The data file therefore sets `asph: {}`.
+
+## Data-File Notes and Verification Summary
+
+The `.data.ts` file scales all patent radii, thicknesses, and air spaces by 0.35 from the patent's $f = 100$ normalized scale to the production $f \approx 35$ mm focal length. The aperture stop is inserted into the patent's $d_6$ air interval by an inferred split from Fig. 2; this affects entrance-pupil geometry and rendering but does not change the system EFL or BFD.
+
+Semi-diameters are estimated because the patent does not publish clear-aperture data. The values were derived from a combined marginal + chief ray trace at 60% of the full field angle, with 5–8% mechanical clearance, then capped by spherical rim limits ($\text{sd}/|R| < 0.90$), element edge thickness ($\geq 0.3$ mm), and signed cross-gap sag intrusion ($\leq 90\%$ of air gap). Front-group SDs are somewhat reduced from the theoretical full-field values to model the natural vignetting expected in the compact Olympus XA body. They should be treated as renderer-safe approximations, not production mechanical drawings.
+
+Independent paraxial verification at the patent scale:
+
+| Quantity | Patent value | Computed value |
+|---|---:|---:|
+| Effective focal length | 100.00 | 100.013 |
+| Back focal distance | 38.85 | 38.862 |
+| Front-group focal length ($f_{123}$) | 62.1 | 62.10 |
+| Rear-group focal length ($f_{45}$) | −90.9 | −90.87 |
+| Petzval sum | not tabulated | +0.001640 |
+
+Production-scale derived quantities:
+
+| Quantity | Value |
+|---|---:|
+| EFL | 35.005 mm |
+| BFD | 13.602 mm |
+| Front-to-image track | 34.43 mm |
+| Telephoto ratio | 0.984 |
+| Half-field angle | 31.7° (patent: 31.5°) |
+
+## Sources
+
+1. Toshihiro Imai, Olympus Optical Co., Ltd., **US Patent 4,235,521**, *Photographic Lens System*, filed November 24, 1978; granted November 25, 1980.
+2. Olympus, **Olympus XA Instructions**, specification page: F.Zuiko 35 mm F2.8, 6 elements in 5 groups; 24 × 36 mm frame; 0.85 m to infinity focusing range.
+3. HOYA Group Optics Division, **Glass Cross Reference Index**.
+4. OHARA GmbH, **Optical Glass Technical Information**, table of recommended glasses.

--- a/src/lens-data/olympus/OlympusXAZuiko35mmf28.data.ts
+++ b/src/lens-data/olympus/OlympusXAZuiko35mmf28.data.ts
@@ -1,0 +1,181 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — OLYMPUS XA F.ZUIKO 35mm f/2.8               ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,235,521 Embodiment 1 (Olympus / Imai).         ║
+ * ║  Compact telephoto-type wide-angle for 35 mm rangefinder camera.   ║
+ * ║  6 elements / 5 groups, all spherical.                             ║
+ * ║  Focus: unit focus (production); patent is infinity-only.          ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent at f = 100; all R, d, sd values scaled ×0.35             ║
+ * ║    to f ≈ 35 mm production focal length.                           ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Patent does not publish clear-aperture data.  SDs estimated     ║
+ * ║    from combined marginal + chief ray trace at 60% field with      ║
+ * ║    ~5–8% mechanical clearance, capped by edge thickness, sd/|R|,   ║
+ * ║    and cross-gap sag intrusion constraints.  Front-group SDs       ║
+ * ║    reflect natural vignetting expected in a compact camera body.   ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP POSITION:                                            ║
+ * ║    Patent d6 = 16.56 air gap split 8.28 / 8.28 (midpoint);        ║
+ * ║    inferred from Fig. 2 iris placement.                            ║
+ * ║                                                                    ║
+ * ║  IMPORTANT: This file describes ONLY the optical design:           ║
+ * ║    ✓ Glass elements and surfaces (front element to image plane)   ║
+ * ║    ✓ Aperture stop and variable focus/zoom gaps                   ║
+ * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts      ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "olympus-xa-zuiko-35-f28",
+  maker: "Olympus",
+  name: "OLYMPUS XA F.ZUIKO 35mm f/2.8",
+  subtitle: "US 4,235,521 EXAMPLE 1 — OLYMPUS / IMAI",
+  specs: ["6 ELEMENTS / 5 GROUPS", "f ≈ 35.0 mm", "F/2.8", "2ω ≈ 63°", "ALL SPHERICAL"],
+
+  /* ── Explicit metadata fields ── */
+  focalLengthMarketing: 35,
+  focalLengthDesign: 35.0,
+  apertureMarketing: 2.8,
+  lensMounts: ["fixed-lens-camera"],
+  imageFormat: "135-full-frame",
+  patentYear: 1980,
+  elementCount: 6,
+  groupCount: 5,
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.788,
+      vd: 47.43,
+      fl: 22.3,
+      glass: "S-LAH64 / N-LAF21 / TAF4 class (788/474)",
+      apd: false,
+      role: "High-index front collector; meniscus bending reduces Petzval burden",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconcave Negative",
+      nd: 1.78472,
+      vd: 25.71,
+      fl: -20.2,
+      glass: "FD110 (HOYA) / S-TIH11 class (785/257)",
+      apd: false,
+      role: "Strong dispersive member; primary first-order chromatic correction",
+    },
+    {
+      id: 3,
+      name: "L3a",
+      label: "Element 3a",
+      type: "Negative Meniscus",
+      nd: 1.8044,
+      vd: 39.62,
+      fl: -32.5,
+      glass: "S-LAH63 / NBFD3 class (804/396)",
+      apd: false,
+      cemented: "C1",
+      role: "Front cemented member; chromatic and spherical-aberration correction at cemented interface",
+    },
+    {
+      id: 4,
+      name: "L3b",
+      label: "Element 3b",
+      type: "Biconvex Positive",
+      nd: 1.72,
+      vd: 46.03,
+      fl: 11.8,
+      glass: "S-LAM61 class (720/460)",
+      apd: false,
+      cemented: "C1",
+      role: "Main positive-power contributor in front group; thick element controls astigmatic difference",
+    },
+    {
+      id: 5,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.804,
+      vd: 46.57,
+      fl: -20.6,
+      glass: "S-LAH65 / TAF3 class (804/466)",
+      apd: false,
+      role: "Rear dispersive telephoto element; displaces rear principal plane forward for compactness",
+    },
+    {
+      id: 6,
+      name: "L5",
+      label: "Element 5",
+      type: "Positive Meniscus",
+      nd: 1.7495,
+      vd: 35.27,
+      fl: 70.3,
+      glass: "S-LAM7 / S-NBH51 class (750/353)",
+      apd: false,
+      role: "Weak positive rear meniscus; reduces positive distortion from strong rear negative group",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Patent US 4,235,521 Embodiment 1, scaled ×0.35.
+   *  STO position inferred from Fig. 2 — midpoint of patent d6 gap.
+   */
+  surfaces: [
+    { label: "1", R: 9.892, d: 2.572, nd: 1.788, elemId: 1, sd: 7.5 }, // L1 front
+    { label: "2", R: 20.006, d: 1.081, nd: 1.0, elemId: 0, sd: 6.0 }, // L1 rear → air
+    { label: "3", R: -97.1, d: 1.029, nd: 1.78472, elemId: 2, sd: 5.5 }, // L2 front
+    { label: "4", R: 18.98, d: 1.564, nd: 1.0, elemId: 0, sd: 5.5 }, // L2 rear → air
+    { label: "5", R: 15.903, d: 1.187, nd: 1.8044, elemId: 3, sd: 5.5 }, // L3a front (cemented)
+    { label: "6", R: 9.558, d: 3.78, nd: 1.72, elemId: 4, sd: 5.5 }, // L3a/L3b cemented interface
+    { label: "7", R: -65.094, d: 2.898, nd: 1.0, elemId: 0, sd: 5.0 }, // L3b rear → air (to STO)
+    { label: "STO", R: 1e15, d: 2.898, nd: 1.0, elemId: 0, sd: 3.5 }, // Aperture stop (inferred from Fig. 2)
+    { label: "8", R: -6.472, d: 1.029, nd: 1.804, elemId: 5, sd: 3.6 }, // L4 front
+    { label: "9", R: -11.387, d: 1.043, nd: 1.0, elemId: 0, sd: 3.8 }, // L4 rear → air
+    { label: "10", R: -65.972, d: 1.75, nd: 1.7495, elemId: 6, sd: 4.0 }, // L5 front
+    { label: "11", R: -29.635, d: 13.602, nd: 1.0, elemId: 0, sd: 4.2 }, // L5 rear → image (BFD)
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings ──
+   *  Patent publishes infinity-focus only; no finite-distance data.
+   *  closeFocusM set to 0.85 m from Olympus XA camera instructions.
+   *  var is empty because the patent provides no moving-group model.
+   */
+  var: {},
+  varLabels: [],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT", fromSurface: "1", toSurface: "7" },
+    { text: "REAR", fromSurface: "8", toSurface: "11" },
+  ],
+
+  doublets: [{ text: "C1", fromSurface: "5", toSurface: "7" }],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.85,
+  focusDescription: "Coupled rangefinder focus, 0.85 m to infinity. Patent is infinity-only.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 2.8,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.55,
+  yScFill: 0.35,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/olympus/OlympusZuiko135mmf35.analysis.md
+++ b/src/lens-data/olympus/OlympusZuiko135mmf35.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 3,838,911
+**Inventor:** Yoshitsugi Ikeda
+**Assignee:** Olympus Optical Co. Ltd.
+**Priority:** JP 47-66514, July 3, 1972
+**Filed:** April 24, 1973
+**Granted:** October 1, 1974
+**Title:** Telephoto Lens System
+**Embodiment analyzed:** Embodiment 1 / Example 1
+
 The relevant patent is **US 3,838,911, "Telephoto Lens System,"** assigned to Olympus Optical Co. Ltd. and naming Yoshitsugi Ikeda as inventor. The U.S. filing date is 24 April 1973, the Japanese priority date is 3 July 1972 (Japanese Application 47-66514), and the U.S. grant date is 1 October 1974. The analysis below uses **Embodiment 1 / Example 1**, the f/3.5 example in the patent.
 
 The identification of Example 1 with the Olympus E.Zuiko Auto-T 1:3.5 f=135mm rests on the convergence of several independent specifications between the patent and the Olympus OM System lens leaflet. No first-party interview or designer commentary naming specific glass melts or describing the internal focusing mechanism was located; all conclusions therefore rest on the patent prescription and the first-party lens sheet.

--- a/src/lens-data/olympus/OlympusZuiko16mmf35.analysis.md
+++ b/src/lens-data/olympus/OlympusZuiko16mmf35.analysis.md
@@ -1,0 +1,233 @@
+# Olympus OM Zuiko 16mm f/3.5 Fisheye — Patent Example 1 Analysis
+
+## Patent Reference and Design Identification
+
+**Patent:** US 3,850,509
+**Inventor:** Jihei Nakagawa
+**Assignee:** Olympus Optical Co., Ltd.
+**Priority:** JP December 7, 1971
+**Filed:** November 30, 1972
+**Granted:** November 26, 1974
+**Title:** Fisheye lens system
+**Embodiment analyzed:** Example 1 / Table 1
+
+The prescription analyzed here is **Example 1 / Table 1** of **U.S. Patent 3,850,509, "Fisheye lens system,"** filed by Jihei Nakagawa for Olympus Optical Co., Ltd. The U.S. filing was made on 1972-11-30 from Japanese priority 1971-12-07 and was granted on 1974-11-26. The patent describes a 180° fisheye objective for a 24 × 36 mm "Leica size" camera, with a long back focal length, a comparatively short overall lens system, and a small front element for the class.[^patent]
+
+The production match is strong. Olympus sales literature lists the OM **Zuiko 16mm f/3.5** as an 11-element, 8-group, 180° fisheye with 0.2 m minimum focus, 31 mm length, built-in filters, and a 16 mm f/3.5 specification.[^olympus-brochure] The patent's Example 1 is normalized to $f = 1.0$ and $F = 1:3.5$; scaling by 16.0 gives the production focal length. The count also reconciles: the patent uses ten powered glass elements arranged as seven optical "lenses" or components, plus a plane-parallel built-in filter plate. Counting that filter as a glass piece gives the published 11 elements in 8 air-spaced groups.
+
+The identification is not based on a named commercial product in the patent. It is based on the combined evidence of focal length class, f/3.5 aperture, 180° diagonal coverage for 35 mm format, element/group count after including the built-in filter, the internal filter placement, and Olympus's first-party product specifications.
+
+No first-party interview located for this review specifically discusses the 16 mm f/3.5 fisheye or assigns its commercial optical design to a named Olympus lens designer beyond the patent inventor. Olympus's published Maitani lecture and related OM-system materials are useful only as system context: they document the OM program's compact-system objectives and the need to build a complete 35 mm SLR system, but they do not identify the optical calculation of this fisheye.[^maitani]
+
+## Optical Architecture
+
+This is a **retrofocus diagonal fisheye** for 35 mm format. The patent's normalized back focal distance is $f_B = 2.2916f$; the independent paraxial trace reproduced $f = 0.999970$ and $f_B = 2.291598$ with the built-in filter modeled as a normal crown plane plate. After 16× scaling, the back focal distance from the last glass surface to the image plane is **36.67 mm**, or **2.292× the effective focal length**. That is the central architectural fact of the design: a 16 mm fisheye must clear a 35 mm SLR mirror box while covering a 180° diagonal field.
+
+Power distribution is negative-positive-negative in the front converter, followed by three positive cemented/relay sections around and behind the stop:
+
+1. **L1–L3 front converter:** strong negative fisheye front group, moderated by a weak positive L2.
+2. **L4 cemented doublet:** positive biconvex cemented component with a deliberate crown/flint dispersion split.
+3. **Built-in filter:** plane-parallel filter plate between L4 and L5; optically zero power but nonzero axial optical path.
+4. **L5 cemented doublet:** positive biconvex cemented component whose cemented surface is a key spherical/chromatic correction surface.
+5. **Stop region:** the patent places the aperture stop behind L5.
+6. **L6 and L7:** rear positive relay and final chromatic/field-correcting doublet.
+
+The first three elements are not merely a scaled wide-angle front group. They are the angular converter. They accept rays approaching a 90° half-field, compress that angular field into the rear system, and help move the image-space focus far behind the final element. The rear components then recover image formation, tune color, and keep astigmatism and field curvature within useful limits.
+
+The design is all-spherical. Its correction burden is carried by power distribution, strongly curved cemented interfaces, and glass selection rather than by aspherical surfaces.
+
+## Element-by-Element Analysis
+
+The element focal lengths below are **standalone in-air focal lengths after 16× scaling**. They are useful for sign and relative power, but they should not be confused with each element's in-situ contribution inside the complete fisheye, especially inside cemented doublets where the adjacent glass changes the interface power.
+
+### L1 — Negative Meniscus, convex to object
+
+**nd = 1.58913, νd = 61.1. Glass: S-BAL35 (OHARA). Standalone f = −23.32 mm.**
+
+L1 is the fisheye entrance element. Its front surface is weakly convex and its rear surface is strongly concave in the patent sign convention, making a powerful negative meniscus. The patent explicitly states that a strong negative meniscus is used to obtain the 180° field and a long back focal length.[^patent]
+
+The use of a high-Abbe crown-class glass at this position is significant. A very wide-angle front negative element sees extreme oblique bundles. If that element were made from a high-dispersion flint, the design would begin with excessive lateral color. S-BAL35 glass keeps the first negative power comparatively low in dispersion while still giving the large geometric bending needed for fisheye coverage.
+
+L1 also keeps the front diameter small for the field angle. The lens is not trying to be rectilinear; it is deliberately mapping a 180° diagonal field into a 24 × 36 mm frame. That lets the first element be smaller than a rectilinear 16 mm with comparable coverage would require.
+
+### L2 — Positive Meniscus, convex to object
+
+**nd = 1.78590, νd = 44.2. Glass: S-LAH51 (OHARA). Standalone f = 59.10 mm.**
+
+L2 is weakly positive. The patent gives $f_2 = 3.694f$, and the independent calculation gives $f_2 = 3.6940f$, or **59.10 mm** at the 16 mm production scale.
+
+This element is the front group's first major correction element. The patent states that a comparatively weak positive second meniscus is effective because oblique rays meet it at large incidence angles; in that position it helps correct intermediate-field aberrations, especially coma, and chromatic aberration of magnification.[^patent]
+
+Its glass is a high-index, medium-dispersion lanthanum-flint-region material. The high index allows L2 to provide useful positive correction without excessive curvature. The νd of 44.2 places it in flint territory by dispersion, even though the glass family name is lanthanum. That distinction matters: L2 is not a crown element in the chromatic sense.
+
+### L3 — Negative Meniscus
+
+**nd = 1.58913, νd = 61.1. Glass: S-BAL35 (OHARA). Standalone f = −18.76 mm.**
+
+L3 is the second negative member of the front converter. Its front radius is extremely weak compared with its rear radius, so most of its standalone negative power is generated at the rear face. The patent says the third lens assists the first lens.[^patent] That means the front converter's negative power is split rather than forcing all field compression into L1.
+
+This split is one reason the front element can remain comparatively small. L1 begins the angular compression; L2 moderates intermediate-field coma and chromatic magnification; L3 then restores negative power before the ray bundle reaches the cemented correction block. The repeated use of S-BAL35 glass for L1 and L3 keeps the high-obliquity negative-power portion from becoming an uncontrolled lateral-color source.
+
+The combined L1–L3 focal length is $f_{123} = -0.6696f$, or **−10.71 mm** at production scale. That independently verifies the patent's stated $f_{123} \approx -0.670f$.
+
+### L4 — Cemented Biconvex Doublet, hyperchromatic-like correction pair
+
+**L4a: nd = 1.69680, νd = 55.6. Glass: S-LAL14 (OHARA). Standalone f = −25.02 mm.**
+
+**L4b: nd = 1.69895, νd = 30.1. Glass: S-TIM35 (OHARA). Standalone f = 15.71 mm.**
+
+**L4 cemented doublet f = 43.91 mm (ABCD thick-lens computation).**
+
+L4 is the first cemented doublet and the patent's main named chromatic correction component. The patent says the fourth lens is composed under conditions similar to a hyperchromatic lens to correct chromatic aberration.[^patent] In practical terms, the design uses two glasses of nearly equal refractive index but very different dispersion. The refractive-index match keeps the cemented interface from being a large monochromatic power discontinuity, while the dispersion difference makes that same interface powerful chromatically.
+
+The key surface is **r8 = 0.6771f**, the cemented interface between L4a and L4b. The Abbe-number split is **ν4 − ν5 = 55.6 − 30.1 = 25.5**, directly inside the patent's required interval. This makes L4 a lateral-color corrector placed soon after the front fisheye converter, where the chief-ray heights and oblique-ray geometry still give it leverage over chromatic magnification.
+
+The rear surface, **r9 = 46.7176f**, is deliberately weak. The patent requires $10f < r_9$ because too much curvature there would enlarge astigmatic difference. Example 1 greatly exceeds that lower bound. The doublet therefore corrects color primarily through its internal cemented surface rather than by adding a strong rear air-glass surface that would damage astigmatism.
+
+### Built-in Filter between L4 and L5
+
+The patent places a filter between the fourth and fifth lenses. In Table 1 it appears as two plane surfaces, r10 and r11, with finite axial thickness. Olympus production literature also lists built-in filters for the 16 mm lens.[^olympus-brochure]
+
+The filter has no paraxial optical power because both surfaces are plane. It nevertheless matters in the axial calculation. Treating it as air gives $f = 0.98353$ and $f_B = 2.27284$, which does not reproduce the patent. Treating it as a normal crown plate ($n \approx 1.51633$, N-BK7 / S-BSL7 equivalent) gives $f = 0.99997$ and $f_B = 2.29160$, matching the patent's stated $f = 1.0$ and $f_B = 2.2916$. The filter index is not printed in the U.S. table, so the normal-crown assignment is a reconstruction for paraxial verification, not a manufacturer-identified glass.
+
+In the data file, the filter is excluded per project convention. Its optical-path contribution is folded into an air-equivalent reduced gap: $d_\text{reduced} = d_9 + d_{10}/n_\text{filter} + d_{11} = 0.0792 + 0.0742/1.51633 + 0.0829 = 0.211034$ (normalized), or 3.377 mm at production scale. This preserves the correct EFL and BFD identically to the full-filter model.
+
+### L5 — Cemented Biconvex Doublet
+
+**L5a: nd = 1.78472, νd = 25.7. Glass: S-TIH11 (OHARA). Standalone f = −19.26 mm.**
+
+**L5b: nd = 1.60342, νd = 38.0. Glass: S-TIM5 (OHARA). Standalone f = 15.91 mm.**
+
+**L5 cemented doublet f = 94.42 mm (ABCD thick-lens computation).**
+
+L5 is the second cemented biconvex component. The patent says that the fifth cemented lens is used so that its cemented surface serves for aberration correction.[^patent] Example 1 makes that explicit: **r13 = 0.6517f**, placing the cemented surface in the required $0.5f < r_{13} < f$ interval.
+
+The glass pairing is unusual if read only as two flints. It is not a conventional crown/flint achromat. L5a is an extremely dispersive dense flint; L5b is a moderate flint. The large index and dispersion differences across r13 allow the designer to tune both spherical aberration and chromatic error after the L4 color correction but before the aperture stop.
+
+Because L5 sits directly in front of the stop region, it has strong control over pupil-dependent aberrations. Its cemented interface contributes correction without creating another air-spaced surface, which would be more prone to flare and would add more degrees of monochromatic aberration.
+
+### Aperture Stop behind L5
+
+The patent places the stop behind the fifth lens. The numerical table does not insert a separate "STO" row, but the sectional drawing and prose identify the stop position between L5 and L6. In the data file, the d14 air gap is split at the midpoint and a STO surface inserted there, with the exact split estimated from Fig. 1.
+
+This stop placement is not incidental. Putting the stop behind the main front converter and the two cemented correction blocks lets the front group accept the 180° field while the rear group controls the aperture-dependent residuals. It also lets L6 and L7 act as a compact rear relay rather than as part of the primary fisheye field collector.
+
+### L6 — Positive Meniscus, convex to image side
+
+**nd = 1.51728, νd = 69.6. Glass: S-APL1 / APL1 (OHARA). Standalone f = 62.10 mm.**
+
+L6 is a positive meniscus placed immediately behind the stop. The patent describes it as having its convex surface on the image side.[^patent] Its role is to recondition the post-stop bundle before it reaches the rear cemented doublet.
+
+The high-Abbe, low-index glass selection is consistent with that role. At this point the rear system should not reintroduce excessive axial color after L4 and L5 have already done the heavy chromatic work. L6 supplies positive relay power with low dispersion and helps control field shape and spherical residuals in the aperture-limited portion of the lens.
+
+The air gap between L5 and L6 is also the stop region. That makes L6 sensitive to marginal-ray geometry: small changes in its curvature would affect spherical aberration and pupil aberration more than field-angle capture.
+
+### L7 — Rear Cemented Biconvex Doublet
+
+**L7a: nd = 1.80518, νd = 25.4. Glass: S-TIH6 (OHARA). Standalone f = −35.71 mm.**
+
+**L7b: nd = 1.51728, νd = 69.6. Glass: S-APL1 / APL1 (OHARA). Standalone f = 19.16 mm.**
+
+**L7 cemented doublet f = 39.24 mm (ABCD thick-lens computation).**
+
+L7 is the final cemented doublet. Its first element is a high-index, high-dispersion dense flint and its second is a low-index, high-Abbe crown. This is a stronger chromatic contrast than L5 and is placed near the image plane, where it has leverage over axial color, residual lateral color, and field curvature at the final image surface.
+
+The final rear surface r19 is negative and relatively strong. It contributes to the final positive image-forming power while maintaining the long image-space clearance. Because the group is cemented, the designer can use a strong internal chromatic lever without adding an air-spaced interface close to the film plane.
+
+The rear group is not a field flattener in the modern aspheric sense. It is a compact spherical relay and final achromatizing component whose job is to make the retrofocus fisheye usable on a 24 × 36 mm SLR frame.
+
+## Glass Identification and Selection
+
+The patent gives refractive index and Abbe number only; it does **not** name glass manufacturers or melt designations. The names below are therefore **catalog-equivalent identifications**, not proof of Olympus procurement from a named vendor. The matches are to OHARA current or historical catalog entries by $n_d$ and $\nu_d$, which is the most defensible manufacturer-catalog mapping available for this Japanese patent.
+
+| Where used | Catalog-equivalent glass | nd | νd | Six-digit code | Function |
+|---|---|---:|---:|---:|---|
+| L1, L3 | S-BAL35 (OHARA) | 1.58913 | 61.1 | 589/611 | Barium crown / high-Abbe crown in the front negative converter. |
+| L2 | S-LAH51 (OHARA) | 1.78590 | 44.2 | 786/442 | High-index dense lanthanum flint; weak positive corrector in high obliquity region. |
+| L4a | S-LAL14 (OHARA) | 1.69680 | 55.6 | 697/556 | Lanthanum crown side of the fourth cemented doublet. |
+| L4b | S-TIM35 (OHARA) | 1.69895 | 30.1 | 699/301 | Dense flint side of the fourth cemented doublet; high dispersion for lateral color control. |
+| L5a | S-TIH11 (OHARA) | 1.78472 | 25.7 | 785/257 | Very high-dispersion dense flint in the fifth doublet. |
+| L5b | S-TIM5 (OHARA) | 1.60342 | 38.0 | 603/380 | Moderate-index flint paired to L5a across a strongly powered cemented surface. |
+| L6, L7b | S-APL1 / APL1 (OHARA) | 1.51728 | 69.6 | 517/696 | Low-index high-Abbe crown used after the stop and in the rear doublet. |
+| L7a | S-TIH6 (OHARA) | 1.80518 | 25.4 | 805/254 | Very high-dispersion dense flint at the front of the rear cemented doublet. |
+
+The palette has three clear patterns.
+
+First, the front negative converter uses high-Abbe crown-class glass for L1 and L3. That limits the amount of lateral color created before the ray bundle reaches the cemented correction blocks.
+
+Second, the strongest chromatic work is concentrated in cemented pairs. L4 uses nearly equal refractive indices with a large Abbe split, making the cemented surface act as a chromatic correction surface with limited monochromatic disruption. L5 and L7 use more aggressive flint/crown or flint/flint pairings to trim residual color and spherical aberration behind the front converter.
+
+Third, the high-index glasses with νd below 50 are flints for classification purposes, even where the family name contains lanthanum or the element has positive power. L2's S-LAH51 glass, for example, is not a crown in dispersion behavior.
+
+## Focus Mechanism
+
+The patent does not publish a focus-distance table, variable air spaces, floating groups, or any moving internal focus component. The production specification gives a 0.2 m minimum focus distance, but it does not identify floating correction for the 16 mm fisheye. In the same Olympus literature, adjacent lenses that do use floating correction are explicitly labeled "Floating Element Design," while the 16 mm fisheye is not.[^olympus-brochure]
+
+The defensible conclusion is that the lens uses **unit focusing by whole-block helicoid motion**: the optical block moves as a unit relative to the film plane, and no individual focusing elements can be identified from the patent. Secondary OM-system tables derived from Olympus sales files describe this class of focusing as a straight helicoid, but the patent itself supplies no focusing-mechanism drawing or close-focus prescription.[^esif] The focusing elements are therefore not L1, L2, or a rear floating group; they are the entire optical assembly moving together.
+
+This is also mechanically plausible for a 16 mm f/3.5 fisheye with a 0.2 m minimum focus. The extension required for unit focusing is modest at such a short focal length (~1.4 mm computed from $f^2 / (d - f) = 256 / 184$), and the system does not need the close-range aberration correction burden seen in some rectilinear retrofocus wide-angles.
+
+## Aspherical Surfaces
+
+There are no aspherical surfaces in Example 1.
+
+The patent gives only spherical radii for r1 through r19 and plane surfaces for the filter. It does not provide an aspheric sag equation, conic constants, or polynomial coefficients, and the claims do not recite aspherical surfaces. The production literature located for this review also does not claim aspherical construction. The design is **all-spherical**.
+
+The absence of aspheres is not a weakness in context. This is an early-1970s 35 mm SLR fisheye. The design solves its problem by distributing power across many spherical surfaces, using three cemented doublets, placing a stop behind L5, and using deliberate glass dispersion contrasts. The L4, L5, and L7 cemented surfaces are the functional substitutes for what a later compact fisheye might accomplish with molded or polished aspheres.
+
+## Conditional Expressions
+
+| Patent condition | Example 1 value | Result | Optical meaning |
+|---|---:|---|---|
+| $0.4f < \lvert f_{123}\rvert < f$, $f_{123} < 0$ | $\lvert f_{123}\rvert = 0.6696f$ | Satisfies | The first three elements remain a compact negative front converter without becoming so strong that off-axis aberrations dominate. |
+| $3f < f_2 < 6f$ | $f_2 = 3.6940f$ | Satisfies | L2 is weakly positive; it corrects intermediate-field coma and lateral color without destroying the front negative power. |
+| $0.4f < r_8 < f$ | $r_8 = 0.6771f$ | Satisfies | The L4 cemented interface has enough curvature to act on chromatic magnification. |
+| $20 < \nu_4 - \nu_5 < 30$ | $55.6 - 30.1 = 25.5$ | Satisfies | The L4 cemented pair has the dispersion split required by the patent's lateral-color strategy. |
+| $10f < r_9$ | $r_9 = 46.7176f$ | Satisfies | The rear face of L4 is weak enough not to drive astigmatic separation. |
+| $0.5f < r_{13} < f$ | $r_{13} = 0.6517f$ | Satisfies | The L5 cemented interface is in the intended spherical/chromatic correction range. |
+
+The prescription is not merely within the broad claims; it sits very close to the values named in the narrower claim language. In particular, $\lvert f_{123}\rvert \approx 0.670f$, $f_2 \approx 3.694f$, and $r_{13} = 0.6517f$ are tight design choices rather than loose tolerances.
+
+## Verification Summary
+
+The prescription was re-entered from the patent table and verified with an independent paraxial $y$-$nu$ ray trace. The built-in filter was modeled as a plane-parallel normal crown plate because the patent table includes the filter thickness but does not print its refractive index. This is not an arbitrary embellishment: with the plate treated as air, the prescription does not reproduce the stated focal length.
+
+| Quantity | Patent value | Independent calculation | 16× production-scale equivalent |
+|---|---:|---:|---:|
+| Effective focal length | $f = 1.0000$ | $0.999970$ | 16.000 mm |
+| Back focal distance from r19 | $f_B = 2.2916$ | $2.291598$ | 36.67 mm |
+| L2 focal length | $f_2 = 3.694$ | $3.693955$ | 59.10 mm |
+| L1–L3 combined focal length | $f_{123} = -0.670$ | $-0.669556$ | −10.71 mm |
+| First surface to last glass surface | — | 2.469000 | 39.50 mm |
+| First surface to image plane (total track) | — | 4.760598 | 76.17 mm |
+| Petzval sum (surface formula $\sum \Phi / n n'$) | — | 0.02425307 | 0.00151582 mm⁻¹ |
+
+The Petzval value above is the surface-by-surface sum. No element-level thin-lens approximation was used.
+
+### Cemented Doublet Focal Lengths (ABCD thick-lens, standalone in air)
+
+| Component | Focal length (mm) |
+|---|---:|
+| L4 (L4a + L4b) | 43.91 |
+| L5 (L5a + L5b) | 94.42 |
+| L7 (L7a + L7b) | 39.24 |
+
+### Patent Transcription Notes
+
+The most important transcription-sensitive values are r8 = 0.6771, r9 = 46.7176, d14 = 0.2116, and r19 = −1.1190. OCR output from the scanned U.S. patent is poor enough that these values should be taken from the page image, not from the raw text layer.
+
+The critical erratum is d2: the main Table 1 prints 0.457, but the claims text (columns 5–6) gives 0.4157. The claims value reproduces the patent's stated EFL; the table value does not. d2 = 0.4157 is used throughout this analysis and in the data file.
+
+## Sources and Notes
+
+[^patent]: U.S. Patent 3,850,509, "Fisheye lens system," Jihei Nakagawa, Olympus Optical Co., Ltd., priority 1971-12-07, filed 1972-11-30, granted 1974-11-26. Google Patents: https://patents.google.com/patent/US3850509A/
+
+[^olympus-brochure]: Olympus Zuiko interchangeable-lens brochure scan, "Olympus Zuiko 16mm f/3.5–f/22," listing 11 elements / 8 groups, 180° angle of view, minimum focus 0.2 m, built-in filters, and catalog number 103-002. The same page notes "Floating Element Design" for some adjacent lenses but not for the 16 mm fisheye.
+
+[^mir]: MIR, "Zuiko Fisheye 16mm f/3.5 Fisheye Lens." Third-party compilation of Olympus OM lens data, used as a secondary cross-check for construction, filter set, dimensions, and weight. URL: https://www.mir.com.my/rb/photography/hardwares/classics/olympusom1n2/shared/zuiko/htmls/fish16mm.htm
+
+[^esif]: The Unofficial Olympus OM Sales Information File, Lens Group pages. Data derived from the Olympus Sales Information File (October 1979) and The OM System Lens Handbook (October 1985). URL: https://esif.world-traveller.org/om-sif/lensgroup.htm
+
+[^maitani]: Olympus Global, "The Olympus OM-1 – the XA Series," Maitani special lecture and translated OM-system interview material. These sources provide system-level context for compactness and OM-system development, not a lens-specific account of the 16 mm fisheye prescription.
+
+Glass-catalog identifications checked against OHARA catalog pages for S-BAL35, S-LAH51, S-LAL14, S-TIM35, S-TIH11, S-TIM5, and S-TIH6, plus the historical OHARA catalog entry for S-APL1 / APL1. The patent does not name the glass supplier; all glass names in this document are catalog-equivalent identifications by $n_d$ and $\nu_d$.

--- a/src/lens-data/olympus/OlympusZuiko16mmf35.data.ts
+++ b/src/lens-data/olympus/OlympusZuiko16mmf35.data.ts
@@ -1,0 +1,248 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  LENS DATA — OLYMPUS OM Zuiko 16mm f/3.5 Fisheye                   ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 3,850,509 Example 1 (Olympus / Nakagawa).         ║
+ * ║  180° diagonal fisheye for 35 mm SLR, all-spherical retrofocus.    ║
+ * ║  11 elements / 8 groups (incl. built-in filter), 0 asph. surfaces. ║
+ * ║  Focus: unit focus (whole-block helicoid, no floating elements).    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent at f = 1.0 (normalized); all R, d, sd values scaled      ║
+ * ║    ×16.0 to f ≈ 16 mm production focal length.                     ║
+ * ║                                                                    ║
+ * ║  NOTE ON FILTER EXCLUSION:                                         ║
+ * ║    The patent includes a built-in plane-parallel filter plate       ║
+ * ║    (r10, r11) between L4 and L5. Per project convention the filter ║
+ * ║    is excluded; its optical-path contribution is folded into an     ║
+ * ║    air-equivalent reduced gap on surface "9":                       ║
+ * ║      d_reduced = d9 + d10/n_filter + d11                           ║
+ * ║                = 0.0792 + 0.0742/1.51633 + 0.0829                  ║
+ * ║                = 0.211034 (norm.) → 3.377 mm.                      ║
+ * ║    This preserves the correct EFL and BFD identically.             ║
+ * ║                                                                    ║
+ * ║  NOTE ON d2 ERRATUM:                                               ║
+ * ║    Table 1 prints d2 = 0.457; the claims text (columns 5–6) gives  ║
+ * ║    d2 = 0.4157. Only 0.4157 reproduces the patent's stated EFL.    ║
+ * ║    d2 = 0.4157 is used here.                                       ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    Front group (L1–L4): estimated from patent Fig. 1 proportions   ║
+ * ║    with physical constraints (edge thickness, sd/|R| < 0.9).       ║
+ * ║    Stop: derived from F/3.5 and paraxial EP radius.                ║
+ * ║    Rear group (L6–L7): combined marginal + chief ray trace at      ║
+ * ║    60% field (54° half-field) with 8% mechanical clearance.        ║
+ * ║                                                                    ║
+ * ║  IMPORTANT: This file describes ONLY the optical design:           ║
+ * ║    ✓ Glass elements and surfaces (front element to image plane)    ║
+ * ║    ✓ Aperture stop and variable focus gap                          ║
+ * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts       ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "olympus-zuiko-16mmf35-fisheye",
+  maker: "Olympus",
+  name: "OLYMPUS OM Zuiko 16mm f/3.5 Fisheye",
+  subtitle: "US 3,850,509 Example 1 — Olympus / Nakagawa",
+  specs: ["11 ELEMENTS / 8 GROUPS", "f ≈ 16.0 mm", "F/3.5", "2ω = 180°", "ALL SPHERICAL"],
+
+  /* ── Explicit metadata ── */
+  focalLengthMarketing: 16,
+  focalLengthDesign: 16.0,
+  apertureMarketing: 3.5,
+  lensMounts: ["olympus-om"],
+  imageFormat: "135-full-frame",
+  patentYear: 1974,
+  elementCount: 11, // 10 optical elements + 1 built-in filter plate (filter excluded from prescription)
+  groupCount: 8, // 7 optical groups + 1 filter group (filter excluded from prescription)
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.58913,
+      vd: 61.1,
+      fl: -23.32,
+      glass: "S-BAL35 (OHARA)",
+      role: "Front fisheye entrance element; strong negative meniscus for 180° field compression and long BFD.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.7859,
+      vd: 44.2,
+      fl: 59.1,
+      glass: "S-LAH51 (OHARA)",
+      role: "Weak positive meniscus; corrects intermediate-field coma and lateral color at high obliquity.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.58913,
+      vd: 61.1,
+      fl: -18.76,
+      glass: "S-BAL35 (OHARA)",
+      role: "Second negative element; assists L1 in splitting front converter power.",
+    },
+    {
+      id: 4,
+      name: "L4a",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.6968,
+      vd: 55.6,
+      fl: -25.02,
+      glass: "S-LAL14 (OHARA)",
+      cemented: "L4",
+      role: "Crown side of L4 hyperchromatic doublet; nearly index-matched to L4b for chromatic correction.",
+    },
+    {
+      id: 5,
+      name: "L4b",
+      label: "Element 5",
+      type: "Positive Meniscus",
+      nd: 1.69895,
+      vd: 30.1,
+      fl: 15.71,
+      glass: "S-TIM35 (OHARA)",
+      cemented: "L4",
+      role: "Flint side of L4 doublet; high-dispersion element for lateral color correction.",
+    },
+    {
+      id: 6,
+      name: "L5a",
+      label: "Element 6",
+      type: "Negative Meniscus",
+      nd: 1.78472,
+      vd: 25.7,
+      fl: -19.26,
+      glass: "S-TIH11 (OHARA)",
+      cemented: "L5",
+      role: "Dense flint in L5 doublet; spherical and chromatic correction before the stop.",
+    },
+    {
+      id: 7,
+      name: "L5b",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.60342,
+      vd: 38.0,
+      fl: 15.91,
+      glass: "S-TIM5 (OHARA)",
+      cemented: "L5",
+      role: "Moderate flint paired with L5a; cemented surface r13 is key aberration corrector.",
+    },
+    {
+      id: 8,
+      name: "L6",
+      label: "Element 8",
+      type: "Positive Meniscus",
+      nd: 1.51728,
+      vd: 69.6,
+      fl: 62.1,
+      glass: "S-APL1 (OHARA)",
+      role: "Post-stop positive meniscus; low-dispersion relay element reconditioning the bundle.",
+    },
+    {
+      id: 9,
+      name: "L7a",
+      label: "Element 9",
+      type: "Negative Meniscus",
+      nd: 1.80518,
+      vd: 25.4,
+      fl: -35.71,
+      glass: "S-TIH6 (OHARA)",
+      cemented: "L7",
+      role: "Dense flint at front of rear cemented doublet; strong chromatic lever near image.",
+    },
+    {
+      id: 10,
+      name: "L7b",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.51728,
+      vd: 69.6,
+      fl: 19.16,
+      glass: "S-APL1 (OHARA)",
+      cemented: "L7",
+      role: "Crown in rear doublet; final achromatizing and image-forming element.",
+    },
+  ],
+
+  /* ── Surface prescription ──
+   *  Filter excluded; air-equivalent gap folded into surface "9".
+   *  STO inserted at midpoint of original d14 air gap (between L5 and L6).
+   *  Patent normalized to f = 1.0; all values ×16 to production scale.
+   */
+  surfaces: [
+    { label: "1", R: 88.294, d: 1.979, nd: 1.58913, elemId: 1, sd: 8.0 }, // L1 front
+    { label: "2", R: 11.792, d: 6.651, nd: 1.0, elemId: 0, sd: 7.0 }, // L1 rear → air
+    { label: "3", R: 25.734, d: 2.97, nd: 1.7859, elemId: 2, sd: 6.5 }, // L2 front
+    { label: "4", R: 54.774, d: 1.485, nd: 1.0, elemId: 0, sd: 5.5 }, // L2 rear → air
+    { label: "5", R: -1385.709, d: 1.187, nd: 1.58913, elemId: 3, sd: 5.0 }, // L3 front
+    { label: "6", R: 11.144, d: 4.157, nd: 1.0, elemId: 0, sd: 5.5 }, // L3 rear → air
+    { label: "7", R: 29.69, d: 0.99, nd: 1.6968, elemId: 4, sd: 5.5 }, // L4a front
+    { label: "8", R: 10.834, d: 2.454, nd: 1.69895, elemId: 5, sd: 5.5 }, // L4 cement (L4a→L4b)
+    { label: "9", R: 747.482, d: 3.377, nd: 1.0, elemId: 0, sd: 5.0 }, // L4b rear → air (filter folded)
+    { label: "10", R: 35.336, d: 1.198, nd: 1.78472, elemId: 6, sd: 5.0 }, // L5a front
+    { label: "11", R: 10.427, d: 3.227, nd: 1.60342, elemId: 7, sd: 5.0 }, // L5 cement (L5a→L5b)
+    { label: "12", R: -106.726, d: 1.693, nd: 1.0, elemId: 0, sd: 4.5 }, // L5b rear → air (pre-stop)
+    { label: "STO", R: 1e15, d: 1.693, nd: 1.0, elemId: 0, sd: 2.29 }, // Aperture stop (midpoint of d14)
+    { label: "13", R: -39.434, d: 1.979, nd: 1.51728, elemId: 8, sd: 6.0 }, // L6 front
+    { label: "14", R: -18.005, d: 0.099, nd: 1.0, elemId: 0, sd: 6.8 }, // L6 rear → air
+    { label: "15", R: 78.68, d: 0.99, nd: 1.80518, elemId: 9, sd: 6.8 }, // L7a front
+    { label: "16", R: 20.939, d: 2.97, nd: 1.51728, elemId: 10, sd: 7.0 }, // L7 cement (L7a→L7b)
+    { label: "17", R: -17.904, d: 36.666, nd: 1.0, elemId: 0, sd: 7.7 }, // L7b rear → BFD
+  ],
+
+  /* ── Aspherical coefficients ── */
+  asph: {},
+
+  /* ── Variable air spacings (unit focus) ──
+   *  Whole-block helicoid; BFD changes with focus.
+   *  Extension at MFD 0.2 m: f²/(MFD−f) = 256/184 ≈ 1.391 mm.
+   */
+  var: {
+    "17": [36.666, 38.057],
+  },
+
+  varLabels: [["17", "BF"]],
+
+  /* ── Group and doublet annotations ── */
+  groups: [
+    { text: "FRONT", fromSurface: "1", toSurface: "6" },
+    { text: "REAR", fromSurface: "13", toSurface: "17" },
+  ],
+
+  doublets: [
+    { text: "L4", fromSurface: "7", toSurface: "9" },
+    { text: "L5", fromSurface: "10", toSurface: "12" },
+    { text: "L7", fromSurface: "15", toSurface: "17" },
+  ],
+
+  /* ── Focus configuration ── */
+  closeFocusM: 0.2,
+  focusDescription:
+    "Unit focus (whole-block helicoid). No floating elements identified in patent or production literature.",
+
+  /* ── Aperture configuration ── */
+  nominalFno: 3.5,
+  fstopSeries: [3.5, 4, 5.6, 8, 11, 16, 22],
+
+  /* ── Layout tuning ── */
+  scFill: 0.5,
+  yScFill: 0.38,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/olympus/OlympusZuiko24mmf2J.analysis.md
+++ b/src/lens-data/olympus/OlympusZuiko24mmf2J.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 3,830,559
+**Inventor:** Masaki Matsubara
+**Assignee:** Olympus Optical Co., Ltd.
+**Priority:** JP 47-31302, March 29, 1972
+**Filed:** March 14, 1973
+**Granted:** August 20, 1974
+**Title:** Super-wide-angle lens systems for photographic cameras
+**Embodiment analyzed:** Example 1, FIG. 1
+
 The relevant patent is **US 3,830,559, "Super-wide-angle lens systems for photographic cameras,"** filed by Masaki Matsubara for Olympus Optical Co., Ltd. The U.S. application was filed on 14 March 1973, claims Japanese priority of 29 March 1972 (No. 47-31302), and was granted on 20 August 1974. The patent describes a large-aperture retrofocus wide-angle lens for 35 mm single-lens reflex cameras with an aperture ratio on the order of **F/2.0**, a picture angle up to **84°**, and use of a conventional **55 mm** front filter.
 
 This analysis uses **Example 1**, the FIG. 1 embodiment. The production lens is not named in the patent, so the match to the Olympus OM-System **J. Zuiko Auto-W 24mm f/2** is inferential rather than explicit. The identification rests on the following convergent evidence:

--- a/src/lens-data/olympus/OlympusZuiko85mmf2.analysis.md
+++ b/src/lens-data/olympus/OlympusZuiko85mmf2.analysis.md
@@ -2,10 +2,12 @@
 
 ## Patent: US 4,063,802 · Embodiment 1
 
-**Inventors:** Toshihiro Imai, Yoshitsugi Ikeda
-**Assignee:** Olympus Optical Co., Ltd., Tokyo, Japan
-**Filed:** July 14, 1976 (Japanese priority: July 18, 1975)
-**Granted:** December 20, 1977
+**Patent:** US 4,063,802
+**Inventors:** Toshihiro Imai, Yoshitsugi Ikeda  
+**Assignee:** Olympus Optical Co., Ltd., Tokyo, Japan  
+**Filed:** July 14, 1976 (Japanese priority: July 18, 1975)  
+**Granted:** December 20, 1977  
+**Embodiment analyzed:** Embodiment 1
 
 ---
 

--- a/src/lens-data/olympus/OlympusZuikoAuto21mmf2.analysis.md
+++ b/src/lens-data/olympus/OlympusZuikoAuto21mmf2.analysis.md
@@ -2,9 +2,14 @@
 
 ## Patent Source
 
-**US Patent 4,210,388** — "Large-Aperture Wide-Angle Lens System for Photographic Cameras"
-Filed March 8, 1978 (priority: JP 52/27700, March 14, 1977). Granted July 1, 1980.
-Inventor: Yoshitsugi Ikeda. Assignee: Olympus Optical Company Limited, Tokyo.
+**Patent:** US 4,210,388
+**Inventor:** Yoshitsugi Ikeda
+**Assignee:** Olympus Optical Company Limited, Tokyo
+**Priority:** JP 52/27700, March 14, 1977
+**Filed:** March 8, 1978
+**Granted:** July 1, 1980
+**Title:** Large-Aperture Wide-Angle Lens System for Photographic Cameras
+**Embodiment analyzed:** Single numerical example
 
 This analysis covers the single numerical example given in the patent, which describes the optical design underlying the production Olympus OM Zuiko Auto-W 21mm f/2 lens.
 

--- a/src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.analysis.md
+++ b/src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.analysis.md
@@ -2,6 +2,13 @@
 
 ## US 4,792,219 — Embodiment 3 (Shin-ichi Mihara / Olympus Optical Co., Ltd.)
 
+**Patent:** US 4,792,219
+**Inventor:** Shin-ichi Mihara
+**Assignee:** Olympus Optical Co., Ltd.
+**Priority:** JP 60-157052, July 18, 1985
+**Granted:** December 20, 1988
+**Embodiment analyzed:** Embodiment 3
+
 ### Patent overview
 
 US Patent 4,792,219 was granted on December 20, 1988, from a Japanese priority filing dated July 18, 1985 (JP 60-157052). The inventor, Shin-ichi Mihara, was one of Olympus's most prolific optical designers during the 1980s and early 1990s, responsible for a broad range of designs spanning catadioptric telephotos, compact camera lenses, and video zoom systems. This particular patent covers the optical design of the Zuiko Auto-Macro 90mm f/2, a lens that held the distinction of being the first macro lens in the 90–105 mm focal length class to offer an f/2 maximum aperture. It was introduced in 1986 as part of the Olympus OM system and remained in production until 2003.

--- a/src/lens-data/olympus/OlympusZuikoAutoS50mmf12.analysis.md
+++ b/src/lens-data/olympus/OlympusZuikoAutoS50mmf12.analysis.md
@@ -2,7 +2,14 @@
 
 ## US Patent 4,099,843 · Embodiment 6 · Toshihiro Imai (Olympus Optical Co., Ltd.)
 
-Filed March 1, 1977 · Granted July 11, 1978 · Priority: Japan 51-22482 (March 2, 1976)
+**Patent:** US 4,099,843
+**Inventor:** Toshihiro Imai
+**Assignee:** Olympus Optical Co., Ltd.
+**Priority:** JP 51-22482, March 2, 1976
+**Filed:** March 1, 1977
+**Granted:** July 11, 1978
+**Title:** Compact Large-Aperture Photographic Lens System with Long Back Focal Length
+**Embodiment analyzed:** Embodiment 6
 
 ---
 

--- a/src/lens-data/olympus/OlympusZuikoAutoS55mmf12.analysis.md
+++ b/src/lens-data/olympus/OlympusZuikoAutoS55mmf12.analysis.md
@@ -1,6 +1,10 @@
 # Olympus G.Zuiko Auto-S 55mm f/1.2 — Optical Analysis
 
-**Patent:** US 3,743,387 · Jihei Nakagawa · Olympus Optical Co., Ltd. · Filed Nov. 5, 1971 · Granted July 3, 1973
+**Patent:** US 3,743,387
+**Inventor:** Jihei Nakagawa
+**Assignee:** Olympus Optical Co., Ltd.
+**Filed:** November 5, 1971
+**Granted:** July 3, 1973
 **Design type:** Modified Gauss (double Gauss variant)
 **Construction:** 7 elements / 6 groups · All spherical surfaces
 **Mount:** Olympus OM bayonet (flange distance 46.0 mm)

--- a/src/lens-data/panasonic/PanasonicLeicaDG15mmf17.analysis.md
+++ b/src/lens-data/panasonic/PanasonicLeicaDG15mmf17.analysis.md
@@ -7,7 +7,7 @@
 **Inventors:** Yoshiaki Kurioka (Osaka), Takehiro Nishioka (Nara).
 **Filed:** February 25, 2015. **Published:** September 24, 2015. **Priority:** March 20, 2014 (JP 2014-057474).
 
-**Embodiment used:** Numerical Example 2, corresponding to Embodiment 2 (FIG. 3, Tables 6–10).
+**Embodiment analyzed:** Numerical Example 2, corresponding to Embodiment 2 (FIG. 3, Tables 6–10).
 
 The identification of Example 2 as the production prescription for the Panasonic Leica DG Summilux 15mm f/1.7 ASPH (model H-X015) rests on the following convergent evidence:
 

--- a/src/lens-data/panasonic/PanasonicLeicaDG9mmf17.analysis.md
+++ b/src/lens-data/panasonic/PanasonicLeicaDG9mmf17.analysis.md
@@ -7,7 +7,7 @@
 **Inventors:** Yuka Ikegami (Hyogo), Takahiro Kitada (Osaka), Kunio Dohno (Osaka).
 **Filed:** May 2, 2023. **Published:** November 16, 2023. **Priority:** JP 2022-080128, filed May 16, 2022.
 
-**Embodiment used:** First Example of Numerical Values (Tables 1A–1F), corresponding to the first embodiment illustrated in FIG. 1A.
+**Embodiment analyzed:** First Example of Numerical Values (Tables 1A–1F), corresponding to the first embodiment illustrated in FIG. 1A.
 
 The following convergent evidence identifies Example 1 as the production Panasonic Leica DG Summilux 9mm F1.7 ASPH (H-X09):
 

--- a/src/lens-data/panasonic/PanasonicLumixS2060mmf3556.analysis.md
+++ b/src/lens-data/panasonic/PanasonicLumixS2060mmf3556.analysis.md
@@ -5,9 +5,9 @@
 **Patent:** JP 2021-179551 A, "ズームレンズ系、撮像装置、カメラシステム" (Zoom Lens System, Imaging Device, Camera System).
 **Applicant:** Panasonic Intellectual Property Management Co., Ltd. (パナソニックＩＰマネジメント株式会社), Osaka, Japan.
 **Inventors:** Kitada Takahiro (北田 高博), Kudo Yuka (工藤 有華), Sueyoshi Masashi (末吉 正史), Li Jindong (李 金東).
-**Filing date:** 15 May 2020 (令和2年5月15日), Application No. 2020-85568.
-**Publication date:** 18 November 2021 (令和3年11月18日).
-**Embodiment used:** Numerical Example 2 (数値実施例2), corresponding to Embodiment 2 (実施の形態2), illustrated in Figs. 3–4.
+**Filed:** 15 May 2020 (令和2年5月15日), Application No. 2020-85568.
+**Published:** 18 November 2021 (令和3年11月18日).
+**Embodiment analyzed:** Numerical Example 2 (数値実施例2), corresponding to Embodiment 2 (実施の形態2), illustrated in Figs. 3–4.
 
 The following convergent evidence identifies Example 2 as the production design for the LUMIX S 20–60mm F3.5–5.6 (model S-R2060):
 

--- a/src/lens-data/panasonic/PanasonicS35mmf18.analysis.md
+++ b/src/lens-data/panasonic/PanasonicS35mmf18.analysis.md
@@ -5,8 +5,8 @@
 **Patent:** CN 216772097 U (Utility Model), "大口径内对焦式光学系" (Large-Aperture Inner-Focus Optical System)  
 **Applicant:** 厦门松下电子信息有限公司 (Xiamen Panasonic Electronic Information Co., Ltd.)  
 **Inventors:** 郑艺丹, 陈汉钊, 詹晓晴  
-**Filing date:** 2021-10-11 &ensp;|&ensp; **Grant date:** 2022-06-17  
-**Embodiment used:** Example 1 (第一实施例, ¶0096–0120)
+**Filed:** 2021-10-11 &ensp;|&ensp; **Granted:** 2022-06-17  
+**Embodiment analyzed:** Example 1 (第一实施例, ¶0096–0120)
 
 ---
 

--- a/src/lens-data/panasonic/PanasonicSPro50mmf14.analysis.md
+++ b/src/lens-data/panasonic/PanasonicSPro50mmf14.analysis.md
@@ -7,7 +7,7 @@
 **Inventors:** Yoshinaga Shunichiro (吉永 俊一郎), Suzuki Yasuhito (鈴木 靖人).
 **Filed:** 2020-01-24 (international), priority 2019-01-28.
 **Published:** 2020-08-06.
-**Embodiment used:** Numerical Example 3 (数値実施例3), corresponding to Embodiment 3 (実施の形態3, ¶0058–0078).
+**Embodiment analyzed:** Numerical Example 3 (数値実施例3), corresponding to Embodiment 3 (実施の形態3, ¶0058–0078).
 
 The identification of Example 3 as the production prescription rests on the following convergent evidence:
 

--- a/src/lens-data/pentax/Pentax11024mmf28.analysis.md
+++ b/src/lens-data/pentax/Pentax11024mmf28.analysis.md
@@ -1,9 +1,13 @@
 ## Patent Reference and Design Identification
 
-**US 4,223,982** — *Semi-Wide Angle Photographic Lens Having Short Overall Length*
-Inventor: Takahiro Sugiyama. Assignee: Asahi Kogaku Kogyo Kabushiki Kaisha (Tokyo, Japan).
-Filed January 9, 1979; granted September 23, 1980.
-Japanese priority: January 23, 1978 (JP 53-6031).
+**Patent:** US 4,223,982
+**Inventor:** Takahiro Sugiyama
+**Assignee:** Asahi Kogaku Kogyo Kabushiki Kaisha (Tokyo, Japan)
+**Priority:** JP 53-6031, January 23, 1978
+**Filed:** January 9, 1979
+**Granted:** September 23, 1980
+**Title:** Semi-Wide Angle Photographic Lens Having Short Overall Length
+**Embodiment analyzed:** Example 2
 
 The prescription transcribes **Example 2** of the patent. The identification of this embodiment with the production Pentax-110 24mm f/2.8 lens rests on the following convergent evidence:
 

--- a/src/lens-data/pentax/PentaxDA1650mmf28.analysis.md
+++ b/src/lens-data/pentax/PentaxDA1650mmf28.analysis.md
@@ -13,7 +13,7 @@
 **Granted:** November 27, 2007
 **Priority:** JP P2005-322558, filed November 7, 2005
 
-**Embodiment used:** Numerical Example 6 (Table 6; Figs. 21–24E)
+**Embodiment analyzed:** Numerical Example 6 (Table 6; Figs. 21–24E)
 
 The identification of Example 6 as the production design rests on the following convergent evidence:
 

--- a/src/lens-data/pentax/PentaxDA50135mmf28.analysis.md
+++ b/src/lens-data/pentax/PentaxDA50135mmf28.analysis.md
@@ -12,7 +12,7 @@
 **Filed:** February 7, 2007 (US); Priority date February 10, 2006 (JP 2006-033506)
 **Granted:** October 30, 2007
 
-**Embodiment used:** Numerical Example 5 (Table 5, Figs. 17–20E)
+**Embodiment analyzed:** Numerical Example 5 (Table 5, Figs. 17–20E)
 
 ### Identification Evidence
 

--- a/src/lens-data/pentax/PentaxF85mmf28Soft.analysis.md
+++ b/src/lens-data/pentax/PentaxF85mmf28Soft.analysis.md
@@ -12,7 +12,7 @@
 **Filed:** October 19, 1990 (US); **Priority:** October 25, 1989 (JP 1-277895)
 **Granted:** November 30, 1993
 
-**Embodiment used:** Example 1 (Numerical Example 1), corresponding to Figs. 1–4 of the patent.
+**Embodiment analyzed:** Example 1 (Numerical Example 1), corresponding to Figs. 1–4 of the patent.
 
 The identification of Example 1 as the production smc PENTAX-F 85mm f/2.8 Soft rests on the following convergent evidence:
 

--- a/src/lens-data/pentax/PentaxFA31mmf18ALLtd.analysis.md
+++ b/src/lens-data/pentax/PentaxFA31mmf18ALLtd.analysis.md
@@ -7,7 +7,7 @@
 **Inventors:** Masayuki Murata; Takayuki Ito
 **Filed:** August 28, 2001 (priority: JP 2000-265256, September 1, 2000)
 **Granted:** May 6, 2003
-**Embodiment used:** Numerical Example 3 (Table 3, Figs. 9–12)
+**Embodiment analyzed:** Numerical Example 3 (Table 3, Figs. 9–12)
 
 The production lens is identified as the SMC Pentax-FA 31mm F1.8 AL Limited (later re-released with HD coating as the HD Pentax-FA 31mm F1.8 Limited) by convergence of the following evidence:
 

--- a/src/lens-data/ricoh/RicohGR218mmf28.analysis.md
+++ b/src/lens-data/ricoh/RicohGR218mmf28.analysis.md
@@ -2,9 +2,11 @@
 
 *Companion to `RicohGR218mmf28.data.ts`*
 
-**Patent:** US 2013/0321936 A1 · Example 3  
-**Inventor / Applicant:** Kazuyasu Ohashi (Funabashi-shi, JP)  
-**Filed:** May 31, 2013 · Priority: JP 2012-127431 (June 4, 2012)  
+**Patent:** US 2013/0321936 A1
+**Inventor:** Kazuyasu Ohashi (Funabashi-shi, JP)
+**Priority:** JP 2012-127431, June 4, 2012
+**Filed:** May 31, 2013
+**Embodiment analyzed:** Example 3
 **Production lens:** Ricoh GR (2013), Ricoh GR II (2015)  
 **Note:** The published application lists no corporate assignee; the inventor filed individually. The described designs are clearly intended for Ricoh compact cameras and portable information terminals.
 

--- a/src/lens-data/ricoh/RicohGR3x.analysis.md
+++ b/src/lens-data/ricoh/RicohGR3x.analysis.md
@@ -4,7 +4,7 @@
 
 **Patent:** US 2022/0026670 A1, *Imaging Lens, Camera, and Portable Information Terminal Apparatus*
 **Inventor:** Kazuyasu Ohashi (individual applicant, Chiba, Japan)
-**Priority date:** March 7, 2019 (JP 2019-041727)
+**Priority:** March 7, 2019 (JP 2019-041727)
 **PCT filed:** February 17, 2020 (PCT/JP2020/006106)
 **Published:** January 27, 2022
 

--- a/src/lens-data/ricoh/RicohGXRA1218mmf25.analysis.md
+++ b/src/lens-data/ricoh/RicohGXRA1218mmf25.analysis.md
@@ -1,8 +1,11 @@
 # Ricoh GR LENS A12 28mm f/2.5 — Optical Analysis
 
-**Patent:** JP 2012-003015 A (filed 2010-06-16, published 2012-01-05)
+**Patent:** JP 2012-003015 A
 **Inventor:** Takashi Kubota (窪田 高士), Ricoh Co., Ltd.
-**Example analyzed:** Example 3 (実施例３), Figure 5
+**Applicant:** Ricoh Co., Ltd.
+**Filed:** 2010-06-16
+**Published:** 2012-01-05
+**Embodiment analyzed:** Example 3 (実施例３), Figure 5
 **Design focal length:** 18.3 mm (28 mm equiv. on APS-C)
 **Design f-number:** f/2.56
 

--- a/src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.analysis.md
+++ b/src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 6,028,720
+**Inventors:** Rolf Wartmann and Udo Schauss
+**Applicant:** Jos. Schneider Optische Werke Kreuznach GmbH & Co. KG
+**Priority:** DE 197 54 758, December 10, 1997
+**Filed:** December 7, 1998
+**Granted:** February 22, 2000
+**Title:** High Resolution Objective for Large-Format Photography
+**Embodiment analyzed:** Second numerical embodiment
+
 US 6,028,720, "High Resolution Objective for Large-Format Photography." Applicant: Jos. Schneider Optische Werke Kreuznach GmbH & Co. KG, Bad Kreuznach, Germany. Inventors: Rolf Wartmann and Udo Schauss. Filed December 7, 1998 (US); priority date December 10, 1997 (DE 197 54 758). Granted February 22, 2000.
 
 The prescription transcribed here is from the patent's **second numerical embodiment** (column 5, lines 1–20; restated in Claim 5), which corresponds to production lenses in the Schneider-Kreuznach APO-Symmar family. Since Example 2 uses an entirely lead-free, arsenic-free, and antimony-free glass palette — a stated design objective — it most likely represents the APO-Symmar L variant ("L" widely understood to denote the later environmentally-reformulated line), rather than the original APO-Symmar. The patent's scalability clause ("any desired scale," column 4) means this prescription covers the entire focal-length family; at the tabulated scale of $f' = 101.2$ mm, it maps to the 100 mm production focal length. Convergent evidence supporting this identification:

--- a/src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.analysis.md
+++ b/src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.analysis.md
@@ -9,7 +9,7 @@
 **Priority:** August 14, 1963 (Germany, Sch 33,712)
 **Granted:** April 2, 1968
 
-**Embodiment used:** Table I (Example 1), which defines an objective system with an aperture ratio of 1:5.6, an overall focal length of 100 linear units, an effective field angle of 100°, and a back-focal length $s' = 68.46$ units. The total axial length $d_\text{total} = 100.56$ units.
+**Embodiment analyzed:** Table I (Example 1), which defines an objective system with an aperture ratio of 1:5.6, an overall focal length of 100 linear units, an effective field angle of 100°, and a back-focal length $s' = 68.46$ units. The total axial length $d_\text{total} = 100.56$ units.
 
 The Table I embodiment is identified as the design basis for the Schneider-Kreuznach Super-Angulon 75mm f/5.6 large-format lens by convergent evidence:
 

--- a/src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.analysis.md
+++ b/src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.analysis.md
@@ -2,6 +2,15 @@
 
 ## Patent Reference and Design Identification
 
+**Patent:** US 5,870,234
+**Inventor:** Hiltrud Ebbesmeier née Schitthof
+**Assignee:** Jos. Schneider Optische Werke Kreuznach GmbH & Co. KG
+**Priority:** DE 196 36 152.4, September 6, 1996
+**Filed:** September 4, 1997
+**Granted:** February 9, 1999
+**Title:** Compact Wide-Angle Lens
+**Embodiment analyzed:** Example 2 (Claim 3)
+
 **US 5,870,234**, "Compact Wide-Angle Lens," assigned to Jos. Schneider Optische Werke Kreuznach GmbH & Co. KG (Bad Kreuznach, Germany). Inventor: Hiltrud Ebbesmeier née Schitthof. Filed September 4, 1997 (US); German priority DE 196 36 152.4, filed September 6, 1996. Granted February 9, 1999.
 
 The patent discloses two numerical embodiments of a five-member compact wide-angle lens. Both embodiments are tabulated at the **e-line (546.1 nm)**, using refractive indices $n_e$ and e-line-referenced Abbe numbers $\nu_e$, as is conventional for German optical patents. All patent-derived optical values quoted in this analysis are e-line quantities unless stated otherwise.

--- a/src/lens-data/sigma/Sigma85mmf14Art.analysis.md
+++ b/src/lens-data/sigma/Sigma85mmf14Art.analysis.md
@@ -8,7 +8,7 @@
 **Filed:** 7 July 2016 (Priority: P2016-134770)
 **Published:** 11 January 2018
 
-**Embodiment used:** Numerical Example 4 (数値実施例４), described in ¶0110–0116 and the accompanying prescription tables.
+**Embodiment analyzed:** Numerical Example 4 (数値実施例４), described in ¶0110–0116 and the accompanying prescription tables.
 
 The identification of Example 4 as the production Sigma 85mm F1.4 DG HSM | Art (product code A016) rests on the following convergent evidence:
 

--- a/src/lens-data/sigma/SigmaArt40mmf14.analysis.md
+++ b/src/lens-data/sigma/SigmaArt40mmf14.analysis.md
@@ -6,8 +6,8 @@
 **Title:** 撮像レンズ (Imaging Lens)
 **Applicant:** Sigma Corporation (株式会社シグマ), Kawasaki-shi, Kanagawa, Japan
 **Inventor:** Yamanaka Kenji (山中 健史)
-**Filing date:** 18 July 2018 (Heisei 30), priority application 特願2018-134615
-**Publication date:** 23 January 2020 (Reiwa 2)
+**Filed:** 18 July 2018 (Heisei 30), priority application 特願2018-134615
+**Published:** 23 January 2020 (Reiwa 2)
 
 The prescription transcribed here is **Numerical Example 1** (数値実施例1), the first of four embodiments disclosed. It is identified as the production design of the **Sigma 40mm f/1.4 DG HSM | Art** (edition A018) by the following convergent evidence:
 

--- a/src/lens-data/sigma/SigmaDGDNA35mmf14.analysis.md
+++ b/src/lens-data/sigma/SigmaDGDNA35mmf14.analysis.md
@@ -1,6 +1,13 @@
 # SIGMA 35 mm F1.4 DG DN | Art — Optical Analysis
 
-*Patent: JP 2022-33487 A · Numerical Example 1 · Sigma Corporation · Inventor: Ryo Shioda · Filed 17 August 2020 · Published 2 March 2022*
+**Patent:** JP 2022-33487 A
+**Inventor:** Ryo Shioda
+**Assignee:** Sigma Corporation
+**Priority:** JP 2020-137411
+**Filed:** 17 August 2020
+**Published:** 2 March 2022
+**Title:** Optical System
+**Embodiment analyzed:** Numerical Example 1
 
 ---
 

--- a/src/lens-data/sigma/SigmaDGDNA85mmf14.analysis.md
+++ b/src/lens-data/sigma/SigmaDGDNA85mmf14.analysis.md
@@ -1,10 +1,12 @@
 # Sigma 85 mm F/1.4 DG DN | Art — Optical Analysis
 
-**Patent reference:** JP 2021-85935 A (公開特許公報, published 3 June 2021)
+**Patent:** JP 2021-85935 A
 **Applicant:** 株式会社シグマ (SIGMA Corporation)
 **Inventor:** 塩田 了 (Ryo Shioda)
-**Filing date:** 26 November 2019 · **Priority:** P2019-213387
-**Embodiment analysed:** Numerical Example 1 (数値実施例 1, fig. 1)
+**Priority:** P2019-213387
+**Filed:** 26 November 2019
+**Published:** 3 June 2021
+**Embodiment analyzed:** Numerical Example 1 (数値実施例 1, fig. 1)
 **Production lens identified as:** Sigma 85 mm F/1.4 DG DN | Art (announced 6 August 2020; mounts: Sony E and L-mount)
 
 ---

--- a/src/lens-data/sigma/SigmaDGDNArt50mmf14.analysis.md
+++ b/src/lens-data/sigma/SigmaDGDNArt50mmf14.analysis.md
@@ -5,9 +5,9 @@
 **Patent:** JP 2023-183894 A, "結像光学系" (Imaging Optical System)
 **Applicant:** Sigma Corporation (株式会社シグマ), Kawasaki, Kanagawa, Japan
 **Inventor:** Yukihiro Yamamoto (山本 幸広)
-**Filing date:** June 17, 2022
-**Publication date:** December 28, 2023
-**Embodiment used:** Numerical Example 1 (数値実施例 1), described in ¶0062–0068 and ¶0136
+**Filed:** June 17, 2022
+**Published:** December 28, 2023
+**Embodiment analyzed:** Numerical Example 1 (数値実施例 1), described in ¶0062–0068 and ¶0136
 
 The prescription in Numerical Example 1 is identified as the design basis of the production Sigma 50mm F1.4 DG DN | Art (Edition A023, released February 2023) on the basis of the following convergent evidence:
 

--- a/src/lens-data/sigma/SigmaDP2X24mmf28.analysis.md
+++ b/src/lens-data/sigma/SigmaDP2X24mmf28.analysis.md
@@ -3,7 +3,7 @@
 ## Source
 
 **Patent:** JP 2010-101979 A (特開2010-101979), published 2010-05-06  
-**Filing date:** 2008-10-22 (Application 特願2008-271510)  
+**Filed:** 2008-10-22 (Application 特願2008-271510)  
 **Applicant:** 株式会社シグマ (Sigma Inc.), Kawasaki, Japan  
 **Inventor:** Noriyuki Ogasahara (小笹原 典行)  
 **Example analysed:** Numerical Example 5 (数値実施例5)

--- a/src/lens-data/sigma/SigmaDP3M50mmf28.analysis.md
+++ b/src/lens-data/sigma/SigmaDP3M50mmf28.analysis.md
@@ -6,6 +6,15 @@
 
 ## 1. Patent Identification
 
+**Patent:** JP 2014-126652 A
+**Inventor:** Noriyuki Ogasawara (小笠原 典行)
+**Assignee:** Sigma Corporation (株式会社シグマ), Kawasaki, Japan
+**Application Number:** 特願2012-282344
+**Filed:** 2012-12-26
+**Published:** 2014-07-07
+**Title:** 結像光学系 (Imaging Optical System)
+**Embodiment analyzed:** Example 3 (数値実施例3)
+
 | Field | Value |
 |---|---|
 | Publication number | JP 2014-126652 A (特開2014-126652) |

--- a/src/lens-data/sigma/SigmaDp2M30mmf28.analysis.md
+++ b/src/lens-data/sigma/SigmaDp2M30mmf28.analysis.md
@@ -7,7 +7,7 @@
 **Inventor:** Tomoki Kōno (幸野 朋来)
 **Filed:** 2012-01-31 (Priority: P2012-17449)
 **Published:** 2013-08-15
-**Embodiment used:** Numerical Example 4 (数値実施例４), ¶0065–¶0070
+**Embodiment analyzed:** Numerical Example 4 (数値実施例４), ¶0065–¶0070
 
 The prescription is identified with the production lens used in the Sigma DP2 Merrill (2012) compact camera by the following convergent evidence:
 

--- a/src/lens-data/sony/SonyFE135mmf18GM.analysis.md
+++ b/src/lens-data/sony/SonyFE135mmf18GM.analysis.md
@@ -6,7 +6,7 @@
 **Applicant:** Sony Corporation (000002185), Tokyo, Japan.
 **Inventors:** Matsuoka Dai (松岡 大), Miyagawa Naoki (宮川 直己), Matsumoto Hiroyuki (松本 博之).
 **Filed:** 4 February 2019 (PCT/JP2019/003857).
-**Priority date:** 30 March 2018 (JP 2018-67276).
+**Priority:** 30 March 2018 (JP 2018-67276).
 **Published:** 3 October 2019.
 
 **Embodiment analyzed:** Numerical Example 1 (数値実施例 1), corresponding to the first embodiment (第1の実施の形態) described beginning at ¶0102 and tabulated in Tables 1–5 (pages 17–18).

--- a/src/lens-data/sony/SonyFE135mmf18GM.analysis.md
+++ b/src/lens-data/sony/SonyFE135mmf18GM.analysis.md
@@ -5,11 +5,11 @@
 **Patent:** WO 2019/187633 A1 (JP re-publication), titled "撮像レンズ及び撮像装置" (Imaging Lens and Imaging Apparatus).
 **Applicant:** Sony Corporation (000002185), Tokyo, Japan.
 **Inventors:** Matsuoka Dai (松岡 大), Miyagawa Naoki (宮川 直己), Matsumoto Hiroyuki (松本 博之).
-**International filing date:** 4 February 2019 (PCT/JP2019/003857).
+**Filed:** 4 February 2019 (PCT/JP2019/003857).
 **Priority date:** 30 March 2018 (JP 2018-67276).
-**International publication date:** 3 October 2019.
+**Published:** 3 October 2019.
 
-**Embodiment used:** Numerical Example 1 (数値実施例 1), corresponding to the first embodiment (第1の実施の形態) described beginning at ¶0102 and tabulated in Tables 1–5 (pages 17–18).
+**Embodiment analyzed:** Numerical Example 1 (数値実施例 1), corresponding to the first embodiment (第1の実施の形態) described beginning at ¶0102 and tabulated in Tables 1–5 (pages 17–18).
 
 The production lens is the **Sony FE 135mm F1.8 GM** (model SEL135F18GM), announced in February 2019 and shipped in spring 2019. The following convergent evidence identifies Example 1 as the production embodiment:
 

--- a/src/lens-data/sony/SonyFE2070mmf4G.analysis.md
+++ b/src/lens-data/sony/SonyFE2070mmf4G.analysis.md
@@ -5,7 +5,7 @@
 **Patent:** WO 2023/153076 A1 — "Zoom Lens and Imaging Device"
 **Applicant:** Sony Group Corporation (JP)
 **Inventors:** Tasaki Ryohei (田崎 涼平), Kumisawa Yuma (組澤 悠真), Juri Hiroo (重里 比呂生)
-**Priority date:** 9 February 2022 (JP 2022-019115)
+**Priority:** 9 February 2022 (JP 2022-019115)
 **Filed:** 15 December 2022 (PCT/JP2022/046159)
 **Published:** 17 August 2023
 

--- a/src/lens-data/sony/SonyFE2070mmf4G.analysis.md
+++ b/src/lens-data/sony/SonyFE2070mmf4G.analysis.md
@@ -6,10 +6,10 @@
 **Applicant:** Sony Group Corporation (JP)
 **Inventors:** Tasaki Ryohei (田崎 涼平), Kumisawa Yuma (組澤 悠真), Juri Hiroo (重里 比呂生)
 **Priority date:** 9 February 2022 (JP 2022-019115)
-**International filing:** 15 December 2022 (PCT/JP2022/046159)
-**Publication:** 17 August 2023
+**Filed:** 15 December 2022 (PCT/JP2022/046159)
+**Published:** 17 August 2023
 
-**Embodiment used:** Example 8 (実施例 8), described at ¶0189–¶0198 and illustrated in Figure 92. The prescription is given in Tables 36–40 (¶0199–¶0203).
+**Embodiment analyzed:** Example 8 (実施例 8), described at ¶0189–¶0198 and illustrated in Figure 92. The prescription is given in Tables 36–40 (¶0199–¶0203).
 
 The identification of Example 8 as the production SEL2070G design rests on the following convergent evidence:
 

--- a/src/lens-data/sony/SonyFE2470mmf28GMII.analysis.md
+++ b/src/lens-data/sony/SonyFE2470mmf28GMII.analysis.md
@@ -5,10 +5,10 @@
 **Patent:** WO 2023/181666 A1, "Zoom Lens and Imaging Device"
 **Applicant:** Sony Group Corporation
 **Inventor:** Masaki Maruyama
-**Filing date:** 6 February 2023 (PCT/JP2023/003793)
-**Publication date:** 28 September 2023
+**Filed:** 6 February 2023 (PCT/JP2023/003793)
+**Published:** 28 September 2023
 **Priority:** JP 2022-046233, filed 23 March 2022
-**Embodiment used:** Example 4 (第4実施例), Figure 40, Tables 16–20
+**Embodiment analyzed:** Example 4 (第4実施例), Figure 40, Tables 16–20
 
 The identification of Example 4 as the production embodiment rests on the following convergent evidence:
 

--- a/src/lens-data/sony/SonyFE24mmf18ZA.analysis.md
+++ b/src/lens-data/sony/SonyFE24mmf18ZA.analysis.md
@@ -8,7 +8,7 @@
 **Filed:** June 26, 2012 (US); **Priority:** August 4, 2011 (JP 2011-171294)
 **Published:** February 7, 2013
 
-**Embodiment used:** Numerical Example 2 (Tables 4–6, Figs. 4–6)
+**Embodiment analyzed:** Numerical Example 2 (Tables 4–6, Figs. 4–6)
 
 The following convergent evidence links Example 2 to the production Sony Carl Zeiss Sonnar T* E 24mm F1.8 ZA (SEL24F18Z):
 

--- a/src/lens-data/sony/SonyFE2870mmf2GM.analysis.md
+++ b/src/lens-data/sony/SonyFE2870mmf2GM.analysis.md
@@ -5,10 +5,10 @@
 **Patent:** WO 2025/263124 A1, "Zoom Lens and Imaging Device" (ズームレンズ、および撮像装置).
 **Applicant:** Sony Group Corporation.
 **Inventors:** Yamasaki Takashi (山崎 貴), Yamada Iwao (山田 巖).
-**Priority:** JP 2024-100711, filed 2024-06-21.
-**International filing:** PCT/JP2025/016405, filed 2025-04-30.
-**Publication:** 2025-12-26.
-**Embodiment used:** Example 1 (実施例 1), corresponding to Figure 1.
+**Priority:** JP 2024-100711, filed June 21, 2024.
+**Filed:** April 30, 2025 (PCT/JP2025/016405).
+**Published:** December 26, 2025.
+**Embodiment analyzed:** Example 1 (実施例 1), corresponding to Figure 1.
 
 The identification of Example 1 as the production SEL2870GM design rests on the following convergent evidence:
 

--- a/src/lens-data/sony/SonyFE55mmf18ZA.analysis.md
+++ b/src/lens-data/sony/SonyFE55mmf18ZA.analysis.md
@@ -7,7 +7,7 @@
 **Inventors:** Yonghua Chen (Tokyo), Naoki Miyagawa (Kanagawa)
 **Filed:** August 21, 2014 (US); **Priority:** September 27, 2013 (JP 2013-201345)
 **Published:** April 2, 2015
-**Embodiment used:** Example 1 (Numerical Example 1, Tables 1–3; Figs. 1, 12, 13)
+**Embodiment analyzed:** Example 1 (Numerical Example 1, Tables 1–3; Figs. 1, 12, 13)
 
 The identification of Example 1 as the production Sony Sonnar T* FE 55mm F1.8 ZA (SEL55F18Z) rests on the following convergent evidence:
 

--- a/src/lens-data/sony/SonyFE70200mmf28GMII.analysis.md
+++ b/src/lens-data/sony/SonyFE70200mmf28GMII.analysis.md
@@ -6,7 +6,7 @@
 **Applicant:** Sony Group Corporation (ソニーグループ株式会社).
 **Inventors:** Naoki Miyakawa (宮川 直己), Shūgo Takahashi (高橋 周吾).
 **Filed:** September 9, 2021. **Published:** March 22, 2023.
-**Embodiment used:** Example 2 (実施例2, Numerical Example 2).
+**Embodiment analyzed:** Example 2 (実施例2, Numerical Example 2).
 
 The identification of Example 2 as the production Sony FE 70-200mm F2.8 GM OSS II (SEL70200GM2) rests on the following convergent evidence:
 

--- a/src/lens-data/sony/SonyFE85mmf14GMII.analysis.md
+++ b/src/lens-data/sony/SonyFE85mmf14GMII.analysis.md
@@ -6,7 +6,7 @@
 **Applicant:** Sony Group Corporation (JP)
 **Inventors:** Yamagishi Masakazu, Tasaki Ryohei, Kumisawa Yuma
 **Filed:** March 25, 2025 (PCT/JP2025/011665)
-**Priority date:** May 17, 2024 (JP 2024-081162)
+**Priority:** May 17, 2024 (JP 2024-081162)
 **Published:** November 20, 2025
 **Embodiment analyzed:** Example 2 (第2の構成例, Numerical Example 2)
 

--- a/src/lens-data/sony/SonyFE85mmf14GMII.analysis.md
+++ b/src/lens-data/sony/SonyFE85mmf14GMII.analysis.md
@@ -5,10 +5,10 @@
 **Patent:** WO 2025/239028 A1 — *Imaging Optical System and Imaging Device*
 **Applicant:** Sony Group Corporation (JP)
 **Inventors:** Yamagishi Masakazu, Tasaki Ryohei, Kumisawa Yuma
-**Filing date:** March 25, 2025 (PCT/JP2025/011665)
+**Filed:** March 25, 2025 (PCT/JP2025/011665)
 **Priority date:** May 17, 2024 (JP 2024-081162)
-**Publication date:** November 20, 2025
-**Embodiment used:** Example 2 (第2の構成例, Numerical Example 2)
+**Published:** November 20, 2025
+**Embodiment analyzed:** Example 2 (第2の構成例, Numerical Example 2)
 
 Example 2 is identified as the production design of the Sony FE 85mm F1.4 GM II (SEL85F14GM2) by the following convergent criteria:
 

--- a/src/lens-data/sony/SonyFE90mmf28.analysis.md
+++ b/src/lens-data/sony/SonyFE90mmf28.analysis.md
@@ -1,10 +1,13 @@
 # Sony FE 90 mm F2.8 Macro G OSS — Optical Analysis
 
-**Patent reference:** WIPO **WO 2016/136352 A1** — Sony Corporation, *"Macro lens and imaging device"*. Priority: JP 2015‑036470 (26 February 2015). International filing: PCT/JP2016/051987 (25 January 2016). Publication: 1 September 2016.
-
-**Inventors:** Yumiko UEHARA, Fumikazu KANETAKA, Hisashi UNO (all Sony Corporation).
-
-**Numerical example analysed:** Example 2 — the embodiment that corresponds to the production lens.
+**Patent:** WO 2016/136352 A1
+**Inventors:** Yumiko Uehara, Fumikazu Kanetaka, Hisashi Uno
+**Applicant:** Sony Corporation
+**Priority:** JP 2015-036470, February 26, 2015
+**Filed:** January 25, 2016 (PCT/JP2016/051987)
+**Published:** September 1, 2016
+**Title:** Macro lens and imaging device
+**Embodiment analyzed:** Example 2
 
 **Production model:** Sony **FE 90 mm F2.8 Macro G OSS** (model **SEL90M28G**), announced March 2015. Sony's product page lists the lens as a 35 mm full‑frame E‑mount macro: 11 groups / 15 elements, 9‑blade circular aperture, F2.8 maximum aperture, F22 minimum aperture, 0.28 m minimum focusing distance, 1:1 maximum magnification, 62 mm filter, 79 × 130.5 mm body, 602 g, with Optical SteadyShot image stabilisation. Sony's lens‑construction diagram on the product page identifies one Aspherical, one Super ED, and one ED element.
 

--- a/src/lens-data/sony/SonyPlanarFE50mmf14ZA.analysis.md
+++ b/src/lens-data/sony/SonyPlanarFE50mmf14ZA.analysis.md
@@ -6,9 +6,9 @@
 **Title:** 撮像レンズおよび撮像装置 (*Imaging Lens and Imaging Apparatus*).
 **Applicant:** Sony Corporation (000002185), Tokyo.
 **Inventor:** Hosoi Masaharu (細井 正晴).
-**Filing:** 15 December 2016 (international); priority 12 February 2016 (JP 2016-024597).
-**Publication:** 17 August 2017 (international); 13 December 2018 (JP republication).
-**Embodiment used:** Numerical Example 2 (数値実施例2), Tables 6–10 (¶0079–0091).
+**Filed:** 15 December 2016 (international); priority 12 February 2016 (JP 2016-024597).
+**Published:** 17 August 2017 (international); 13 December 2018 (JP republication).
+**Embodiment analyzed:** Numerical Example 2 (数値実施例2), Tables 6–10 (¶0079–0091).
 
 Convergent evidence linking Example 2 to the production Sony Planar T\* FE 50mm F1.4 ZA (SEL50F14Z):
 

--- a/src/lens-data/sony/SonyPlanarT50mmf14ZA.analysis.md
+++ b/src/lens-data/sony/SonyPlanarT50mmf14ZA.analysis.md
@@ -2,11 +2,12 @@
 
 ## Patent Reference and Design Identification
 
-**Patent:** US 2014/0071331 A1, "Imaging Lens and Imaging Apparatus," published 13 March 2014.
+**Patent:** US 2014/0071331 A1, "Imaging Lens and Imaging Apparatus."
 **Applicant:** Sony Corporation, Tokyo, Japan.
 **Inventors:** Kouji Katou, Yumiko Uehara, Motoyuki Otake.
 **Priority:** JP 2012-196889, filed 7 September 2012.
-**Embodiment used:** Numerical Example 4 (Table 10, aspheric Table 11, specs Table 12; cross-section FIG. 7; aberrations FIG. 8).
+**Published:** 13 March 2014.
+**Embodiment analyzed:** Numerical Example 4 (Table 10, aspheric Table 11, specs Table 12; cross-section FIG. 7; aberrations FIG. 8).
 
 The prescription is identified with the production **Sony Planar T* 50mm F1.4 ZA SSM** (model SAL50F14Z) on the basis of converging evidence:
 

--- a/src/lens-data/vivitar/VivitarSeries1200mmf3.analysis.md
+++ b/src/lens-data/vivitar/VivitarSeries1200mmf3.analysis.md
@@ -2,6 +2,13 @@
 
 ## Patent & Design Overview
 
+**Patent:** US 3,942,876
+**Inventor:** Ellis I. Betensky
+**Assignee:** Ponder & Best, Inc.
+**Granted:** March 9, 1976
+**Title:** Telephoto Lens
+**Embodiment analyzed:** Example 4 (Table IV, FIG. 5)
+
 US Patent 3,942,876, "Telephoto Lens," was granted on March 9, 1976, to Ellis I. Betensky and assigned to Ponder & Best, Inc. (the corporate parent of the Vivitar brand) of Santa Monica, California. The patent discloses five numerical embodiments of a telephoto lens family characterized by a movable front objective group and a stationary rear "correcting" or "compensating" element fixed relative to the film plane. Example 4 (Table IV, illustrated in FIG. 5) corresponds to the production Vivitar Series 1 200mm f/3.0 VMC Auto Telephoto, a six-element, six-group prime lens manufactured by Komine Co., Ltd. of Japan. The lens was part of the original Series 1 launch lineup and was widely available by 1974.
 
 **Key marketed specifications:**

--- a/src/lens-data/vivitar/VivitarSeries13585mmf28.analysis.md
+++ b/src/lens-data/vivitar/VivitarSeries13585mmf28.analysis.md
@@ -1,6 +1,14 @@
 # Vivitar Series 1 35–85mm f/2.8 VMC — Key Findings
 
 ## Patent Overview
+
+**Patent:** US 3,975,089
+**Inventor:** Ellis I. Betensky
+**Assignee:** Ponder & Best, Inc.
+**Filed:** April 1974
+**Granted:** August 1976
+**Embodiment analyzed:** Published optical prescription
+
 US Patent 3,975,089, filed April 1974 and granted August 1976, describes Ellis I. Betensky's innovative zoom lens design for Vivitar's premium Series 1 line. The optical prescription comprises 12 spherical elements arranged in four functional groups with a distinctive three-moving-group architecture.
 
 ## Core Innovation

--- a/src/lens-data/vivitar/VivitarSeries170210mmf284.analysis.md
+++ b/src/lens-data/vivitar/VivitarSeries170210mmf284.analysis.md
@@ -7,7 +7,7 @@
 **Assignee:** Vivitar Corporation, Santa Monica, California.
 **Filed:** April 5, 1984. Continuation-in-part of Ser. No. 189,591 (Oct. 1, 1980, issued as US 4,462,664), itself a CIP of Ser. No. 082,010 (Oct. 5, 1979, abandoned).
 
-**Embodiment used:** Example 4 (Table IV, FIG. 4).
+**Embodiment analyzed:** Example 4 (Table IV, FIG. 4).
 
 The patent discloses eight numerical examples of a three-group telephoto zoom lens in a plus–minus–plus configuration. Example 4 — the fourth of the eight — is the embodiment that was adopted for the production Vivitar Series 1 70–210 mm f/2.8–4 VMC Macro Focusing Zoom, the fourth-generation variant of Vivitar's flagship telephoto zoom. The identification rests on the following convergent evidence:
 

--- a/src/lens-data/voigtlander/VoigtlanderApoLanthar180mmf4.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderApoLanthar180mmf4.analysis.md
@@ -2,11 +2,14 @@
 
 ## Patent Reference and Design Identification
 
-**Patent:** JP 2003-270529 A (P2003-270529A), 「望遠レンズ」 (Telephoto Lens).
-**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nakano, Nagano, Japan.
-**Inventor:** 蓬田 祥寿 (romanization uncertain; possibly Yomogida Yoshitoshi or similar).
-**Filed:** 2002-03-14 (Heisei 14). **Published:** 2003-09-25 (Heisei 15).
-**Application No.:** 特願2002-069772.
+**Patent:** JP 2003-270529 A (P2003-270529A)
+**Application Number:** 特願2002-069772
+**Filed:** March 14, 2002 (Heisei 14)
+**Published:** September 25, 2003 (Heisei 15)
+**Inventor:** 蓬田 祥寿 (romanization uncertain; possibly Yomogida Yoshitoshi or similar)
+**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nakano, Nagano, Japan
+**Title:** Telephoto Lens (望遠レンズ)
+**Embodiment analyzed:** Example 1 (第1実施例), Table 1 (表1)
 
 The prescription transcribes **Example 1** (第1実施例, Table 1 / 表1), the primary embodiment in the patent filed for the Cosina Voigtländer APO-Lanthar 180mm f/4 SL Close Focus. The following evidence links the patent to the production lens, though questions remain about which of the two examples was manufactured:
 

--- a/src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.analysis.md
@@ -4,18 +4,17 @@
 
 ## 1. Patent Overview
 
-| Field | Detail |
-|---|---|
-| Patent Number | JP2021-43376A |
-| Application Number | 特願2019-166556 (P2019-166556) |
-| Filing Date | September 12, 2019 (令和1年9月12日) |
-| Publication Date | March 18, 2021 (令和3年3月18日) |
-| Inventor | Yasuyuki Sugano (菅野 靖之) |
-| Applicant | Cosina Co., Ltd. (株式会社コシナ), Nakano-shi, Nagano |
-| Title | Imaging Optical System (撮像光学系) |
-| Classification | G02B 13/00, G02B 13/18 |
-| Total Claims | 18 |
-| Total Worked Examples | 14 |
+**Patent:** JP2021-43376A
+**Application Number:** 特願2019-166556 (P2019-166556)
+**Filed:** September 12, 2019 (令和1年9月12日)
+**Published:** March 18, 2021 (令和3年3月18日)
+**Inventor:** Yasuyuki Sugano (菅野 靖之)
+**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nakano-shi, Nagano
+**Title:** Imaging Optical System (撮像光学系)
+**Classification:** G02B 13/00, G02B 13/18
+**Total Claims:** 18
+**Total Worked Examples:** 14
+**Embodiment analyzed:** Example 5
 
 This patent was filed by Cosina in September 2019 — the same year the Voigtländer APO-LANTHAR 50mm f/2.0 Aspherical launched for Sony E-mount. It discloses a family of quasi-symmetric imaging optical systems for interchangeable-lens digital cameras, covering 14 worked examples that span focal lengths from 25.8 mm to 134 mm, all at f/2.2 or faster. The inventor, Yasuyuki Sugano, is distinct from the designers named in previously analyzed Cosina patents (Kazuhiro Ogino for the Nokton 50mm f/1.0; Shoju Hatta and Yoshitoshi Aida for the Nokton 35mm f/1.2).
 

--- a/src/lens-data/voigtlander/VoigtlanderHeliar.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderHeliar.analysis.md
@@ -1,9 +1,12 @@
 # The Original Voigtländer Heliar: Analysis of US Patent 716,035
 
-**Patent:** US 716,035 — *Lens*
+**Patent:** US 716,035
+**Filed:** February 4, 1901
+**Granted:** December 16, 1902
 **Inventor:** Carl August Hans Harting, Brunswick, Germany
 **Assignee:** Voigtländer & Sohn Aktien Gesellschaft, Brunswick, Germany
-**Filed:** February 4, 1901 — **Granted:** December 16, 1902
+**Title:** Lens
+**Embodiment analyzed:** Original symmetric Heliar design
 
 ---
 

--- a/src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.analysis.md
@@ -2,11 +2,13 @@
 
 ## Patent Reference and Design Identification
 
-**Patent:** JP 2002-090622 A (特開2002-90622), "中望遠マクロレンズ" (Medium Telephoto Macro Lens).
-**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nakano-shi, Nagano Prefecture.
-**Inventor:** Aida Yoshihisa (逢田 祥寿).
-**Filed:** September 20, 2000 (平成12年9月20日). **Published:** March 27, 2002 (平成14年3月27日).
-**Embodiment analyzed:** Example 2 (第2実施形態), Table 2 (表2), described at ¶0018–0022.
+**Patent:** JP 2002-090622 A (特開2002-90622)
+**Filed:** September 20, 2000 (平成12年9月20日)
+**Published:** March 27, 2002 (平成14年3月27日)
+**Inventor:** Aida Yoshihisa (逢田 祥寿)
+**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nakano-shi, Nagano Prefecture
+**Title:** Medium Telephoto Macro Lens (中望遠マクロレンズ)
+**Embodiment analyzed:** Example 2 (第2実施形態), Table 2 (表2), ¶0018–0022
 
 This analysis transcribes Example 2 as requested. The following evidence supports and complicates the identification of this embodiment as the production design:
 

--- a/src/lens-data/voigtlander/VoigtlanderNokton35mmf12.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderNokton35mmf12.analysis.md
@@ -1,10 +1,11 @@
 # Voigtländer NOKTON 35mm f/1.2 Aspherical — Optical Analysis
 
-**Patent:** JP 2004-101880A, Example 2 (Table 3 / Table 4)
-**Inventor:** Yoshitoshi Hoda (蓬田 祥寿)
-**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nagano Prefecture, Japan
+**Patent:** JP 2004-101880 A
 **Filed:** September 10, 2002 (Heisei 14)
 **Published:** April 2, 2004 (Heisei 16)
+**Inventor:** Yoshitoshi Hoda (蓬田 祥寿)
+**Applicant:** Cosina Co., Ltd. (株式会社コシナ), Nagano Prefecture, Japan
+**Embodiment analyzed:** Example 2, Table 3 / Table 4
 
 ---
 

--- a/src/lens-data/voigtlander/VoigtlanderNokton50f1.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderNokton50f1.analysis.md
@@ -1,10 +1,11 @@
 # Cosina / Voigtländer Nokton 50mm f/1.0 — Complete Optical Analysis
-## Patent JP2023063766A (also published as JP7748091B2)
 
-**Inventor:** Kazuhiro Ogino  
-**Assignee:** Cosina Co., Ltd.  
-**Filed:** 25 October 2021 · **Granted:** 2 October 2025  
-**Analysis performed:** March 2026
+**Patent:** JP2023063766A; JP7748091B2
+**Filed:** October 25, 2021
+**Granted:** October 2, 2025
+**Inventor:** Kazuhiro Ogino
+**Applicant:** Cosina Co., Ltd.
+**Embodiment analyzed:** First embodiment, Table 1 / Table 2
 
 ---
 

--- a/src/lens-data/voigtlander/VoigtlanderNoktonX50mmf12.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderNoktonX50mmf12.analysis.md
@@ -1,10 +1,12 @@
 # Voigtländer NOKTON 50mm f/1.2 X-Mount — Patent Optical Analysis
 
-**Patent:** JP 2025-58577 A (Published 2025-04-09)
-**Filing date:** 2023-09-28 (Application No. 2023-168590)
-**Applicant:** Cosina Co., Ltd. (Nakano-shi, Nagano)
+**Patent:** JP 2025-58577 A
+**Application Number:** 2023-168590
+**Filed:** September 28, 2023
+**Published:** April 9, 2025
 **Inventor:** Shibata Yūki (柴田 裕輝)
-**Focus:** Example 1 (実施例1) — the implemented production design
+**Applicant:** Cosina Co., Ltd. (Nakano-shi, Nagano)
+**Embodiment analyzed:** Example 1 (実施例1)
 
 ---
 

--- a/src/lens-data/voigtlander/VoigtlanderUltron28f2.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderUltron28f2.analysis.md
@@ -1,10 +1,11 @@
 # Voigtländer ULTRON Vintage Line 28mm F2 Aspherical — Patent Analysis
 
-## JP2022-100641A, Example 1 (Cosina Co., Ltd.)
-
+**Patent:** JP2022-100641A
+**Filed:** December 24, 2020
+**Published:** July 6, 2022
 **Inventors:** Shōju Hatta (蓬田祥寿), Yūki Shibata (柴田裕輝)
-**Filed:** 2020-12-24 · **Published:** 2022-07-06
-**Assignee:** Cosina Co., Ltd., Nakano, Nagano, Japan
+**Applicant:** Cosina Co., Ltd., Nakano, Nagano, Japan
+**Embodiment analyzed:** Example 1
 
 ---
 

--- a/src/lens-data/voigtlander/VoigtlanderUltron50f2.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderUltron50f2.analysis.md
@@ -1,7 +1,7 @@
 # Voigtländer Ultron 50mm f/2 — Optical Design Analysis
 
 **Patent:** US 2,627,204
-**Priority Date:** April 29, 1950 (Swiss priority)
+**Priority:** April 29, 1950 (Swiss priority)
 **Filed:** December 28, 1950
 **Granted:** February 3, 1953
 **Inventor:** Albrecht Wilhelm Tronnier, Göttingen, Germany

--- a/src/lens-data/voigtlander/VoigtlanderUltron50f2.analysis.md
+++ b/src/lens-data/voigtlander/VoigtlanderUltron50f2.analysis.md
@@ -1,12 +1,13 @@
 # Voigtländer Ultron 50mm f/2 — Optical Design Analysis
 
-## US 2,627,204 Example II (Production Embodiment)
-
-**Patent:** US 2,627,204 — "Four-Component Gauss-Type Photographic Objective of High Light-Transmitting Capacity"
+**Patent:** US 2,627,204
+**Priority Date:** April 29, 1950 (Swiss priority)
+**Filed:** December 28, 1950
+**Granted:** February 3, 1953
 **Inventor:** Albrecht Wilhelm Tronnier, Göttingen, Germany
 **Assignee:** Voigtländer & Sohn AG, Braunschweig, Germany
-**Filed:** December 28, 1950 (Swiss priority: April 29, 1950)
-**Granted:** February 3, 1953
+**Title:** Four-Component Gauss-Type Photographic Objective of High Light-Transmitting Capacity
+**Embodiment analyzed:** Example II
 
 ---
 


### PR DESCRIPTION
## Summary

- Standardized lens analysis patent metadata on the robust bold-label block format across the corpus.
- Completed the remaining maker batches and updated the patent metadata backfill record.
- Normalized legacy top-block labels such as `Embodiment used`, `Filing date`, and `Publication date` to the current spec language.

## Validation

- Robust metadata scan: `209 / 209` analysis files pass; `0` missing.
- Confirmed no exact `Field | Detail` patent overview tables remain.
- `npm run format:check` passed.

Note: local `gh` auth is stale, so this PR was opened through the GitHub connector.