### PR TITLE
Enable Carl Zeiss Hologon 15 mm f/8 with internal-stop modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart TD
 
 ## Current Scope
 
-- `240` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
+- `241` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Canon, Carl Zeiss Jena, Carl Zeiss Oberkochen, Fujifilm,
   Hasselblad, Laowa, Leica, Minolta, Nikon, Olympus, Panasonic, Pentax, Ricoh, Schneider-Kreuznach, Sigma, Sony,
   Vivitar, and Voigtländer

--- a/__tests__/src/optics/buildLens.test.ts
+++ b/__tests__/src/optics/buildLens.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import buildLens, { paraxialTrace, realTraceToStop } from "../../../src/optics/buildLens.js";
+import { doLayout } from "../../../src/optics/optics.js";
 import LENS_DEFAULTS from "../../../src/lens-data/defaults.js";
 import type { LensData, SurfaceData } from "../../../src/types/optics.js";
 
@@ -13,6 +14,7 @@ import NikonFisheye6mmf28Raw from "../../../src/lens-data/nikon/NikonFisheyeNikk
 import NikonFisheye6mmf56Raw from "../../../src/lens-data/nikon/NikonFisheyeNikkor6mmf56.data.js";
 import CanonEF815mmf4LFisheyeRaw from "../../../src/lens-data/canon/CanonEF815mmf4LFisheye.data.js";
 import Sonnar50f15Raw from "../../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.js";
+import Hologon15f8Raw from "../../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.js";
 import NikkorZ70200Raw from "../../../src/lens-data/nikon/NikonNikkorZ70200f28.data.js";
 
 const ApoLanthar = { ...LENS_DEFAULTS, ...ApoLantharRaw } as LensData;
@@ -24,6 +26,7 @@ const NikonFisheye6mmf28 = { ...LENS_DEFAULTS, ...NikonFisheye6mmf28Raw } as Len
 const NikonFisheye6mmf56 = { ...LENS_DEFAULTS, ...NikonFisheye6mmf56Raw } as LensData;
 const CanonEF815mmf4LFisheye = { ...LENS_DEFAULTS, ...CanonEF815mmf4LFisheyeRaw } as LensData;
 const Sonnar50f15 = { ...LENS_DEFAULTS, ...Sonnar50f15Raw } as LensData;
+const Hologon15f8 = { ...LENS_DEFAULTS, ...Hologon15f8Raw } as LensData;
 
 describe("paraxialTrace", () => {
   const simpleSurfaces = [
@@ -168,6 +171,32 @@ describe("buildLens — production lenses", () => {
     const rectilinearData = { ...NikonFisheye6mmf28, projection: undefined } as LensData;
 
     expect(() => buildLens(rectilinearData)).toThrow(/computed Gaussian EFL/);
+  });
+
+  it("Hologon uses rectilinear declared coverage while retaining safe trace metadata", () => {
+    const L = buildLens(Hologon15f8);
+    const surfaceSDs = Object.fromEntries(L.S.map((s) => [s.label, s.sd]));
+    const infinityLayout = doLayout(0, 0, L);
+    const closeFocusLayout = doLayout(1, 0, L);
+
+    expect(L.elements).toHaveLength(3);
+    expect(L.ES).toContainEqual([2, 2, 4]);
+    expect(surfaceSDs["1"]).toBeCloseTo(11.45, 6);
+    expect(surfaceSDs["2"]).toBeCloseTo(3.82, 6);
+    expect(surfaceSDs["3"]).toBeCloseTo(3.83, 6);
+    expect(surfaceSDs.STO).toBeCloseTo(0.9375, 6);
+    expect(surfaceSDs["4"]).toBeCloseTo(3.83, 6);
+    expect(surfaceSDs["5"]).toBeCloseTo(3.6, 6);
+    expect(surfaceSDs["6"]).toBeCloseTo(8.84, 6);
+    expect(L.stopPhysSD).toBeCloseTo(0.9375, 6);
+    expect(L.data.maxRimAngleDeg).toBe(84);
+    expect(closeFocusLayout.th[L.N - 1]).toBeCloseTo(5.7612, 6);
+    expect(closeFocusLayout.imgZ - infinityLayout.imgZ).toBeCloseTo(1.2162, 4);
+    expect(L.projection.kind).toBe("rectilinear");
+    expect(L.apertureReferenceFocalLength).toBeCloseTo(L.EFL, 12);
+    expect(L.halfField).toBeCloseTo(60, 6);
+    expect(L.tracingHalfField).toBeGreaterThan(0);
+    expect(L.tracingHalfField).toBeLessThan(L.halfField);
   });
 
   /* ── Structural checks ── */
@@ -380,6 +409,37 @@ describe("buildLens — error handling", () => {
     const L = buildLens(data as unknown as LensData);
     expect(L.EFL).toBeGreaterThan(0);
     expect(L.N).toBe(3);
+  });
+
+  it("builds explicit element spans across an internal stop", () => {
+    const data = makeMinimalData({
+      elements: [
+        {
+          id: 1,
+          name: "L1",
+          label: "E1",
+          type: "test",
+          nd: 1.5,
+          vd: 50,
+          fl: 50,
+          glass: "test",
+          fromSurface: "1",
+          toSurface: "2",
+        },
+      ],
+      surfaces: [
+        { label: "1", R: 80, d: 4, nd: 1.5, elemId: 1, sd: 8 },
+        { label: "STO", R: 1e15, d: 4, nd: 1.5, elemId: 1, sd: 3, stopPlacement: "inside-element" },
+        { label: "2", R: -80, d: 40, nd: 1.0, elemId: 0, sd: 8 },
+      ],
+    });
+    const L = buildLens(data as unknown as LensData);
+
+    expect(L.ES).toEqual([[1, 0, 2]]);
+    expect(L.stopIdx).toBe(1);
+    expect(L.S[L.stopIdx].elemId).toBe(1);
+    expect(L.stopPhysSD).toBeCloseTo(3, 6);
+    expect(L.vdByIdx[L.stopIdx]).toBe(50);
   });
 
   it("throws when EFL is not finite (afocal system)", () => {

--- a/__tests__/src/optics/chiefRaySolver.test.ts
+++ b/__tests__/src/optics/chiefRaySolver.test.ts
@@ -11,6 +11,7 @@ import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 
 const RECTILINEAR_FIXTURE = "nokton-50f1";
 const FISHEYE_FIXTURE = "nikon-fisheye-nikkor-6mm-f28";
+const HOLOGON_FIXTURE = "zeiss-hologon-15f8";
 
 describe("projectionLaunchSlopeForField", () => {
   it("returns -tan(theta) for rectilinear lenses at moderate fields", () => {
@@ -72,6 +73,18 @@ describe("solveChiefRay", () => {
       expect(Number.isFinite(result.yLaunch)).toBe(true);
     }
   });
+
+  it("converges for representative wide Hologon object-plane chief rays", () => {
+    const L = buildLens(LENS_CATALOG[HOLOGON_FIXTURE]);
+
+    for (const deg of [30, 35]) {
+      const result = solveChiefRay(deg, 0, 0, L);
+      expect(result.launchSurface).toBe("object-plane");
+      expect(result.status).toBe("converged");
+      expect(result.iterations).toBeLessThanOrEqual(30);
+      expect(Number.isFinite(result.yLaunch)).toBe(true);
+    }
+  });
 });
 
 describe("computeFieldGeometryAtState halfField clamp", () => {
@@ -91,6 +104,16 @@ describe("computeFieldGeometryAtState halfField clamp", () => {
     const L = buildLens(LENS_CATALOG[RECTILINEAR_FIXTURE]);
     const geom = computeFieldGeometryAtState(0, 0, L);
     const edge = projectionLaunchSlopeForField(L, geom.halfFieldDeg);
+    expect(edge.status).toBe("ok");
+  });
+
+  it("uses declared rectilinear Hologon coverage without fisheye dispatch", () => {
+    const L = buildLens(LENS_CATALOG[HOLOGON_FIXTURE]);
+    const geom = computeFieldGeometryAtState(0, 0, L);
+    const edge = projectionLaunchSlopeForField(L, geom.halfFieldDeg);
+
+    expect(L.projection.kind).toBe("rectilinear");
+    expect(geom.halfFieldDeg).toBeCloseTo(60, 6);
     expect(edge.status).toBe("ok");
   });
 

--- a/__tests__/src/optics/diagramGeometry.test.ts
+++ b/__tests__/src/optics/diagramGeometry.test.ts
@@ -314,6 +314,31 @@ describe("computeElementShapes", () => {
     expect(shapes[2].eid).toBe(2);
   });
 
+  it("uses explicit span endpoints when a stop sits inside an element", () => {
+    const L = {
+      ES: [[1, 0, 2]],
+      S: [
+        { label: "1", R: 80, sd: 8, nd: 1.5, d: 4 },
+        { label: "STO", R: 1e15, sd: 3, nd: 1.5, d: 4, elemId: 1, stopPlacement: "inside-element" },
+        { label: "2", R: -80, sd: 8, nd: 1.0, d: 40 },
+      ],
+      asphByIdx: {},
+      maxRimSin: 0.95,
+      maxRimTan,
+      gapSagFrac: 0.9,
+      N: 3,
+    } as unknown as RuntimeLens;
+    const zPos = [0, 4, 8];
+    const diagnostics = computeElementRenderDiagnostics(L, zPos);
+    const shapes = computeElementShapes(L, zPos, sx, sy);
+
+    expect(diagnostics[0].front.surfaceLabel).toBe("1");
+    expect(diagnostics[0].rear.surfaceLabel).toBe("2");
+    expect(shapes).toHaveLength(1);
+    expect(shapes[0].z1).toBe(0);
+    expect(shapes[0].z2).toBe(8);
+  });
+
   it("gap trimming: rear surface with positive sag into narrow gap", () => {
     // Element 0: front flat, rear with R=15 (positive sag curves forward)
     // Element 1: front flat, rear flat

--- a/__tests__/src/optics/validateLensData.test.ts
+++ b/__tests__/src/optics/validateLensData.test.ts
@@ -223,6 +223,35 @@ describe("validateLensData", () => {
     expect(ok.some((error) => error.includes("projection.maxTraceFieldDeg"))).toBe(false);
   });
 
+  it("accepts rectilinear declared coverage metadata", () => {
+    expect(
+      validateLensData(
+        makeValid({
+          projection: {
+            kind: "rectilinear",
+            fullFieldDeg: 120,
+            maxTraceFieldDeg: 60,
+          },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects invalid rectilinear declared coverage metadata", () => {
+    const errors = validateLensData(
+      makeValid({
+        projection: {
+          kind: "rectilinear",
+          fullFieldDeg: 200,
+          maxTraceFieldDeg: 100,
+        },
+      }),
+    );
+
+    expect(errors.some((error) => error.includes("projection.fullFieldDeg"))).toBe(true);
+    expect(errors.some((error) => error.includes("projection.maxTraceFieldDeg"))).toBe(true);
+  });
+
   it("catches missing STO surface", () => {
     const data = makeValid({
       surfaces: [
@@ -302,6 +331,82 @@ describe("validateLensData", () => {
     });
     const errors = validateLensData(data);
     expect(errors.some((e) => e.includes("Element 99"))).toBe(true);
+  });
+
+  it("accepts an explicitly flagged internal stop inside one element span", () => {
+    const data = makeValid({
+      elements: [
+        {
+          id: 1,
+          name: "L1",
+          label: "E1",
+          type: "test",
+          nd: 1.5,
+          vd: 50,
+          fl: 50,
+          glass: "test",
+          fromSurface: "1",
+          toSurface: "2",
+        },
+      ],
+      surfaces: [
+        { label: "1", R: 100, d: 5, nd: 1.5, elemId: 1, sd: 8 },
+        { label: "STO", R: 1e15, d: 5, nd: 1.5, elemId: 1, sd: 4, stopPlacement: "inside-element" },
+        { label: "2", R: -100, d: 40, nd: 1.0, elemId: 0, sd: 8 },
+      ],
+    });
+
+    expect(validateLensData(data)).toEqual([]);
+  });
+
+  it("rejects an unflagged stop inside an explicit element span", () => {
+    const data = makeValid({
+      elements: [
+        {
+          id: 1,
+          name: "L1",
+          label: "E1",
+          type: "test",
+          nd: 1.5,
+          fromSurface: "1",
+          toSurface: "2",
+        },
+      ],
+      surfaces: [
+        { label: "1", R: 100, d: 5, nd: 1.5, elemId: 1, sd: 8 },
+        { label: "STO", R: 1e15, d: 5, nd: 1.5, elemId: 1, sd: 4 },
+        { label: "2", R: -100, d: 40, nd: 1.0, elemId: 0, sd: 8 },
+      ],
+    });
+
+    const errors = validateLensData(data);
+    expect(errors.some((error) => error.includes('requires stopPlacement: "inside-element"'))).toBe(true);
+  });
+
+  it("rejects malformed explicit element spans", () => {
+    const missing = validateLensData(
+      makeValid({
+        elements: [{ id: 1, name: "L1", label: "E1", type: "test", nd: 1.5, fromSurface: "1" }],
+      }),
+    );
+    expect(missing.some((error) => error.includes("fromSurface and toSurface must be provided together"))).toBe(true);
+
+    const reversed = validateLensData(
+      makeValid({
+        elements: [
+          {
+            id: 1,
+            name: "L1",
+            label: "E1",
+            type: "test",
+            nd: 1.5,
+            fromSurface: "2",
+            toSurface: "1",
+          },
+        ],
+      }),
+    );
+    expect(reversed.some((error) => error.includes("must come before"))).toBe(true);
   });
 
   it("catches elemId referencing nonexistent element", () => {
@@ -466,6 +571,7 @@ import NoktonRaw from "../../../src/lens-data/voigtlander/VoigtlanderNokton50f1.
 import NikkorRaw from "../../../src/lens-data/nikon/NikonNikkorZ50f18S.data.js";
 import Nikkor105Raw from "../../../src/lens-data/nikon/NikonNikkor105f14E.data.js";
 import Sonnar50f15Raw from "../../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.js";
+import Hologon15f8Raw from "../../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.js";
 import CanonRF1535Raw from "../../../src/lens-data/canon/CanonRF1535f28.data.js";
 import Nikkor1424Raw from "../../../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.js";
 import Nikkor1635Raw from "../../../src/lens-data/nikon/NikonNikkorAFS1635mmf4.data.js";
@@ -477,6 +583,7 @@ describe("validateLensData — production lenses", () => {
     ["NikkorZ50", { ...LENS_DEFAULTS, ...NikkorRaw }],
     ["Nikkor105", { ...LENS_DEFAULTS, ...Nikkor105Raw }],
     ["Sonnar50f15", { ...LENS_DEFAULTS, ...Sonnar50f15Raw }],
+    ["Hologon15f8", { ...LENS_DEFAULTS, ...Hologon15f8Raw }],
     ["Canon RF 15-35", { ...LENS_DEFAULTS, ...CanonRF1535Raw }],
     ["Nikkor 14-24", { ...LENS_DEFAULTS, ...Nikkor1424Raw }],
     ["Nikkor 16-35", { ...LENS_DEFAULTS, ...Nikkor1635Raw }],

--- a/agent_docs/adding_a_lens.md
+++ b/agent_docs/adding_a_lens.md
@@ -105,7 +105,7 @@ After the SDs validate, compare the rendered silhouette against any published op
 
 ### Validation
 
-`buildLens()` calls `validateLensData()` internally. Malformed data throws descriptive errors listing all issues. The validator checks: required fields, canonical mount/format ids when present, surface label uniqueness, element ID references, STO surface presence, edge thickness, SD ratio (max 3.0 sanity check), rim slope (actual aspherical slope at SD, threshold 64.2°), cross-gap overlap (at all zoom positions for zoom lenses), and conic height limits (K > 0).
+`buildLens()` calls `validateLensData()` internally. Malformed data throws descriptive errors listing all issues. The validator checks: required fields, canonical mount/format ids when present, surface label uniqueness, element ID references, STO surface presence, edge thickness, SD ratio (max 3.0 sanity check), rim slope (actual aspherical slope at SD, threshold 64.2°), cross-gap overlap (at all zoom positions for zoom lenses), and conic height limits (K > 0). Rare designs with the aperture stop physically inside a glass element use `stopPlacement: "inside-element"` on `STO` and `fromSurface`/`toSurface` on the containing element; see `src/lens-data/LENS_DATA_SPEC.md` for the embedded-stop rules.
 
 ### Zoom Lenses
 

--- a/agent_docs/architecture/optics-engine.md
+++ b/agent_docs/architecture/optics-engine.md
@@ -46,13 +46,17 @@ lens data; analysis tabs use current focus, zoom, and aperture state.
 - Element/group/doublet/aspheric/variable maps for runtime lookup.
 
 **`halfField` vs `tracingHalfField`.** Rectilinear lenses set both to the same slope-launch-bisected value
-(real chief ray vignetting check). Fisheye lenses set `halfField = projection.maxTraceFieldDeg` (the
-declared coverage — the patent-stated half-field, which can be wider than what slope-launch chief rays can
-traverse) and `tracingHalfField = halfFieldBisected × TRACING_SAFETY_FACTOR` (the bisection-narrowed value
-with a small safety margin). The diagram's off-axis ray rendering uses `tracingHalfField` so bundle rays
-actually reach the image plane on fisheyes; `halfField` drives distortion grid extent, projection metadata,
-and info displays. Zoom variants use `zoomHalfFields[]` / `zoomTracingHalfFields[]` accessed via
-`halfFieldAtZoom()` / `tracingHalfFieldAtZoom()`.
+(real chief ray vignetting check) by default. Fisheye lenses set `halfField = projection.maxTraceFieldDeg`
+(the declared coverage — the patent-stated half-field, which can be wider than what slope-launch chief rays
+can traverse) and `tracingHalfField = halfFieldBisected × TRACING_SAFETY_FACTOR` (the bisection-narrowed
+value with a small safety margin). The diagram's off-axis ray rendering uses `tracingHalfField` so bundle
+rays actually reach the image plane on fisheyes; `halfField` drives distortion grid extent, projection
+metadata, and info displays. Zoom variants use `zoomHalfFields[]` / `zoomTracingHalfFields[]` accessed via
+`halfFieldAtZoom()` / `tracingHalfFieldAtZoom()`. Rectilinear lenses may opt into the declared-coverage
+behavior by setting `projection: { kind: "rectilinear", fullFieldDeg, maxTraceFieldDeg }` — used for
+ultrawides like the Carl Zeiss Hologon 15 mm f/8 where the paraxial chief-ray bisector under-counts the
+published 120° coverage. The override only changes `halfField`; `tracingHalfField` still uses the bisected
+value so rendered ray bundles stay safely within what real surfaces can carry.
 
 `paraxialTrace()` is exported for low-level first-order tracing tests.
 
@@ -271,7 +275,10 @@ These functions feed `AsphericComparisonOverlay.tsx` exclusively and must not be
 ## Validation And Rendering Geometry
 
 `validateLensData.ts` checks required fields, references, STO presence, element edge thickness, SD consistency, rim slope,
-boundary-surface cross-gap overlap, conic limits, and zoom field consistency.
+boundary-surface cross-gap overlap, conic limits, and zoom field consistency. Elements that span more than one surface
+(via `fromSurface`/`toSurface`) and stops marked `stopPlacement: "inside-element"` are validated against tighter rules:
+explicit spans must be ordered and confined to one `elemId`, internal stops must be flat with `nd` matching the
+containing glass, and every interior surface inside a multi-surface element must itself be a flagged internal stop.
 
 `diagramGeometry.ts` provides:
 

--- a/agent_docs/generated/sellmeier-coverage.generated.md
+++ b/agent_docs/generated/sellmeier-coverage.generated.md
@@ -10,7 +10,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 ## Summary
 
 - **241** lenses scanned
-- **240** visible lenses scanned
+- **241** visible lenses scanned
 - **50** lenses fully covered
 - **50** visible lenses fully covered
 - **2123 / 2783** non-air surfaces use trusted Sellmeier data
@@ -226,7 +226,7 @@ Fully covered lenses are listed above; this table focuses on the remaining catal
 |  | **50-54.9% coverage** |  |  |  |  |  |
 | 138 | [SONY FE 135mm F1.8 GM](../../src/lens-data/sony/SonyFE135mmf18GM.data.ts) | 53.8% | 7/13 | 7/13 | 6 | abbe: 6 |
 | 139 | [Minolta AF 70-200mm f/2.8 APO G (D) SSM](../../src/lens-data/minolta/MinoltaAF70200mmf28APO.data.ts) | 52.6% | 10/19 | 10/19 | 9 | abbe: 9 |
-| 140 | [CARL ZEISS HOLOGON 15 mm f/8](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) *(hidden)* | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 140 | [CARL ZEISS HOLOGON 15 mm f/8](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) | 50.0% | 2/4 | 2/3 | 2 | abbe: 2 |
 | 141 | [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
 | 142 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
 | 143 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
@@ -1325,6 +1325,13 @@ Incomplete visible lenses, still ordered by descending completeness.
 | 22 | Element 13 | abbe | `E-LAF7 (HOYA) / N-LAF7 class` | No catalog match |
 | 25 | Element 14 | abbe | `781446 - high-index mid-dispersion glass (unresolved)` | No catalog match |
 | ... | ... | ... | ... | 1 more missing surface |
+
+### [CARL ZEISS HOLOGON 15 mm f/8](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) - 50.0% (2/4) - DE 1,241,637 B
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 3 | Element 2 | abbe | `LAK8 (Schott)` | No catalog match |
+| STO | Element 2 | abbe | `LAK8 (Schott)` | No catalog match |
 
 ### [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) - 50.0% (2/4) - FR 1.066.698
 

--- a/agent_docs/generated/unresolved-glass.generated.md
+++ b/agent_docs/generated/unresolved-glass.generated.md
@@ -10,8 +10,8 @@ or per-lens patent backfills.
 
 - **241** lenses scanned
 - **2783** non-air surfaces examined
-- **2777** element glass declarations examined
-- **550** non-explicit-unmatched annotations did not resolve
+- **2776** element glass declarations examined
+- **549** non-explicit-unmatched annotations did not resolve
 - **201** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency

--- a/agent_docs/records/hologon-rereview.md
+++ b/agent_docs/records/hologon-rereview.md
@@ -1,0 +1,61 @@
+# Hologon 15 mm f/8 Enablement
+
+## Summary
+
+- Flip `ZeissHologon15mmf8` to `visible: true` and add the lens-data primitives the design requires.
+- Two unusual properties drove the supporting work: (1) the aperture stop is physically inside the central
+  glass element, and (2) it is a 120° rectilinear ultrawide whose paraxial chief-ray bisector under-counts
+  the published coverage.
+
+## Changes
+
+- **Types** ([src/types/optics.ts](../../src/types/optics.ts)): added optional `SurfaceData.stopPlacement`,
+  optional `ElementData.fromSurface` / `toSurface`, and optional `fullFieldDeg` / `maxTraceFieldDeg` on
+  `RectilinearProjectionConfig`. All fields are additive and ignored for ordinary lenses.
+- **Build** ([src/optics/buildLens.ts](../../src/optics/buildLens.ts),
+  [src/optics/internal/lensState.ts](../../src/optics/internal/lensState.ts)): preserve authored stop SD when
+  `STO.stopPlacement === "inside-element"`; build element spans from explicit `fromSurface`/`toSurface`
+  endpoints when supplied (require both fields together — partial input falls through to the legacy
+  first-matching-elemId path).
+- **Projection** ([src/optics/projection.ts](../../src/optics/projection.ts)): new
+  `rectilinearProjectionMaxTraceField()` helper; returns `undefined` unless a rectilinear lens declares
+  `maxTraceFieldDeg` or `fullFieldDeg`. `buildLens` and `computeFieldGeometryAtState` consume it via
+  `helper(projection) ?? halfFieldBisected`, so ordinary rectilinear lenses still use the bisected value.
+- **Chief-ray solver** ([src/optics/fieldGeometry.ts](../../src/optics/fieldGeometry.ts)): on
+  initial-bracket failure the object-plane solver now scans outward in four doubling attempts (96 samples
+  each) mirroring the existing bounding-sphere scan, and tracks `fLo` through bisection so sign flips inside
+  the bracket are honored.
+- **Validation** ([src/optics/validateLensData.ts](../../src/optics/validateLensData.ts)): rectilinear
+  `fullFieldDeg`/`maxTraceFieldDeg` ranges (`fullFieldDeg < 180`, `maxTraceFieldDeg < 89`,
+  `maxTraceFieldDeg ≤ fullFieldDeg / 2`); explicit element spans must be ordered, single-`elemId`, and
+  contain only flagged internal stops; embedded `STO` must be flat with `nd`/`elemId` matching the
+  containing glass; edge-thickness check accumulates `centerThickness` across the span so multi-surface
+  elements remain consistent.
+- **Lens data**
+  ([src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts)):
+  rewrote L_II as one element spanning surfaces 3-4 across an internal flat STO with the f/8 physical
+  aperture (0.9375 mm); rebuilt SDs from a patent redraw; corrected `var.6` close-focus from subtractive to
+  additive (`4.545 → 5.7612` mm = `15²/(200−15)`); added `maxRimAngleDeg: 84`; added `projection: { kind:
+  "rectilinear", fullFieldDeg: 120, maxTraceFieldDeg: 60 }`.
+- **Docs**: [LENS_DATA_SPEC.md](../../src/lens-data/LENS_DATA_SPEC.md) and
+  [TEMPLATE.data.ts.template](../../src/lens-data/TEMPLATE.data.ts.template) document the new fields;
+  [architecture/optics-engine.md](../architecture/optics-engine.md) and
+  [adding_a_lens.md](../adding_a_lens.md) reference the rectilinear-coverage override and embedded-stop
+  rules; the user-facing changelog gets a single `lens` entry for 2026-05-21.
+- **Tests**: production-lens validator suite includes Hologon; new tests cover Hologon build (SDs,
+  close-focus shift, half-field, vd table), chief-ray convergence at 30°/35°, diagram element-span
+  rendering, and explicit-stop validator accept/reject paths.
+
+## Verification
+
+- `npm run typecheck` — passed
+- `npm run lint` — passed
+- `npm run format:check` — to run pre-commit
+- `npm run test` — 137 files / 1747 tests passed
+- One-off validator pass across all 241 lens data files — 0 failures (confirms no production lens trips
+  the new STO `nd !== 1.0` guard).
+
+## Follow-ups
+
+- None blocking. If another lens with an internal stop is added later, reuse the same
+  `stopPlacement: "inside-element"` + element-span pattern documented in `LENS_DATA_SPEC.md`.

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -91,7 +91,7 @@ These must be specified in every lens file — they have no defaults.
 | `elementCount` | `number` | | Total number of glass elements in the design. |
 | `groupCount` | `number` | | Total number of air-separated groups in the design. |
 | `perspectiveControl` | `object` | | Optional tilt/shift movement limits for perspective-control lenses. Omit for all ordinary lenses. |
-| `projection` | `object` | `{ kind: "rectilinear" }` | Optional projection metadata. Use only when the published focal length is a projection constant rather than the Gaussian EFL used by the centered paraxial trace, e.g. circular fisheyes. |
+| `projection` | `object` | `{ kind: "rectilinear" }` | Optional projection metadata. Use for non-rectilinear lenses, or for rare rectilinear designs whose published coverage should override the paraxial field estimate. |
 | `focusDescription` | `string` | | Human-readable focus mechanism description |
 | `asph` | `object` | | Aspherical coefficients (see below) |
 | `var` | `object` | | Variable air gaps for focus (see below) |
@@ -135,7 +135,19 @@ Suggested backfill order:
 
 ## Projection Metadata
 
-Most lenses should omit `projection`; they default to rectilinear behavior, and `focalLengthDesign` is expected to be close to the computed Gaussian EFL. Add projection metadata for non-rectilinear lenses when the published focal length is the imaging/projection constant used for f-number and image-circle descriptions.
+Most lenses should omit `projection`; they default to rectilinear behavior, and `focalLengthDesign` is expected to be close to the computed Gaussian EFL. Add projection metadata for non-rectilinear lenses when the published focal length is the imaging/projection constant used for f-number and image-circle descriptions. For unusual rectilinear ultrawides, projection metadata may also declare the published coverage when the paraxial chief-ray estimate is known to undercount the design.
+
+For unusual rectilinear ultrawides whose published coverage overrides the paraxial estimate:
+
+```javascript
+projection: {
+  kind: "rectilinear",
+  fullFieldDeg: 120,
+  maxTraceFieldDeg: 60,
+},
+```
+
+For non-rectilinear (fisheye) projections:
 
 ```javascript
 projection: {
@@ -147,7 +159,8 @@ projection: {
 },
 ```
 
-- `kind: "rectilinear"` is the implicit default.
+- `kind: "rectilinear"` is the implicit default. Omit it for ordinary lenses. When declared, `fullFieldDeg` is the published full field and `maxTraceFieldDeg` is the authoritative half-field used for `halfField`. Rectilinear launch slopes remain `tan(theta)`, and per-ray tracing still clips rays that do not pass the physical surfaces.
+- Rectilinear `fullFieldDeg` and `maxTraceFieldDeg` are single numbers, not zoom arrays. `maxTraceFieldDeg` must be less than 89° and cannot exceed half of `fullFieldDeg`.
 - `kind: "fisheye-equidistant"` (r = f·θ) uses `focalLengthMm` for aperture sizing while preserving the separately computed Gaussian EFL for optical diagnostics. Distortion residuals are measured against the equidistant reference.
 - `kind: "fisheye-equisolid"` (r = 2f·sin(θ/2)) — the common photographic fisheye projection used by lenses like the Sigma 15mm, Nikkor AF 8mm, and Olympus 8mm. Behaves like `fisheye-equidistant` for aperture/EFL handling but evaluates distortion residuals against the equal-area reference instead.
 - Zoom fisheyes may provide arrays for `focalLengthMm`, `fullFieldDeg`, `imageCircleMm`, and `maxTraceFieldDeg`; values are interpolated across the zoom range just like `zoomPositions`.
@@ -198,6 +211,8 @@ Each entry in the `elements` array describes one physical glass element.
   nC:       1.49514,                        // optional: measured refractive index at C line (656.3 nm), when published
   nF:       1.50123,                        // optional: measured refractive index at F line (486.1 nm), when published
   ng:       1.50632,                        // optional: measured refractive index at g line (435.8 nm), when published
+  fromSurface: "3",                         // optional: explicit physical span start for special internal surfaces
+  toSurface:   "4",                         // optional: explicit physical span end; provide with fromSurface
   role:     "Front positive meniscus...",    // optional: optical role description
   cemented: "D1",                           // optional: doublet/triplet group name
 }
@@ -219,6 +234,7 @@ the patent publishes partial dispersion or line indices, prefer transcribing the
 **Validation rules:**
 - Each `id` must be unique across all elements
 - Every element must be referenced by at least one surface's `elemId`
+- `fromSurface` and `toSurface` are normally omitted. Use them only when one physical element contains an optically neutral internal surface, currently the supported case is an embedded aperture stop. Both labels must exist, `fromSurface` must precede `toSurface`, and the internal surfaces between them must be explicitly flagged as internal stops.
 
 ---
 
@@ -306,6 +322,7 @@ Each entry in the `surfaces` array describes one optical surface, in strict fron
   nd:     1.85249,    // REQUIRED: refractive index of medium AFTER this surface
   elemId: 2,          // REQUIRED: element ID (0 = air interface)
   sd:     14.5,       // REQUIRED: semi-diameter (half clear aperture) in mm
+  stopPlacement: "inside-element", // optional: only valid on an embedded STO surface
 }
 ```
 
@@ -346,6 +363,7 @@ Each entry in the `surfaces` array describes one optical surface, in strict fron
   { label: "10",  R: -17.503, d: 0.14, nd: 1.56093, elemId: 6, sd: ... },  // Glass/resin junction — elemId: 6
   { label: "11A", R: -16.276, d: ...,  nd: 1.0,     elemId: 0, sd: ... },  // Resin rear (asph) → air
   ```
+- **Embedded stop inside glass:** Rare designs may put the aperture stop inside a glass element. In that case the `STO` surface stays optically neutral and flat, uses the same `nd` and `elemId` as the containing element, and sets `stopPlacement: "inside-element"`. The containing element must declare `fromSurface` and `toSurface` so the renderer uses the real outer glass surfaces as the element silhouette.
 - **Last surface:** `d` = back focal distance to image plane
 
 ### Aperture Stop
@@ -355,6 +373,7 @@ Exactly one surface must have `label: "STO"`. This is typically a flat surface (
 **Determining stop position:**
 - **Patent specifies stop:** Use the exact surface index or gap from the patent table.
 - **Patent does not specify (common in older patents):** Estimate from the patent figure drawing. Split the air gap at the inferred iris location — the preceding surface's `d` is the distance from that surface to the stop, and the STO surface's `d` is the remaining distance to the next surface. Document the estimate in a code comment (e.g., "STO position inferred from Fig. 1 iris placement").
+- **Patent places stop inside a glass element:** Use `stopPlacement: "inside-element"` on `STO`, keep the stop flat, set `STO.nd` to the containing glass index, set `STO.elemId` to the containing element id, and add `fromSurface`/`toSurface` to that element. Do not use this flag for ordinary air stops.
 
 ---
 

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -66,10 +66,11 @@ const LENS_DATA = {
    *  perspectiveControl    Optional tilt/shift movement limits for real PC lenses only.
    *                        Omit for ordinary lenses; defaults are no tilt/shift controls.
    *                        Use official manufacturer sources for shift/tilt ranges.
-   *  projection            Optional non-rectilinear projection metadata.
+   *  projection            Optional projection metadata.
    *                        Omit for ordinary rectilinear lenses. Use for circular fisheyes
-   *                        when the published focal length is a projection constant rather
-   *                        than the computed Gaussian EFL of the centered optical system.
+   *                        when the published focal length is a projection constant, or for
+   *                        unusual rectilinear ultrawides whose published coverage should
+   *                        override the paraxial field estimate.
    */
   focalLengthMarketing: 50,             // or [70, 200] for zooms
   focalLengthDesign:    51.2,           // omit if same as focalLengthMarketing
@@ -94,6 +95,7 @@ const LENS_DATA = {
   // Optional: declare non-rectilinear projection metadata for fisheyes.
   // Use "fisheye-equidistant" (r = f·θ) or "fisheye-equisolid" (r = 2f·sin(θ/2),
   // common in photographic fisheyes like the Sigma 15mm or Nikkor AF 8mm).
+  // For rare rectilinear ultrawides, use kind: "rectilinear" with fullFieldDeg/maxTraceFieldDeg.
   // projection: {
   //   kind: "fisheye-equidistant",
   //   focalLengthMm: 6.3,
@@ -121,11 +123,14 @@ const LENS_DATA = {
    *    nC       (number, optional)  Measured refractive index at C line (656.3 nm), when published in the source patent.
    *    nF       (number, optional)  Measured refractive index at F line (486.1 nm), when published.
    *    ng       (number, optional)  Measured refractive index at g line (435.8 nm), when published.
+   *    fromSurface/toSurface (string, optional) Explicit physical span for an element that contains an optically neutral internal surface.
    *    role     (string, optional)  Description of the element's optical role/function
    *    cemented (string, optional)  Doublet/triplet group name if cemented, e.g. "Jb", "L4"
    */
   elements: [
     { id: 1, name: "L1", label: "Element 1", type: "Biconvex Positive",  nd: 1.00000, vd: 00.00, fl:  00.0, glass: "Glass Name (CATALOG)", apd: false, role: "Description of optical role" },
+    // Embedded-stop element example:
+    // { id: 2, name: "L2", label: "Element 2", type: "Biconvex Positive", nd: 1.70000, fromSurface: "3", toSurface: "4", ... },
     // ... one entry per glass element, front to rear
   ],
 
@@ -192,8 +197,10 @@ const LENS_DATA = {
    *  elemId assignment rules:
    *    - Each glass element gets EXACTLY ONE surface with its elemId: its front (entry) surface.
    *    - Air gap surfaces (nd = 1.0 after a glass element) always use elemId: 0.
-   *    - The aperture stop (STO) uses elemId: 0.
+   *    - The aperture stop (STO) uses elemId: 0 unless it is explicitly inside a glass element.
    *    - The last surface's d is the back focal distance (BFD) to the image plane.
+   *    - Embedded glass stop exception: use stopPlacement: "inside-element" on STO, set STO.nd
+   *      and STO.elemId to the containing glass, and add fromSurface/toSurface to that element.
    *
    *  Standalone element pattern:
    *    { label: "1",  R: ..., d: ..., nd: 1.xxxxx, elemId: 1, sd: ... },  // L1 front — elemId: 1
@@ -235,6 +242,8 @@ const LENS_DATA = {
     //  If not (common in older patents), infer from the patent figure and split the
     //  air gap accordingly — preceding surface d = distance to stop, STO d = remainder.
     //  Document the estimate in a comment (e.g. "STO position inferred from Fig. 1").
+    //  If the stop is physically inside glass, keep STO flat and use:
+    //    { label: "STO", R: 1e15, d: ..., nd: glass_nd, elemId: glass_elem_id, sd: ..., stopPlacement: "inside-element" }
     // ...
   ],
 

--- a/src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts
+++ b/src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts
@@ -18,23 +18,17 @@ import type { LensDataInput } from "../../types/optics.js";
  * ║  NOTE ON STOP PLACEMENT:                                           ║
  * ║    The aperture stop is physically inside the central element       ║
  * ║    L_II at its center plane — there is no air gap at the stop.     ║
- * ║    L_II is modeled as two half-elements (L_IIa, L_IIb) with the   ║
- * ║    STO surface at the junction, following the cemented-pair        ║
- * ║    convention. Both halves share nd = 1.71300 (LAK8). The actual   ║
- * ║    lens has 3 physical elements; the split is a modeling artifact. ║
+ * ║    L_II is modeled as one physical element whose explicit surface   ║
+ * ║    span crosses an optically neutral internal STO plane. Both       ║
+ * ║    sides of the stop remain in nd = 1.71300 (LAK8) glass.           ║
  * ║                                                                    ║
  * ║  NOTE ON SEMI-DIAMETERS:                                           ║
- * ║    Patent does not list SDs. Paraxial chief-ray estimation fails   ║
- * ║    for this ultrawide design (60° half-field invalidates small-    ║
- * ║    angle assumptions). SDs estimated from physical constraints:    ║
- * ║    inner meniscus surfaces limited by sd/|R| ≤ 0.86 (near-        ║
- * ║    hemispherical geometry per patent description); outer surfaces  ║
- * ║    fitted against the patent section silhouette so the rendered     ║
- * ║    lens reads more like the drawing's fuller outer shells and       ║
- * ║    broader central shoulders while staying inside the project's     ║
- * ║    current SD/slope/ratio limits. All constraints pass:            ║
- * ║    rim slope < 2.065, edge thickness > 0.5 mm, cross-gap          ║
- * ║    intrusion < 90%.                                                ║
+ * ║    Patent does not list SDs. These values are measured from a       ║
+ * ║    patent redraw whose spherical arcs match the tabulated radii,    ║
+ * ║    then scaled to f ≈ 15 mm. Near-hemispherical rims are kept       ║
+ * ║    just inside exact tangent/full-radius limits so renderer and     ║
+ * ║    validation geometry remain stable. The stop SD is the f/8        ║
+ * ║    physical aperture: 15 / (2 × 8) = 0.9375 mm.                    ║
  * ║                                                                    ║
  * ║  IMPORTANT: This file describes ONLY the optical design:           ║
  * ║    ✓ Glass elements and surfaces (front element to image plane)   ║
@@ -47,22 +41,27 @@ const LENS_DATA = {
   key: "zeiss-hologon-15f8",
   maker: "Carl Zeiss Oberkochen",
   name: "CARL ZEISS HOLOGON 15 mm f/8",
-  visible: false,
+  visible: true,
   subtitle: "DE 1,241,637 B — GLATZEL & SCHULZ / CARL ZEISS",
   specs: ["3 ELEMENTS / 3 GROUPS", "f ≈ 15.0 mm", "F/8.0 (FIXED)", "2ω = 110°", "ALL SPHERICAL"],
 
   /* ── Explicit metadata fields ── */
   focalLengthMarketing: 15,
   apertureMarketing: 8,
-  lensMounts: ["fixed-lens-camera","leica-m"],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 120,
+    maxTraceFieldDeg: 60,
+  },
+  lensMounts: ["fixed-lens-camera", "leica-m"],
   imageFormat: "135-full-frame",
   patentYear: 1967,
   elementCount: 3,
   groupCount: 3,
 
   /* ── Elements ──
-   *  L_II is split into two half-elements (L_IIa, L_IIb) at the internal
-   *  aperture stop for rendering purposes. The physical lens has 3 elements.
+   *  L_II explicitly spans across the internal aperture stop. The STO surface
+   *  is an optically neutral aperture plane inside the physical glass.
    */
   elements: [
     {
@@ -79,32 +78,20 @@ const LENS_DATA = {
     },
     {
       id: 2,
-      name: "L_IIa",
-      label: "Element 2a (L_II front half)",
-      type: "Biconvex Positive (front half, split at STO)",
+      name: "L_II",
+      label: "Element 2",
+      type: "Biconvex Positive (internal stop)",
       nd: 1.713,
       vd: 53.89,
       fl: 5.5,
       glass: "LAK8 (Schott)",
       apd: false,
-      cemented: "L_II",
-      role: "Central positive element (front half) — converging power, chromatic anchor",
+      fromSurface: "3",
+      toSurface: "4",
+      role: "Central positive element with internal stop — converging power, chromatic anchor",
     },
     {
       id: 3,
-      name: "L_IIb",
-      label: "Element 2b (L_II rear half)",
-      type: "Biconvex Positive (rear half, split at STO)",
-      nd: 1.713,
-      vd: 53.89,
-      fl: 5.5,
-      glass: "LAK8 (Schott)",
-      apd: false,
-      cemented: "L_II",
-      role: "Central positive element (rear half) — converging power, chromatic anchor",
-    },
-    {
-      id: 4,
       name: "L_III",
       label: "Element 3",
       type: "Negative Meniscus",
@@ -123,13 +110,13 @@ const LENS_DATA = {
    *  All surfaces spherical.
    */
   surfaces: [
-    { label: "1", R: 11.64, d: 7.9785, nd: 1.80518, elemId: 1, sd: 8.05 }, // L_I front (r₁)
-    { label: "2", R: 3.843, d: 2.703, nd: 1.0, elemId: 0, sd: 3.45 }, // L_I rear → air (r₂)
-    { label: "3", R: 5.6685, d: 3.8243, nd: 1.713, elemId: 2, sd: 2.98 }, // L_II front (r₃) → L_IIa
-    { label: "STO", R: 1e15, d: 3.8243, nd: 1.713, elemId: 3, sd: 1.0 }, // Stop at center of L_II → L_IIb
-    { label: "4", R: -5.508, d: 2.4045, nd: 1.0, elemId: 0, sd: 2.98 }, // L_II rear → air (r₄)
-    { label: "5", R: -3.6285, d: 5.2365, nd: 1.80518, elemId: 4, sd: 3.24 }, // L_III front (r₅)
-    { label: "6", R: -8.9835, d: 4.545, nd: 1.0, elemId: 0, sd: 6.55 }, // L_III rear → BFD (r₆)
+    { label: "1", R: 11.64, d: 7.9785, nd: 1.80518, elemId: 1, sd: 11.45 }, // L_I front (r₁)
+    { label: "2", R: 3.843, d: 2.703, nd: 1.0, elemId: 0, sd: 3.82 }, // L_I rear → air (r₂)
+    { label: "3", R: 5.6685, d: 3.8243, nd: 1.713, elemId: 2, sd: 3.83 }, // L_II front (r₃)
+    { label: "STO", R: 1e15, d: 3.8243, nd: 1.713, elemId: 2, sd: 0.9375, stopPlacement: "inside-element" }, // Internal stop inside L_II
+    { label: "4", R: -5.508, d: 2.4045, nd: 1.0, elemId: 0, sd: 3.83 }, // L_II rear → air (r₄)
+    { label: "5", R: -3.6285, d: 5.2365, nd: 1.80518, elemId: 3, sd: 3.6 }, // L_III front (r₅)
+    { label: "6", R: -8.9835, d: 4.545, nd: 1.0, elemId: 0, sd: 8.84 }, // L_III rear → BFD (r₆)
   ],
 
   /* ── Aspherical coefficients ── */
@@ -137,10 +124,10 @@ const LENS_DATA = {
 
   /* ── Variable air spacings (unit focus) ──
    *  Leica M version: entire lens translates, only BFD changes.
-   *  Close focus at 0.2 m; extension ≈ f²/(d−f) = 1.22 mm.
+   *  Close focus at 0.2 m increases BFD by ≈15²/(200−15) = 1.2162 mm.
    */
   var: {
-    "6": [4.545, 3.33],
+    "6": [4.545, 5.7612],
   },
 
   varLabels: [["6", "BF"]],
@@ -167,6 +154,7 @@ const LENS_DATA = {
   /* ── Layout tuning ── */
   scFill: 0.5,
   yScFill: 0.58,
+  maxRimAngleDeg: 84,
 } satisfies LensDataInput;
 
 export default LENS_DATA;

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -31,6 +31,7 @@ import {
   fisheyeProjectionFocalLengthAtZoom,
   fisheyeProjectionMaxTraceFieldAtZoom,
   isFisheyeProjection,
+  rectilinearProjectionMaxTraceField,
   TRACING_SAFETY_FACTOR,
 } from "./projection.js";
 import { resolveSurfaceTraceMode, type SurfaceTraceMode } from "./traceMode.js";
@@ -292,6 +293,8 @@ export default function buildLens(data: LensData, options: BuildLensOptions = {}
 
   const stopIdx = S.findIndex((row) => row.label === "STO");
 
+  const preserveAuthoredStopSD = S[stopIdx]?.stopPlacement === "inside-element";
+
   /* ── Derive stop SD and entrance pupil from nominal f-number ──
    *  nominalFno is a required field (validated).  We back-compute:
    *    epSD = aperture-reference focal length / (2·Fno)
@@ -301,6 +304,8 @@ export default function buildLens(data: LensData, options: BuildLensOptions = {}
    *  the physical stop SD.  This accounts for aspherics and higher-order
    *  aberrations that the paraxial model ignores — without it, real rays
    *  overshoot the stop on lenses with strong aspherics (e.g. Nikon 60mm).
+   *  Embedded glass stops preserve their authored SD because that surface is
+   *  also part of the drawn physical element geometry.
    *  Falls back to the paraxial yRatio if the real trace hits TIR. */
   const { y: nomYRatio } = paraxialTrace(S, 1, 0, { stopAt: stopIdx });
   const { u: nomUe } = paraxialTrace(S, 1, 0, { skipLastTransfer: true });
@@ -310,7 +315,9 @@ export default function buildLens(data: LensData, options: BuildLensOptions = {}
   const baseNomFno = Array.isArray(data.nominalFno) ? data.nominalFno[0] : data.nominalFno!;
   const nominalEPSD = apertureReferenceFocalLength / (2 * baseNomFno);
   const nomRealY = realTraceToStop(S, asphByIdx, nominalEPSD, 0, stopIdx, traceMode);
-  S[stopIdx].sd = isFinite(nomRealY) && Math.abs(nomRealY) > 1e-15 ? nomRealY : nominalEPSD * nomYRatio;
+  if (!preserveAuthoredStopSD) {
+    S[stopIdx].sd = isFinite(nomRealY) && Math.abs(nomRealY) > 1e-15 ? nomRealY : nominalEPSD * nomYRatio;
+  }
 
   /* ── Optical constants ──
    *  EFL: trace a unit-height marginal ray (y=1, u=0) and read off the
@@ -450,7 +457,7 @@ export default function buildLens(data: LensData, options: BuildLensOptions = {}
 
   const halfField = fisheye
     ? (fisheyeProjectionMaxTraceFieldAtZoom(projection, 0) ?? halfFieldParaxial)
-    : halfFieldBisected;
+    : (rectilinearProjectionMaxTraceField(projection) ?? halfFieldBisected);
   const tracingHalfField = fisheye ? halfFieldBisected * TRACING_SAFETY_FACTOR : halfFieldBisected;
 
   /* ── Petzval sum ──
@@ -657,7 +664,7 @@ export default function buildLens(data: LensData, options: BuildLensOptions = {}
       const zFisheye = isFisheyeProjection(projection);
       const zHalfField = zFisheye
         ? (fisheyeProjectionMaxTraceFieldAtZoom(projection, zZoomT) ?? zHalfFieldParaxial)
-        : zHalfFieldBisected;
+        : (rectilinearProjectionMaxTraceField(projection) ?? zHalfFieldBisected);
       zoomHalfFields.push(zHalfField);
       zoomTracingHalfFields.push(zFisheye ? zHalfFieldBisected * TRACING_SAFETY_FACTOR : zHalfFieldBisected);
     }

--- a/src/optics/fieldGeometry.ts
+++ b/src/optics/fieldGeometry.ts
@@ -17,6 +17,7 @@ import {
   launchSurfaceForFieldDeg,
   MAX_FIELD_LAUNCH_DEG,
   projectionLaunchSlopeForField,
+  rectilinearProjectionMaxTraceField,
   type LaunchSurface,
 } from "./projection.js";
 import { traceRay, traceRayVector, type RayTraceOptions } from "./rayTrace.js";
@@ -70,6 +71,7 @@ export interface OffsetVectorFieldRay {
 const CHIEF_RAY_MAX_ITERATIONS = 30;
 const CHIEF_RAY_BRACKET_EPSILON = 1e-9;
 const CHIEF_RAY_RESIDUAL_TOLERANCE = 1e-7;
+const OBJECT_PLANE_BRACKET_SCAN_SAMPLES = 96;
 const BOUNDING_SPHERE_BRACKET_SCAN_SAMPLES = 96;
 
 const chiefRaySolveCache: WeakMap<RuntimeLens, Map<string, ChiefRaySolveResult>> = new WeakMap();
@@ -178,6 +180,7 @@ export function computeFieldGeometryAtState(
     halfFieldDeg = lo;
   }
 
+  halfFieldDeg = rectilinearProjectionMaxTraceField(L.projection) ?? halfFieldDeg;
   halfFieldDeg = Math.min(halfFieldDeg, MAX_FIELD_LAUNCH_DEG - 1e-3);
 
   return { halfFieldDeg, yRatio, b, epRatio };
@@ -337,8 +340,51 @@ function computeChiefRaySolve(
 
   const yLo = heightAtStop(lo);
   const yHi = heightAtStop(hi);
-  if (yLo === null || yHi === null || yLo * yHi > 0) {
-    return { yLaunch: paraxialYChief, uField, status: "bracket-failed", iterations: 0, launchSurface };
+  let fLo: number;
+  if (yLo !== null && yHi !== null && yLo * yHi <= 0) {
+    fLo = yLo;
+  } else {
+    let bracket: { lo: number; hi: number; yLo: number } | null = null;
+    let nearestYLaunch = paraxialYChief;
+    let nearestAbsHeight = Infinity;
+
+    for (let attempt = 0; attempt < 4 && bracket === null; attempt++) {
+      const scanHalf = bracketHalf * (2 << attempt);
+      const scanLo = paraxialYChief - scanHalf;
+      const scanHi = paraxialYChief + scanHalf;
+      let prev: { yLaunch: number; height: number } | null = null;
+
+      for (let i = 0; i <= OBJECT_PLANE_BRACKET_SCAN_SAMPLES; i++) {
+        const yLaunch = scanLo + ((scanHi - scanLo) * i) / OBJECT_PLANE_BRACKET_SCAN_SAMPLES;
+        const height = heightAtStop(yLaunch);
+        if (height === null) {
+          prev = null;
+          continue;
+        }
+
+        const absHeight = Math.abs(height);
+        if (absHeight < nearestAbsHeight) {
+          nearestAbsHeight = absHeight;
+          nearestYLaunch = yLaunch;
+        }
+        if (absHeight < CHIEF_RAY_RESIDUAL_TOLERANCE) {
+          return { yLaunch, uField, status: "converged", iterations: 0, launchSurface };
+        }
+
+        if (prev !== null && prev.height * height <= 0) {
+          bracket = { lo: prev.yLaunch, hi: yLaunch, yLo: prev.height };
+          break;
+        }
+        prev = { yLaunch, height };
+      }
+    }
+
+    if (bracket === null) {
+      return { yLaunch: nearestYLaunch, uField, status: "bracket-failed", iterations: 0, launchSurface };
+    }
+    lo = bracket.lo;
+    hi = bracket.hi;
+    fLo = bracket.yLo;
   }
 
   for (let i = 0; i < CHIEF_RAY_MAX_ITERATIONS; i++) {
@@ -350,8 +396,12 @@ function computeChiefRaySolve(
     if (Math.abs(yMid) < CHIEF_RAY_RESIDUAL_TOLERANCE) {
       return { yLaunch: mid, uField, status: "converged", iterations: i + 1, launchSurface };
     }
-    if (yMid < 0 === yLo < 0) lo = mid;
-    else hi = mid;
+    if (yMid < 0 === fLo < 0) {
+      lo = mid;
+      fLo = yMid;
+    } else {
+      hi = mid;
+    }
     if (Math.abs(hi - lo) < CHIEF_RAY_BRACKET_EPSILON) {
       return { yLaunch: (lo + hi) / 2, uField, status: "converged", iterations: i + 1, launchSurface };
     }

--- a/src/optics/internal/lensState.ts
+++ b/src/optics/internal/lensState.ts
@@ -53,7 +53,14 @@ export function resolveAnnotations(
 }
 
 export function buildElementSpans(surfaces: SurfaceData[], elements: ElementData[]): ElementSpan[] {
+  const labelIdx = buildLabelIndex(surfaces);
   return elements.map((element) => {
+    if (element.fromSurface !== undefined && element.toSurface !== undefined) {
+      const startIdx = labelIdx[element.fromSurface];
+      const endIdx = labelIdx[element.toSurface];
+      return [element.id, startIdx ?? -1, endIdx ?? -1];
+    }
+
     let startIdx = -1;
     for (let i = 0; i < surfaces.length; i++) {
       if (surfaces[i].elemId === element.id) {

--- a/src/optics/projection.ts
+++ b/src/optics/projection.ts
@@ -59,6 +59,17 @@ export function fisheyeProjectionMaxTraceFieldAtZoom(
   return projectionValueAtZoom(projection.maxTraceFieldDeg, zoomT);
 }
 
+export function rectilinearProjectionMaxTraceField(projection: LensProjectionConfig | undefined): number | undefined {
+  if (projection?.kind !== "rectilinear") return undefined;
+  if (typeof projection.maxTraceFieldDeg === "number" && isFinite(projection.maxTraceFieldDeg)) {
+    return projection.maxTraceFieldDeg;
+  }
+  if (typeof projection.fullFieldDeg === "number" && isFinite(projection.fullFieldDeg)) {
+    return projection.fullFieldDeg / 2;
+  }
+  return undefined;
+}
+
 export function distortionProjectionReferenceForLens(
   L: RuntimeLens,
   rectilinearScale: number,

--- a/src/optics/validateLensData.ts
+++ b/src/optics/validateLensData.ts
@@ -12,7 +12,7 @@
 import type { AsphericCoefficients, PerspectiveControlConfig, SurfaceData } from "../types/optics.js";
 import { isImageFormatId, isLensMountId } from "../utils/catalog/lensTaxonomy.js";
 import { buildAsphereIndex, buildLabelIndex, firstInfinityThickness } from "./internal/lensState.js";
-import { conicPolySag, MAX_RIM_SLOPE_TAN, sagSlopeRaw } from "./internal/surfaceMath.js";
+import { conicPolySag, FLAT_R_THRESHOLD, MAX_RIM_SLOPE_TAN, sagSlopeRaw } from "./internal/surfaceMath.js";
 
 /* Validation operates on untrusted data — use a permissive record type
  * so dynamic-key checks compile without casts on every property access. */
@@ -67,13 +67,6 @@ function validateProjection(value: unknown, errors: string[]): void {
   }
 
   const config = value as Record<string, unknown>;
-  if (config.kind === "rectilinear") return;
-
-  if (config.kind !== "fisheye-equidistant" && config.kind !== "fisheye-equisolid") {
-    errors.push(`"projection.kind" must be "rectilinear", "fisheye-equidistant", or "fisheye-equisolid"`);
-    return;
-  }
-
   const validateProjectionNumber = (
     field: "focalLengthMm" | "fullFieldDeg" | "imageCircleMm" | "maxTraceFieldDeg",
     candidate: unknown,
@@ -97,6 +90,44 @@ function validateProjection(value: unknown, errors: string[]): void {
       }
     }
   };
+
+  if (config.kind === "rectilinear") {
+    if (Array.isArray(config.fullFieldDeg)) {
+      errors.push(`"projection.fullFieldDeg" must be a finite number for rectilinear projections`);
+    }
+    if (Array.isArray(config.maxTraceFieldDeg)) {
+      errors.push(`"projection.maxTraceFieldDeg" must be a finite number for rectilinear projections`);
+    }
+    validateProjectionNumber(
+      "fullFieldDeg",
+      config.fullFieldDeg,
+      false,
+      (n) => n > 0 && n < 180,
+      `must be finite and between 0 and 180 degrees when provided for rectilinear projections`,
+    );
+    validateProjectionNumber(
+      "maxTraceFieldDeg",
+      config.maxTraceFieldDeg,
+      false,
+      (n) => n > 0 && n < 89,
+      `must be finite and between 0 and 89 degrees when provided for rectilinear projections`,
+    );
+    if (
+      typeof config.fullFieldDeg === "number" &&
+      typeof config.maxTraceFieldDeg === "number" &&
+      isFinite(config.fullFieldDeg) &&
+      isFinite(config.maxTraceFieldDeg) &&
+      config.maxTraceFieldDeg > config.fullFieldDeg / 2 + 1e-9
+    ) {
+      errors.push(`"projection.maxTraceFieldDeg" must not exceed half of "projection.fullFieldDeg"`);
+    }
+    return;
+  }
+
+  if (config.kind !== "fisheye-equidistant" && config.kind !== "fisheye-equisolid") {
+    errors.push(`"projection.kind" must be "rectilinear", "fisheye-equidistant", or "fisheye-equisolid"`);
+    return;
+  }
 
   validateProjectionNumber(
     "focalLengthMm",
@@ -256,6 +287,12 @@ export default function validateLensData(data: UntrustedLensData): string[] {
     if (typeof s.d !== "number") errors.push(`surfaces[${i}] ("${s.label}"): missing or invalid d`);
     if (typeof s.nd !== "number") errors.push(`surfaces[${i}] ("${s.label}"): missing or invalid nd`);
     if (typeof s.sd !== "number") errors.push(`surfaces[${i}] ("${s.label}"): missing or invalid sd`);
+    if (s.stopPlacement !== undefined && s.stopPlacement !== "inside-element") {
+      errors.push(`surfaces[${i}] ("${s.label}"): stopPlacement must be "inside-element" when provided`);
+    }
+    if (s.stopPlacement !== undefined && s.label !== "STO") {
+      errors.push(`surfaces[${i}] ("${s.label}"): stopPlacement is only valid on the "STO" surface`);
+    }
   }
   if (stoCount === 0) errors.push('No surface with label "STO" found');
   if (stoCount > 1) errors.push(`Multiple surfaces with label "STO" found (${stoCount})`);
@@ -323,7 +360,102 @@ export default function validateLensData(data: UntrustedLensData): string[] {
   const labelToIdx = buildLabelIndex(
     data.surfaces.filter((surface: SurfaceData) => typeof surface.label === "string") as Pick<SurfaceData, "label">[],
   );
+  const S = data.surfaces;
   const nz = isZoom ? data.zoomPositions.length : 0;
+
+  const explicitSpans = new Map<number, { from: number; to: number; element: UntrustedLensData }>();
+  for (const elem of data.elements) {
+    const hasFrom = elem.fromSurface !== undefined;
+    const hasTo = elem.toSurface !== undefined;
+    if (hasFrom !== hasTo) {
+      errors.push(`Element ${elem.id} ("${elem.name}"): fromSurface and toSurface must be provided together`);
+      continue;
+    }
+    if (!hasFrom) continue;
+    if (typeof elem.fromSurface !== "string" || typeof elem.toSurface !== "string") {
+      errors.push(`Element ${elem.id} ("${elem.name}"): fromSurface and toSurface must be surface labels`);
+      continue;
+    }
+    if (!surfaceLabels.has(elem.fromSurface)) {
+      errors.push(`Element ${elem.id} ("${elem.name}"): fromSurface "${elem.fromSurface}" not found`);
+      continue;
+    }
+    if (!surfaceLabels.has(elem.toSurface)) {
+      errors.push(`Element ${elem.id} ("${elem.name}"): toSurface "${elem.toSurface}" not found`);
+      continue;
+    }
+
+    const from = labelToIdx[elem.fromSurface];
+    const to = labelToIdx[elem.toSurface];
+    if (from >= to) {
+      errors.push(
+        `Element ${elem.id} ("${elem.name}"): fromSurface "${elem.fromSurface}" must come before toSurface "${elem.toSurface}"`,
+      );
+      continue;
+    }
+    explicitSpans.set(elem.id, { from, to, element: elem });
+
+    if (S[from]?.elemId !== elem.id) {
+      errors.push(
+        `Element ${elem.id} ("${elem.name}"): fromSurface "${elem.fromSurface}" must reference elemId ${elem.id}`,
+      );
+    }
+
+    for (let i = from + 1; i < to; i++) {
+      const surface = S[i];
+      if (surface.label !== "STO" || surface.stopPlacement !== "inside-element") {
+        errors.push(
+          `Element ${elem.id} ("${elem.name}"): internal surface "${surface.label}" requires stopPlacement: "inside-element"`,
+        );
+      }
+    }
+
+    if (typeof elem.nd === "number" && isFinite(elem.nd)) {
+      for (let i = from; i < to; i++) {
+        if (typeof S[i].nd !== "number") continue;
+        if (Math.abs(S[i].nd - elem.nd) > 1e-6) {
+          errors.push(
+            `Element ${elem.id} ("${elem.name}"): medium after surface "${S[i].label}" must match element nd=${elem.nd} within explicit span`,
+          );
+        }
+      }
+    }
+  }
+
+  const stopIdx = typeof labelToIdx.STO === "number" ? labelToIdx.STO : -1;
+  if (stopIdx >= 0) {
+    const stop = S[stopIdx];
+    if (stop.stopPlacement === "inside-element") {
+      if (Math.abs(stop.R) <= FLAT_R_THRESHOLD) {
+        errors.push(`Surface "STO": stopPlacement "inside-element" requires a flat stop surface`);
+      }
+      const containers = [...explicitSpans.values()].filter(({ from, to }) => from < stopIdx && stopIdx < to);
+      if (containers.length !== 1) {
+        errors.push(
+          `Surface "STO": stopPlacement "inside-element" requires exactly one explicit containing element span`,
+        );
+      } else {
+        const [{ from, element }] = containers;
+        if (stop.elemId !== element.id) {
+          errors.push(`Surface "STO": internal stop elemId must match containing element id ${element.id}`);
+        }
+        if (
+          typeof element.nd === "number" &&
+          typeof stop.nd === "number" &&
+          isFinite(element.nd) &&
+          isFinite(stop.nd) &&
+          Math.abs(stop.nd - element.nd) > 1e-6
+        ) {
+          errors.push(`Surface "STO": internal stop nd must match containing element nd=${element.nd}`);
+        }
+        if (from <= stopIdx - 1 && Math.abs(S[stopIdx - 1].nd - stop.nd) > 1e-6) {
+          errors.push(`Surface "STO": internal stop nd must match the glass medium before the stop`);
+        }
+      }
+    } else if (typeof stop.nd === "number" && stop.nd !== 1.0) {
+      errors.push(`Surface "STO": glass-side stop surfaces require stopPlacement: "inside-element"`);
+    }
+  }
 
   /* ── var keys reference real surface labels ── */
   if (data.var && typeof data.var === "object") {
@@ -444,22 +576,24 @@ export default function validateLensData(data: UntrustedLensData): string[] {
   /* ── Element geometry: edge thickness and SD consistency ──
    *  For each element, find its front/rear surface pair (same logic as buildLens ES)
    *  and check that (a) the element has positive edge thickness at the rendering SD,
-   *  and (b) the front/rear SDs are consistent (ratio ≤ 1.25).
+   *  and (b) the front/rear SDs are consistent.
    */
-  const S = data.surfaces;
-
   const asphByIdx = buildAsphereIndex(data.asph as Record<string, AsphericCoefficients> | undefined, labelToIdx);
 
   for (const elem of data.elements) {
-    let s1 = -1;
-    for (let i = 0; i < S.length; i++) {
-      if (S[i].elemId === elem.id) {
-        s1 = i;
-        break;
+    const explicitSpan = explicitSpans.get(elem.id);
+    let s1 = explicitSpan?.from ?? -1;
+    let s2 = explicitSpan?.to ?? -1;
+    if (!explicitSpan) {
+      for (let i = 0; i < S.length; i++) {
+        if (S[i].elemId === elem.id) {
+          s1 = i;
+          break;
+        }
       }
+      s2 = s1 + 1;
     }
-    if (s1 < 0 || s1 + 1 >= S.length) continue;
-    const s2 = s1 + 1;
+    if (s1 < 0 || s2 <= s1 || s2 >= S.length) continue;
     const front = S[s1],
       rear = S[s2];
     if (typeof front.sd !== "number" || typeof rear.sd !== "number") continue;
@@ -470,7 +604,9 @@ export default function validateLensData(data: UntrustedLensData): string[] {
     /* Edge thickness check (uses aspherical sag when available) */
     const sagFront = conicPolySag(sd, front.R, asphByIdx[s1]);
     const sagRear = conicPolySag(sd, rear.R, asphByIdx[s2]);
-    const edgeThickness = front.d + sagRear - sagFront;
+    let centerThickness = 0;
+    for (let i = s1; i < s2; i++) centerThickness += typeof S[i].d === "number" ? S[i].d : 0;
+    const edgeThickness = centerThickness + sagRear - sagFront;
     if (edgeThickness <= 0)
       errors.push(
         `Element ${elem.id} ("${elem.name}"): negative edge thickness (${edgeThickness.toFixed(3)} mm) at sd=${sd} — surfaces "${front.label}" / "${rear.label}" cross at the rim`,

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -14,6 +14,7 @@ export interface SurfaceData {
   nd: number;
   sd: number;
   elemId: number;
+  stopPlacement?: "inside-element";
 }
 
 export interface AsphericCoefficients {
@@ -50,6 +51,9 @@ export interface ElementData {
   nF?: number;
   /** Measured refractive index at the g line (435.8 nm), when published. */
   ng?: number;
+  /** Explicit physical span for elements that contain optically neutral internal surfaces such as an embedded stop. */
+  fromSurface?: string;
+  toSurface?: string;
 }
 
 export interface AnnotationData {
@@ -73,6 +77,8 @@ export interface PerspectiveControlConfig {
 
 export interface RectilinearProjectionConfig {
   kind: "rectilinear";
+  fullFieldDeg?: number;
+  maxTraceFieldDeg?: number;
 }
 
 export type ProjectionZoomValue = number | number[];

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -23,6 +23,11 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-05-21",
     type: "lens",
+    summary: "Added the Carl Zeiss Hologon 15 mm f/8 with its stop modeled inside the central element",
+  },
+  {
+    date: "2026-05-21",
+    type: "lens",
     summary: "Added six Canon EF L-series lenses from fisheye zoom to macro and telephoto",
   },
   {


### PR DESCRIPTION
## Summary

- Flip `ZeissHologon15mmf8` to `visible: true` and add the lens-data primitives the design needs and that no existing lens has required.
- Two unusual properties drove the supporting work: (1) the aperture stop is physically inside the central glass element (L_II), and (2) it is a 120° rectilinear ultrawide whose paraxial chief-ray bisector under-counts the published coverage.
- Both new lens-data fields are opt-in and validated; all 240 other published lenses follow identical code paths after this change.

## What changed

- **Types** ([src/types/optics.ts](src/types/optics.ts)): optional `SurfaceData.stopPlacement`, optional `ElementData.fromSurface` / `toSurface`, and optional `fullFieldDeg` / `maxTraceFieldDeg` on `RectilinearProjectionConfig`.
- **Build & state** ([src/optics/buildLens.ts](src/optics/buildLens.ts), [src/optics/internal/lensState.ts](src/optics/internal/lensState.ts)): preserve authored stop SD when `STO.stopPlacement === "inside-element"`; element spans honour explicit `fromSurface`/`toSurface` endpoints when both are supplied.
- **Projection** ([src/optics/projection.ts](src/optics/projection.ts)): new `rectilinearProjectionMaxTraceField()` helper; ordinary rectilinear lenses still fall back to the bisected `halfFieldBisected` value.
- **Chief-ray solver** ([src/optics/fieldGeometry.ts](src/optics/fieldGeometry.ts)): wider object-plane bracket scan (4 doubling attempts, 96 samples each), mirroring the existing bounding-sphere scan; bisection tracks `fLo` so sign flips during descent are honored.
- **Validation** ([src/optics/validateLensData.ts](src/optics/validateLensData.ts)): rectilinear `fullFieldDeg < 180`, `maxTraceFieldDeg < 89`, `maxTraceFieldDeg <= fullFieldDeg / 2`; explicit element spans must be ordered, single-`elemId`, and contain only flagged internal stops; embedded `STO` must be flat with `nd`/`elemId` matching the containing glass; edge-thickness accumulates across the span.
- **Lens data** ([src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts](src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts)): rewrote L_II as one element spanning surfaces 3-4 across an internal flat STO with the f/8 physical aperture (0.9375 mm); rebuilt SDs from a patent redraw; corrected `var.6` close-focus to additive (`4.545 → 5.7612` mm = `15²/(200−15)`); added `maxRimAngleDeg: 84` and `projection: { kind: "rectilinear", fullFieldDeg: 120, maxTraceFieldDeg: 60 }`.
- **Docs**: [LENS_DATA_SPEC.md](src/lens-data/LENS_DATA_SPEC.md), [TEMPLATE.data.ts.template](src/lens-data/TEMPLATE.data.ts.template), [architecture/optics-engine.md](agent_docs/architecture/optics-engine.md), and [adding_a_lens.md](agent_docs/adding_a_lens.md) document the new fields and the rectilinear-coverage override; user-facing changelog gets a single `lens` entry for 2026-05-21; branch record at [agent_docs/records/hologon-rereview.md](agent_docs/records/hologon-rereview.md).
- **Tests**: production-lens validator suite now includes Hologon; new tests cover Hologon build (SDs, close-focus shift, half-field, vd table), chief-ray convergence at 30°/35°, diagram element-span rendering, and explicit-stop validator accept/reject paths.

## Why other lenses are unaffected

- `stopPlacement`, `fromSurface`/`toSurface`, and rectilinear `fullFieldDeg`/`maxTraceFieldDeg` are all optional and absent on every other production lens (verified by grep).
- `buildElementSpans` falls through to the prior find-first-matching-elemId path when both `fromSurface` and `toSurface` are absent (the `||` was tightened to `&&` so partial input also falls through).
- `preserveAuthoredStopSD` only suppresses the real-trace SD overwrite when the STO is flagged as inside-element; otherwise the previous behavior is identical.
- `rectilinearProjectionMaxTraceField()` returns `undefined` for rectilinear lenses that omit the new fields, so `helper(projection) ?? halfFieldBisected` reduces to `halfFieldBisected` bit-for-bit.
- A one-off run of `validateLensData` over all 241 lens data files passed with 0 errors (no production lens trips the new STO `nd !== 1.0` guard).

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run format:check` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — 137 files / 1747 tests pass
- [x] Full-catalog `validateLensData` pass — 241/241 lenses pass
- [x] Manual UI: confirm Hologon page renders L_II as one solid element across the iris (no spurious glass-air seam), aperture blades read as the f/8 physical aperture (0.9375 mm) inside the larger glass housing, vignetting / pupil / ray bundles look sensible, close-focus animation extends the BFD by ~1.22 mm
- [x] Manual UI: confirm at least one ordinary rectilinear prime (e.g. Nokton 50/1) still reports the same `halfField` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)