### PR TITLE
Widen fisheye off-axis ray launch via bounding sphere

### DIFF
--- a/__tests__/src/components/hooks/useOffAxisRays.test.ts
+++ b/__tests__/src/components/hooks/useOffAxisRays.test.ts
@@ -4,17 +4,26 @@ import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import useOffAxisRays from "../../../../src/components/hooks/useOffAxisRays.js";
 import buildLens from "../../../../src/optics/buildLens.js";
-import { doLayout, entrancePupilAtState, fopenAtZoom } from "../../../../src/optics/optics.js";
+import {
+  doLayout,
+  entrancePupilAtState,
+  fopenAtZoom,
+  halfFieldAtZoom,
+  tracingHalfFieldAtZoom,
+} from "../../../../src/optics/optics.js";
 import { createCoordinateTransforms } from "../../../../src/optics/diagramGeometry.js";
 import { raySampleCountForDensity } from "../../../../src/optics/raySampling.js";
 import LENS_DEFAULTS from "../../../../src/lens-data/defaults.js";
 import type { LensData, RuntimeLens } from "../../../../src/types/optics.js";
 import SonnarRaw from "../../../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.js";
+import NikonFisheye6mmf28Raw from "../../../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.js";
+import { computeOffAxisTraceGeometry } from "../../../../src/components/hooks/offAxisRayUtils.js";
 
 const Sonnar = { ...LENS_DEFAULTS, ...SonnarRaw } as LensData;
+const NikonFisheye6mmf28 = { ...LENS_DEFAULTS, ...NikonFisheye6mmf28Raw } as LensData;
 
-function buildTestFixture(focusT = 0, zoomT = 0) {
-  const L = buildLens(Sonnar);
+function buildTestFixture(focusT = 0, zoomT = 0, data: LensData = Sonnar) {
+  const L = buildLens(data);
   const ref = doLayout(0, 0, L);
   const IMG_MM = ref.imgZ;
   const cur = doLayout(focusT, zoomT, L);
@@ -116,6 +125,24 @@ describe("useOffAxisRays", () => {
     }
   });
 
+  it("keeps rectilinear off-axis rendering on the tracing-half-field safety scale", () => {
+    const { L, zPos, IMG_MM, sx, sy } = buildTestFixture();
+    const geometry = computeOffAxisTraceGeometry({
+      L,
+      zPos,
+      IMG_MM,
+      focusT: 0,
+      zoomT: 0,
+      sx,
+      sy,
+      showOffAxis: "trueAngle",
+    });
+
+    expect(geometry?.kind).toBe("slope");
+    expect(geometry?.fieldAngleDeg).toBeCloseTo(tracingHalfFieldAtZoom(0, L) * L.offAxisFieldFrac, 5);
+    expect(geometry?.fieldAngleDeg).toBeLessThan(halfFieldAtZoom(0, L) * L.offAxisFieldFrac);
+  });
+
   it("uses diagnostic ray sampling when requested", () => {
     const { L, zPos, IMG_MM, sx, sy, clampedRayEnd, currentPhysStopSD, currentEPSD } = buildTestFixture();
     const { result } = renderHook(() =>
@@ -190,6 +217,55 @@ describe("useOffAxisRays", () => {
     );
     expect(result.current.error).toBeNull();
     expect(result.current.segments.length).toBeGreaterThan(0);
+  });
+
+  it("targets the declared fisheye field with vector off-axis rendering", () => {
+    const { L, zPos, IMG_MM, sx, sy, clampedRayEnd, currentPhysStopSD, currentEPSD } = buildTestFixture(
+      0,
+      0,
+      NikonFisheye6mmf28,
+    );
+
+    const geometry = computeOffAxisTraceGeometry({
+      L,
+      zPos,
+      IMG_MM,
+      focusT: 0,
+      zoomT: 0,
+      sx,
+      sy,
+      showOffAxis: "trueAngle",
+    });
+
+    expect(geometry?.kind).toBe("vector");
+    expect(geometry?.fieldAngleDeg).toBeCloseTo(66, 8);
+    if (geometry?.kind === "vector") {
+      expect(geometry.vectorLaunch.totalFieldDeg).toBeCloseTo(66, 8);
+    }
+
+    const { result } = renderHook(() =>
+      useOffAxisRays({
+        L,
+        zPos,
+        IMG_MM,
+        focusT: 0,
+        zoomT: 0,
+        sx,
+        sy,
+        clampedRayEnd,
+        currentPhysStopSD,
+        currentEPSD,
+        rayDensity: "normal",
+        rayTracksF: false,
+        focusK: 0,
+        showOffAxis: "trueAngle",
+        lensKey: "nikon-fisheye-nikkor-6mm-f28",
+      }),
+    );
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.segments.length).toBe(L.offAxisFractions.length);
+    expect(result.current.segments.some((seg) => seg.sp.length > 0 || seg.gp.length > 0)).toBe(true);
   });
 
   it("catches errors and returns them", () => {

--- a/__tests__/src/optics/aberration/bokeh.test.ts
+++ b/__tests__/src/optics/aberration/bokeh.test.ts
@@ -22,7 +22,7 @@ import {
   doLayout,
   epAtZoom,
   fopenAtZoom,
-  solveChiefRayLaunchHeight,
+  solveChiefRay,
 } from "../../../../src/optics/optics.js";
 import { computeOffAxisFieldGeometry } from "../../../../src/optics/aberration/offAxis.js";
 import buildLens from "../../../../src/optics/buildLens.js";
@@ -159,10 +159,7 @@ describe("state-aware off-axis geometry", () => {
     const result = computeStateAwareOffAxisFieldGeometry(L, layout.z, focusT, 0, 0.75);
 
     expect(result).not.toBeNull();
-    expect(result!.yChief).toBeCloseTo(
-      solveChiefRayLaunchHeight(result!.fieldAngleDeg, focusT, 0, L, stateGeometry),
-      6,
-    );
+    expect(result!.yChief).toBeCloseTo(solveChiefRay(result!.fieldAngleDeg, focusT, 0, L, stateGeometry).yLaunch, 6);
   });
 
   it("differs from the paraxial chief-ray launch on a vignetted wide-angle field", () => {

--- a/__tests__/src/optics/boundingSphereLaunch.test.ts
+++ b/__tests__/src/optics/boundingSphereLaunch.test.ts
@@ -10,6 +10,7 @@ import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 
 const RECTILINEAR_FIXTURE = "nokton-50f1";
 const FISHEYE_FIXTURE = "nikon-fisheye-nikkor-6mm-f28";
+const FISHEYE_F56_FIXTURE = "nikon-fisheye-nikkor-6mm-f56";
 
 describe("launchSurfaceForFieldDeg", () => {
   it("returns object-plane for fields below the cap", () => {
@@ -112,18 +113,17 @@ describe("bounding-sphere parity vs object-plane (PR 8 Step 4)", () => {
       expect(boundingSphere.status).toBe("converged");
       expect(boundingSphere.launchSurface).toBe("bounding-sphere");
 
-      // Bit-identity to ~1e-12: both paths describe the same physical chief
-      // ray; the only divergence comes from the bisection's convergence
-      // tolerance (1e-9 mm at the stop). Projecting back to z=0 scales that
-      // by ~1/cos(θ), still well within the test bound.
-      expect(boundingSphere.yLaunch).toBeCloseTo(objectPlane.yLaunch, 9);
+      // Both paths describe the same physical chief ray; divergence comes from
+      // the bisection's residual tolerance (~1e-7 mm at the stop). Projected
+      // back to z=0 scales that by ~1/cos(θ), still well within the bound.
+      expect(boundingSphere.yLaunch).toBeCloseTo(objectPlane.yLaunch, 6);
     },
   );
 
   it("rectilinear cap boundary: solveChiefRay at 88° agrees with bounding-sphere at 88° on the Nokton", () => {
     // The dispatch routes rectilinear lenses through object-plane below the
-    // cap. Calling solveChiefRayBoundingSphere directly should agree to ~1e-12
-    // mm with the object-plane result it would otherwise replace.
+    // cap. Calling solveChiefRayBoundingSphere directly should agree to within
+    // the bisection's residual tolerance (~1e-7 mm) with the object-plane result.
     const L = buildLens(LENS_CATALOG[RECTILINEAR_FIXTURE]);
     const dispatched = solveChiefRay(15, 0, 0, L);
     const directBoundingSphere = solveChiefRayBoundingSphere(15, 0, 0, L, undefined, 0, undefined);
@@ -132,7 +132,7 @@ describe("bounding-sphere parity vs object-plane (PR 8 Step 4)", () => {
     expect(directBoundingSphere.launchSurface).toBe("bounding-sphere");
     expect(dispatched.status).toBe("converged");
     expect(directBoundingSphere.status).toBe("converged");
-    expect(directBoundingSphere.yLaunch).toBeCloseTo(dispatched.yLaunch, 9);
+    expect(directBoundingSphere.yLaunch).toBeCloseTo(dispatched.yLaunch, 6);
   });
 });
 
@@ -167,5 +167,29 @@ describe("past-cap chief rays exercise the bounding-sphere tracer (PR 8 integrat
     expect(above1).not.toBe(below1);
     expect(below1.launchSurface).toBe("object-plane");
     expect(above1.launchSurface).toBe("bounding-sphere");
+  });
+});
+
+describe("wide fisheye chief-ray bracketing", () => {
+  it("finds an internal valid bracket for the Nikon 6mm f/2.8 default off-axis field", () => {
+    const L = buildLens(LENS_CATALOG[FISHEYE_FIXTURE]);
+    const result = solveChiefRay(66, 0, 0, L);
+
+    expect(result.launchSurface).toBe("bounding-sphere");
+    expect(result.status).toBe("converged");
+    expect(result.vectorLaunch).toBeDefined();
+    expect(result.vectorLaunch?.totalFieldDeg).toBeCloseTo(66, 8);
+    expect(Number.isFinite(result.yLaunch)).toBe(true);
+  });
+
+  it("keeps a vector fallback when the Nikon 6mm f/5.6 field is physically blocked", () => {
+    const L = buildLens(LENS_CATALOG[FISHEYE_F56_FIXTURE]);
+    const result = solveChiefRay(66, 0, 0, L);
+
+    expect(result.launchSurface).toBe("bounding-sphere");
+    expect(result.status).toBe("bracket-failed");
+    expect(result.vectorLaunch).toBeDefined();
+    expect(result.vectorLaunch?.totalFieldDeg).toBeCloseTo(66, 8);
+    expect(Number.isFinite(result.yLaunch)).toBe(true);
   });
 });

--- a/__tests__/src/optics/buildLens.test.ts
+++ b/__tests__/src/optics/buildLens.test.ts
@@ -10,6 +10,7 @@ import NikkorRaw from "../../../src/lens-data/nikon/NikonNikkorZ50f18S.data.js";
 import Nikkor105Raw from "../../../src/lens-data/nikon/NikonNikkor105f14E.data.js";
 import NikkorN5cmf11Raw from "../../../src/lens-data/nikon/NikonN5cmf11.data.js";
 import NikonFisheye6mmf28Raw from "../../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.js";
+import NikonFisheye6mmf56Raw from "../../../src/lens-data/nikon/NikonFisheyeNikkor6mmf56.data.js";
 import Sonnar50f15Raw from "../../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.js";
 import NikkorZ70200Raw from "../../../src/lens-data/nikon/NikonNikkorZ70200f28.data.js";
 
@@ -19,6 +20,7 @@ const Nikkor = { ...LENS_DEFAULTS, ...NikkorRaw } as LensData;
 const Nikkor105 = { ...LENS_DEFAULTS, ...Nikkor105Raw } as LensData;
 const NikkorN5cmf11 = { ...LENS_DEFAULTS, ...NikkorN5cmf11Raw } as LensData;
 const NikonFisheye6mmf28 = { ...LENS_DEFAULTS, ...NikonFisheye6mmf28Raw } as LensData;
+const NikonFisheye6mmf56 = { ...LENS_DEFAULTS, ...NikonFisheye6mmf56Raw } as LensData;
 const Sonnar50f15 = { ...LENS_DEFAULTS, ...Sonnar50f15Raw } as LensData;
 
 describe("paraxialTrace", () => {
@@ -133,6 +135,16 @@ describe("buildLens — production lenses", () => {
     // but fisheyes skip that bisection — see buildLens.ts comment block and
     // TRACE_MODEL_IMPROVEMENT_PLAN.md PR 8 step 7.
     expect(L.halfField).toBeCloseTo(110, 6);
+  });
+
+  it("Nikon 6mm fisheyes keep declared 110° half-field metadata", () => {
+    const fast = buildLens(NikonFisheye6mmf28);
+    const slow = buildLens(NikonFisheye6mmf56);
+
+    expect(fast.halfField).toBeCloseTo(110, 6);
+    expect(slow.halfField).toBeCloseTo(110, 6);
+    expect(fast.tracingHalfField).toBeLessThan(fast.halfField);
+    expect(slow.tracingHalfField).toBeLessThan(slow.halfField);
   });
 
   it("throws when a large focalLengthDesign mismatch lacks projection metadata", () => {

--- a/__tests__/src/optics/chiefRaySolver.test.ts
+++ b/__tests__/src/optics/chiefRaySolver.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import buildLens from "../../../src/optics/buildLens.js";
-import {
-  computeFieldGeometryAtState,
-  solveChiefRay,
-  solveChiefRayLaunchHeight,
-} from "../../../src/optics/fieldGeometry.js";
+import { computeFieldGeometryAtState, solveChiefRay } from "../../../src/optics/fieldGeometry.js";
 import {
   ABSOLUTE_HALF_FIELD_CEILING,
   MAX_FIELD_LAUNCH_DEG,
@@ -44,16 +40,6 @@ describe("projectionLaunchSlopeForField", () => {
 });
 
 describe("solveChiefRay", () => {
-  it("returns yLaunch matching the legacy solveChiefRayLaunchHeight for rectilinear lenses", () => {
-    const L = buildLens(LENS_CATALOG[RECTILINEAR_FIXTURE]);
-    for (const deg of [0, 5, 15, 25]) {
-      const typed = solveChiefRay(deg, 0, 0, L);
-      const legacy = solveChiefRayLaunchHeight(deg, 0, 0, L);
-      expect(typed.yLaunch).toBeCloseTo(legacy, 12);
-      expect(typed.status === "converged" || typed.status === "paraxial-fallback").toBe(true);
-    }
-  });
-
   it("memoizes repeat solves on the same lens/state/field", () => {
     const L = buildLens(LENS_CATALOG[RECTILINEAR_FIXTURE]);
     const first = solveChiefRay(20, 0, 0, L);

--- a/__tests__/src/optics/distortionAnalysis.test.ts
+++ b/__tests__/src/optics/distortionAnalysis.test.ts
@@ -6,7 +6,7 @@ import {
   eflAtFocus,
   fopenAtZoom,
   skewImagePlaneIntercept,
-  solveChiefRayLaunchHeight,
+  solveChiefRay,
   thick,
   traceSkewRay,
 } from "../../../src/optics/optics.js";
@@ -329,7 +329,7 @@ describe("computeDistortionFieldGrid", () => {
     const fieldSlopeY = -edgePoint.idealY / rectilinearScale;
     const equivalentAngleDeg = (Math.atan(Math.hypot(fieldSlopeX, fieldSlopeY)) * 180) / Math.PI;
     const paraxialYChief = geometry.epRatio * Math.tan((equivalentAngleDeg * Math.PI) / 180);
-    const solvedYChief = solveChiefRayLaunchHeight(equivalentAngleDeg, focusT, zoomT, L, geometry);
+    const solvedYChief = solveChiefRay(equivalentAngleDeg, focusT, zoomT, L, geometry).yLaunch;
     const correction = Math.abs(paraxialYChief) > 1e-12 ? solvedYChief / paraxialYChief : 1;
     const correctedEpRatio = geometry.epRatio * correction;
     const trace = traceSkewRay(

--- a/__tests__/src/optics/exactSurfaceTraceVector.test.ts
+++ b/__tests__/src/optics/exactSurfaceTraceVector.test.ts
@@ -4,6 +4,7 @@ import {
   traceExactSurfaceStack,
   traceExactSurfaceStackVector,
 } from "../../../src/optics/internal/exactSurfaceTrace.js";
+import { doLayout, solveChiefRay, traceRay, traceRayVector } from "../../../src/optics/optics.js";
 import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 import type { RuntimeLens } from "../../../src/types/optics.js";
 
@@ -85,5 +86,46 @@ describe("traceExactSurfaceStackVector", () => {
     expect(vector.returnVertexIdx).toBe(slope.returnVertexIdx);
     expect(vector.y).toBeCloseTo(slope.y, 10);
     expect(vector.uy).toBeCloseTo(slope.uy, 10);
+  });
+
+  it("public traceRayVector matches slope tracing below the object-plane cap", () => {
+    const L = lensFor("nokton-50f1");
+    const { z: zPos } = doLayout(0, 0, L);
+    const fieldDeg = 15;
+    const thetaRad = (fieldDeg * Math.PI) / 180;
+    const y0 = 1.25;
+
+    const slope = traceRay(y0, -Math.tan(thetaRad), zPos, 0, 0, L.stopPhysSD, true, L);
+    const vector = traceRayVector(
+      {
+        origin: [0, y0, 0],
+        direction: [0, -Math.sin(thetaRad), Math.cos(thetaRad)],
+      },
+      zPos,
+      L.stopPhysSD,
+      true,
+      L,
+    );
+
+    expect(vector.y).toBeCloseTo(slope.y, 10);
+    expect(vector.u).toBeCloseTo(slope.u, 10);
+    expect(vector.clipped).toBe(slope.clipped);
+    expect(vector.pts.length).toBeGreaterThan(0);
+  });
+
+  it("public traceRayVector draws finite ghost points for past-cap fisheye launches", () => {
+    const L = lensFor("nikon-fisheye-nikkor-6mm-f28");
+    const { z: zPos } = doLayout(0, 0, L);
+    const launch = solveChiefRay(110, 0, 0, L).vectorLaunch;
+
+    expect(launch).toBeDefined();
+    const result = traceRayVector(launch!, zPos, L.stopPhysSD, true, L);
+    const points = [...result.pts, ...result.ghostPts];
+
+    expect(points.length).toBeGreaterThan(0);
+    for (const [z, y] of points) {
+      expect(Number.isFinite(z)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+    }
   });
 });

--- a/__tests__/src/optics/opticsEdgeCases.test.ts
+++ b/__tests__/src/optics/opticsEdgeCases.test.ts
@@ -2,7 +2,7 @@
  * Edge-case tests for optics engine — targeting uncovered branches in
  * optics.ts, buildLens.ts, bokeh.ts, and coma.ts.
  *
- * Focuses on: traceParaxialRay, solveChiefRayLaunchHeight fallbacks,
+ * Focuses on: traceParaxialRay, solveChiefRay fallbacks,
  * solveFieldAngleForImageHeight(Accurate) null paths, bokeh unusable-field
  * paths, and coma insufficient-samples paths.
  */
@@ -11,7 +11,7 @@ import { describe, it, expect } from "vitest";
 import buildLens from "../../../src/optics/buildLens.js";
 import {
   traceParaxialRay,
-  solveChiefRayLaunchHeight,
+  solveChiefRay,
   solveFieldAngleForImageHeight,
   solveFieldAngleForImageHeightAccurate,
   chiefRayImageHeight,
@@ -69,31 +69,31 @@ describe("traceParaxialRay", () => {
   });
 });
 
-/* ── solveChiefRayLaunchHeight ── */
+/* ── solveChiefRay launch height ── */
 
-describe("solveChiefRayLaunchHeight", () => {
+describe("solveChiefRay (launch height)", () => {
   const L = build(ApoLantharRaw);
 
   it("returns a finite launch height at 0 degrees", () => {
-    const result = solveChiefRayLaunchHeight(0, 0, 0, L);
+    const result = solveChiefRay(0, 0, 0, L).yLaunch;
     expect(isFinite(result)).toBe(true);
     expect(result).toBeCloseTo(0, 6);
   });
 
   it("returns a finite launch height at moderate field angle", () => {
-    const result = solveChiefRayLaunchHeight(10, 0, 0, L);
+    const result = solveChiefRay(10, 0, 0, L).yLaunch;
     expect(isFinite(result)).toBe(true);
     expect(Math.abs(result)).toBeGreaterThan(0);
   });
 
   it("returns a finite result even at the half-field angle", () => {
-    const result = solveChiefRayLaunchHeight(L.halfField, 0, 0, L);
+    const result = solveChiefRay(L.halfField, 0, 0, L).yLaunch;
     expect(isFinite(result)).toBe(true);
   });
 
   it("returns paraxial fallback for extreme beyond-field angles", () => {
     /* Beyond the vignetting limit — the bisection bracket may have no sign change */
-    const result = solveChiefRayLaunchHeight(85, 0, 0, L);
+    const result = solveChiefRay(85, 0, 0, L).yLaunch;
     expect(isFinite(result)).toBe(true);
   });
 });

--- a/src/components/hooks/offAxisRayUtils.ts
+++ b/src/components/hooks/offAxisRayUtils.ts
@@ -1,14 +1,39 @@
 import { computeStateAwareOffAxisFieldGeometry } from "../../optics/aberration/offAxis.js";
-import { eflAtZoom, halfFieldAtZoom, tracingHalfFieldAtZoom, traceRay } from "../../optics/optics.js";
+import {
+  computeFieldGeometryAtState,
+  eflAtZoom,
+  halfFieldAtZoom,
+  solveChiefRay,
+  traceRay,
+  traceRayVector,
+  tracingHalfFieldAtZoom,
+  type VectorFieldRayLaunch,
+} from "../../optics/optics.js";
+import { isFisheyeProjection, projectionImageHeightForLensAngle } from "../../optics/projection.js";
 import { ENABLE_EDGE_PROJECTION } from "../../utils/featureFlags.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { OffAxisMode } from "../../types/state.js";
 
-export interface OffAxisTraceGeometry {
-  uField: number;
-  yChief: number;
-  edgeEnd: number[];
-  useEdge: boolean;
+export type OffAxisTraceGeometry =
+  | {
+      kind: "slope";
+      fieldAngleDeg: number;
+      uField: number;
+      yChief: number;
+      edgeEnd: number[];
+      useEdge: boolean;
+    }
+  | {
+      kind: "vector";
+      fieldAngleDeg: number;
+      vectorLaunch: VectorFieldRayLaunch;
+      edgeEnd: number[];
+      useEdge: boolean;
+    };
+
+function idealOffAxisImageHeight(L: RuntimeLens, zoomT: number, fieldAngleDeg: number): number {
+  const thetaRad = (fieldAngleDeg * Math.PI) / 180;
+  return -projectionImageHeightForLensAngle(L, eflAtZoom(zoomT, L), thetaRad);
 }
 
 export function computeOffAxisTraceGeometry({
@@ -32,28 +57,58 @@ export function computeOffAxisTraceGeometry({
   sy: (y: number) => number;
   showOffAxis: OffAxisMode;
 }): OffAxisTraceGeometry | null {
-  // Off-axis ray rendering uses `tracingHalfField` (slope-launch-bisected with
-  // safety margin), not the declared `halfField`. For fisheyes the declared
-  // half-field can be much wider than what chief rays can physically traverse,
-  // and we want the visible off-axis bundle to actually reach the image plane.
-  // For rectilinear lenses the ratio is `TRACING_SAFETY_FACTOR` (e.g., 0.9).
   const halfDeg = halfFieldAtZoom(zoomT, L);
   const tracingDeg = tracingHalfFieldAtZoom(zoomT, L);
-  const safeFieldFrac = halfDeg > 0 ? L.offAxisFieldFrac * (tracingDeg / halfDeg) : L.offAxisFieldFrac;
-  const geometry = computeStateAwareOffAxisFieldGeometry(L, zPos, focusT, zoomT, safeFieldFrac, undefined, aberrationT);
-  if (geometry === null) return null;
-  const { fieldAngleDeg: currentOffAxisDeg, uField, yChief } = geometry;
-
   const useEdge = ENABLE_EDGE_PROJECTION && showOffAxis === "edge";
-  let edgeImgH: number;
-  if (useEdge) {
-    const chiefTrace = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, false, L, aberrationT);
-    const lastSurfZ = zPos[L.N - 1];
-    const chiefEndY = chiefTrace.y + chiefTrace.u * (IMG_MM - lastSurfZ);
-    edgeImgH = isFinite(chiefEndY) ? chiefEndY : -(eflAtZoom(zoomT, L) * Math.tan((currentOffAxisDeg * Math.PI) / 180));
-  } else {
-    edgeImgH = -(eflAtZoom(zoomT, L) * Math.tan((currentOffAxisDeg * Math.PI) / 180));
+  const isFisheye = isFisheyeProjection(L.projection);
+
+  // Promote to vector-launch only when the declared off-axis field exceeds the
+  // slope-valid tracing half-field, and only for fisheye projections. Below the
+  // cap the slope path is sufficient and cheaper; rectilinear lenses keep the
+  // pre-existing safe-zone clamp.
+  const declaredOffAxisDeg = halfDeg * L.offAxisFieldFrac;
+  if (isFisheye && declaredOffAxisDeg > tracingDeg) {
+    const stateGeometry = computeFieldGeometryAtState(focusT, zoomT, L, aberrationT);
+    const solve = solveChiefRay(declaredOffAxisDeg, focusT, zoomT, L, stateGeometry, aberrationT);
+    if (!solve.vectorLaunch) return null;
+
+    const idealEdgeImgH = idealOffAxisImageHeight(L, zoomT, declaredOffAxisDeg);
+    let edgeImgH = idealEdgeImgH;
+    if (useEdge) {
+      const chiefTrace = traceRayVector(solve.vectorLaunch, zPos, undefined, false, L);
+      const chiefEndY = chiefTrace.y + chiefTrace.u * (IMG_MM - zPos[L.N - 1]);
+      if (isFinite(chiefEndY)) edgeImgH = chiefEndY;
+    }
+    return {
+      kind: "vector",
+      fieldAngleDeg: declaredOffAxisDeg,
+      vectorLaunch: solve.vectorLaunch,
+      edgeEnd: [sx(IMG_MM), sy(edgeImgH)],
+      useEdge,
+    };
   }
 
-  return { uField, yChief, edgeEnd: [sx(IMG_MM), sy(edgeImgH)], useEdge };
+  // Slope path. Fisheye lenses within the slope-safe zone launch at the
+  // declared field directly; rectilinear lenses keep the safe-zone clamp.
+  const fieldFrac = isFisheye || halfDeg <= 0 ? L.offAxisFieldFrac : L.offAxisFieldFrac * (tracingDeg / halfDeg);
+  const geometry = computeStateAwareOffAxisFieldGeometry(L, zPos, focusT, zoomT, fieldFrac, undefined, aberrationT);
+  if (geometry === null) return null;
+  const { uField, yChief, fieldAngleDeg } = geometry;
+
+  const idealEdgeImgH = idealOffAxisImageHeight(L, zoomT, fieldAngleDeg);
+  let edgeImgH = idealEdgeImgH;
+  if (useEdge) {
+    const chiefTrace = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, false, L, aberrationT);
+    const chiefEndY = chiefTrace.y + chiefTrace.u * (IMG_MM - zPos[L.N - 1]);
+    if (isFinite(chiefEndY)) edgeImgH = chiefEndY;
+  }
+
+  return {
+    kind: "slope",
+    fieldAngleDeg,
+    uField,
+    yChief,
+    edgeEnd: [sx(IMG_MM), sy(edgeImgH)],
+    useEdge,
+  };
 }

--- a/src/components/hooks/useChromaticRays.ts
+++ b/src/components/hooks/useChromaticRays.ts
@@ -7,7 +7,12 @@
  * monochrome off-axis fan.
  */
 import { useMemo } from "react";
-import { traceRayChromatic, computeChromaticSpread } from "../../optics/optics.js";
+import {
+  computeChromaticSpread,
+  offsetVectorFieldRay,
+  traceRayChromatic,
+  traceRayVectorChromatic,
+} from "../../optics/optics.js";
 import { rayFractionsForDensity } from "../../optics/raySampling.js";
 import type { RuntimeLens, ChromaticChannel, ChromaticSpread, ChromaticSpreadByAxis } from "../../types/optics.js";
 import type { LensMovementTransform } from "../../optics/lensMovement.js";
@@ -175,25 +180,32 @@ export default function useChromaticRays({
           showOffAxis,
         });
         if (geometry) {
-          const { uField, yChief, edgeEnd, useEdge } = geometry;
           for (const f of rayFractionsForDensity(L.offAxisFractions, rayDensity)) {
             const h = f * currentEPSD;
-            const y0 = yChief + h;
             const uConverge = rayTracksF ? h * focusK : 0;
-            const uIn = uField + uConverge;
             for (const ch of channels) {
-              const rawResult = traceRayChromatic(
-                y0,
-                uIn,
-                zPos,
-                focusT,
-                zoomT,
-                currentPhysStopSD,
-                true,
-                L,
-                ch,
-                aberrationT,
-              );
+              const rawResult =
+                geometry.kind === "vector"
+                  ? traceRayVectorChromatic(
+                      offsetVectorFieldRay(geometry.vectorLaunch, 0, h, uConverge),
+                      zPos,
+                      currentPhysStopSD,
+                      true,
+                      L,
+                      ch,
+                    )
+                  : traceRayChromatic(
+                      geometry.yChief + h,
+                      geometry.uField + uConverge,
+                      zPos,
+                      focusT,
+                      zoomT,
+                      currentPhysStopSD,
+                      true,
+                      L,
+                      ch,
+                      aberrationT,
+                    );
               const result = movementTransform ? movementTransform.trace(rawResult) : rawResult;
               const seg = compileRaySegment(
                 result.pts,
@@ -204,7 +216,7 @@ export default function useChromaticRays({
                 sy,
                 clampedRayEnd,
                 IMG_MM,
-                useEdge ? edgeEnd : undefined,
+                geometry.useEdge ? geometry.edgeEnd : undefined,
               );
               out.push({
                 ...seg,

--- a/src/components/hooks/useOffAxisRays.ts
+++ b/src/components/hooks/useOffAxisRays.ts
@@ -7,7 +7,7 @@
  *   "edge"      — project to the paraxial image height on the image plane
  */
 import { useMemo } from "react";
-import { traceRay } from "../../optics/optics.js";
+import { offsetVectorFieldRay, traceRay, traceRayVector } from "../../optics/optics.js";
 import { rayFractionsForDensity } from "../../optics/raySampling.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { LensMovementTransform } from "../../optics/lensMovement.js";
@@ -76,14 +76,29 @@ export default function useOffAxisRays({
         showOffAxis,
       });
       if (geometry === null) return { segments: [], error: null };
-      const { uField, yChief, edgeEnd, useEdge } = geometry;
-
       for (const f of rayFractionsForDensity(L.offAxisFractions, rayDensity)) {
         const h = f * currentEPSD;
-        const y0 = yChief + h;
         const uConverge = rayTracksF ? h * focusK : 0;
-        const uIn = uField + uConverge;
-        const rawResult = traceRay(y0, uIn, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT);
+        const rawResult =
+          geometry.kind === "vector"
+            ? traceRayVector(
+                offsetVectorFieldRay(geometry.vectorLaunch, 0, h, uConverge),
+                zPos,
+                currentPhysStopSD,
+                true,
+                L,
+              )
+            : traceRay(
+                geometry.yChief + h,
+                geometry.uField + uConverge,
+                zPos,
+                focusT,
+                zoomT,
+                currentPhysStopSD,
+                true,
+                L,
+                aberrationT,
+              );
         const result = movementTransform ? movementTransform.trace(rawResult) : rawResult;
         out.push(
           compileRaySegment(
@@ -95,7 +110,7 @@ export default function useOffAxisRays({
             sy,
             clampedRayEnd,
             IMG_MM,
-            useEdge ? edgeEnd : undefined,
+            geometry.useEdge ? geometry.edgeEnd : undefined,
           ),
         );
       }

--- a/src/optics/aberration/offAxis.ts
+++ b/src/optics/aberration/offAxis.ts
@@ -5,7 +5,7 @@ import {
   sampleCircularPupil,
   sampleOrthogonalPupilFan,
   skewImagePlaneIntercept,
-  solveChiefRayLaunchHeight,
+  solveChiefRay,
   thick,
   traceChiefRelativeSkewRay,
   traceChiefRelativeSkewRayChromatic,
@@ -147,7 +147,7 @@ export function computeStateAwareOffAxisFieldGeometry(
   const launch = projectionLaunchSlopeForField(L, fieldAngleDeg);
   if (launch.status === "out-of-domain") return null;
   const uField = launch.uField;
-  const yChief = solveChiefRayLaunchHeight(fieldAngleDeg, focusT, zoomT, L, geometry, aberrationT, options);
+  const yChief = solveChiefRay(fieldAngleDeg, focusT, zoomT, L, geometry, aberrationT, options).yLaunch;
   const lastSurfZ = zPos[L.N - 1];
   const imagePlaneZ = lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
   if (!isFinite(uField) || !isFinite(yChief) || !isFinite(imagePlaneZ)) return null;

--- a/src/optics/distortionAnalysis.ts
+++ b/src/optics/distortionAnalysis.ts
@@ -14,12 +14,14 @@ import {
   chiefRayImageHeight,
   chiefRayImageHeightAccurate,
   computeAnalysisFieldGeometryAtState,
+  computeBoundingSphereVectorFieldLaunch,
   computeFieldGeometryAtState,
   skewImagePlaneIntercept,
-  solveChiefRayLaunchHeight,
+  solveChiefRay,
   solveFieldAngleForImageHeightAccurate,
   thick,
   traceSkewRay,
+  traceSkewRayVector,
 } from "./optics.js";
 import {
   distortionProjectionReferenceForLens,
@@ -32,7 +34,7 @@ import {
   type ProjectionReference,
   type ProjectionReferenceKind,
 } from "./projection.js";
-import type { FieldGeometryState } from "./optics.js";
+import type { FieldGeometryState, SkewRayTraceResult } from "./optics.js";
 import { isHeavyLensForRayWork } from "./raySampling.js";
 import type { RayTraceOptions } from "./rayTrace.js";
 import type { RuntimeLens } from "../types/optics.js";
@@ -95,6 +97,7 @@ interface DistortionReference {
   projectionReference: ProjectionReference;
   edgeImageHeight: number;
   idealFieldRadius: number;
+  zPos: number[];
   lastSurfZ: number;
   imagePlaneZ: number;
 }
@@ -134,6 +137,7 @@ function computeDistortionReference(
       projectionReference,
       edgeImageHeight: -idealFieldRadius,
       idealFieldRadius,
+      zPos,
       lastSurfZ,
       imagePlaneZ,
     };
@@ -181,6 +185,7 @@ function computeDistortionReference(
     projectionReference,
     edgeImageHeight,
     idealFieldRadius,
+    zPos,
     lastSurfZ,
     imagePlaneZ,
   };
@@ -309,15 +314,7 @@ function buildPupilCorrectionTable(
       continue;
     }
     const paraxialYChief = -reference.geometry.epRatio * launch.uField;
-    const solvedYChief = solveChiefRayLaunchHeight(
-      angleDeg,
-      focusT,
-      zoomT,
-      L,
-      reference.geometry,
-      aberrationT,
-      options,
-    );
+    const solvedYChief = solveChiefRay(angleDeg, focusT, zoomT, L, reference.geometry, aberrationT, options).yLaunch;
     const ratio = Math.abs(paraxialYChief) > 1e-12 ? solvedYChief / paraxialYChief : 1;
     table.push({ angleDeg, ratio: isFinite(ratio) ? ratio : 1 });
   }
@@ -337,13 +334,23 @@ function interpolatePupilCorrection(table: PupilCorrectionEntry[], angleDeg: num
   return 1;
 }
 
-interface DistortionGridLaunch {
-  fieldSlopeX: number;
-  fieldSlopeY: number;
-  equivalentAngleDeg: number;
-  idealX: number;
-  idealY: number;
-}
+type DistortionGridLaunch =
+  | {
+      kind: "slope";
+      fieldSlopeX: number;
+      fieldSlopeY: number;
+      equivalentAngleDeg: number;
+      idealX: number;
+      idealY: number;
+    }
+  | {
+      kind: "vector";
+      fieldAngleXDeg: number;
+      fieldAngleYDeg: number;
+      equivalentAngleDeg: number;
+      idealX: number;
+      idealY: number;
+    };
 
 function resolveDistortionGridLaunch(
   xNormalized: number,
@@ -351,13 +358,21 @@ function resolveDistortionGridLaunch(
   reference: DistortionReference,
 ): DistortionGridLaunch | null {
   if (reference.projectionReference.kind !== "rectilinear") {
-    const launch = projectionLaunchVectorForFieldAngles(
-      reference.projectionReference,
-      xNormalized * reference.geometry.halfFieldDeg,
-      yNormalized * reference.geometry.halfFieldDeg,
-    );
-    if (launch.status === "out-of-domain") return null;
+    const fieldAngleXDeg = xNormalized * reference.geometry.halfFieldDeg;
+    const fieldAngleYDeg = yNormalized * reference.geometry.halfFieldDeg;
+    const launch = projectionLaunchVectorForFieldAngles(reference.projectionReference, fieldAngleXDeg, fieldAngleYDeg);
+    if (launch.status === "out-of-domain") {
+      return {
+        kind: "vector",
+        fieldAngleXDeg,
+        fieldAngleYDeg,
+        equivalentAngleDeg: launch.totalFieldDeg,
+        idealX: launch.idealImageX,
+        idealY: launch.idealImageY,
+      };
+    }
     return {
+      kind: "slope",
       fieldSlopeX: launch.fieldSlopeX,
       fieldSlopeY: launch.fieldSlopeY,
       equivalentAngleDeg: launch.totalFieldDeg,
@@ -371,12 +386,69 @@ function resolveDistortionGridLaunch(
   const fieldSlopes = projectionFieldSlopesForImagePoint(reference.projectionReference, idealX, idealY);
   if (fieldSlopes === null) return null;
   return {
+    kind: "slope",
     fieldSlopeX: fieldSlopes.fieldSlopeX,
     fieldSlopeY: fieldSlopes.fieldSlopeY,
     equivalentAngleDeg: fieldSlopes.equivalentAngleDeg,
     idealX,
     idealY,
   };
+}
+
+type DistortionGridLaunchVector = Extract<DistortionGridLaunch, { kind: "vector" }>;
+type DistortionGridLaunchSlope = Extract<DistortionGridLaunch, { kind: "slope" }>;
+
+function traceDistortionGridPointVector(
+  launch: DistortionGridLaunchVector,
+  reference: DistortionReference,
+  currentPhysStopSD: number,
+  L: RuntimeLens,
+  aberrationT: number,
+  options?: RayTraceOptions,
+): SkewRayTraceResult | null {
+  const vectorLaunch = computeBoundingSphereVectorFieldLaunch(
+    L,
+    reference.geometry,
+    launch.fieldAngleXDeg,
+    launch.fieldAngleYDeg,
+    aberrationT,
+  );
+  if (vectorLaunch === null) return null;
+  return traceSkewRayVector(vectorLaunch, reference.zPos, currentPhysStopSD, true, L, options);
+}
+
+// The slope launch starts from the paraxial EP; pupil aberration is applied
+// post-hoc by scaling `epRatio` with the interpolated correction at the
+// equivalent field angle. The vector branch doesn't need this — the
+// bounding-sphere chief-ray bisection lands on the real stop center directly.
+function traceDistortionGridPointSlope(
+  launch: DistortionGridLaunchSlope,
+  reference: DistortionReference,
+  focusT: number,
+  zoomT: number,
+  currentPhysStopSD: number,
+  L: RuntimeLens,
+  pupilCorrection: PupilCorrectionEntry[],
+  aberrationT: number,
+  options?: RayTraceOptions,
+): SkewRayTraceResult {
+  const correction = interpolatePupilCorrection(pupilCorrection, launch.equivalentAngleDeg);
+  const correctedEpRatio = reference.geometry.epRatio * correction;
+  const chiefLaunchX = -correctedEpRatio * launch.fieldSlopeX;
+  const chiefLaunchY = -correctedEpRatio * launch.fieldSlopeY;
+  return traceSkewRay(
+    chiefLaunchX,
+    chiefLaunchY,
+    launch.fieldSlopeX,
+    launch.fieldSlopeY,
+    focusT,
+    zoomT,
+    currentPhysStopSD,
+    true,
+    L,
+    aberrationT,
+    options,
+  );
 }
 
 function traceDistortionGridPoint(
@@ -421,27 +493,34 @@ function traceDistortionGridPoint(
       usable: false,
     };
   }
-  const { fieldSlopeX, fieldSlopeY, equivalentAngleDeg, idealX, idealY } = launch;
+  const { idealX, idealY } = launch;
 
-  /* Apply pupil-aberration correction based on the equivalent field angle */
-  const correction = interpolatePupilCorrection(pupilCorrection, equivalentAngleDeg);
-  const correctedEpRatio = reference.geometry.epRatio * correction;
+  const trace =
+    launch.kind === "vector"
+      ? traceDistortionGridPointVector(launch, reference, currentPhysStopSD, L, aberrationT, options)
+      : traceDistortionGridPointSlope(
+          launch,
+          reference,
+          focusT,
+          zoomT,
+          currentPhysStopSD,
+          L,
+          pupilCorrection,
+          aberrationT,
+          options,
+        );
 
-  const chiefLaunchX = -correctedEpRatio * fieldSlopeX;
-  const chiefLaunchY = -correctedEpRatio * fieldSlopeY;
-  const trace = traceSkewRay(
-    chiefLaunchX,
-    chiefLaunchY,
-    fieldSlopeX,
-    fieldSlopeY,
-    focusT,
-    zoomT,
-    currentPhysStopSD,
-    true,
-    L,
-    aberrationT,
-    options,
-  );
+  if (trace === null) {
+    return {
+      idealX,
+      idealY,
+      tracedX: null,
+      tracedY: null,
+      radiusNormalized,
+      insideImageCircle: true,
+      usable: false,
+    };
+  }
 
   if (trace.clipped) {
     return {

--- a/src/optics/fieldGeometry.ts
+++ b/src/optics/fieldGeometry.ts
@@ -18,7 +18,7 @@ import {
   projectionLaunchSlopeForField,
   type LaunchSurface,
 } from "./projection.js";
-import { traceRay, type RayTraceOptions } from "./rayTrace.js";
+import { traceRay, traceRayVector, type RayTraceOptions } from "./rayTrace.js";
 import { resolveSurfaceTraceMode } from "./traceMode.js";
 import { recordChiefRayStatus } from "./chiefRayDiagnostics.js";
 
@@ -44,11 +44,32 @@ export interface ChiefRaySolveResult {
   status: "converged" | "paraxial-fallback" | "bracket-failed" | "out-of-domain";
   iterations: number;
   launchSurface: LaunchSurface;
+  vectorLaunch?: VectorFieldRayLaunch;
+}
+
+export interface VectorFieldRayLaunch {
+  origin: Vector3;
+  direction: Vector3;
+  launchBoundT: number;
+  launchRadiusMm: number;
+  fieldAngleXDeg: number;
+  fieldAngleYDeg: number;
+  totalFieldDeg: number;
+  radialPupilAxis: Vector3;
+  sagittalPupilAxis: Vector3;
+  launchSurface: "bounding-sphere";
+}
+
+export interface OffsetVectorFieldRay {
+  origin: Vector3;
+  direction: Vector3;
+  launchBoundT: number;
 }
 
 const CHIEF_RAY_MAX_ITERATIONS = 30;
 const CHIEF_RAY_BRACKET_EPSILON = 1e-9;
-const CHIEF_RAY_RESIDUAL_TOLERANCE = 1e-6;
+const CHIEF_RAY_RESIDUAL_TOLERANCE = 1e-7;
+const BOUNDING_SPHERE_BRACKET_SCAN_SAMPLES = 96;
 
 const chiefRaySolveCache: WeakMap<RuntimeLens, Map<string, ChiefRaySolveResult>> = new WeakMap();
 
@@ -347,7 +368,7 @@ function computeChiefRaySolve(
 // b-factor directly so it can be called from inside `computeFieldGeometryAtState`
 // (where the geometry struct isn't yet assembled) as well as from
 // `solveChiefRayBoundingSphere` (with a full `FieldGeometryState`).
-function computeBoundingSphereLaunchRadiusMm(L: RuntimeLens, chiefB: number): number {
+export function computeBoundingSphereLaunchRadiusMm(L: RuntimeLens, chiefB: number): number {
   let totalThickness = 0;
   let maxSD = 0;
   for (const s of L.S) {
@@ -355,6 +376,90 @@ function computeBoundingSphereLaunchRadiusMm(L: RuntimeLens, chiefB: number): nu
     if (s.sd && s.sd > maxSD) maxSD = s.sd;
   }
   return Math.max(2 * maxSD, totalThickness + Math.abs(chiefB) + 5);
+}
+
+function normalizeVector([x, y, z]: Vector3): Vector3 {
+  const length = Math.hypot(x, y, z);
+  if (!isFinite(length) || length <= 0) return [NaN, NaN, NaN];
+  return [x / length, y / length, z / length];
+}
+
+function addScaledVector(a: Vector3, b: Vector3, scale: number): Vector3 {
+  return [a[0] + b[0] * scale, a[1] + b[1] * scale, a[2] + b[2] * scale];
+}
+
+function vectorFieldAxes(
+  fieldAngleXDeg: number,
+  fieldAngleYDeg: number,
+): {
+  radialPupilAxis: Vector3;
+  sagittalPupilAxis: Vector3;
+  totalFieldDeg: number;
+} {
+  const totalFieldDeg = Math.hypot(fieldAngleXDeg, fieldAngleYDeg);
+  if (totalFieldDeg < 1e-12) {
+    return {
+      radialPupilAxis: [0, 1, 0],
+      sagittalPupilAxis: [1, 0, 0],
+      totalFieldDeg,
+    };
+  }
+
+  const thetaRad = (totalFieldDeg * Math.PI) / 180;
+  const cosTheta = Math.cos(thetaRad);
+  const sinTheta = Math.sin(thetaRad);
+  const cosAz = fieldAngleXDeg / totalFieldDeg;
+  const sinAz = fieldAngleYDeg / totalFieldDeg;
+
+  return {
+    radialPupilAxis: normalizeVector([cosTheta * cosAz, cosTheta * sinAz, sinTheta]),
+    sagittalPupilAxis: normalizeVector([-sinAz, cosAz, 0]),
+    totalFieldDeg,
+  };
+}
+
+export function computeBoundingSphereVectorFieldLaunch(
+  L: RuntimeLens,
+  geometry: FieldGeometryState,
+  fieldAngleXDeg: number,
+  fieldAngleYDeg: number,
+  aberrationT = 0,
+): VectorFieldRayLaunch | null {
+  void aberrationT;
+  const launchRadius = computeBoundingSphereLaunchRadiusMm(L, geometry.b);
+  const launch = boundingSphereLaunchVector(geometry.epRatio, fieldAngleXDeg, fieldAngleYDeg, launchRadius);
+  if (launch.status !== "ok") return null;
+
+  const axes = vectorFieldAxes(fieldAngleXDeg, fieldAngleYDeg);
+  return {
+    origin: launch.origin,
+    direction: launch.direction,
+    launchBoundT: 2 * launchRadius,
+    launchRadiusMm: launchRadius,
+    fieldAngleXDeg,
+    fieldAngleYDeg,
+    totalFieldDeg: axes.totalFieldDeg,
+    radialPupilAxis: axes.radialPupilAxis,
+    sagittalPupilAxis: axes.sagittalPupilAxis,
+    launchSurface: "bounding-sphere",
+  };
+}
+
+export function offsetVectorFieldRay(
+  launch: VectorFieldRayLaunch,
+  sagittalOffsetMm: number,
+  radialOffsetMm: number,
+  radialDirectionDelta = 0,
+): OffsetVectorFieldRay {
+  let origin = addScaledVector(launch.origin, launch.sagittalPupilAxis, sagittalOffsetMm);
+  origin = addScaledVector(origin, launch.radialPupilAxis, radialOffsetMm);
+
+  const direction =
+    Math.abs(radialDirectionDelta) > 1e-15
+      ? normalizeVector(addScaledVector(launch.direction, launch.radialPupilAxis, radialDirectionDelta))
+      : launch.direction;
+
+  return { origin, direction, launchBoundT: launch.launchBoundT };
 }
 
 export function solveChiefRayBoundingSphere(
@@ -374,12 +479,11 @@ export function solveChiefRayBoundingSphere(
   // bisection: a ray launched at `(y = -epRatio·u, slope = u)` from z=0 passes
   // through `(y=0, z=epRatio)` for any u, which is the paraxial EP definition.
   const epZ = geom.epRatio;
-  const launchRadius = computeBoundingSphereLaunchRadiusMm(L, geom.b);
   // Meridional convention: object-plane bisection slope-launches along the
   // y axis (uy0 = -tan θ), so the bounding-sphere meridional direction lives
   // in the y-z plane. Pass `fieldAngleDeg` as θ_y, not θ_x.
-  const launch = boundingSphereLaunchVector(epZ, 0, fieldAngleDeg, launchRadius);
-  if (launch.status !== "ok") {
+  const baseLaunch = computeBoundingSphereVectorFieldLaunch(L, { ...geom, epRatio: epZ }, 0, fieldAngleDeg);
+  if (baseLaunch === null) {
     return { yLaunch: NaN, uField: NaN, status: "out-of-domain", iterations: 0, launchSurface };
   }
 
@@ -391,8 +495,8 @@ export function solveChiefRayBoundingSphere(
   const cosTheta = Math.cos(thetaRad);
   const perpY = cosTheta;
   const perpZ = sinTheta;
-  const direction = launch.direction;
-  const baseOrigin = launch.origin;
+  const direction = baseLaunch.direction;
+  const baseOrigin = baseLaunch.origin;
 
   // The slope-launch equivalent uField, finite only for forward-cone fields.
   // Past 89° the consumer can't legitimately use this as a slope anyway; the
@@ -413,18 +517,23 @@ export function solveChiefRayBoundingSphere(
 
   const S = stateSurfaces(focusT, zoomT, L, aberrationT);
   const stopIdx = L.stopIdx;
-  const launchBoundT = 2 * launchRadius;
+  const launchBoundT = baseLaunch.launchBoundT;
 
   const heightAtStop = (yEP: number): number | null => {
     const origin: Vector3 = [baseOrigin[0], baseOrigin[1] + yEP * perpY, baseOrigin[2] + yEP * perpZ];
     const result = traceExactSurfaceStackVector(
       { S, asphByIdx: L.asphByIdx, stopIdx: L.stopIdx },
       { origin, direction },
-      { stopAt: stopIdx, launchBoundT },
+      { stopAt: stopIdx, launchBoundT, checkSemiDiameter: true },
     );
-    if (result.failureReason !== null) return null;
+    if (result.failureReason !== null || result.clipped) return null;
     return result.y;
   };
+
+  const launchAtYEP = (yEP: number): VectorFieldRayLaunch => ({
+    ...baseLaunch,
+    origin: [baseOrigin[0], baseOrigin[1] + yEP * perpY, baseOrigin[2] + yEP * perpZ],
+  });
 
   // Paraxial seed for yEP: with origin already centered such that yEP=0 passes
   // through the paraxial EP center `(0, 0, epRatio)`, the paraxial chief ray
@@ -440,36 +549,66 @@ export function solveChiefRayBoundingSphere(
       status: "converged",
       iterations: 0,
       launchSurface,
+      vectorLaunch: launchAtYEP(paraxialYEP),
     };
   }
 
   const bracketHalf = Math.max(0.5 * Math.abs(geom.epRatio * sinTheta), 0.5);
-  let lo = paraxialYEP - bracketHalf;
-  let hi = paraxialYEP + bracketHalf;
-  let yLo = heightAtStop(lo);
-  let yHi = heightAtStop(hi);
+  let bracket: { lo: number; hi: number; yLo: number } | null = null;
+  let nearestYEP = paraxialYEP;
+  let nearestAbsHeight = Infinity;
 
-  // Widen the bracket if the initial guess doesn't straddle the stop center.
-  // Bounding-sphere launches at past-cap fields can have less-predictable
-  // paraxial seeds than the object-plane path; allow a few doublings before
-  // giving up.
-  for (let attempt = 0; attempt < 3 && (yLo === null || yHi === null || yLo * yHi > 0); attempt++) {
-    lo = paraxialYEP - bracketHalf * (2 << attempt);
-    hi = paraxialYEP + bracketHalf * (2 << attempt);
-    yLo = heightAtStop(lo);
-    yHi = heightAtStop(hi);
+  for (let attempt = 0; attempt < 4 && bracket === null; attempt++) {
+    const scanHalf = bracketHalf * (2 << attempt);
+    const scanLo = paraxialYEP - scanHalf;
+    const scanHi = paraxialYEP + scanHalf;
+    let prev: { yEP: number; height: number } | null = null;
+
+    for (let i = 0; i <= BOUNDING_SPHERE_BRACKET_SCAN_SAMPLES; i++) {
+      const yEP = scanLo + ((scanHi - scanLo) * i) / BOUNDING_SPHERE_BRACKET_SCAN_SAMPLES;
+      const height = heightAtStop(yEP);
+      if (height === null) {
+        prev = null;
+        continue;
+      }
+
+      const absHeight = Math.abs(height);
+      if (absHeight < nearestAbsHeight) {
+        nearestAbsHeight = absHeight;
+        nearestYEP = yEP;
+      }
+      if (absHeight < CHIEF_RAY_RESIDUAL_TOLERANCE) {
+        return {
+          yLaunch: projectYLaunchToZ0(yEP),
+          uField: uFieldEquivalent,
+          status: "converged",
+          iterations: 0,
+          launchSurface,
+          vectorLaunch: launchAtYEP(yEP),
+        };
+      }
+
+      if (prev !== null && prev.height * height <= 0) {
+        bracket = { lo: prev.yEP, hi: yEP, yLo: prev.height };
+        break;
+      }
+      prev = { yEP, height };
+    }
   }
-  if (yLo === null || yHi === null || yLo * yHi > 0) {
+
+  if (bracket === null) {
     return {
-      yLaunch: projectYLaunchToZ0(paraxialYEP),
+      yLaunch: projectYLaunchToZ0(nearestYEP),
       uField: uFieldEquivalent,
       status: "bracket-failed",
       iterations: 0,
       launchSurface,
+      vectorLaunch: launchAtYEP(nearestYEP),
     };
   }
 
-  let fLo = yLo;
+  let { lo, hi } = bracket;
+  let fLo = bracket.yLo;
   for (let i = 0; i < CHIEF_RAY_MAX_ITERATIONS; i++) {
     const mid = (lo + hi) / 2;
     const yMid = heightAtStop(mid);
@@ -480,6 +619,7 @@ export function solveChiefRayBoundingSphere(
         status: "paraxial-fallback",
         iterations: i + 1,
         launchSurface,
+        vectorLaunch: launchAtYEP(paraxialYEP),
       };
     }
     if (Math.abs(yMid) < CHIEF_RAY_RESIDUAL_TOLERANCE) {
@@ -489,6 +629,7 @@ export function solveChiefRayBoundingSphere(
         status: "converged",
         iterations: i + 1,
         launchSurface,
+        vectorLaunch: launchAtYEP(mid),
       };
     }
     if (yMid < 0 === fLo < 0) {
@@ -504,28 +645,19 @@ export function solveChiefRayBoundingSphere(
         status: "converged",
         iterations: i + 1,
         launchSurface,
+        vectorLaunch: launchAtYEP((lo + hi) / 2),
       };
     }
   }
+  const solvedYEP = (lo + hi) / 2;
   return {
-    yLaunch: projectYLaunchToZ0((lo + hi) / 2),
+    yLaunch: projectYLaunchToZ0(solvedYEP),
     uField: uFieldEquivalent,
     status: "converged",
     iterations: CHIEF_RAY_MAX_ITERATIONS,
     launchSurface,
+    vectorLaunch: launchAtYEP(solvedYEP),
   };
-}
-
-export function solveChiefRayLaunchHeight(
-  fieldAngleDeg: number,
-  focusT: number,
-  zoomT: number,
-  L: RuntimeLens,
-  geometry?: FieldGeometryState,
-  aberrationT = 0,
-  options?: RayTraceOptions,
-): number {
-  return solveChiefRay(fieldAngleDeg, focusT, zoomT, L, geometry, aberrationT, options).yLaunch;
 }
 
 export function chiefRayImageHeightAccurate(
@@ -539,8 +671,14 @@ export function chiefRayImageHeightAccurate(
   options?: RayTraceOptions,
 ): number {
   const launch = projectionLaunchSlopeForField(L, fieldAngleDeg);
+  const solve = solveChiefRay(fieldAngleDeg, focusT, zoomT, L, geometry, aberrationT, options);
+  if (solve.vectorLaunch) {
+    const trace = traceRayVector(solve.vectorLaunch, zPos, undefined, false, L, options);
+    if (trace.clipped) return NaN;
+    return trace.y + trace.u * thick(L.N - 1, focusT, zoomT, L, aberrationT);
+  }
   const uField = launch.uField;
-  const yChief = solveChiefRayLaunchHeight(fieldAngleDeg, focusT, zoomT, L, geometry, aberrationT, options);
+  const yChief = solve.yLaunch;
   const trace = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT, options);
   return trace.y + trace.u * thick(L.N - 1, focusT, zoomT, L, aberrationT);
 }

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -201,7 +201,7 @@ export function traceExactSurfaceStackVector(
       failureReason = hit.failureReason;
       if (!ghost) break;
 
-      const fallbackPoint = fallbackSurfacePoint(origin, direction, vertexZ, i, lens);
+      const fallbackPoint = fallbackSurfacePoint(origin, direction, vertexZ, i, lens, maxT);
       if (fallbackPoint === null) continue;
       point = fallbackPoint.point;
       normal = fallbackPoint.normal;
@@ -346,16 +346,40 @@ function surfaceIntersectionMaxT(
   return launchBoundT && launchBoundT > 0 ? launchBoundT : 0;
 }
 
+// Only reached on the ghost-render path for grazing or backward rays from
+// bounding-sphere launches (forward production rays never trip the
+// `|direction[2]| < 1e-12` brute-force scan).
 function fallbackSurfacePoint(
   origin: Vector3,
   direction: Vector3,
   vertexZ: number,
   surfIdx: number,
   lens: ExactTraceLens,
+  maxT: number,
 ): { point: Vector3; normal: Vector3 } | null {
-  if (Math.abs(direction[2]) <= 1e-12) return null;
-  const t = (vertexZ - origin[2]) / direction[2];
-  if (!isFinite(t) || t < 0) return null;
+  const projectedT = Math.abs(direction[2]) > 1e-12 ? (vertexZ - origin[2]) / direction[2] : NaN;
+  let t = isFinite(projectedT) && projectedT >= 0 && (!isFinite(maxT) || projectedT <= maxT) ? projectedT : NaN;
+
+  if (!isFinite(t)) {
+    if (!isFinite(maxT) || maxT <= 0) return null;
+    const samples = 32;
+    let bestT = NaN;
+    let bestResidual = Infinity;
+    for (let i = 0; i <= samples; i++) {
+      const candidateT = (maxT * i) / samples;
+      const x = origin[0] + direction[0] * candidateT;
+      const y = origin[1] + direction[1] * candidateT;
+      const z = origin[2] + direction[2] * candidateT;
+      const surfaceZ = vertexZ + conicPolySag(Math.hypot(x, y), lens.S[surfIdx].R, lens.asphByIdx[surfIdx]);
+      const residual = Math.abs(z - surfaceZ);
+      if (isFinite(residual) && residual < bestResidual) {
+        bestResidual = residual;
+        bestT = candidateT;
+      }
+    }
+    if (!isFinite(bestT)) return null;
+    t = bestT;
+  }
 
   const x = origin[0] + direction[0] * t;
   const y = origin[1] + direction[1] * t;

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -32,11 +32,13 @@ export {
   chiefRayImageHeight,
   chiefRayImageHeightAccurate,
   computeAnalysisFieldGeometryAtState,
+  computeBoundingSphereVectorFieldLaunch,
   computeFieldGeometryAtState,
+  computeBoundingSphereLaunchRadiusMm,
   conjugateK,
   entrancePupilAtState,
+  offsetVectorFieldRay,
   solveChiefRay,
-  solveChiefRayLaunchHeight,
   solveFieldAngleForImageHeight,
   solveFieldAngleForImageHeightAccurate,
   traceChiefRayAtAngle,
@@ -44,6 +46,8 @@ export {
   type ChiefRaySolveResult,
   type EntrancePupilState,
   type FieldGeometryState,
+  type OffsetVectorFieldRay,
+  type VectorFieldRayLaunch,
 } from "./fieldGeometry.js";
 export {
   DEFAULT_CIRCULAR_PUPIL_RING_SAMPLES,
@@ -56,8 +60,12 @@ export {
   traceChiefRelativeSkewRayChromatic,
   traceRay,
   traceRayChromatic,
+  traceRayVector,
+  traceRayVectorChromatic,
   traceSkewRay,
   traceSkewRayChromatic,
+  traceSkewRayVector,
+  traceSkewRayVectorChromatic,
   traceToImage,
   wavelengthNd,
   type CircularPupilSample,
@@ -65,6 +73,7 @@ export {
   type RayTraceOptions,
   type SkewImagePlaneIntercept,
   type SkewRayTraceResult,
+  type VectorRayTraceInput,
 } from "./rayTrace.js";
 export { formatDist, formatPetzvalRadius } from "./opticsFormat.js";
 export { resolveSurfaceTraceMode, type SurfaceTraceMode } from "./traceMode.js";

--- a/src/optics/projection.ts
+++ b/src/optics/projection.ts
@@ -66,6 +66,25 @@ export function projectionImageHeightForAngle(reference: ProjectionReference, fi
   }
 }
 
+// Ideal projection image height for a lens at a given field angle, using the
+// lens's declared projection (fisheye focal length) or falling back to
+// `rectilinearScaleMm * tan(θ)` for rectilinear lenses.
+export function projectionImageHeightForLensAngle(
+  L: RuntimeLens,
+  rectilinearScaleMm: number,
+  fieldAngleRad: number,
+): number {
+  const projection = resolveProjection(L.projection);
+  switch (projection.kind) {
+    case "fisheye-equidistant":
+      return projection.focalLengthMm * fieldAngleRad;
+    case "fisheye-equisolid":
+      return 2 * projection.focalLengthMm * Math.sin(fieldAngleRad / 2);
+    default:
+      return rectilinearScaleMm * Math.tan(fieldAngleRad);
+  }
+}
+
 export function projectionFieldAngleForImageHeight(reference: ProjectionReference, imageHeight: number): number {
   const radius = Math.abs(imageHeight);
   if (!isFinite(radius) || reference.focalScaleMm <= 0) return NaN;

--- a/src/optics/pupilAberration.ts
+++ b/src/optics/pupilAberration.ts
@@ -33,8 +33,9 @@ import {
   epZRelStopAtZoom,
   xpZRelLastSurfAtZoom,
   doLayout,
-  solveChiefRayLaunchHeight,
+  solveChiefRay,
   traceRay,
+  traceRayVector,
 } from "./optics.js";
 import type { FieldGeometryState } from "./optics.js";
 import { stateSurfaces } from "./layout.js";
@@ -220,6 +221,7 @@ export function computePupilAberrationProfile(
     const fieldFrac = i / (n - 1);
     const fieldDeg = fieldFrac * halfFieldDeg;
     const launch = projectionLaunchSlopeForField(L, fieldDeg);
+    const solve = solveChiefRay(fieldDeg, focusT, zoomT, L, geom, aberrationT, options);
     if (launch.status === "out-of-domain") {
       samples.push({ fieldFrac, fieldDeg, chiefRayCorrection: 1, epShiftMm: 0 });
       continue;
@@ -231,7 +233,7 @@ export function computePupilAberrationProfile(
     // paraxialYChief = −epRatio × uField (mm).  Zero at fieldDeg = 0.
     const paraxialYChief = -epRatio * launch.uField;
     if (Math.abs(paraxialYChief) > 1e-12) {
-      const solvedYChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT, options);
+      const solvedYChief = solve.yLaunch;
       chiefRayCorrection = isFinite(solvedYChief) ? solvedYChief / paraxialYChief : 1;
       epShiftMm = (chiefRayCorrection - 1) * epRatio;
     }
@@ -294,7 +296,8 @@ export function computeExitPupilAberrationProfile(
     const fieldFrac = i / (n - 1);
     const fieldDeg = fieldFrac * halfFieldDeg;
     const launch = projectionLaunchSlopeForField(L, fieldDeg);
-    if (launch.status === "out-of-domain") {
+    const solve = solveChiefRay(fieldDeg, focusT, zoomT, L, geom, aberrationT, options);
+    if (launch.status === "out-of-domain" && !solve.vectorLaunch) {
       samples.push({ fieldFrac, fieldDeg, xpZRelLastSurf: paraxialXpZRelLastSurf, xpShiftMm: 0 });
       continue;
     }
@@ -306,8 +309,10 @@ export function computeExitPupilAberrationProfile(
     // At θ = 0, uField = 0 and the chief ray is the optical axis — no useful
     // back-projection is possible.  Use the paraxial baseline directly.
     if (Math.abs(fieldDeg) > 1e-9) {
-      const yChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT, options);
-      const result = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT, options);
+      const yChief = solve.yLaunch;
+      const result = solve.vectorLaunch
+        ? traceRayVector(solve.vectorLaunch, zPos, undefined, true, L, options)
+        : traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT, options);
 
       // Back-project: XP z = −y_last / u_last (relative to last surface).
       // Guard against near-zero exit slope (XP at infinity).
@@ -384,7 +389,7 @@ export function computeBothPupilAberrationProfiles(
         let chiefRayCorrection = 1;
         let epShiftMm = 0;
         if (Math.abs(paraxialYChief) > 1e-12) {
-          const solvedYChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT, options);
+          const solvedYChief = solveChiefRay(fieldDeg, focusT, zoomT, L, geom, aberrationT, options).yLaunch;
           chiefRayCorrection = isFinite(solvedYChief) ? solvedYChief / paraxialYChief : 1;
           epShiftMm = (chiefRayCorrection - 1) * epRatio;
         }
@@ -419,7 +424,8 @@ export function computeBothPupilAberrationProfiles(
     const fieldFrac = i / (n - 1);
     const fieldDeg = fieldFrac * halfFieldDeg;
     const launch = projectionLaunchSlopeForField(L, fieldDeg);
-    if (launch.status === "out-of-domain") {
+    const solve = solveChiefRay(fieldDeg, focusT, zoomT, L, geom, aberrationT, options);
+    if (launch.status === "out-of-domain" && !solve.vectorLaunch) {
       epSamples.push({ fieldFrac, fieldDeg, chiefRayCorrection: 1, epShiftMm: 0 });
       xpSamples.push({ fieldFrac, fieldDeg, xpZRelLastSurf: paraxialXpZRelLastSurf, xpShiftMm: 0 });
       continue;
@@ -434,16 +440,18 @@ export function computeBothPupilAberrationProfiles(
     const paraxialYChief = -epRatio * uField;
 
     if (Math.abs(fieldDeg) > 1e-9) {
-      const yChief = solveChiefRayLaunchHeight(fieldDeg, focusT, zoomT, L, geom, aberrationT, options);
+      const yChief = solve.yLaunch;
 
       // EP fields
-      if (Math.abs(paraxialYChief) > 1e-12) {
+      if (launch.status !== "out-of-domain" && Math.abs(paraxialYChief) > 1e-12) {
         chiefRayCorrection = isFinite(yChief) ? yChief / paraxialYChief : 1;
         epShiftMm = (chiefRayCorrection - 1) * epRatio;
       }
 
       // XP fields — trace the same solved chief ray through the full system
-      const result = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT, options);
+      const result = solve.vectorLaunch
+        ? traceRayVector(solve.vectorLaunch, zPos, undefined, true, L, options)
+        : traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT, options);
       if (isFinite(result.y) && isFinite(result.u) && Math.abs(result.u) > 1e-9) {
         xpZRelLastSurf = -result.y / result.u;
         xpShiftMm = xpZRelLastSurf - paraxialXpZRelLastSurf;

--- a/src/optics/rayTrace.ts
+++ b/src/optics/rayTrace.ts
@@ -5,7 +5,9 @@ import {
   normalizeDirection,
   refractDirection,
   traceExactSurfaceStack,
+  traceExactSurfaceStackVector,
   type ExactSurfaceTraceHit,
+  type Vector3,
 } from "./internal/exactSurfaceTrace.js";
 import { traceSurfacesParaxial } from "./internal/traceSurfaces.js";
 import { resolveSurfaceTraceMode } from "./traceMode.js";
@@ -21,6 +23,12 @@ export interface SkewRayTraceResult {
   ux: number;
   uy: number;
   clipped: boolean;
+}
+
+export interface VectorRayTraceInput {
+  origin: Vector3;
+  direction: Vector3;
+  launchBoundT?: number;
 }
 
 export interface SkewImagePlaneIntercept {
@@ -172,12 +180,25 @@ function appendExactTracePoints(
 ): void {
   for (const hit of hits) {
     const pt = [hit.point[2], hit.point[1]];
+    if (!isFinite(pt[0]) || !isFinite(pt[1])) continue;
     if (hit.clipped) {
       if (ghost) ghostPts.push(pt);
     } else {
       pts.push(pt);
     }
   }
+}
+
+function vectorLeadPoint(
+  input: VectorRayTraceInput,
+  firstHit: ExactSurfaceTraceHit | undefined,
+  leadDistance: number,
+): [number, number] {
+  const reference = firstHit?.point ?? input.origin;
+  const lead = Math.max(0, leadDistance);
+  const z = reference[2] - input.direction[2] * lead;
+  const y = reference[1] - input.direction[1] * lead;
+  return isFinite(z) && isFinite(y) ? [z, y] : [input.origin[2], input.origin[1]];
 }
 
 function surfaceZPositions(focusT: number, zoomT: number, L: RuntimeLens, aberrationT = 0): number[] {
@@ -304,6 +325,39 @@ function traceSkewRayExactCore(
   };
 }
 
+function traceSkewRayVectorExactCore(
+  input: VectorRayTraceInput,
+  zPos: number[],
+  stopSD: number | undefined,
+  ghost: boolean,
+  L: RuntimeLens,
+  channel: ChromaticChannel | undefined,
+): SkewRayTraceResult {
+  const result = traceExactSurfaceStackVector(
+    L,
+    { origin: input.origin, direction: input.direction },
+    {
+      zPos,
+      checkSemiDiameter: true,
+      stopSemiDiameter: stopSD,
+      ghost,
+      stopOnClip: true,
+      launchBoundT: input.launchBoundT,
+      indexAtSurface: channel
+        ? (i, nd) => L.indexByIdx?.[i]?.fn(channel) ?? wavelengthNd(nd, L.vdByIdx[i], channel)
+        : undefined,
+    },
+  );
+
+  return {
+    x: result.x,
+    y: result.y,
+    ux: result.ux,
+    uy: result.uy,
+    clipped: result.clipped,
+  };
+}
+
 export function traceSkewRay(
   x0: number,
   y0: number,
@@ -341,6 +395,33 @@ export function traceSkewRayChromatic(
   return mode === "exact"
     ? traceSkewRayExactCore(x0, y0, ux0, uy0, focusT, zoomT, stopSD, ghost, L, channel, aberrationT)
     : traceSkewRayLegacyCore(x0, y0, ux0, uy0, focusT, zoomT, stopSD, ghost, L, channel, aberrationT);
+}
+
+export function traceSkewRayVector(
+  input: VectorRayTraceInput,
+  zPos: number[],
+  stopSD: number | undefined,
+  ghost: boolean,
+  L: RuntimeLens,
+  options?: RayTraceOptions,
+): SkewRayTraceResult {
+  const mode = resolveSurfaceTraceMode(L, options?.mode);
+  if (mode !== "exact") return { x: NaN, y: NaN, ux: NaN, uy: NaN, clipped: true };
+  return traceSkewRayVectorExactCore(input, zPos, stopSD, ghost, L, undefined);
+}
+
+export function traceSkewRayVectorChromatic(
+  input: VectorRayTraceInput,
+  zPos: number[],
+  stopSD: number | undefined,
+  ghost: boolean,
+  L: RuntimeLens,
+  channel: ChromaticChannel,
+  options?: RayTraceOptions,
+): SkewRayTraceResult {
+  const mode = resolveSurfaceTraceMode(L, options?.mode);
+  if (mode !== "exact") return { x: NaN, y: NaN, ux: NaN, uy: NaN, clipped: true };
+  return traceSkewRayVectorExactCore(input, zPos, stopSD, ghost, L, channel);
 }
 
 export function skewImagePlaneIntercept(
@@ -509,6 +590,65 @@ export function traceRayChromatic(
   return mode === "exact"
     ? traceRayExactCore(y0, u0, zPos, focusT, zoomT, stopSD, ghost, L, channel, aberrationT)
     : traceRayLegacyCore(y0, u0, zPos, focusT, zoomT, stopSD, ghost, L, channel, aberrationT);
+}
+
+function traceRayVectorExactCore(
+  input: VectorRayTraceInput,
+  zPos: number[],
+  stopSD: number | undefined,
+  ghost: boolean,
+  L: RuntimeLens,
+  channel: ChromaticChannel | undefined,
+): RayTraceResult {
+  const result = traceExactSurfaceStackVector(
+    L,
+    { origin: input.origin, direction: input.direction },
+    {
+      zPos,
+      checkSemiDiameter: true,
+      stopSemiDiameter: stopSD,
+      ghost,
+      stopOnClip: true,
+      launchBoundT: input.launchBoundT,
+      indexAtSurface: channel
+        ? (i, nd) => L.indexByIdx?.[i]?.fn(channel) ?? wavelengthNd(nd, L.vdByIdx[i], channel)
+        : undefined,
+    },
+  );
+
+  const pts: number[][] = [];
+  const ghostPts: number[][] = [];
+  const lead = L.rayLead ?? 0;
+  pts.push(vectorLeadPoint(input, result.hits[0], lead));
+  appendExactTracePoints(result.hits, pts, ghostPts, ghost);
+  return { pts, ghostPts, y: result.y, u: result.uy, clipped: result.clipped };
+}
+
+export function traceRayVector(
+  input: VectorRayTraceInput,
+  zPos: number[],
+  stopSD: number | undefined,
+  ghost: boolean,
+  L: RuntimeLens,
+  options?: RayTraceOptions,
+): RayTraceResult {
+  const mode = resolveSurfaceTraceMode(L, options?.mode);
+  if (mode !== "exact") return { pts: [], ghostPts: [], y: NaN, u: NaN, clipped: true };
+  return traceRayVectorExactCore(input, zPos, stopSD, ghost, L, undefined);
+}
+
+export function traceRayVectorChromatic(
+  input: VectorRayTraceInput,
+  zPos: number[],
+  stopSD: number | undefined,
+  ghost: boolean,
+  L: RuntimeLens,
+  channel: ChromaticChannel,
+  options?: RayTraceOptions,
+): RayTraceResult {
+  const mode = resolveSurfaceTraceMode(L, options?.mode);
+  if (mode !== "exact") return { pts: [], ghostPts: [], y: NaN, u: NaN, clipped: true };
+  return traceRayVectorExactCore(input, zPos, stopSD, ghost, L, channel);
 }
 
 interface MarginalRayData {

--- a/src/optics/vignetteAnalysis.ts
+++ b/src/optics/vignetteAnalysis.ts
@@ -22,7 +22,13 @@
  * state in a React hook rather than embedding in a component.
  */
 
-import { traceRay, solveChiefRayLaunchHeight, computeAnalysisFieldGeometryAtState } from "./optics.js";
+import {
+  computeAnalysisFieldGeometryAtState,
+  offsetVectorFieldRay,
+  solveChiefRay,
+  traceRay,
+  traceRayVector,
+} from "./optics.js";
 import { projectionLaunchSlopeForField } from "./projection.js";
 import type { FieldGeometryState } from "./optics.js";
 import { isHeavyLensForRayWork } from "./raySampling.js";
@@ -107,23 +113,31 @@ export function computeVignettingCurve(
 
   for (let i = 0; i < fieldSamples; i++) {
     const fieldAngleDeg = (i / (fieldSamples - 1)) * halfFieldDeg;
+    const solve = solveChiefRay(fieldAngleDeg, focusT, zoomT, L, geom, aberrationT, options);
     const launch = projectionLaunchSlopeForField(L, fieldAngleDeg);
-    if (launch.status === "out-of-domain") {
+    if (launch.status === "out-of-domain" && !solve.vectorLaunch) {
       rawGT.push(0);
       continue;
     }
-    const uField = launch.uField;
 
-    /* Solved chief-ray launch: iteratively corrects for pupil aberration.
-     * Falls back to paraxial for small angles (<1°) automatically. */
-    const yChief = solveChiefRayLaunchHeight(fieldAngleDeg, focusT, zoomT, L, geom, aberrationT, options);
+    const uField = launch.uField;
+    const yChief = solve.vectorLaunch ? NaN : solve.yLaunch;
 
     /* Dense meridional pupil sweep: nPupil evenly-spaced fractions in [−1, +1] */
     let surviving = 0;
     for (let j = 0; j < nPupil; j++) {
       const pupilFrac = -1 + (2 * j) / (nPupil - 1);
-      const y0 = yChief + pupilFrac * currentEPSD;
-      const trace = traceRay(y0, uField, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT, options);
+      const pupilOffset = pupilFrac * currentEPSD;
+      const trace = solve.vectorLaunch
+        ? traceRayVector(
+            offsetVectorFieldRay(solve.vectorLaunch, 0, pupilOffset),
+            zPos,
+            currentPhysStopSD,
+            true,
+            L,
+            options,
+          )
+        : traceRay(yChief + pupilOffset, uField, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT, options);
       if (!trace.clipped) surviving++;
     }
 


### PR DESCRIPTION
Promote past-cap fisheye off-axis bundles (chief, off-axis fans, chromatic, distortion, vignetting, pupil-aberration) to a 3D bounding-sphere launch instead of the slope-clamped tracing half-field. The chief-ray solver carries a VectorFieldRayLaunch on the result struct; consumers branch on it via discriminated unions. Slope launch is retained for rectilinear lenses and for fisheye fields still inside the slope-safe zone.