### PR TITLE
[codex] Add mirror lens tracing and fixture authoring support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ npm run organize:lens-data # Move stray root-level lens files into maker folders
 npm run preview
 npm run test
 npm run test:coverage
+npm run generate:glass-reports
+npm run generate:mirror-reports
 npm run typecheck
 npm run lint
 npm run lint:fix
@@ -83,7 +85,8 @@ Read only the relevant focused doc before changing that area:
 - `agent_docs/glass-catalog-buildout.md` - chromatic dispersion catalog, resolver, and how to add Sellmeier entries safely
 - `agent_docs/glass-relabel-followup.md` - per-lens catalog mismatch relabel queue and audit workflow pointers
 - `agent_docs/proprietary-glass-backfill.md` - patent line-index backfill workflow for unresolved proprietary glasses
-- `agent_docs/generated/` - generated glass reports and queues; refresh all with `npm run generate:glass-reports`
+- `agent_docs/generated/` - generated glass and mirror fixture reports; refresh glass reports with
+  `npm run generate:glass-reports` and hidden mirror fixture reports with `npm run generate:mirror-reports`
 - `agent_docs/records/exact-surface-trace.md` - historical staged implementation notes for the exact trace rollout
 - `TRACE_MODEL_IMPROVEMENT_PLAN.md` - current/historical fisheye projection, vector launch, and bounding-sphere trace status
 - `MIRROR_LENS_FUTURE_ENHANCEMENTS.md` - follow-up backlog for mirror-lens analysis, tracing, UI, and authoring improvements
@@ -130,7 +133,8 @@ Read only the relevant focused doc before changing that area:
 For a lens: start from `src/lens-data/TEMPLATE.data.ts.template`, use `satisfies LensDataInput`, optionally add a matching
 `*.analysis.md`, and populate `lensMounts` / `imageFormat` when the mount and format are unambiguous. For mirror or
 telescope designs, use the hidden fixtures under `src/lens-data/reference/` and the folded-path section of
-`src/lens-data/LENS_DATA_SPEC.md` as examples. Track backfill status in `agent_docs/lens-mount-format-backfill.md`.
+`src/lens-data/LENS_DATA_SPEC.md` as examples, then run `npm run generate:mirror-reports` if a hidden mirror fixture
+changed. Track backfill status in `agent_docs/lens-mount-format-backfill.md`.
 `npm run generate:metadata` or `npm run build` will move root-level draft lens files into maker folders and fix nested
 imports.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,11 @@ Read only the relevant focused doc before changing that area:
 - Fisheye and ultra-wide field launch must go through `src/optics/projection.ts` and `solveChiefRay`; do not inline
   `Math.tan(field)` or bypass the bounding-sphere vector path.
 - Mirror/folded systems opt into `LensData.opticalPath` and per-surface `interaction` / `innerSd`. Preserve ordinary
-  sequential defaults for refractive lenses, use explicit `surfaceOrder` when hit order is known, and keep folded-system
-  paraxial analysis guarded until the specific tab is mirror-safe.
+  sequential defaults for refractive lenses, use explicit `surfaceOrder` when hit order is known, and route folded
+  stop/chief-ray solves through the generalized tracer instead of sequential `stopAt` partial traces.
+- Keep folded-system complex analysis tabs guarded until the specific tab is mirror-safe. Axial cardinal overlays and
+  mirror-safe spherical/blur paths are adapted; do not assume that for coma, distortion, vignetting, field curvature, or
+  pupil tabs without fixture-backed validation.
 - Keep slider-state-dependent analysis out of `buildLens()`; analysis tabs compute from current focus/zoom/aperture state.
 - Use existing shared utilities/components before adding new abstractions.
 - Use `src/components/markdown/ThemedMarkdown.tsx` for article and lens-description markdown.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,9 @@
 
 LensVisualizer (public site: Surface & Stop) is an interactive React + TypeScript optical lens cross-section visualizer.
 It renders patent-derived camera lens sections as inline SVG, traces rays in real time, and exposes analysis tools for
-aberrations, pupils, distortion, vignetting, bokeh, chromatic behavior, glass, lens comparison, and perspective-control
-movement, including projection-aware fisheye tracing. The site is prerendered for SEO and deployed to Cloudflare Pages.
+aberrations, pupils, distortion, vignetting, bokeh, chromatic behavior, glass, lens comparison, perspective-control
+movement, folded mirror paths, annular apertures/obstructions, arbitrary image planes, and projection-aware fisheye
+tracing. The site is prerendered for SEO and deployed to Cloudflare Pages.
 
 ## Tech Stack
 
@@ -85,6 +86,7 @@ Read only the relevant focused doc before changing that area:
 - `agent_docs/generated/` - generated glass reports and queues; refresh all with `npm run generate:glass-reports`
 - `agent_docs/records/exact-surface-trace.md` - historical staged implementation notes for the exact trace rollout
 - `TRACE_MODEL_IMPROVEMENT_PLAN.md` - current/historical fisheye projection, vector launch, and bounding-sphere trace status
+- `MIRROR_LENS_FUTURE_ENHANCEMENTS.md` - follow-up backlog for mirror-lens analysis, tracing, UI, and authoring improvements
 - `agent_docs/adding_a_lens.md` - lens data workflow and validation troubleshooting
 - `agent_docs/lens-mount-format-backfill.md` - mount/format metadata backfill status and review queue
 - `agent_docs/lens-patent-audit.md` - standard procedure for re-checking a lens against its patent and logging the result
@@ -109,6 +111,9 @@ Read only the relevant focused doc before changing that area:
   or thread `mode` / `traceMode` options through new helpers.
 - Fisheye and ultra-wide field launch must go through `src/optics/projection.ts` and `solveChiefRay`; do not inline
   `Math.tan(field)` or bypass the bounding-sphere vector path.
+- Mirror/folded systems opt into `LensData.opticalPath` and per-surface `interaction` / `innerSd`. Preserve ordinary
+  sequential defaults for refractive lenses, use explicit `surfaceOrder` when hit order is known, and keep folded-system
+  paraxial analysis guarded until the specific tab is mirror-safe.
 - Keep slider-state-dependent analysis out of `buildLens()`; analysis tabs compute from current focus/zoom/aperture state.
 - Use existing shared utilities/components before adding new abstractions.
 - Use `src/components/markdown/ThemedMarkdown.tsx` for article and lens-description markdown.
@@ -123,9 +128,11 @@ Read only the relevant focused doc before changing that area:
 ## Adding Content
 
 For a lens: start from `src/lens-data/TEMPLATE.data.ts.template`, use `satisfies LensDataInput`, optionally add a matching
-`*.analysis.md`, and populate `lensMounts` / `imageFormat` when the mount and format are unambiguous. Track backfill
-status in `agent_docs/lens-mount-format-backfill.md`. `npm run generate:metadata` or `npm run build` will move
-root-level draft lens files into maker folders and fix nested imports.
+`*.analysis.md`, and populate `lensMounts` / `imageFormat` when the mount and format are unambiguous. For mirror or
+telescope designs, use the hidden fixtures under `src/lens-data/reference/` and the folded-path section of
+`src/lens-data/LENS_DATA_SPEC.md` as examples. Track backfill status in `agent_docs/lens-mount-format-backfill.md`.
+`npm run generate:metadata` or `npm run build` will move root-level draft lens files into maker folders and fix nested
+imports.
 
 For an article: create `src/content/**/*.md` with required `slug` and `title` frontmatter. Use `series` and
 `seriesOrder` for article series, and `toc: true` for long pieces. Run `npm run build` when route metadata should be

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -1,0 +1,58 @@
+# Mirror Lens Future Enhancements
+
+This is the working backlog for mirror-lens, telescope, annular-aperture, and folded-optics support after the first implementation pass. Keep this file focused on future engineering work; current authoring rules live in `src/lens-data/LENS_DATA_SPEC.md`, and architecture notes live under `agent_docs/`.
+
+## Current Baseline
+
+- Lens data can describe `SurfaceData.innerSd`, side-aware `SurfaceData.interaction`, first-surface and second-surface mirrors, blockers, tilted meridional planes, explicit/repeated `opticalPath.surfaceOrder`, `mode: "auto"` next-surface resolution, and arbitrary meridional `opticalPath.imagePlane`.
+- Hidden reference fixtures under `src/lens-data/reference/` exercise first-surface primary mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, and Cassegrain-style folded paths.
+- Diagram rendering supports annular element paths, tilted flat fold mirrors, and non-default image planes.
+- Visible ray sampling avoids central blocking geometry for folded systems.
+- Analysis guardrails prevent folded systems from showing sequential paraxial/cardinal/pupil/field results until each tab is adapted. Mirror-safe spherical aberration and related blur helpers have an initial generalized image-plane path.
+
+## Highest-Priority Follow-Ups
+
+1. **Expose Folded Path Diagnostics**
+   - Add a lightweight public diagnostic object on `RuntimeLens` or trace results for expected path mode, final medium, image-plane hit status, surface hit labels, and clipping/blocking reasons.
+   - Surface these diagnostics in development UI and fixture tests without requiring imports from `src/optics/internal/`.
+
+2. **Adapt More Analysis Tabs Safely**
+   - Generalize cardinal, pupil, distortion, vignetting, focus-breathing, field-curvature, and coma calculations only where the math is valid for folded systems.
+   - Keep unsupported tabs gated until each tab has reference-fixture coverage and a clear physical interpretation for arbitrary image-plane normals.
+
+3. **Improve First-Order Mirror Math**
+   - Add paraxial matrix support for reflective surfaces and folded coordinate frames.
+   - Decide how to report effective focal length, principal planes, nodal points, and pupil locations for systems whose final imaging plane is not normal to the original z axis.
+
+4. **Strengthen Auto-Path Robustness**
+   - Add richer loop detection beyond `maxInteractions`.
+   - Record why candidate surfaces were skipped in auto mode.
+   - Stress-test near-grazing fold mirrors, close repeated hits, and mixed block/reflect/refract surfaces.
+
+5. **Broaden Fixture Coverage**
+   - Add a compact Schmidt-Cassegrain or Maksutov-style meniscus/primary/secondary reference fixture.
+   - Add a Gregorian-style secondary fixture to exercise alternate secondary curvature/sign behavior.
+   - Add a ring blocker fixture where an annular obstruction blocks the ring while the center passes.
+
+## UI And Authoring Improvements
+
+- Add an inspector readout for `interaction.type`, mirror kind, active side, `innerSd`, and explicit image-plane geometry.
+- Add a diagram overlay that labels folded hit order for reference fixtures and debugging.
+- Make hidden reference fixtures easier to temporarily expose without hand-editing `visible`.
+- Add a small authoring validator that suggests when a tilted mirror backing plane is missing the same `interaction.normal` as the reflective face.
+- Add docs/examples for choosing `incidentSide` on curved mirrors, especially when the surface normal orientation is not obvious from the SVG.
+
+## Physics And Rendering Improvements
+
+- Model reflectivity/transmission losses for mirror coatings, obstructions, and second-surface substrates when relative illumination or bokeh brightness needs it.
+- Decide whether second-surface mirrors should optionally render a coating line distinct from the glass substrate.
+- Support optional spider-vane diffraction or obstruction metadata as display annotations without letting mechanical details pollute optical tracing.
+- Consider 3D folded assemblies only after the 2D meridional model is exhausted; the current pass intentionally supports rotationally symmetric optics plus meridional fold mirrors.
+
+## Verification Backlog
+
+- Add production smoke tests that intentionally include hidden reference fixtures for folded-path validation while keeping public-catalog assertions scoped to visible lenses.
+- Add screenshot or SVG-geometry tests for side image-plane rendering and tilted flat mirror backing planes.
+- Add path-stability tests for `mode: "auto"` under small focus/zoom/aperture perturbations once folded zoom/focus fixtures exist.
+- Run the full gate after any mirror-path change: `npm run typecheck`, `npm run format:check`, `npm run lint`, `npm run test`, and `npm run build`.
+

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -59,7 +59,10 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 
 ## Verification Backlog
 
-- Add production smoke tests that intentionally include hidden reference fixtures for folded-path validation while keeping public-catalog assertions scoped to visible lenses.
-- Add screenshot or SVG-geometry tests for side image-plane rendering and tilted flat mirror backing planes.
-- Add path-stability tests for `mode: "auto"` under small focus/zoom/aperture perturbations once folded zoom/focus fixtures exist.
-- Run the full gate after any mirror-path change: `npm run typecheck`, `npm run format:check`, `npm run lint`, `npm run test`, and `npm run build`.
+- Done: production smoke tests intentionally include hidden reference fixtures for folded-path validation while keeping
+  public-catalog assertions scoped to visible lenses.
+- Done: SVG-geometry coverage includes side image-plane rendering and tilted flat mirror backing planes.
+- Partly done: `mode: "auto"` path-stability tests cover small ray-height and aperture perturbations for the current
+  folded fixtures. Focus/zoom perturbations remain pending until folded zoom/focus fixtures exist.
+- Done for this pass: run the full gate after any mirror-path change: `npm run typecheck`, `npm run format:check`,
+  `npm run lint`, `npm run test`, and `npm run build`.

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 
 ## Current Baseline
 
-- Lens data can describe `SurfaceData.innerSd`, side-aware `SurfaceData.interaction`, first-surface and second-surface mirrors, inactive-side mirror blocking by default, explicit pass-through mirrors, blockers, tilted meridional planes, explicit/repeated `opticalPath.surfaceOrder`, `mode: "auto"` next-surface resolution, and arbitrary meridional `opticalPath.imagePlane`.
+- Lens data can describe `SurfaceData.innerSd`, side-aware `SurfaceData.interaction`, first-surface and second-surface mirrors, inactive-side mirror blocking, blockers, tilted meridional planes, explicit/repeated `opticalPath.surfaceOrder`, `mode: "auto"` next-surface resolution, and arbitrary meridional `opticalPath.imagePlane`.
 - Hidden reference fixtures under `src/lens-data/reference/` exercise first-surface primary mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, and Cassegrain-style folded paths.
 - Diagram rendering supports annular element paths, tilted flat fold mirrors, second-surface coating accents, and
   non-default image planes.

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -6,7 +6,8 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 
 - Lens data can describe `SurfaceData.innerSd`, side-aware `SurfaceData.interaction`, first-surface and second-surface mirrors, blockers, tilted meridional planes, explicit/repeated `opticalPath.surfaceOrder`, `mode: "auto"` next-surface resolution, and arbitrary meridional `opticalPath.imagePlane`.
 - Hidden reference fixtures under `src/lens-data/reference/` exercise first-surface primary mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, and Cassegrain-style folded paths.
-- Diagram rendering supports annular element paths, tilted flat fold mirrors, and non-default image planes.
+- Diagram rendering supports annular element paths, tilted flat fold mirrors, second-surface coating accents, and
+  non-default image planes.
 - Visible ray sampling avoids central blocking geometry for folded systems.
 - Analysis guardrails prevent folded systems from showing sequential paraxial/cardinal/pupil/field results until each tab is adapted. Mirror-safe spherical aberration and related blur helpers have an initial generalized image-plane path.
 
@@ -49,13 +50,15 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 - Done: folded diagrams label the resolved/declared hit order as a compact debugging overlay.
 - Done: the lens library accepts `?view=all` for all lens files and `?view=debug` for hidden/reference fixtures.
 - Done: validation flags tilted flat mirror backing planes that omit the reflective face's `interaction.normal`.
+- Done: hidden/reference mirror fixtures have an authoring report at
+  `agent_docs/generated/mirror-fixtures.generated.md`, regenerated with `npm run generate:mirror-reports`.
 - Done: `src/lens-data/LENS_DATA_SPEC.md` includes incident-side examples for curved mirrors, returning beams, and
   second-surface paths.
 
 ## Physics And Rendering Improvements
 
 - Model reflectivity/transmission losses for mirror coatings, obstructions, and second-surface substrates when relative illumination or bokeh brightness needs it.
-- Decide whether second-surface mirrors should optionally render a coating line distinct from the glass substrate.
+- Done: second-surface mirrors render a dashed coating accent line distinct from the glass substrate.
 - Support optional spider-vane diffraction or obstruction metadata as display annotations without letting mechanical details pollute optical tracing.
 - Consider 3D folded assemblies only after the 2D meridional model is exhausted; the current pass intentionally supports rotationally symmetric optics plus meridional fold mirrors.
 

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 
 ## Current Baseline
 
-- Lens data can describe `SurfaceData.innerSd`, side-aware `SurfaceData.interaction`, first-surface and second-surface mirrors, blockers, tilted meridional planes, explicit/repeated `opticalPath.surfaceOrder`, `mode: "auto"` next-surface resolution, and arbitrary meridional `opticalPath.imagePlane`.
+- Lens data can describe `SurfaceData.innerSd`, side-aware `SurfaceData.interaction`, first-surface and second-surface mirrors, inactive-side mirror blocking by default, explicit pass-through mirrors, blockers, tilted meridional planes, explicit/repeated `opticalPath.surfaceOrder`, `mode: "auto"` next-surface resolution, and arbitrary meridional `opticalPath.imagePlane`.
 - Hidden reference fixtures under `src/lens-data/reference/` exercise first-surface primary mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, and Cassegrain-style folded paths.
 - Diagram rendering supports annular element paths, tilted flat fold mirrors, second-surface coating accents, and
   non-default image planes.

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -44,11 +44,13 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 
 ## UI And Authoring Improvements
 
-- Add an inspector readout for `interaction.type`, mirror kind, active side, `innerSd`, and explicit image-plane geometry.
-- Add a diagram overlay that labels folded hit order for reference fixtures and debugging.
-- Make hidden reference fixtures easier to temporarily expose without hand-editing `visible`.
-- Add a small authoring validator that suggests when a tilted mirror backing plane is missing the same `interaction.normal` as the reflective face.
-- Add docs/examples for choosing `incidentSide` on curved mirrors, especially when the surface normal orientation is not obvious from the SVG.
+- Done: the element inspector surfaces folded metadata for `interaction.type`, mirror kind, active side, `innerSd`, tilted
+  normals, and explicit image-plane geometry.
+- Done: folded diagrams label the resolved/declared hit order as a compact debugging overlay.
+- Done: the lens library accepts `?view=all` for all lens files and `?view=debug` for hidden/reference fixtures.
+- Done: validation flags tilted flat mirror backing planes that omit the reflective face's `interaction.normal`.
+- Done: `src/lens-data/LENS_DATA_SPEC.md` includes incident-side examples for curved mirrors, returning beams, and
+  second-surface paths.
 
 ## Physics And Rendering Improvements
 

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -9,7 +9,10 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 - Diagram rendering supports annular element paths, tilted flat fold mirrors, second-surface coating accents, and
   non-default image planes.
 - Visible ray sampling avoids central blocking geometry for folded systems.
-- Analysis guardrails prevent folded systems from showing sequential paraxial/cardinal/pupil/field results until each tab is adapted. Mirror-safe spherical aberration and related blur helpers have an initial generalized image-plane path.
+- Folded off-axis launch geometry now uses generalized stop/chief-ray traces and path-aware image-plane intersections
+  instead of sequential refractive approximations.
+- Analysis guardrails prevent folded systems from showing complex sequential analysis tabs until each tab is adapted.
+  Axial cardinal overlays and mirror-safe spherical aberration/blur helpers have generalized folded paths.
 
 ## Completed Highest-Priority Follow-Ups
 
@@ -23,9 +26,11 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 2. **Adapt More Analysis Tabs Safely** - Done for currently valid surfaces; still gated where the interpretation is not
    physically settled.
    - Axial folded mirror systems can now compute first-order cardinal overlays through the shared cardinal helper.
+   - Folded field and pupil real-ray wrappers now carry `opticalPath`, `imagePlane`, and folded context into generalized
+     tracing, so future tab enablement can build on correct stop and image-plane geometry.
    - Focus-breathing remains available for folded systems because it is metadata/state based for fixed mirror fixtures.
-   - Pupil, distortion, vignetting, field-curvature, and coma tabs remain gated for folded systems until their math uses
-     generalized image-plane normals and each tab has fixture-backed physical interpretation.
+   - Pupil, distortion, vignetting, field-curvature, and coma tabs remain gated for folded systems until each tab has
+     fixture-backed physical interpretation and UI copy for folded image-plane conventions.
 
 3. **Improve First-Order Mirror Math** - Done for axial reflective folded systems.
    - Reflective paraxial path support handles signed folded transfers and mirror slope reversal/power.
@@ -42,6 +47,22 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 5. **Broaden Fixture Coverage** - Done.
    - Added hidden reference fixtures for a Maksutov-Cassegrain-style meniscus/primary/secondary path, a Gregorian-style
      secondary path, and an annular ring blocker that clips the ring while allowing the center through.
+
+6. **Fix Folded Off-Axis Accuracy** - Done.
+   - Folded stop-height solves now use `traceToStopViaGeneralized()` rather than sequential `stopAt` tracing.
+   - `buildLens()` derives folded entrance/exit pupil geometry from generalized real-ray basis traces, with finite
+     fallback values for hard-to-trace paths.
+   - Image-plane coordinate math is shared across folded and sequential callers while preserving focus-adjusted
+     sequential behavior.
+   - Regression tests cover off-axis spherical primary, Cassegrain, and Newtonian chief-ray behavior, meridional
+     symmetry, repeated stop selection, and a representative non-folded refractive snapshot.
+
+7. **Harden Folded Validation And Numerics** - Done.
+   - Validation rejects explicit paths whose `maxInteractions` cannot cover the declared hit order plus image plane.
+   - Validation rejects mismatched paired `innerSd` values on annular mirror/backing surfaces.
+   - Folded image-plane reachability now reports conservative errors only when probe traces clearly cannot reach the
+     declared image plane.
+   - Tilted/flat first-surface lead distance inference uses tilted-plane aperture extent rather than spherical sag only.
 
 ## UI And Authoring Improvements
 

--- a/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
+++ b/MIRROR_LENS_FUTURE_ENHANCEMENTS.md
@@ -10,29 +10,37 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 - Visible ray sampling avoids central blocking geometry for folded systems.
 - Analysis guardrails prevent folded systems from showing sequential paraxial/cardinal/pupil/field results until each tab is adapted. Mirror-safe spherical aberration and related blur helpers have an initial generalized image-plane path.
 
-## Highest-Priority Follow-Ups
+## Completed Highest-Priority Follow-Ups
 
-1. **Expose Folded Path Diagnostics**
-   - Add a lightweight public diagnostic object on `RuntimeLens` or trace results for expected path mode, final medium, image-plane hit status, surface hit labels, and clipping/blocking reasons.
-   - Surface these diagnostics in development UI and fixture tests without requiring imports from `src/optics/internal/`.
+1. **Expose Folded Path Diagnostics** - Done.
+   - Public `RayTraceResult.diagnostics` now reports expected path mode, expected/hit surface labels, final medium,
+     image-plane hit status, terminal surface, termination reason, clip/block events, auto skipped-candidate reasons,
+     and loop detection state.
+   - Development analysis UI shows a compact folded trace diagnostic readout, and fixture tests assert the public
+     diagnostic result without importing generalized trace internals.
 
-2. **Adapt More Analysis Tabs Safely**
-   - Generalize cardinal, pupil, distortion, vignetting, focus-breathing, field-curvature, and coma calculations only where the math is valid for folded systems.
-   - Keep unsupported tabs gated until each tab has reference-fixture coverage and a clear physical interpretation for arbitrary image-plane normals.
+2. **Adapt More Analysis Tabs Safely** - Done for currently valid surfaces; still gated where the interpretation is not
+   physically settled.
+   - Axial folded mirror systems can now compute first-order cardinal overlays through the shared cardinal helper.
+   - Focus-breathing remains available for folded systems because it is metadata/state based for fixed mirror fixtures.
+   - Pupil, distortion, vignetting, field-curvature, and coma tabs remain gated for folded systems until their math uses
+     generalized image-plane normals and each tab has fixture-backed physical interpretation.
 
-3. **Improve First-Order Mirror Math**
-   - Add paraxial matrix support for reflective surfaces and folded coordinate frames.
-   - Decide how to report effective focal length, principal planes, nodal points, and pupil locations for systems whose final imaging plane is not normal to the original z axis.
+3. **Improve First-Order Mirror Math** - Done for axial reflective folded systems.
+   - Reflective paraxial path support handles signed folded transfers and mirror slope reversal/power.
+   - Systems whose final image plane is not normal to the original z axis intentionally return no cardinal result until
+     the UI has a clear convention for reporting principal/nodal points in that rotated frame.
 
-4. **Strengthen Auto-Path Robustness**
-   - Add richer loop detection beyond `maxInteractions`.
-   - Record why candidate surfaces were skipped in auto mode.
-   - Stress-test near-grazing fold mirrors, close repeated hits, and mixed block/reflect/refract surfaces.
+4. **Strengthen Auto-Path Robustness** - Done.
+   - Auto mode now records skipped candidates and distinguishes intersection failures, passive same-index surfaces,
+     self-hits, and non-forward hits.
+   - Auto mode detects repeated surface/point/direction/index states before falling back to the generic
+     `maxInteractions` ceiling.
+   - Fixture tests cover auto skip reasons, blocking reasons, and a deliberately looping flat-mirror path.
 
-5. **Broaden Fixture Coverage**
-   - Add a compact Schmidt-Cassegrain or Maksutov-style meniscus/primary/secondary reference fixture.
-   - Add a Gregorian-style secondary fixture to exercise alternate secondary curvature/sign behavior.
-   - Add a ring blocker fixture where an annular obstruction blocks the ring while the center passes.
+5. **Broaden Fixture Coverage** - Done.
+   - Added hidden reference fixtures for a Maksutov-Cassegrain-style meniscus/primary/secondary path, a Gregorian-style
+     secondary path, and an annular ring blocker that clips the ring while allowing the center through.
 
 ## UI And Authoring Improvements
 
@@ -55,4 +63,3 @@ This is the working backlog for mirror-lens, telescope, annular-aperture, and fo
 - Add screenshot or SVG-geometry tests for side image-plane rendering and tilted flat mirror backing planes.
 - Add path-stability tests for `mode: "auto"` under small focus/zoom/aperture perturbations once folded zoom/focus fixtures exist.
 - Run the full gate after any mirror-path change: `npm run typecheck`, `npm run format:check`, `npm run lint`, `npm run test`, and `npm run build`.
-

--- a/MIRROR_OPTICS_ACCURACY_PLAN.md
+++ b/MIRROR_OPTICS_ACCURACY_PLAN.md
@@ -1,20 +1,40 @@
-# Plan: Improve mirror/folded optics accuracy and shared structure
+# Completed Plan: Improve mirror/folded optics accuracy and shared structure
+
+## Status
+
+Completed on branch `ronbuening/MirrorLensTest`.
+
+- Accuracy implementation: `1c2d783 fix: improve folded mirror off-axis accuracy`
+- Optional shared paraxial stepper: `a6af1fc refactor: share paraxial cardinal stepper`
+
+Workstreams A, B, C, E, and F were implemented, and the optional Workstream D was also completed. Complex folded-system
+analysis tabs that are not mirror-safe remain guarded; the pass intentionally updates off-axis geometry, mirror-safe
+spherical/blur paths, validation, tests, and shared internal stepping only.
+
+Verification completed:
+
+- `npm run typecheck`
+- `npm run format:check`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+
+The build passed with the existing `%VITE_GOATCOUNTER_URL%` and large chunk warnings.
 
 ## Context
 
-This branch (`claude/compassionate-mayer-ix92F`, commits `e696eeb`..`22072d5`) adds mirror/telescope
-support: `SurfaceData.interaction` (reflect/refract/block), `innerSd` annular obstructions,
-`opticalPath` (explicit `surfaceOrder` or `auto`), tilted meridional planes, and 8 hidden reference
-fixtures. The trace engine is already well-built: `exactSurfaceTrace.ts` has **one** generalized loop
-that branches on `interaction.type`, so on-axis tracing through mirrors is correct and tested.
+The earlier mirror/telescope support added `SurfaceData.interaction` (reflect/refract/block), `innerSd` annular
+obstructions, `opticalPath` (explicit `surfaceOrder` or `auto`), tilted meridional planes, and hidden reference
+fixtures. The trace engine already had **one** generalized loop in `exactSurfaceTrace.ts` that branches on
+`interaction.type`, so on-axis tracing through mirrors was correct and tested before this pass.
 
-The problem is everything *around* the trace. Off-axis (chief/field) rays are launched from an
+The problem was everything *around* the trace. Off-axis (chief/field) rays were launched from an
 entrance-pupil position and ratio that, for folded systems, are **stubbed** rather than solved from
-real rays. So the trace math is right but its *inputs* are approximate for mirrors. There is also
-duplication (`isFoldedOptics ? generalized : sequential` forks) and **zero off-axis test coverage** —
-every fixture/test is on-axis.
+real rays. The trace math was right but its *inputs* were approximate for mirrors. There was also
+duplication (`isFoldedOptics ? generalized : sequential` forks) and no off-axis test coverage for the
+reference mirror fixtures.
 
-**Goal (approved scope):** make off-axis ray geometry genuinely accurate for mirror systems, refactor
+**Goal achieved:** make off-axis ray geometry genuinely accurate for mirror systems, refactor
 the folded and refractive paths onto shared helpers, harden validation/numerics, and anchor the
 reference fixtures to closed-form ground truth. Keep the complex analysis tabs (coma, distortion,
 vignetting, field curvature, pupils) guarded — re-enabling them is explicitly out of scope this pass.
@@ -34,7 +54,7 @@ Both feed the same downstream consumer: off-axis ray launch uses `EP.yRatio`/`ep
 
 ## Workstreams
 
-### A. Thread folded context into the real-ray trace wrappers  *(root cause, do first)*
+### A. Thread folded context into the real-ray trace wrappers  *(done)*
 - In `fieldGeometry.ts` (`traceStateSurfacesReal`, ~:871) and `pupilAberration.ts` (~:480), include
   `isFoldedOptics`, `opticalPath`, `imagePlane` in the `ExactTraceLens` they construct, so folded
   lenses actually reach the generalized tracer.
@@ -43,7 +63,7 @@ Both feed the same downstream consumer: off-axis ray launch uses `EP.yRatio`/`ep
   `traceToStopViaGeneralized` helper (Workstream B) instead.
 - Leave non-folded behavior byte-for-byte unchanged: only folded lenses get the new context/path.
 
-### B. Real-ray chief/marginal + pupil solve for the `buildLens` folded branch
+### B. Real-ray chief/marginal + pupil solve for the `buildLens` folded branch  *(done)*
 - Add `traceToStopViaGeneralized(lens, input, stopIdx, options)` to `exactSurfaceTrace.ts`. It runs a
   full generalized vector trace (no `stopAt`), scans the existing `hits` array for the first unclipped
   hit with `surfaceIdx === stopIdx`, and returns `{ y, x, uy, ux, found }`. Returns `found: false`
@@ -58,7 +78,7 @@ Both feed the same downstream consumer: off-axis ray launch uses `EP.yRatio`/`ep
 - **Fallback:** when the chief/marginal trace reports `found: false` or clips, keep the current
   geometric `EP.yRatio`/`B: 0` so a hard-to-trace fold never produces NaNs.
 
-### C. Unify the image-plane intercept
+### C. Unify the image-plane intercept  *(done)*
 - Replace the duplicated `L.isFoldedOptics ? generalizedImagePlaneIntercept : imagePlaneIntercept`
   (`aberration/shared.ts:93-95`, `aberration/spherical.ts:41,149`) with a single
   `imagePlaneCoordinate(y, u, referenceZ, L, planeZ)` that runs the generalized normal math against an
@@ -67,13 +87,13 @@ Both feed the same downstream consumer: off-axis ray launch uses `EP.yRatio`/`ep
   compute today — this preserves focus-dependent sequential intercepts exactly while removing the fork.
   (Safe because `RuntimeLens.imagePlane` is always populated — verified.)
 
-### D. Share the paraxial stepper for cardinal elements  *(optional, lower priority)*
+### D. Share the paraxial stepper for cardinal elements  *(done)*
 - `traceFoldedReflectiveParaxialPath` (`cardinalElements.ts:229`) and the refractive `paraxialTrace`
   duplicate a transfer/refract step. Consider one interaction-aware step function with a reflect branch
   (`u' = -u - 2y/R`). Only pursue if it doesn't complicate the refractive path; the cardinal guards
   (meridional-only image plane, air-to-air) stay as-is.
 
-### E. Validation & numerical hardening (`validateLensData.ts`, `exactSurfaceTrace.ts`)
+### E. Validation & numerical hardening (`validateLensData.ts`, `exactSurfaceTrace.ts`)  *(done)*
 - Flag `opticalPath.maxInteractions` that is too low for the declared `surfaceOrder` length (+ image
   plane) — currently silent runtime clipping.
 - Warn when `imagePlane.z` is unreachable by any forward/folded path (no surface can direct a ray to it).
@@ -81,7 +101,7 @@ Both feed the same downstream consumer: off-axis ray launch uses `EP.yRatio`/`ep
 - Fix `inferLeadDistance` (`exactSurfaceTrace.ts:741`) for a tilted/flat first surface — `conicPolySag`
   returns 0 for a tilted plane, giving a ~1 mm lead that can mis-place the launch origin.
 
-### F. Off-axis fixtures + analytic anchors (tests)
+### F. Off-axis fixtures + analytic anchors (tests)  *(done)*
 - Add field-angle (off-axis) variants for at least the spherical-primary, Cassegrain, and Newtonian
   reference fixtures; assert the chief ray reaches the expected meridional image height and that
   reflection preserves the meridional symmetry.

--- a/MIRROR_OPTICS_ACCURACY_PLAN.md
+++ b/MIRROR_OPTICS_ACCURACY_PLAN.md
@@ -1,0 +1,122 @@
+# Plan: Improve mirror/folded optics accuracy and shared structure
+
+## Context
+
+This branch (`claude/compassionate-mayer-ix92F`, commits `e696eeb`..`22072d5`) adds mirror/telescope
+support: `SurfaceData.interaction` (reflect/refract/block), `innerSd` annular obstructions,
+`opticalPath` (explicit `surfaceOrder` or `auto`), tilted meridional planes, and 8 hidden reference
+fixtures. The trace engine is already well-built: `exactSurfaceTrace.ts` has **one** generalized loop
+that branches on `interaction.type`, so on-axis tracing through mirrors is correct and tested.
+
+The problem is everything *around* the trace. Off-axis (chief/field) rays are launched from an
+entrance-pupil position and ratio that, for folded systems, are **stubbed** rather than solved from
+real rays. So the trace math is right but its *inputs* are approximate for mirrors. There is also
+duplication (`isFoldedOptics ? generalized : sequential` forks) and **zero off-axis test coverage** —
+every fixture/test is on-axis.
+
+**Goal (approved scope):** make off-axis ray geometry genuinely accurate for mirror systems, refactor
+the folded and refractive paths onto shared helpers, harden validation/numerics, and anchor the
+reference fixtures to closed-form ground truth. Keep the complex analysis tabs (coma, distortion,
+vignetting, field curvature, pupils) guarded — re-enabling them is explicitly out of scope this pass.
+
+## Root cause (verified)
+
+1. **Runtime field/pupil geometry silently runs sequential for folded lenses.**
+   `traceStateSurfacesReal` (`fieldGeometry.ts:871-879`) and the equivalent in
+   `pupilAberration.ts` build an `ExactTraceLens` of only `{ S, asphByIdx, stopIdx }`. With no
+   `isFoldedOptics`/`opticalPath`/`imagePlane`, `shouldUseGeneralizedTrace` returns false on its first
+   guard, so folded chief/field rays trace as if the system were sequential refractive.
+2. **`buildLens` folded branch stubs the pupil model** (`buildLens.ts:322-464`): `EP.yRatio` is pure
+   geometry, `B: 0`, `epZRelStop: 0`, `xpZRelLastSurf: 0`, `xpSD: epSD`. The refractive branch
+   (`465+`) derives all of these from real Snell traces to the stop.
+
+Both feed the same downstream consumer: off-axis ray launch uses `EP.yRatio`/`epZRelStop`.
+
+## Workstreams
+
+### A. Thread folded context into the real-ray trace wrappers  *(root cause, do first)*
+- In `fieldGeometry.ts` (`traceStateSurfacesReal`, ~:871) and `pupilAberration.ts` (~:480), include
+  `isFoldedOptics`, `opticalPath`, `imagePlane` in the `ExactTraceLens` they construct, so folded
+  lenses actually reach the generalized tracer.
+- For folded lenses that pass `stopAt` (e.g. `fieldGeometry.ts:118-119,321`), do **not** rely on the
+  `stopAt` partial trace (the generalized tracer ignores `stopAt`). Route them through the new
+  `traceToStopViaGeneralized` helper (Workstream B) instead.
+- Leave non-folded behavior byte-for-byte unchanged: only folded lenses get the new context/path.
+
+### B. Real-ray chief/marginal + pupil solve for the `buildLens` folded branch
+- Add `traceToStopViaGeneralized(lens, input, stopIdx, options)` to `exactSurfaceTrace.ts`. It runs a
+  full generalized vector trace (no `stopAt`), scans the existing `hits` array for the first unclipped
+  hit with `surfaceIdx === stopIdx`, and returns `{ y, x, uy, ux, found }`. Returns `found: false`
+  when the ray never reaches the stop unclipped.
+- Factor the entrance/exit-pupil two-ray math currently inline at `buildLens.ts:516-558` into a shared
+  pure helper `computePupilGeometry({ realYRatio, realB, margFull, chiefFull, epSD, zStopBaseline })`
+  returning `{ epZRelStop, xpZRelLastSurf, xpSD }`. Call it from **both** branches.
+- In the folded branch, derive `realYRatio`/`realB` from `traceToStopViaGeneralized` (marginal at pupil
+  edge, chief aimed at stop center) and replace the literal stubs with computed values. Folded-specific
+  inputs: the stop z and last-surface z come from the relevant `hits[].point[2]` (path-aware), not from
+  summed back-thickness, since a mirror folds z.
+- **Fallback:** when the chief/marginal trace reports `found: false` or clips, keep the current
+  geometric `EP.yRatio`/`B: 0` so a hard-to-trace fold never produces NaNs.
+
+### C. Unify the image-plane intercept
+- Replace the duplicated `L.isFoldedOptics ? generalizedImagePlaneIntercept : imagePlaneIntercept`
+  (`aberration/shared.ts:93-95`, `aberration/spherical.ts:41,149`) with a single
+  `imagePlaneCoordinate(y, u, referenceZ, L, planeZ)` that runs the generalized normal math against an
+  effective plane `{ z: planeZ, y: L.imagePlane.y, normal: L.imagePlane.normal }`.
+- Folded callers pass `planeZ = L.imagePlane.z`; sequential callers pass the focus-adjusted z they
+  compute today — this preserves focus-dependent sequential intercepts exactly while removing the fork.
+  (Safe because `RuntimeLens.imagePlane` is always populated — verified.)
+
+### D. Share the paraxial stepper for cardinal elements  *(optional, lower priority)*
+- `traceFoldedReflectiveParaxialPath` (`cardinalElements.ts:229`) and the refractive `paraxialTrace`
+  duplicate a transfer/refract step. Consider one interaction-aware step function with a reflect branch
+  (`u' = -u - 2y/R`). Only pursue if it doesn't complicate the refractive path; the cardinal guards
+  (meridional-only image plane, air-to-air) stay as-is.
+
+### E. Validation & numerical hardening (`validateLensData.ts`, `exactSurfaceTrace.ts`)
+- Flag `opticalPath.maxInteractions` that is too low for the declared `surfaceOrder` length (+ image
+  plane) — currently silent runtime clipping.
+- Warn when `imagePlane.z` is unreachable by any forward/folded path (no surface can direct a ray to it).
+- Check paired-surface `innerSd` consistency (front face annular but backing plane solid renders wrong).
+- Fix `inferLeadDistance` (`exactSurfaceTrace.ts:741`) for a tilted/flat first surface — `conicPolySag`
+  returns 0 for a tilted plane, giving a ~1 mm lead that can mis-place the launch origin.
+
+### F. Off-axis fixtures + analytic anchors (tests)
+- Add field-angle (off-axis) variants for at least the spherical-primary, Cassegrain, and Newtonian
+  reference fixtures; assert the chief ray reaches the expected meridional image height and that
+  reflection preserves the meridional symmetry.
+- Add closed-form regression anchors: spherical mirror EFL ≈ R/2; Cassegrain/Gregorian back-focus vs.
+  declared `imagePlane.z`; off-axis chief-ray image height vs. `f·tan(θ)` (rectilinear). These catch
+  sign/scale errors the current hit-order/clip tests cannot.
+
+## Critical files
+- `src/optics/internal/exactSurfaceTrace.ts` — add `traceToStopViaGeneralized`; fix `inferLeadDistance`.
+- `src/optics/buildLens.ts` — folded branch (`322-464`) real-ray solve; extract `computePupilGeometry`.
+- `src/optics/fieldGeometry.ts` / `src/optics/aberration/pupilAberration.ts` — thread folded context into `traceStateSurfacesReal`.
+- `src/optics/aberration/shared.ts`, `src/optics/aberration/spherical.ts` — `imagePlaneCoordinate` unification.
+- `src/optics/validateLensData.ts` — new validation rules.
+- `src/optics/cardinalElements.ts` — optional paraxial-stepper sharing.
+- `__tests__/src/optics/mirrorOptics.test.ts` (+ new fixtures under `src/lens-data/reference/`) — off-axis + analytic anchors.
+
+## Sequencing
+A and B together (they share `traceToStopViaGeneralized` and are the accuracy core) → F to lock the
+gains with anchored tests → C (mechanical, low risk) → E (independent hardening) → D (optional).
+
+## Guardrails / regression risk
+- **Do not relax** `shouldUseGeneralizedTrace`'s `stopAt` guard. Folded systems bypass `stopAt` via the
+  new helper; non-folded systems keep the sequential `stopAt` path untouched (CLAUDE.md: preserve
+  ordinary sequential defaults).
+- A folded ray may cross the stop more than once; take the first unclipped `surfaceIdx === stopIdx`
+  hit, and when `opticalPath.surfaceOrder` lists the stop twice prefer the cursor-matching occurrence.
+  Add a fixture covering this.
+- `δ`-based finite-difference chief/marginal assumes local linearity through mirrors; validate against a
+  directly stop-center-aimed ray for strongly tilted folds before trusting `realB`.
+
+## Verification
+- `npm run typecheck && npm run format:check && npm run lint && npm run test`, then `npm run build`
+  (lens-data/route/metadata) per CLAUDE.md.
+- New/updated tests in `mirrorOptics.test.ts` must pass, including off-axis and analytic-anchor cases.
+- Manually confirm a non-folded catalog lens's EP/XP/half-field values are unchanged (diff a built
+  RuntimeLens before/after) to prove no refractive regression.
+- Load a reference fold fixture via `?view=debug` and confirm off-axis ray bundles enter at the
+  corrected pupil position and converge at the declared image plane.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 - Renders patent-derived lens cross-sections as inline SVG with real surface sag, aspheric overlays, and diagnostics that prevent hidden semi-diameter clipping artifacts
 - Traces density-controlled on-axis, off-axis, and chromatic rays through the current focus, aperture, and zoom state
 - Adds opt-in, URL-shareable tilt/shift visualization controls for supported perspective-control lenses
+- Supports hidden/reference mirror fixtures with folded paths, annular apertures, tilted fold planes, side image planes,
+  and second-surface coating accents
 - Shows analysis views for spherical aberration, a real 2D coma point cloud, meridional and sagittal coma, distortion, focus breathing, lens-group movement, vignetting, pupil aberration, chromatic field curvature, and aspheric surface deviation
 - Includes Abbe-diagram and Petzval overlays, plus enlarged LCA visualization
 - Provides infinite-resolution zoom and pan for inspecting fine lens details, with mouse wheel, drag, pinch-to-zoom, and keyboard shortcuts
@@ -64,6 +66,7 @@ The catalog is auto-registered from `src/lens-data/**/*.data.ts`, so the README 
 - **Exact surface tracing**: the tracer intersects spherical/aspheric sag surfaces directly
 - **Projection-aware fisheyes**: equidistant and equisolid fisheye metadata use projection-native distortion references, vector/bounding-sphere chief-ray launches, and safe diagram bundle fields for lenses with extreme declared coverage
 - **Perspective-control movement**: supported PC lenses expose signed SHIFT and TILT sliders that move the 2D lens/ray trace relative to a fixed image plane and round-trip through shared URLs
+- **Mirror and folded-path fixtures**: hidden reference prescriptions exercise first-surface mirrors, Mangin-style second-surface mirrors, annular obstructions, tilted fold mirrors, automatic folded path selection, and non-default image planes; the lens library can expose them with `?view=debug`
 - **Lens-group movement**: focus and zoom sliders can open a URL-shareable overlay that stacks inferred lens groups vertically and charts each group center against the fixed focus plane
 - **Analysis drawer**: dedicated tabs for aberrations, coma, distortion, breathing, vignetting, and pupils, including spherical aberration, a real 2D coma point cloud, meridional and sagittal coma fan plots, separate parabasal and real-ray field curvature charts, isolated astigmatism split, optional chromatic (R/G/B) focus shifts inside the Aberrations tab, and entrance/exit pupil position shift vs field in the Pupils tab
 - **Aspheric deviation inspector**: click any aspheric element to compare its surface profile against the base sphere or a least-squares best-fit sphere, with adjustable exaggeration and click-to-measure Δsag (mm or μm)
@@ -114,6 +117,7 @@ npm run build         # Production build + prerender + sitemap
 npm run preview       # Preview built output
 npm run test          # Full Vitest suite
 npm run test:coverage # Coverage run
+npm run generate:mirror-reports # Hidden mirror fixture authoring report
 npm run typecheck     # TypeScript checks
 npm run lint          # ESLint
 npm run lint:fix      # ESLint autofix
@@ -172,7 +176,7 @@ npm run typecheck && npm run format:check && npm run lint && npm run test
 5. The catalog will pick the new lens up automatically through `import.meta.glob`.
 6. `npm run generate:metadata` or `npm run build` will move the lens into its maker folder and rewrite the type import to match the nested path.
 
-See [`src/lens-data/LENS_DATA_SPEC.md`](src/lens-data/LENS_DATA_SPEC.md) for the full data-file format, including glass identification conventions and canonical mount/format metadata. See [`src/lens-data/LENS_MOUNT_FORMAT_OPTIONS.md`](src/lens-data/LENS_MOUNT_FORMAT_OPTIONS.md) for the allowed mount and image-format ids. See [`src/lens-data/LENS_ANALYSIS_SPEC.md`](src/lens-data/LENS_ANALYSIS_SPEC.md) for the companion analysis-file standard (required sections, voice, conditional sections).
+See [`src/lens-data/LENS_DATA_SPEC.md`](src/lens-data/LENS_DATA_SPEC.md) for the full data-file format, including glass identification conventions, canonical mount/format metadata, and hidden mirror fixture guidance. Run `npm run generate:mirror-reports` after changing hidden mirror/telescope fixtures. See [`src/lens-data/LENS_MOUNT_FORMAT_OPTIONS.md`](src/lens-data/LENS_MOUNT_FORMAT_OPTIONS.md) for the allowed mount and image-format ids. See [`src/lens-data/LENS_ANALYSIS_SPEC.md`](src/lens-data/LENS_ANALYSIS_SPEC.md) for the companion analysis-file standard (required sections, voice, conditional sections).
 
 
 ## Agent Reference Docs

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Created by **Ron Buening**. For project background and methodology, see [About T
 - Traces density-controlled on-axis, off-axis, and chromatic rays through the current focus, aperture, and zoom state
 - Adds opt-in, URL-shareable tilt/shift visualization controls for supported perspective-control lenses
 - Supports hidden/reference mirror fixtures with folded paths, annular apertures, tilted fold planes, side image planes,
-  and second-surface coating accents
+  second-surface coating accents, and real-ray folded off-axis pupil/chief-ray geometry
 - Shows analysis views for spherical aberration, a real 2D coma point cloud, meridional and sagittal coma, distortion, focus breathing, lens-group movement, vignetting, pupil aberration, chromatic field curvature, and aspheric surface deviation
 - Includes Abbe-diagram and Petzval overlays, plus enlarged LCA visualization
 - Provides infinite-resolution zoom and pan for inspecting fine lens details, with mouse wheel, drag, pinch-to-zoom, and keyboard shortcuts
@@ -66,7 +66,7 @@ The catalog is auto-registered from `src/lens-data/**/*.data.ts`, so the README 
 - **Exact surface tracing**: the tracer intersects spherical/aspheric sag surfaces directly
 - **Projection-aware fisheyes**: equidistant and equisolid fisheye metadata use projection-native distortion references, vector/bounding-sphere chief-ray launches, and safe diagram bundle fields for lenses with extreme declared coverage
 - **Perspective-control movement**: supported PC lenses expose signed SHIFT and TILT sliders that move the 2D lens/ray trace relative to a fixed image plane and round-trip through shared URLs
-- **Mirror and folded-path fixtures**: hidden reference prescriptions exercise first-surface mirrors, Mangin-style second-surface mirrors, annular obstructions, tilted fold mirrors, automatic folded path selection, and non-default image planes; the lens library can expose them with `?view=debug`
+- **Mirror and folded-path fixtures**: hidden reference prescriptions exercise first-surface mirrors, Mangin-style second-surface mirrors, annular obstructions, tilted fold mirrors, automatic folded path selection, and non-default image planes; off-axis ray bundles solve against the generalized folded stop and image plane instead of using sequential refractive approximations, and the lens library can expose the fixtures with `?view=debug`
 - **Lens-group movement**: focus and zoom sliders can open a URL-shareable overlay that stacks inferred lens groups vertically and charts each group center against the fixed focus plane
 - **Analysis drawer**: dedicated tabs for aberrations, coma, distortion, breathing, vignetting, and pupils, including spherical aberration, a real 2D coma point cloud, meridional and sagittal coma fan plots, separate parabasal and real-ray field curvature charts, isolated astigmatism split, optional chromatic (R/G/B) focus shifts inside the Aberrations tab, and entrance/exit pupil position shift vs field in the Pupils tab
 - **Aspheric deviation inspector**: click any aspheric element to compare its surface profile against the base sphere or a least-squares best-fit sphere, with adjustable exaggeration and click-to-measure Δsag (mm or μm)
@@ -193,6 +193,8 @@ See [`src/lens-data/LENS_DATA_SPEC.md`](src/lens-data/LENS_DATA_SPEC.md) for the
 - [Adding a lens](agent_docs/adding_a_lens.md)
 - [Mount/format backfill](agent_docs/lens-mount-format-backfill.md)
 - [Trace model and fisheye launch status](TRACE_MODEL_IMPROVEMENT_PLAN.md)
+- [Mirror/folded optics accuracy status](MIRROR_OPTICS_ACCURACY_PLAN.md)
+- [Mirror-lens follow-up backlog](MIRROR_LENS_FUTURE_ENHANCEMENTS.md)
 - [Glass catalog buildout](agent_docs/glass-catalog-buildout.md)
 - [Chromatic dispersion notes](CHROMATIC_DISPERSION_NOTES.md)
 - [Lens data format](src/lens-data/LENS_DATA_SPEC.md)

--- a/__tests__/src/components/diagram/DiagramSVG.test.tsx
+++ b/__tests__/src/components/diagram/DiagramSVG.test.tsx
@@ -61,6 +61,7 @@ const baseLens = {
   lyStoPad: 4,
   lyImgLine: 40,
   lyImgLabel: 55,
+  imagePlane: { z: 43, y: 0, normal: { z: 1, y: 0 }, label: "IMG" },
   stopIdx: 0,
   epZRelStop: 0,
   N: 1,
@@ -189,6 +190,65 @@ describe("DiagramSVG", () => {
     expect(onSelect).toHaveBeenCalledWith(1);
     expect(onLcaInsetClick).toHaveBeenCalledTimes(1);
     expect(onPetzvalBadgeClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a side image plane using its resolved normal", () => {
+    const sideLens = {
+      ...baseLens,
+      lyImgLine: 10,
+      lyImgLabel: 12,
+      imagePlane: { z: 35, y: 25, normal: { z: 0, y: 1 }, label: "SIDE" },
+    } as RuntimeLens;
+    const { container } = render(
+      <DiagramSVG
+        L={sideLens}
+        t={themes.dark}
+        dark={true}
+        sx={(z) => z + 100}
+        sy={(y) => 300 + y}
+        CX={220}
+        IX={950}
+        effectiveSC={1}
+        zPos={[120]}
+        IMG_MM={43}
+        shapes={[]}
+        filterId="diagram-side-image-plane"
+        stopZ={220}
+        currentPhysStopSD={8}
+        rays={[]}
+        offAxisRays={[]}
+        chromaticRays={[]}
+        chromSpread={null}
+        showOnAxis={false}
+        showOffAxis="off"
+        showChromatic={false}
+        showPupils={false}
+        zoomT={0}
+        act={null}
+        onHover={onHover}
+        onSelect={onSelect}
+        sel={null}
+        maxSvgHeight="500px"
+        useSideLayout={false}
+        headerHeight={40}
+        compact={false}
+        flashVisible={false}
+        flashKey={1}
+        flashFading={false}
+      />,
+    );
+
+    const imageLine = Array.from(container.querySelectorAll('line[stroke-dasharray="4,3"]')).find(
+      (line) => line.getAttribute("stroke") === themes.dark.imgLine,
+    );
+    const label = Array.from(container.querySelectorAll("text")).find((text) => text.textContent === "SIDE");
+
+    expect(imageLine?.getAttribute("x1")).toBe("125");
+    expect(imageLine?.getAttribute("y1")).toBe("325");
+    expect(imageLine?.getAttribute("x2")).toBe("145");
+    expect(imageLine?.getAttribute("y2")).toBe("325");
+    expect(label?.getAttribute("x")).toBe("147");
+    expect(label?.getAttribute("y")).toBe("325");
   });
 
   it("switches into grab-mode event wiring when zoom-pan is active", () => {

--- a/__tests__/src/components/diagram/DiagramSVG.test.tsx
+++ b/__tests__/src/components/diagram/DiagramSVG.test.tsx
@@ -11,6 +11,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import DiagramSVG from "../../../../src/components/diagram/DiagramSVG.js";
+import buildLens from "../../../../src/optics/buildLens.js";
+import { doLayout } from "../../../../src/optics/optics.js";
+import { LENS_CATALOG } from "../../../../src/utils/catalog/lensCatalog.js";
 import themes from "../../../../src/utils/theme/themes.js";
 import type { RuntimeLens, ElementShape } from "../../../../src/types/optics.js";
 
@@ -249,6 +252,63 @@ describe("DiagramSVG", () => {
     expect(imageLine?.getAttribute("y2")).toBe("325");
     expect(label?.getAttribute("x")).toBe("147");
     expect(label?.getAttribute("y")).toBe("325");
+  });
+
+  it("renders the hidden Newtonian fixture image plane from its side-focus metadata", () => {
+    const L = buildLens(LENS_CATALOG["reference-newtonian-side-focus"]);
+    const layout = doLayout(0, 0, L);
+    const { container } = render(
+      <DiagramSVG
+        L={L}
+        t={themes.dark}
+        dark={true}
+        sx={(z) => z + 100}
+        sy={(y) => 300 + y}
+        CX={220}
+        IX={950}
+        effectiveSC={1}
+        zPos={layout.z}
+        IMG_MM={layout.imgZ}
+        shapes={[]}
+        filterId="diagram-newtonian-side-image-plane"
+        stopZ={220}
+        currentPhysStopSD={L.stopPhysSD}
+        rays={[]}
+        offAxisRays={[]}
+        chromaticRays={[]}
+        chromSpread={null}
+        showOnAxis={false}
+        showOffAxis="off"
+        showChromatic={false}
+        showPupils={false}
+        zoomT={0}
+        act={null}
+        onHover={onHover}
+        onSelect={onSelect}
+        sel={null}
+        maxSvgHeight="500px"
+        useSideLayout={false}
+        headerHeight={40}
+        compact={false}
+        flashVisible={false}
+        flashKey={1}
+        flashFading={false}
+      />,
+    );
+
+    const imageLine = Array.from(container.querySelectorAll('line[stroke-dasharray="4,3"]')).find(
+      (line) => line.getAttribute("stroke") === themes.dark.imgLine,
+    );
+    const label = Array.from(container.querySelectorAll("text")).find((text) => text.textContent === "IMG");
+
+    expect(imageLine).toBeDefined();
+    expect(label).toBeDefined();
+    expect(Number(imageLine!.getAttribute("y1"))).toBeCloseTo(325, 10);
+    expect(Number(imageLine!.getAttribute("y2"))).toBeCloseTo(325, 10);
+    expect(Number(imageLine!.getAttribute("x1"))).toBeCloseTo(100 + L.imagePlane.z - L.lyImgLine, 10);
+    expect(Number(imageLine!.getAttribute("x2"))).toBeCloseTo(100 + L.imagePlane.z + L.lyImgLine, 10);
+    expect(Number(label!.getAttribute("x"))).toBeCloseTo(100 + L.imagePlane.z + L.lyImgLabel, 10);
+    expect(Number(label!.getAttribute("y"))).toBeCloseTo(325, 10);
   });
 
   it("switches into grab-mode event wiring when zoom-pan is active", () => {

--- a/__tests__/src/components/diagram/DiagramSVG.test.tsx
+++ b/__tests__/src/components/diagram/DiagramSVG.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import DiagramSVG from "../../../../src/components/diagram/DiagramSVG.js";
 import buildLens from "../../../../src/optics/buildLens.js";
+import { computeElementShapes } from "../../../../src/optics/diagramGeometry.js";
 import { doLayout } from "../../../../src/optics/optics.js";
 import { LENS_CATALOG } from "../../../../src/utils/catalog/lensCatalog.js";
 import themes from "../../../../src/utils/theme/themes.js";
@@ -357,6 +358,60 @@ describe("DiagramSVG", () => {
 
     expect(screen.getByText("1 M1")).toBeTruthy();
     expect(screen.getByText("2 SEC")).toBeTruthy();
+  });
+
+  it("renders second-surface mirror coating accents from element shapes", () => {
+    const L = buildLens(LENS_CATALOG["reference-mangin-second-surface-mirror"]);
+    const layout = doLayout(0, 0, L);
+    const shapes = computeElementShapes(
+      L,
+      layout.z,
+      (z) => z + 100,
+      (y) => 300 + y,
+    );
+    const { container } = render(
+      <DiagramSVG
+        L={L}
+        t={themes.dark}
+        dark={true}
+        sx={(z) => z + 100}
+        sy={(y) => 300 + y}
+        CX={220}
+        IX={950}
+        effectiveSC={1}
+        zPos={layout.z}
+        IMG_MM={layout.imgZ}
+        shapes={shapes}
+        filterId="diagram-mangin-second-surface"
+        stopZ={220}
+        currentPhysStopSD={L.stopPhysSD}
+        rays={[]}
+        offAxisRays={[]}
+        chromaticRays={[]}
+        chromSpread={null}
+        showOnAxis={false}
+        showOffAxis="off"
+        showChromatic={false}
+        showPupils={false}
+        zoomT={0}
+        act={null}
+        onHover={onHover}
+        onSelect={onSelect}
+        sel={null}
+        maxSvgHeight="500px"
+        useSideLayout={false}
+        headerHeight={40}
+        compact={false}
+        flashVisible={false}
+        flashKey={1}
+        flashFading={false}
+      />,
+    );
+
+    const coating = container.querySelector(`[data-testid="surface-accent-second-surface-coating-${L.labelIdx.MG2}"]`);
+    expect(coating).toBeTruthy();
+    expect(coating?.getAttribute("stroke")).toBe(themes.dark.imgLine);
+    expect(coating?.getAttribute("stroke-dasharray")).toBe("3,2");
   });
 
   it("switches into grab-mode event wiring when zoom-pan is active", () => {

--- a/__tests__/src/components/diagram/DiagramSVG.test.tsx
+++ b/__tests__/src/components/diagram/DiagramSVG.test.tsx
@@ -311,6 +311,54 @@ describe("DiagramSVG", () => {
     expect(Number(label!.getAttribute("y"))).toBeCloseTo(325, 10);
   });
 
+  it("renders folded hit-order labels for debug fixtures", () => {
+    const L = buildLens(LENS_CATALOG["reference-newtonian-side-focus"]);
+    const layout = doLayout(0, 0, L);
+
+    render(
+      <DiagramSVG
+        L={L}
+        t={themes.dark}
+        dark={true}
+        sx={(z) => z + 100}
+        sy={(y) => 300 + y}
+        CX={220}
+        IX={950}
+        effectiveSC={1}
+        zPos={layout.z}
+        IMG_MM={layout.imgZ}
+        shapes={[]}
+        filterId="diagram-folded-hit-order"
+        stopZ={220}
+        currentPhysStopSD={L.stopPhysSD}
+        rays={[]}
+        offAxisRays={[]}
+        chromaticRays={[]}
+        chromSpread={null}
+        showOnAxis={false}
+        showOffAxis="off"
+        showChromatic={false}
+        showPupils={false}
+        foldedHitOrderLabels={["M1", "SEC"]}
+        zoomT={0}
+        act={null}
+        onHover={onHover}
+        onSelect={onSelect}
+        sel={null}
+        maxSvgHeight="500px"
+        useSideLayout={false}
+        headerHeight={40}
+        compact={false}
+        flashVisible={false}
+        flashKey={1}
+        flashFading={false}
+      />,
+    );
+
+    expect(screen.getByText("1 M1")).toBeTruthy();
+    expect(screen.getByText("2 SEC")).toBeTruthy();
+  });
+
   it("switches into grab-mode event wiring when zoom-pan is active", () => {
     const onSvgWheel = vi.fn();
     const onSvgPointerDown = vi.fn();

--- a/__tests__/src/components/display/ElementInspector.test.tsx
+++ b/__tests__/src/components/display/ElementInspector.test.tsx
@@ -103,7 +103,7 @@ describe("ElementInspector", () => {
     render(<ElementInspector info={info} L={L} t={mockTheme} showChromatic={false} />);
 
     expect(screen.getByText("SEC:")).toBeTruthy();
-    expect(screen.getByText(/reflect, first-surface, active rear, inactive ignore, normal z=1 y=1/)).toBeTruthy();
+    expect(screen.getByText(/reflect, first-surface, active rear, inactive block, normal z=1 y=1/)).toBeTruthy();
     expect(screen.getByText("SECB:")).toBeTruthy();
     expect(screen.getByText(/refract, active both, normal z=1 y=1/)).toBeTruthy();
     expect(screen.getByText("Image plane IMG:")).toBeTruthy();

--- a/__tests__/src/components/display/ElementInspector.test.tsx
+++ b/__tests__/src/components/display/ElementInspector.test.tsx
@@ -3,6 +3,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import ElementInspector from "../../../../src/components/display/ElementInspector.js";
+import buildLens from "../../../../src/optics/buildLens.js";
+import { LENS_CATALOG } from "../../../../src/utils/catalog/lensCatalog.js";
 
 afterEach(() => cleanup());
 import type { RuntimeLens, ElementData } from "../../../../src/types/optics.js";
@@ -23,6 +25,7 @@ const mockTheme = {
   apdNote: "#f80",
   role: "#8af",
   elemType: "#ccc",
+  panelBorder: "#333",
 } as unknown as Theme;
 
 const basicElement: ElementData = {
@@ -91,6 +94,20 @@ describe("ElementInspector", () => {
   it("renders focal length when available", () => {
     render(<ElementInspector info={basicElement} L={mockLens} t={mockTheme} showChromatic={false} />);
     expect(screen.getByText(/85\.3 mm/)).toBeTruthy();
+  });
+
+  it("renders folded surface metadata and explicit image-plane geometry", () => {
+    const L = buildLens(LENS_CATALOG["reference-newtonian-side-focus"]);
+    const info = L.elements.find((element) => element.id === 2)!;
+
+    render(<ElementInspector info={info} L={L} t={mockTheme} showChromatic={false} />);
+
+    expect(screen.getByText("SEC:")).toBeTruthy();
+    expect(screen.getByText(/reflect, first-surface, active rear, inactive ignore, normal z=1 y=1/)).toBeTruthy();
+    expect(screen.getByText("SECB:")).toBeTruthy();
+    expect(screen.getByText(/refract, active both, normal z=1 y=1/)).toBeTruthy();
+    expect(screen.getByText("Image plane IMG:")).toBeTruthy();
+    expect(screen.getByText(/z=35 mm y=25 mm normal z=0 y=1/)).toBeTruthy();
   });
 });
 

--- a/__tests__/src/components/display/analysis/AberrationsPanel.test.tsx
+++ b/__tests__/src/components/display/analysis/AberrationsPanel.test.tsx
@@ -41,6 +41,8 @@ vi.mock("../../../../../src/optics/aberrationAnalysis.js", () => ({
 const theme = {
   panelBg: "#111",
   panelBorder: "#222",
+  panelDivider: "#333",
+  desc: "#aaa",
   muted: "#999",
   axis: "#666",
   value: "#0f0",
@@ -450,6 +452,17 @@ describe("AberrationsPanel", () => {
     expect(screen.getAllByText("EDGE T / S").length).toBeGreaterThan(0);
     expect(screen.getByText("T -0.45 mm / S -0.21 mm")).toBeTruthy();
     expect(screen.getAllByText("5/5").length).toBeGreaterThan(0);
+  });
+
+  it("keeps folded optics on spherical aberration and hides field-model sections", () => {
+    mockComputeSphericalAberration.mockReturnValue(makeSaResult(-0.012));
+
+    render(<AberrationsPanel {...baseProps} L={{ ...baseProps.L, isFoldedOptics: true }} />);
+
+    expect(screen.getAllByText("BEST-FOCUS SPREAD").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Field curvature and astigmatism remain hidden for folded mirror systems/i)).toBeTruthy();
+    expect(screen.queryByText("Field Curves")).toBeNull();
+    expect(screen.queryByText("Astigmatism")).toBeNull();
   });
 
   it("forwards aberration-control state into spherical and field-curvature calculations", () => {

--- a/__tests__/src/components/hooks/useLensComputation.test.ts
+++ b/__tests__/src/components/hooks/useLensComputation.test.ts
@@ -11,6 +11,7 @@ import { LENS_CATALOG } from "../../../../src/utils/catalog/lensCatalog.js";
 
 describe("useLensComputation", () => {
   const baseLensKey = "sonnar-50f15";
+  const focusLensKey = "sony-fe-14mm-f18-gm";
 
   it("returns a valid RuntimeLens and geometry for a known lens key", () => {
     const { result } = renderHook(() =>
@@ -68,6 +69,23 @@ describe("useLensComputation", () => {
     );
     expect(result.current.shapes.length).toBeGreaterThan(0);
     expect(result.current.shapeError).toBeNull();
+  });
+
+  it("omits cardinal elements for folded mirror fixtures", () => {
+    const { result } = renderHook(() =>
+      useLensComputation({
+        lensKey: "reference-newtonian-side-focus",
+        focusT: 0,
+        zoomT: 0,
+        stopdownT: 0,
+        scaleRatio: null,
+        panelId: "test",
+        includeCardinalExtents: true,
+      }),
+    );
+
+    expect(result.current.L?.isFoldedOptics).toBe(true);
+    expect(result.current.cardinalElements).toBeNull();
   });
 
   it("computes aperture metrics", () => {
@@ -201,7 +219,7 @@ describe("useLensComputation", () => {
   it("zPos shifts when focus changes but IMG_MM stays fixed", () => {
     const { result: r0 } = renderHook(() =>
       useLensComputation({
-        lensKey: baseLensKey,
+        lensKey: focusLensKey,
         focusT: 0,
         zoomT: 0,
         stopdownT: 0,
@@ -211,7 +229,7 @@ describe("useLensComputation", () => {
     );
     const { result: r1 } = renderHook(() =>
       useLensComputation({
-        lensKey: baseLensKey,
+        lensKey: focusLensKey,
         focusT: 0.8,
         zoomT: 0,
         stopdownT: 0,

--- a/__tests__/src/components/hooks/useLensComputation.test.ts
+++ b/__tests__/src/components/hooks/useLensComputation.test.ts
@@ -71,7 +71,7 @@ describe("useLensComputation", () => {
     expect(result.current.shapeError).toBeNull();
   });
 
-  it("omits cardinal elements for folded mirror fixtures", () => {
+  it("omits cardinal elements for tilted-image folded mirror fixtures", () => {
     const { result } = renderHook(() =>
       useLensComputation({
         lensKey: "reference-newtonian-side-focus",
@@ -86,6 +86,24 @@ describe("useLensComputation", () => {
 
     expect(result.current.L?.isFoldedOptics).toBe(true);
     expect(result.current.cardinalElements).toBeNull();
+  });
+
+  it("computes cardinal elements for axial folded mirror fixtures", () => {
+    const { result } = renderHook(() =>
+      useLensComputation({
+        lensKey: "reference-spherical-primary-mirror",
+        focusT: 0,
+        zoomT: 0,
+        stopdownT: 0,
+        scaleRatio: null,
+        panelId: "test",
+        includeCardinalExtents: true,
+      }),
+    );
+
+    expect(result.current.L?.isFoldedOptics).toBe(true);
+    expect(result.current.cardinalElements).not.toBeNull();
+    expect(result.current.cardinalElements?.points.rearFocal.z).toBeCloseTo(result.current.L!.imagePlane.z, 8);
   });
 
   it("computes aperture metrics", () => {

--- a/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
+++ b/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
@@ -68,8 +68,8 @@ vi.mock("../../../../../src/components/display/analysis/VignettingTab.js", () =>
 
 const baseProps = {
   activeTab: "aberrations",
-  L: { N: 2 } as RuntimeLens,
-  t: { value: "#0f0" } as Theme,
+  L: { N: 2, isFoldedOptics: false } as RuntimeLens,
+  t: { value: "#0f0", panelDivider: "#333", panelBg: "#111", desc: "#aaa" } as Theme,
   zPos: [0, 5],
   focusT: 0,
   zoomT: 0,
@@ -137,6 +137,14 @@ describe("AnalysisDrawerContent", () => {
     expect(mockPupilAberrationTab).toHaveBeenCalledTimes(1);
     expect(mockPupilAberrationTab.mock.calls[0][0].aberrationT).toBe(0.37);
     expect(mockVignettingTab).not.toHaveBeenCalled();
+  });
+
+  it("shows a folded-optics guard instead of invoking sequential analysis tabs", () => {
+    render(<AnalysisDrawerContent {...baseProps} L={{ ...baseProps.L, isFoldedOptics: true }} activeTab="pupils" />);
+
+    expect(screen.getByText(/Folded mirror optical path detected/)).toBeTruthy();
+    expect(screen.getByText(/not available for folded mirror systems yet/)).toBeTruthy();
+    expect(mockPupilAberrationTab).not.toHaveBeenCalled();
   });
 
   it("has exactly one renderer for every registered analysis tab", () => {

--- a/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
+++ b/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import AnalysisDrawerContent from "../../../../../src/components/layout/lensDiagram/AnalysisDrawerContent.js";
 import { ANALYSIS_TAB_RENDERERS } from "../../../../../src/components/layout/lensDiagram/analysisTabRenderers.js";
 import { ANALYSIS_TABS } from "../../../../../src/components/layout/lensDiagram/analysisTabs.js";
@@ -81,6 +81,10 @@ const baseProps = {
 };
 
 describe("AnalysisDrawerContent", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     mockAberrationsPanel.mockReset();
     mockComaTab.mockReset();
@@ -145,6 +149,16 @@ describe("AnalysisDrawerContent", () => {
     expect(screen.getByText(/Folded mirror optical path detected/)).toBeTruthy();
     expect(screen.getByText(/not available for folded mirror systems yet/)).toBeTruthy();
     expect(mockPupilAberrationTab).not.toHaveBeenCalled();
+  });
+
+  it("allows folded optics to use the mirror-safe aberrations tab", () => {
+    render(
+      <AnalysisDrawerContent {...baseProps} L={{ ...baseProps.L, isFoldedOptics: true }} activeTab="aberrations" />,
+    );
+
+    expect(screen.getByText(/Folded mirror optical path detected/)).toBeTruthy();
+    expect(screen.getByText("Aberrations:true")).toBeTruthy();
+    expect(mockAberrationsPanel).toHaveBeenCalledTimes(1);
   });
 
   it("has exactly one renderer for every registered analysis tab", () => {

--- a/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
+++ b/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
@@ -161,6 +161,14 @@ describe("AnalysisDrawerContent", () => {
     expect(mockAberrationsPanel).toHaveBeenCalledTimes(1);
   });
 
+  it("allows folded optics to use the metadata-only focus breathing tab", () => {
+    render(<AnalysisDrawerContent {...baseProps} L={{ ...baseProps.L, isFoldedOptics: true }} activeTab="breathing" />);
+
+    expect(screen.getByText(/Folded mirror optical path detected/)).toBeTruthy();
+    expect(screen.getByText("Breathing")).toBeTruthy();
+    expect(mockFocusBreathingTab).toHaveBeenCalledTimes(1);
+  });
+
   it("has exactly one renderer for every registered analysis tab", () => {
     expect(Object.keys(ANALYSIS_TAB_RENDERERS).sort()).toEqual(ANALYSIS_TABS.map((tab) => tab.id).sort());
   });

--- a/__tests__/src/optics/cardinalElements.test.ts
+++ b/__tests__/src/optics/cardinalElements.test.ts
@@ -66,6 +66,22 @@ describe("computeCardinalElementsAtState", () => {
     expect(close.points.rearPrincipal.z).not.toBeCloseTo(infinity.points.rearPrincipal.z, 3);
   });
 
+  it("computes reflective cardinal elements for an axial folded primary mirror", () => {
+    const L = buildLens(LENS_CATALOG["reference-spherical-primary-mirror"]);
+    const result = cardinalsFor(L);
+
+    expect(result).not.toBeNull();
+    expect(result!.points.rearFocal.z).toBeCloseTo(L.imagePlane.z, 8);
+    expect(Math.abs(result!.distances.efl.valueMm)).toBeCloseTo(L.EFL, 8);
+    expect(result!.distances.efl.valueMm).toBeLessThan(0);
+  });
+
+  it("keeps tilted image-plane folded systems out of first-order cardinal reporting", () => {
+    const L = buildLens(LENS_CATALOG["reference-newtonian-side-focus"]);
+
+    expect(cardinalsFor(L)).toBeNull();
+  });
+
   it("returns null for afocal or zero-power systems", () => {
     const L = {
       S: [{ label: "1", R: 1e15, d: 0, nd: 1, elemId: 1, sd: 10 }],

--- a/__tests__/src/optics/diagramGeometry.test.ts
+++ b/__tests__/src/optics/diagramGeometry.test.ts
@@ -189,6 +189,7 @@ describe("computeElementShapes", () => {
     expect(shapes[0].z2).toBe(5);
     expect(shapes[0].d).toMatch(/^M.*Z$/); // starts with M, ends with Z (closed)
     expect(shapes[0].asphPaths).toEqual([]);
+    expect(shapes[0].surfaceAccentPaths).toEqual([]);
   });
 
   it("zero point transform preserves element shape coordinates", () => {
@@ -565,5 +566,19 @@ describe("computeElementShapes", () => {
     expect(rearTop[0]).toBeCloseTo(layout.z[L.labelIdx.SECB] + 10, 10);
     expect(rearBottom[1]).toBeCloseTo(10, 10);
     expect(rearBottom[0]).toBeCloseTo(layout.z[L.labelIdx.SECB] - 10, 10);
+  });
+
+  it("emits a coating accent path for second-surface mirror fixtures", () => {
+    const L = buildLens(LENS_CATALOG["reference-mangin-second-surface-mirror"]);
+    const layout = doLayout(0, 0, L);
+    const shapes = computeElementShapes(L, layout.z, sx, sy);
+    const manginShape = shapes.find((shape) => shape.eid === 1);
+    const coating = manginShape?.surfaceAccentPaths.find(
+      (path) => path.kind === "second-surface-coating" && path.surfIdx === L.labelIdx.MG2,
+    );
+
+    expect(coating).toBeDefined();
+    expect(coating?.pathD).toMatch(/^M/);
+    expect(pathCoords(coating?.pathD ?? "")).toHaveLength(SVG_PATH_SUBDIVISIONS + 1);
   });
 });

--- a/__tests__/src/optics/diagramGeometry.test.ts
+++ b/__tests__/src/optics/diagramGeometry.test.ts
@@ -4,8 +4,10 @@ import {
   computeElementRenderDiagnostics,
   computeElementShapes,
 } from "../../../src/optics/diagramGeometry.js";
-import { SVG_PATH_SUBDIVISIONS } from "../../../src/optics/optics.js";
+import buildLens from "../../../src/optics/buildLens.js";
+import { doLayout, SVG_PATH_SUBDIVISIONS } from "../../../src/optics/optics.js";
 import type { RuntimeLens, AsphericCoefficients } from "../../../src/types/optics.js";
+import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 
 /* ═══════════════════════════════════════════════════════════════════
  * §1  createCoordinateTransforms
@@ -541,5 +543,27 @@ describe("computeElementShapes", () => {
     expect(rearTop[1]).toBeCloseTo(-12);
     expect(frontBottom[1]).toBeCloseTo(18);
     expect(rearBottom[1]).toBeCloseTo(12);
+  });
+
+  it("renders a tilted fold mirror and its passive backing plane with matching meridional normals", () => {
+    const L = buildLens(LENS_CATALOG["reference-newtonian-side-focus"]);
+    const layout = doLayout(0, 0, L);
+    const shapes = computeElementShapes(L, layout.z, sx, sy);
+    const secondaryShape = shapes.find((shape) => shape.eid === 2);
+    const coords = pathCoords(secondaryShape?.d ?? "");
+    const frontTop = coords[0];
+    const frontBottom = coords[SVG_PATH_SUBDIVISIONS];
+    const rearBottom = coords[SVG_PATH_SUBDIVISIONS + 1];
+    const rearTop = coords[coords.length - 1];
+
+    expect(secondaryShape).toBeDefined();
+    expect(frontTop[1]).toBeCloseTo(-10, 10);
+    expect(frontTop[0]).toBeCloseTo(layout.z[L.labelIdx.SEC] + 10, 10);
+    expect(frontBottom[1]).toBeCloseTo(10, 10);
+    expect(frontBottom[0]).toBeCloseTo(layout.z[L.labelIdx.SEC] - 10, 10);
+    expect(rearTop[1]).toBeCloseTo(-10, 10);
+    expect(rearTop[0]).toBeCloseTo(layout.z[L.labelIdx.SECB] + 10, 10);
+    expect(rearBottom[1]).toBeCloseTo(10, 10);
+    expect(rearBottom[0]).toBeCloseTo(layout.z[L.labelIdx.SECB] - 10, 10);
   });
 });

--- a/__tests__/src/optics/exactTraceCatalog.test.ts
+++ b/__tests__/src/optics/exactTraceCatalog.test.ts
@@ -21,6 +21,49 @@ const REPRESENTATIVE_KEYS = [
   "sony-fe-90mm-f2p8-macro",
 ] as const;
 
+const HIDDEN_FOLDED_TRACE_CASES = [
+  {
+    key: "reference-spherical-primary-mirror",
+    y0: 5,
+    expectedHitLabels: ["STO", "M1"],
+  },
+  {
+    key: "reference-annular-obscured-mirror",
+    y0: 12,
+    expectedHitLabels: ["STO", "M1"],
+  },
+  {
+    key: "reference-mangin-second-surface-mirror",
+    y0: 4,
+    expectedHitLabels: ["STO", "MG1", "MG2", "MG1"],
+  },
+  {
+    key: "reference-newtonian-side-focus",
+    y0: 12,
+    expectedHitLabels: ["M1", "SEC"],
+  },
+  {
+    key: "reference-cassegrain-back-focus",
+    y0: 12,
+    expectedHitLabels: ["M1", "SEC"],
+  },
+  {
+    key: "reference-maksutov-cassegrain-meniscus",
+    y0: 12,
+    expectedHitLabels: ["MEN1", "MEN2", "M1", "SEC"],
+  },
+  {
+    key: "reference-gregorian-secondary",
+    y0: 12,
+    expectedHitLabels: ["M1", "SEC"],
+  },
+  {
+    key: "reference-annular-ring-blocker",
+    y0: 0,
+    expectedHitLabels: [],
+  },
+] as const;
+
 function buildCatalogLens(key: string): RuntimeLens {
   return buildLens({ ...LENS_DEFAULTS, ...LENS_CATALOG[key] } as LensData);
 }
@@ -93,6 +136,23 @@ describe("exact surface trace catalog smoke coverage", () => {
         expectFiniteTraceResult(meridional);
         expectFiniteTraceResult(skew);
       }
+    }
+  });
+
+  it("keeps hidden folded reference fixtures covered outside the public catalog smoke test", () => {
+    for (const { key, y0, expectedHitLabels } of HIDDEN_FOLDED_TRACE_CASES) {
+      expect(LENS_CATALOG[key]?.visible, key).toBe(false);
+      expect(CATALOG_KEYS, key).not.toContain(key);
+
+      const L = buildCatalogLens(key);
+      const layout = doLayout(0, 0, L);
+      const trace = traceRay(y0, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+
+      expect(trace.clipped, key).toBe(false);
+      expect(trace.reachedImagePlane, key).toBe(true);
+      expect(trace.diagnostics?.hitSurfaceLabels, key).toEqual(expectedHitLabels);
+      expect(trace.diagnostics?.finalMedium, key).toBeCloseTo(1, 12);
+      expectFiniteTraceResult(trace);
     }
   });
 

--- a/__tests__/src/optics/mirrorFixtureAuthoringReport.test.ts
+++ b/__tests__/src/optics/mirrorFixtureAuthoringReport.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Mirror fixture authoring report.
+ *
+ * Scans hidden/reference mirror fixtures and emits a markdown checklist for
+ * optical-path, mirror, blocker, annular, and image-plane metadata.
+ *
+ * Always passes - its job is to emit an authoring report, not to gate CI.
+ *
+ * Regenerate: `npm test -- mirrorFixtureAuthoringReport`
+ */
+import { describe, expect, it } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import buildLens from "../../../src/optics/buildLens.js";
+import { foldedHitOrderLabelsForDisplay } from "../../../src/optics/foldedPathDisplay.js";
+import { doLayout } from "../../../src/optics/optics.js";
+import validateLensData from "../../../src/optics/validateLensData.js";
+import type { LensData, RuntimeLens, SurfaceData } from "../../../src/types/optics.js";
+import { LENS_CATALOG, isDebugLensKey } from "../../../src/utils/catalog/lensCatalog.js";
+
+const modules = import.meta.glob<{ default: LensData }>("../../../src/lens-data/**/*.data.ts", { eager: true });
+
+const REPORT_DIR = "agent_docs/generated";
+const REPORT_PATH = `${REPORT_DIR}/mirror-fixtures.generated.md`;
+
+interface FixtureRow {
+  key: string;
+  name: string;
+  filePath: string;
+  pathMode: string;
+  hitOrder: string[];
+  imagePlane: string;
+  reflectLabels: string[];
+  blockLabels: string[];
+  annularLabels: string[];
+  secondSurfaceLabels: string[];
+  tiltedLabels: string[];
+  validationErrors: string[];
+}
+
+function toRepoRelativeLensPath(modulePath: string): string {
+  const lensDataIndex = modulePath.indexOf("src/lens-data/");
+  return lensDataIndex >= 0 ? modulePath.slice(lensDataIndex) : modulePath.replace(/^(\.\.\/)+/, "");
+}
+
+function buildLensFilePathByKey(): Map<string, string> {
+  const paths = new Map<string, string>();
+  for (const [modulePath, mod] of Object.entries(modules)) {
+    if (mod.default?.key) paths.set(mod.default.key, toRepoRelativeLensPath(modulePath));
+  }
+  return paths;
+}
+
+function hasMirrorFixtureMetadata(data: LensData): boolean {
+  return (
+    Boolean(data.opticalPath) ||
+    data.surfaces.some(
+      (surface) =>
+        surface.innerSd !== undefined ||
+        surface.interaction?.type === "reflect" ||
+        surface.interaction?.type === "block" ||
+        surface.interaction?.normal !== undefined,
+    )
+  );
+}
+
+function surfaceLabels(L: RuntimeLens, predicate: (surface: SurfaceData) => boolean): string[] {
+  return L.S.filter(predicate).map((surface) => surface.label);
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2);
+}
+
+function describeImagePlane(L: RuntimeLens): string {
+  const plane = L.imagePlane;
+  return `${plane.label}: z=${formatNumber(plane.z)}, y=${formatNumber(plane.y)}, n=(${formatNumber(
+    plane.normal.z,
+  )}, ${formatNumber(plane.normal.y)})`;
+}
+
+function describePathMode(L: RuntimeLens): string {
+  if (L.opticalPath.surfaceLabels) return "explicit";
+  return L.opticalPath.mode;
+}
+
+function formatLabels(labels: readonly string[]): string {
+  return labels.length > 0 ? labels.map((label) => `\`${label}\``).join(" -> ") : "None";
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, "<br>");
+}
+
+function fixtureRows(): FixtureRow[] {
+  const filePathByKey = buildLensFilePathByKey();
+  return Object.entries(LENS_CATALOG)
+    .filter(([key, data]) => data.visible === false && isDebugLensKey(key) && hasMirrorFixtureMetadata(data))
+    .map(([key, data]) => {
+      const validationErrors = validateLensData(data as unknown as Record<string, unknown>);
+      const L = buildLens(data);
+      const layout = doLayout(0, 0, L);
+      const hitOrder = foldedHitOrderLabelsForDisplay({
+        L,
+        zPos: layout.z,
+        focusT: 0,
+        zoomT: 0,
+        aberrationT: 0,
+        currentPhysStopSD: L.stopPhysSD,
+        currentEPSD: L.EP.epSD,
+      });
+
+      return {
+        key,
+        name: data.name ?? key,
+        filePath: filePathByKey.get(key) ?? `src/lens-data/${key}.data.ts`,
+        pathMode: describePathMode(L),
+        hitOrder,
+        imagePlane: describeImagePlane(L),
+        reflectLabels: surfaceLabels(L, (surface) => surface.interaction?.type === "reflect"),
+        blockLabels: surfaceLabels(L, (surface) => surface.interaction?.type === "block"),
+        annularLabels: surfaceLabels(L, (surface) => surface.innerSd !== undefined),
+        secondSurfaceLabels: surfaceLabels(L, (surface) => surface.interaction?.mirrorKind === "second-surface"),
+        tiltedLabels: surfaceLabels(L, (surface) => surface.interaction?.normal !== undefined),
+        validationErrors,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function buildReport(rows: FixtureRow[]): string {
+  const validationIssueCount = rows.filter((row) => row.validationErrors.length > 0).length;
+  const secondSurfaceCount = rows.filter((row) => row.secondSurfaceLabels.length > 0).length;
+  const tiltedCount = rows.filter((row) => row.tiltedLabels.length > 0).length;
+  const annularCount = rows.filter((row) => row.annularLabels.length > 0).length;
+
+  const lines: string[] = [];
+  lines.push("# Mirror Fixture Authoring Report (auto-generated)");
+  lines.push("");
+  lines.push(
+    "Hidden/reference fixtures that exercise mirror, folded-path, annular, blocker, and image-plane metadata.",
+  );
+  lines.push("");
+  lines.push("**Regenerate this file** by running `npm test -- mirrorFixtureAuthoringReport`.");
+  lines.push("Regenerate the mirror report set with `npm run generate:mirror-reports`.");
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- **${rows.length}** hidden/reference fixtures scanned`);
+  lines.push(`- **${secondSurfaceCount}** fixtures include second-surface mirror metadata`);
+  lines.push(`- **${tiltedCount}** fixtures include tilted meridional plane metadata`);
+  lines.push(`- **${annularCount}** fixtures include annular aperture or obstruction metadata`);
+  lines.push(`- **${validationIssueCount}** fixtures currently report validation errors`);
+  lines.push("");
+  lines.push("## Fixture Matrix");
+  lines.push("");
+  lines.push("| Fixture | Path | Hit order | Image plane | Reflect | Block | Annular | Second surface | Validation |");
+  lines.push("|---|---|---|---|---|---|---|---|---|");
+  for (const row of rows) {
+    const validation = row.validationErrors.length > 0 ? `${row.validationErrors.length} issue(s)` : "OK";
+    lines.push(
+      `| [${escapeTableCell(row.name)}](../../${row.filePath}) | ${row.pathMode} | ${escapeTableCell(
+        formatLabels(row.hitOrder),
+      )} | ${escapeTableCell(row.imagePlane)} | ${escapeTableCell(formatLabels(row.reflectLabels))} | ${escapeTableCell(
+        formatLabels(row.blockLabels),
+      )} | ${escapeTableCell(formatLabels(row.annularLabels))} | ${escapeTableCell(
+        formatLabels(row.secondSurfaceLabels),
+      )} | ${validation} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Fixture Details");
+  lines.push("");
+  for (const row of rows) {
+    lines.push(`### [${row.name}](../../${row.filePath})`);
+    lines.push("");
+    lines.push(`- Key: \`${row.key}\``);
+    lines.push(`- Path mode: ${row.pathMode}`);
+    lines.push(`- Hit order: ${formatLabels(row.hitOrder)}`);
+    lines.push(`- Image plane: ${row.imagePlane}`);
+    lines.push(`- Reflective surfaces: ${formatLabels(row.reflectLabels)}`);
+    lines.push(`- Blocking surfaces: ${formatLabels(row.blockLabels)}`);
+    lines.push(`- Annular surfaces: ${formatLabels(row.annularLabels)}`);
+    lines.push(`- Second-surface coatings: ${formatLabels(row.secondSurfaceLabels)}`);
+    lines.push(`- Tilted planes: ${formatLabels(row.tiltedLabels)}`);
+    if (row.validationErrors.length > 0) {
+      lines.push("- Validation:");
+      for (const error of row.validationErrors) lines.push(`  - ${error}`);
+    } else {
+      lines.push("- Validation: OK");
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+describe("mirror fixture authoring report", () => {
+  it("emits a hidden/reference mirror fixture report", () => {
+    const rows = fixtureRows();
+    const report = buildReport(rows);
+
+    mkdirSync(REPORT_DIR, { recursive: true });
+    writeFileSync(REPORT_PATH, report);
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some((row) => row.key === "reference-mangin-second-surface-mirror")).toBe(true);
+    expect(report).toContain("Second-surface coatings");
+  });
+});

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -172,22 +172,6 @@ describe("mirror optics support", () => {
     });
   });
 
-  it("lets explicitly ignored inactive mirror sides pass through", () => {
-    const lens = singleSurfaceBackHitMirror({
-      type: "reflect",
-      incidentSide: "front",
-      inactiveSide: "ignore",
-      mirrorKind: "first-surface",
-    });
-    const result = traceBackSideMirror(lens, 5);
-
-    expect(result.clipped).toBe(false);
-    expect(result.hits).toHaveLength(0);
-    expect(result.reachedImagePlane).toBe(true);
-    expect(result.terminalPoint[2]).toBeCloseTo(-10, 10);
-    expect(result.diagnostics.clipEvents).toEqual([]);
-  });
-
   it("blocks inactive annular mirror rings while passing central holes", () => {
     const lens = singleSurfaceBackHitMirror(
       {
@@ -319,11 +303,10 @@ describe("mirror optics support", () => {
     expect(Number.isFinite(result.terminalPoint[2])).toBe(true);
   });
 
-  it("traces off-axis Newtonian chief rays to the side image-plane coordinate", () => {
+  it("clips Newtonian off-axis chief rays that hit the blocking secondary", () => {
     const L = buildLens(newtonianData);
     const layout = doLayout(0, 0, L);
     const fieldDeg = 2;
-    const expected = L.EFL * Math.tan((fieldDeg * Math.PI) / 180);
 
     const positiveSolve = solveChiefRay(fieldDeg, 0, 0, L);
     const negativeSolve = solveChiefRay(-fieldDeg, 0, 0, L);
@@ -335,10 +318,17 @@ describe("mirror optics support", () => {
     expect(positiveSolve.status).toBe("converged");
     expect(positive.reachedImagePlane).toBe(true);
     expect(negative.reachedImagePlane).toBe(true);
-    expect(positive.clipped).toBe(false);
-    expect(negative.clipped).toBe(false);
-    expect(Math.abs(positiveCoordinate)).toBeCloseTo(expected, 2);
-    expect(positiveCoordinate).toBeCloseTo(-negativeCoordinate, 8);
+    for (const trace of [positive, negative]) {
+      expect(trace.clipped).toBe(true);
+      expect(trace.diagnostics?.clipEvents).toContainEqual({
+        surfaceIdx: L.labelIdx.SEC,
+        surfaceLabel: "SEC",
+        reason: "inactive-side-block",
+        failureReason: null,
+      });
+    }
+    expect(Number.isFinite(positiveCoordinate)).toBe(true);
+    expect(Number.isFinite(negativeCoordinate)).toBe(true);
   });
 
   it("keeps auto folded hit order stable under small ray-height and aperture perturbations", () => {
@@ -491,7 +481,7 @@ describe("mirror optics support", () => {
           nd: 1.0,
           elemId: 1,
           sd: 20,
-          interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "ignore", mirrorKind: "first-surface" },
+          interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "block", mirrorKind: "first-surface" },
         },
         {
           label: "M1",
@@ -511,7 +501,11 @@ describe("mirror optics support", () => {
       },
     } satisfies LensData);
     const layout = doLayout(0, 0, L);
-    const result = traceRay(5, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const result = traceExactSurfaceStackVector(
+      L,
+      { origin: [0, 5, 5], direction: [0, 0, 1] },
+      { zPos: layout.z, launchBoundT: 50 },
+    );
 
     expect(result.clipped).toBe(true);
     expect(result.diagnostics?.loopDetected).toBe(true);

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import buildLens from "../../../src/optics/buildLens.js";
+import { computeElementShapes } from "../../../src/optics/diagramGeometry.js";
 import { traceExactSurfaceStack } from "../../../src/optics/internal/exactSurfaceTrace.js";
 import { doLayout, traceRay } from "../../../src/optics/optics.js";
+import { obstructionAwareRayFractionsForDensity } from "../../../src/optics/raySampling.js";
 import validateLensData from "../../../src/optics/validateLensData.js";
 import type { LensData } from "../../../src/types/optics.js";
 import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 
 const mirrorData = LENS_CATALOG["reference-spherical-primary-mirror"] as LensData;
+const annularData = LENS_CATALOG["reference-annular-obscured-mirror"] as LensData;
 
 function reflectYz(incidentY: number, incidentZ: number, normalY: number, normalZ: number): [number, number] {
   const dot = incidentY * normalY + incidentZ * normalZ;
@@ -73,5 +76,38 @@ describe("mirror optics support", () => {
     expect(result.y).toBeCloseTo(0, 2);
     expect(lastPoint[0]).toBeCloseTo(L.imagePlane.z, 10);
     expect(lastPoint[1]).toBeCloseTo(result.y, 10);
+  });
+
+  it("clips central rays on an obstruction while sampling the usable annular pupil", () => {
+    const L = buildLens(annularData);
+    const layout = doLayout(0, 0, L);
+    const central = traceExactSurfaceStack(L, { y0: 0, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
+    const obstructionHit = central.hits.find((hit) => hit.surfaceIdx === L.labelIdx.OBS);
+
+    expect(validateLensData(annularData)).toEqual([]);
+    expect(obstructionHit).toBeDefined();
+    expect(obstructionHit!.clipped).toBe(true);
+    expect(central.clipped).toBe(true);
+
+    const samples = obstructionAwareRayFractionsForDensity(L, L.rayFractions, "normal", L.EP.epSD);
+    const blockedFraction = L.S[L.labelIdx.OBS].sd / L.EP.epSD;
+    expect(samples.length).toBeGreaterThan(0);
+    expect(samples.every((fraction) => Math.abs(fraction) >= blockedFraction - 1e-9)).toBe(true);
+  });
+
+  it("renders annular mirror elements with an even-odd aperture hole", () => {
+    const L = buildLens(annularData);
+    const layout = doLayout(0, 0, L);
+    const shapes = computeElementShapes(
+      L,
+      layout.z,
+      (z) => z,
+      (y) => y,
+    );
+    const mirrorShape = shapes.find((shape) => shape.eid === 1);
+
+    expect(mirrorShape).toBeDefined();
+    expect(mirrorShape!.fillRule).toBe("evenodd");
+    expect((mirrorShape!.d.match(/M/g) ?? []).length).toBeGreaterThan(1);
   });
 });

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -18,6 +18,9 @@ const annularData = LENS_CATALOG["reference-annular-obscured-mirror"] as LensDat
 const manginData = LENS_CATALOG["reference-mangin-second-surface-mirror"] as LensData;
 const newtonianData = LENS_CATALOG["reference-newtonian-side-focus"] as LensData;
 const cassegrainData = LENS_CATALOG["reference-cassegrain-back-focus"] as LensData;
+const maksutovData = LENS_CATALOG["reference-maksutov-cassegrain-meniscus"] as LensData;
+const gregorianData = LENS_CATALOG["reference-gregorian-secondary"] as LensData;
+const ringBlockerData = LENS_CATALOG["reference-annular-ring-blocker"] as LensData;
 
 function reflectYz(incidentY: number, incidentZ: number, normalY: number, normalZ: number): [number, number] {
   const dot = incidentY * normalY + incidentZ * normalZ;
@@ -158,6 +161,26 @@ describe("mirror optics support", () => {
     expect(Number.isFinite(result.terminalPoint[2])).toBe(true);
   });
 
+  it("exposes folded-path diagnostics through the public ray trace result", () => {
+    const L = buildLens(newtonianData);
+    const layout = doLayout(0, 0, L);
+    const result = traceRay(12, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const diagnostics = result.diagnostics;
+
+    expect(diagnostics).toBeDefined();
+    expect(diagnostics!.expectedPathMode).toBe("auto");
+    expect(diagnostics!.hitSurfaceLabels).toEqual(["M1", "SEC"]);
+    expect(diagnostics!.reachedImagePlane).toBe(true);
+    expect(diagnostics!.finalMedium).toBeCloseTo(1, 12);
+    expect(diagnostics!.terminationReason).toBe("image-plane");
+    expect(diagnostics!.autoSteps.some((step) => step.skippedCandidates.length > 0)).toBe(true);
+    expect(
+      diagnostics!.autoSteps
+        .flatMap((step) => step.skippedCandidates)
+        .some((skip) => skip.reason === "passive-same-index"),
+    ).toBe(true);
+  });
+
   it("renders the Newtonian secondary as a tilted fold mirror", () => {
     const L = buildLens(newtonianData);
     const layout = doLayout(0, 0, L);
@@ -197,6 +220,120 @@ describe("mirror optics support", () => {
     expect(marginal.clipped).toBe(false);
     expect(marginal.terminalPoint[2]).toBeCloseTo(L.imagePlane.z, 10);
     expect(samples.every((fraction) => Math.abs(fraction) >= blockedFraction - 1e-9)).toBe(true);
+  });
+
+  it("records inactive-side blocking as a folded-path clip reason", () => {
+    const L = buildLens(cassegrainData);
+    const layout = doLayout(0, 0, L);
+    const result = traceRay(0, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+
+    expect(result.clipped).toBe(true);
+    expect(result.diagnostics?.clipEvents).toContainEqual({
+      surfaceIdx: L.labelIdx.SEC,
+      surfaceLabel: "SEC",
+      reason: "inactive-side-block",
+      failureReason: null,
+    });
+  });
+
+  it("detects repeated auto-path states before maxInteractions is exhausted", () => {
+    const L = buildLens({
+      ...mirrorData,
+      key: "reference-looping-flat-mirrors",
+      name: "REFERENCE Looping Flat Mirrors",
+      elements: [
+        {
+          id: 1,
+          name: "LOOP",
+          label: "Loop mirrors",
+          type: "Flat Mirror Pair",
+          nd: 1.0,
+          vd: 0,
+          glass: "Aluminized front surfaces",
+          apd: false,
+          fromSurface: "STO",
+          toSurface: "M1",
+        },
+      ],
+      surfaces: [
+        {
+          label: "STO",
+          R: 1e15,
+          d: 10,
+          nd: 1.0,
+          elemId: 1,
+          sd: 20,
+          interaction: { type: "reflect", incidentSide: "rear", mirrorKind: "first-surface" },
+        },
+        {
+          label: "M1",
+          R: 1e15,
+          d: 0,
+          nd: 1.0,
+          elemId: 1,
+          sd: 20,
+          interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+        },
+      ],
+      groups: [{ text: "Loop", fromSurface: "STO", toSurface: "M1" }],
+      opticalPath: {
+        mode: "auto",
+        imagePlane: { z: 50, label: "IMG" },
+        maxInteractions: 8,
+      },
+    } satisfies LensData);
+    const layout = doLayout(0, 0, L);
+    const result = traceRay(5, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+
+    expect(result.clipped).toBe(true);
+    expect(result.diagnostics?.loopDetected).toBe(true);
+    expect(result.diagnostics?.terminationReason).toBe("loop-detected");
+    expect(result.diagnostics?.hitSurfaceLabels).toEqual(["M1", "STO", "M1"]);
+    expect(result.diagnostics?.hitSurfaceLabels.length).toBeLessThan(L.opticalPath.maxInteractions);
+  });
+
+  it("supports a compact Maksutov-Cassegrain-style meniscus fixture", () => {
+    const L = buildLens(maksutovData);
+    const layout = doLayout(0, 0, L);
+    const marginal = traceRay(12, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+
+    expect(validateLensData(maksutovData)).toEqual([]);
+    expect(L.isFoldedOptics).toBe(true);
+    expect(marginal.diagnostics?.hitSurfaceLabels).toEqual(["MEN1", "MEN2", "M1", "SEC"]);
+    expect(marginal.reachedImagePlane).toBe(true);
+    expect(marginal.clipped).toBe(false);
+    expect(marginal.diagnostics?.finalMedium).toBeCloseTo(1, 12);
+  });
+
+  it("supports a Gregorian-style secondary fixture with alternate secondary curvature", () => {
+    const L = buildLens(gregorianData);
+    const layout = doLayout(0, 0, L);
+    const marginal = traceRay(12, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+
+    expect(validateLensData(gregorianData)).toEqual([]);
+    expect(L.isFoldedOptics).toBe(true);
+    expect(layout.z[L.labelIdx.SEC]).toBeLessThan(layout.z[L.labelIdx.STO]);
+    expect(marginal.diagnostics?.hitSurfaceLabels).toEqual(["M1", "SEC"]);
+    expect(marginal.reachedImagePlane).toBe(true);
+    expect(marginal.clipped).toBe(false);
+  });
+
+  it("supports an annular blocker that clips a ring while allowing the center through", () => {
+    const L = buildLens(ringBlockerData);
+    const layout = doLayout(0, 0, L);
+    const central = traceRay(0, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const ring = traceRay(8, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+
+    expect(validateLensData(ringBlockerData)).toEqual([]);
+    expect(central.clipped).toBe(false);
+    expect(central.reachedImagePlane).toBe(true);
+    expect(ring.clipped).toBe(true);
+    expect(ring.diagnostics?.clipEvents).toContainEqual({
+      surfaceIdx: L.labelIdx.RING,
+      surfaceLabel: "RING",
+      reason: "block-surface",
+      failureReason: null,
+    });
   });
 
   it("computes mirror-safe on-axis spherical aberration against the explicit image plane", () => {

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -7,7 +7,12 @@ import {
 import buildLens from "../../../src/optics/buildLens.js";
 import { computeElementShapes } from "../../../src/optics/diagramGeometry.js";
 import { foldedHitOrderLabelsForDisplay } from "../../../src/optics/foldedPathDisplay.js";
-import { traceExactSurfaceStack, traceToStopViaGeneralized } from "../../../src/optics/internal/exactSurfaceTrace.js";
+import {
+  traceExactSurfaceStack,
+  traceExactSurfaceStackVector,
+  traceToStopViaGeneralized,
+  type ExactTraceLens,
+} from "../../../src/optics/internal/exactSurfaceTrace.js";
 import { doLayout, solveChiefRay, SVG_PATH_SUBDIVISIONS, traceRay } from "../../../src/optics/optics.js";
 import { obstructionAwareRayFractionsForDensity } from "../../../src/optics/raySampling.js";
 import validateLensData from "../../../src/optics/validateLensData.js";
@@ -41,6 +46,37 @@ function imagePlaneCoordinateFromTrace(result: { pts: number[][] }, L: RuntimeLe
   const tangentZ = -L.imagePlane.normal.y;
   const tangentY = L.imagePlane.normal.z;
   return (point[0] - L.imagePlane.z) * tangentZ + (point[1] - L.imagePlane.y) * tangentY;
+}
+
+function singleSurfaceBackHitMirror(
+  interaction: ExactTraceLens["S"][number]["interaction"],
+  surface?: Partial<ExactTraceLens["S"][number]>,
+): ExactTraceLens {
+  return {
+    S: [
+      {
+        label: "M1",
+        R: 1e15,
+        d: 0,
+        nd: 1,
+        sd: 10,
+        ...surface,
+        interaction,
+      },
+    ],
+    asphByIdx: {},
+    opticalPath: { mode: "sequential", surfaceOrder: [0], surfaceLabels: ["M1"], maxInteractions: 3 },
+    imagePlane: { z: -10, y: 0, normal: { z: 1, y: 0 }, label: "IMG" },
+    isFoldedOptics: true,
+  };
+}
+
+function traceBackSideMirror(lens: ExactTraceLens, y: number) {
+  return traceExactSurfaceStackVector(
+    lens,
+    { origin: [0, y, 10], direction: [0, 0, -1] },
+    { zPos: [0], launchBoundT: 25, stopOnClip: true },
+  );
 }
 
 describe("mirror optics support", () => {
@@ -114,6 +150,60 @@ describe("mirror optics support", () => {
     const [expectedY, expectedZ] = reflectYz(0, 1, mirrorHit!.normal[1], mirrorHit!.normal[2]);
     expect(result.terminalDirection[1]).toBeCloseTo(expectedY, 10);
     expect(result.terminalDirection[2]).toBeCloseTo(expectedZ, 10);
+  });
+
+  it("blocks inactive-side hits on reflective surfaces by default", () => {
+    const lens = singleSurfaceBackHitMirror({
+      type: "reflect",
+      incidentSide: "front",
+      mirrorKind: "first-surface",
+    });
+    const result = traceBackSideMirror(lens, 5);
+
+    expect(result.clipped).toBe(true);
+    expect(result.reachedImagePlane).toBe(false);
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0]!.clipReason).toBe("inactive-side-block");
+    expect(result.diagnostics.clipEvents).toContainEqual({
+      surfaceIdx: 0,
+      surfaceLabel: "M1",
+      reason: "inactive-side-block",
+      failureReason: null,
+    });
+  });
+
+  it("lets explicitly ignored inactive mirror sides pass through", () => {
+    const lens = singleSurfaceBackHitMirror({
+      type: "reflect",
+      incidentSide: "front",
+      inactiveSide: "ignore",
+      mirrorKind: "first-surface",
+    });
+    const result = traceBackSideMirror(lens, 5);
+
+    expect(result.clipped).toBe(false);
+    expect(result.hits).toHaveLength(0);
+    expect(result.reachedImagePlane).toBe(true);
+    expect(result.terminalPoint[2]).toBeCloseTo(-10, 10);
+    expect(result.diagnostics.clipEvents).toEqual([]);
+  });
+
+  it("blocks inactive annular mirror rings while passing central holes", () => {
+    const lens = singleSurfaceBackHitMirror(
+      {
+        type: "reflect",
+        incidentSide: "front",
+        mirrorKind: "first-surface",
+      },
+      { innerSd: 3 },
+    );
+    const central = traceBackSideMirror(lens, 2);
+    const ring = traceBackSideMirror(lens, 5);
+
+    expect(central.clipped).toBe(false);
+    expect(central.reachedImagePlane).toBe(true);
+    expect(ring.clipped).toBe(true);
+    expect(ring.hits[0]!.clipReason).toBe("inactive-side-block");
   });
 
   it("traces finite visible rays to the explicit front image plane", () => {
@@ -401,7 +491,7 @@ describe("mirror optics support", () => {
           nd: 1.0,
           elemId: 1,
           sd: 20,
-          interaction: { type: "reflect", incidentSide: "rear", mirrorKind: "first-surface" },
+          interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "ignore", mirrorKind: "first-surface" },
         },
         {
           label: "M1",

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "vitest";
+import {
+  computeBestFocusZ,
+  computeSAProfile,
+  computeSphericalAberration,
+} from "../../../src/optics/aberrationAnalysis.js";
 import buildLens from "../../../src/optics/buildLens.js";
 import { computeElementShapes } from "../../../src/optics/diagramGeometry.js";
 import { traceExactSurfaceStack } from "../../../src/optics/internal/exactSurfaceTrace.js";
@@ -167,5 +172,20 @@ describe("mirror optics support", () => {
     expect(marginal.clipped).toBe(false);
     expect(marginal.terminalPoint[2]).toBeCloseTo(L.imagePlane.z, 10);
     expect(samples.every((fraction) => Math.abs(fraction) >= blockedFraction - 1e-9)).toBe(true);
+  });
+
+  it("computes mirror-safe on-axis spherical aberration against the explicit image plane", () => {
+    const L = buildLens(mirrorData);
+    const layout = doLayout(0, 0, L);
+    const result = computeSphericalAberration(L, layout.z, 0, 0, L.EP.epSD, L.stopPhysSD);
+    const profile = computeSAProfile(L, layout.z, 0, 0, L.EP.epSD, L.stopPhysSD);
+    const bestFocusZ = computeBestFocusZ(L, 0, 0, L.EP.epSD, L.stopPhysSD);
+
+    expect(result).not.toBeNull();
+    expect(result!.imagePlaneZ).toBeCloseTo(L.imagePlane.z, 10);
+    expect(Number.isFinite(result!.bestFocusZ)).toBe(true);
+    expect(Number.isFinite(result!.currentPlaneRmsMm)).toBe(true);
+    expect(profile.length).toBeGreaterThan(2);
+    expect(Number.isFinite(bestFocusZ)).toBe(true);
   });
 });

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -7,7 +7,7 @@ import {
 import buildLens from "../../../src/optics/buildLens.js";
 import { computeElementShapes } from "../../../src/optics/diagramGeometry.js";
 import { traceExactSurfaceStack } from "../../../src/optics/internal/exactSurfaceTrace.js";
-import { doLayout, traceRay } from "../../../src/optics/optics.js";
+import { doLayout, SVG_PATH_SUBDIVISIONS, traceRay } from "../../../src/optics/optics.js";
 import { obstructionAwareRayFractionsForDensity } from "../../../src/optics/raySampling.js";
 import validateLensData from "../../../src/optics/validateLensData.js";
 import type { LensData } from "../../../src/types/optics.js";
@@ -25,6 +25,10 @@ function reflectYz(incidentY: number, incidentZ: number, normalY: number, normal
   const z = incidentZ - 2 * dot * normalZ;
   const inv = 1 / Math.hypot(y, z);
   return [y * inv, z * inv];
+}
+
+function pathCoords(pathD: string): [number, number][] {
+  return [...pathD.matchAll(/[ML]([\d.e+-]+),([\d.e+-]+)/g)].map((match) => [Number(match[1]), Number(match[2])]);
 }
 
 describe("mirror optics support", () => {
@@ -152,6 +156,27 @@ describe("mirror optics support", () => {
     expect(result.clipped).toBe(false);
     expect(result.terminalPoint[1]).toBeCloseTo(25, 10);
     expect(Number.isFinite(result.terminalPoint[2])).toBe(true);
+  });
+
+  it("renders the Newtonian secondary as a tilted fold mirror", () => {
+    const L = buildLens(newtonianData);
+    const layout = doLayout(0, 0, L);
+    const shapes = computeElementShapes(
+      L,
+      layout.z,
+      (z) => z,
+      (y) => y,
+    );
+    const secondaryShape = shapes.find((shape) => shape.eid === 2);
+    const coords = pathCoords(secondaryShape?.d ?? "");
+    const frontTop = coords[0];
+    const frontBottom = coords[SVG_PATH_SUBDIVISIONS];
+
+    expect(secondaryShape).toBeDefined();
+    expect(frontTop[1]).toBeCloseTo(-10, 10);
+    expect(frontTop[0]).toBeCloseTo(layout.z[L.labelIdx.SEC] + 10, 10);
+    expect(frontBottom[1]).toBeCloseTo(10, 10);
+    expect(frontBottom[0]).toBeCloseTo(layout.z[L.labelIdx.SEC] - 10, 10);
   });
 
   it("supports a Cassegrain-style obstruction and back-focus image plane fixture", () => {

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -161,6 +161,30 @@ describe("mirror optics support", () => {
     expect(Number.isFinite(result.terminalPoint[2])).toBe(true);
   });
 
+  it("keeps auto folded hit order stable under small ray-height and aperture perturbations", () => {
+    const cases = [
+      { data: newtonianData, y0: 12, expectedHitLabels: ["M1", "SEC"] },
+      { data: cassegrainData, y0: 12, expectedHitLabels: ["M1", "SEC"] },
+    ] as const;
+
+    for (const { data, y0, expectedHitLabels } of cases) {
+      const L = buildLens(data);
+      const layout = doLayout(0, 0, L);
+
+      for (const yOffset of [-0.15, 0, 0.15]) {
+        for (const stopScale of [0.98, 1, 1.02]) {
+          const result = traceRay(y0 + yOffset, 0, layout.z, 0, 0, L.stopPhysSD * stopScale, true, L);
+
+          expect(result.clipped, `${data.key} yOffset=${yOffset} stopScale=${stopScale}`).toBe(false);
+          expect(result.reachedImagePlane, `${data.key} yOffset=${yOffset} stopScale=${stopScale}`).toBe(true);
+          expect(result.diagnostics?.hitSurfaceLabels, `${data.key} yOffset=${yOffset} stopScale=${stopScale}`).toEqual(
+            expectedHitLabels,
+          );
+        }
+      }
+    }
+  });
+
   it("exposes folded-path diagnostics through the public ray trace result", () => {
     const L = buildLens(newtonianData);
     const layout = doLayout(0, 0, L);

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -7,11 +7,11 @@ import {
 import buildLens from "../../../src/optics/buildLens.js";
 import { computeElementShapes } from "../../../src/optics/diagramGeometry.js";
 import { foldedHitOrderLabelsForDisplay } from "../../../src/optics/foldedPathDisplay.js";
-import { traceExactSurfaceStack } from "../../../src/optics/internal/exactSurfaceTrace.js";
-import { doLayout, SVG_PATH_SUBDIVISIONS, traceRay } from "../../../src/optics/optics.js";
+import { traceExactSurfaceStack, traceToStopViaGeneralized } from "../../../src/optics/internal/exactSurfaceTrace.js";
+import { doLayout, solveChiefRay, SVG_PATH_SUBDIVISIONS, traceRay } from "../../../src/optics/optics.js";
 import { obstructionAwareRayFractionsForDensity } from "../../../src/optics/raySampling.js";
 import validateLensData from "../../../src/optics/validateLensData.js";
-import type { LensData } from "../../../src/types/optics.js";
+import type { LensData, RuntimeLens } from "../../../src/types/optics.js";
 import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 
 const mirrorData = LENS_CATALOG["reference-spherical-primary-mirror"] as LensData;
@@ -22,6 +22,7 @@ const cassegrainData = LENS_CATALOG["reference-cassegrain-back-focus"] as LensDa
 const maksutovData = LENS_CATALOG["reference-maksutov-cassegrain-meniscus"] as LensData;
 const gregorianData = LENS_CATALOG["reference-gregorian-secondary"] as LensData;
 const ringBlockerData = LENS_CATALOG["reference-annular-ring-blocker"] as LensData;
+const planarData = LENS_CATALOG["zeiss-planar-t-50f14"] as LensData;
 
 function reflectYz(incidentY: number, incidentZ: number, normalY: number, normalZ: number): [number, number] {
   const dot = incidentY * normalY + incidentZ * normalZ;
@@ -33,6 +34,13 @@ function reflectYz(incidentY: number, incidentZ: number, normalY: number, normal
 
 function pathCoords(pathD: string): [number, number][] {
   return [...pathD.matchAll(/[ML]([\d.e+-]+),([\d.e+-]+)/g)].map((match) => [Number(match[1]), Number(match[2])]);
+}
+
+function imagePlaneCoordinateFromTrace(result: { pts: number[][] }, L: RuntimeLens): number {
+  const point = result.pts[result.pts.length - 1]!;
+  const tangentZ = -L.imagePlane.normal.y;
+  const tangentY = L.imagePlane.normal.z;
+  return (point[0] - L.imagePlane.z) * tangentZ + (point[1] - L.imagePlane.y) * tangentY;
 }
 
 describe("mirror optics support", () => {
@@ -60,6 +68,26 @@ describe("mirror optics support", () => {
       ),
     });
     expect(badBackingNormal.some((error) => error.includes("tilted mirror backing plane"))).toBe(true);
+
+    const badMaxInteractions = validateLensData({
+      ...mirrorData,
+      opticalPath: { ...mirrorData.opticalPath, maxInteractions: 2 },
+    });
+    expect(badMaxInteractions.some((error) => error.includes("opticalPath.maxInteractions"))).toBe(true);
+
+    const badInnerPair = validateLensData({
+      ...annularData,
+      surfaces: annularData.surfaces.map((surface) =>
+        surface.label === "M1B" ? { ...surface, innerSd: undefined } : surface,
+      ),
+    });
+    expect(badInnerPair.some((error) => error.includes("matching innerSd"))).toBe(true);
+
+    const unreachableImagePlane = validateLensData({
+      ...mirrorData,
+      opticalPath: { ...mirrorData.opticalPath, imagePlane: { z: 500, label: "IMG" } },
+    });
+    expect(unreachableImagePlane.some((error) => error.includes("imagePlane"))).toBe(true);
   });
 
   it("builds the hidden spherical mirror fixture as folded optics", () => {
@@ -100,6 +128,37 @@ describe("mirror optics support", () => {
     expect(result.y).toBeCloseTo(0, 2);
     expect(lastPoint[0]).toBeCloseTo(L.imagePlane.z, 10);
     expect(lastPoint[1]).toBeCloseTo(result.y, 10);
+  });
+
+  it("anchors the spherical primary fixture to the closed-form R/2 focal plane", () => {
+    const L = buildLens(mirrorData);
+    const layout = doLayout(0, 0, L);
+    const mirror = L.S[L.labelIdx.M1];
+    const expectedFocusZ = layout.z[L.labelIdx.M1] + mirror.R / 2;
+
+    expect(L.imagePlane.z).toBeCloseTo(expectedFocusZ, 10);
+  });
+
+  it("traces off-axis spherical-mirror chief rays to the rectilinear image height", () => {
+    const L = buildLens(mirrorData);
+    const layout = doLayout(0, 0, L);
+    const fieldDeg = 2;
+    const expected = L.EFL * Math.tan((fieldDeg * Math.PI) / 180);
+
+    const positiveSolve = solveChiefRay(fieldDeg, 0, 0, L);
+    const negativeSolve = solveChiefRay(-fieldDeg, 0, 0, L);
+    const positive = traceRay(positiveSolve.yLaunch, positiveSolve.uField, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const negative = traceRay(negativeSolve.yLaunch, negativeSolve.uField, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const positiveHeight = imagePlaneCoordinateFromTrace(positive, L);
+    const negativeHeight = imagePlaneCoordinateFromTrace(negative, L);
+
+    expect(positiveSolve.status).toBe("converged");
+    expect(positive.reachedImagePlane).toBe(true);
+    expect(negative.reachedImagePlane).toBe(true);
+    expect(positive.clipped).toBe(false);
+    expect(negative.clipped).toBe(false);
+    expect(Math.abs(positiveHeight)).toBeCloseTo(expected, 2);
+    expect(positiveHeight).toBeCloseTo(-negativeHeight, 8);
   });
 
   it("clips central rays on an obstruction while sampling the usable annular pupil", () => {
@@ -168,6 +227,28 @@ describe("mirror optics support", () => {
     expect(result.clipped).toBe(false);
     expect(result.terminalPoint[1]).toBeCloseTo(25, 10);
     expect(Number.isFinite(result.terminalPoint[2])).toBe(true);
+  });
+
+  it("traces off-axis Newtonian chief rays to the side image-plane coordinate", () => {
+    const L = buildLens(newtonianData);
+    const layout = doLayout(0, 0, L);
+    const fieldDeg = 2;
+    const expected = L.EFL * Math.tan((fieldDeg * Math.PI) / 180);
+
+    const positiveSolve = solveChiefRay(fieldDeg, 0, 0, L);
+    const negativeSolve = solveChiefRay(-fieldDeg, 0, 0, L);
+    const positive = traceRay(positiveSolve.yLaunch, positiveSolve.uField, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const negative = traceRay(negativeSolve.yLaunch, negativeSolve.uField, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const positiveCoordinate = imagePlaneCoordinateFromTrace(positive, L);
+    const negativeCoordinate = imagePlaneCoordinateFromTrace(negative, L);
+
+    expect(positiveSolve.status).toBe("converged");
+    expect(positive.reachedImagePlane).toBe(true);
+    expect(negative.reachedImagePlane).toBe(true);
+    expect(positive.clipped).toBe(false);
+    expect(negative.clipped).toBe(false);
+    expect(Math.abs(positiveCoordinate)).toBeCloseTo(expected, 2);
+    expect(positiveCoordinate).toBeCloseTo(-negativeCoordinate, 8);
   });
 
   it("keeps auto folded hit order stable under small ray-height and aperture perturbations", () => {
@@ -257,6 +338,10 @@ describe("mirror optics support", () => {
     const layout = doLayout(0, 0, L);
     const central = traceExactSurfaceStack(L, { y0: 0, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
     const marginal = traceExactSurfaceStack(L, { y0: 12, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
+    const offAxisStop = traceToStopViaGeneralized(L, { y0: 0, uy0: -Math.tan((2 * Math.PI) / 180) }, L.stopIdx, {
+      zPos: layout.z,
+      leadDistance: 0,
+    });
     const centralSecondary = central.hits.find((hit) => hit.surfaceIdx === L.labelIdx.SEC);
     const marginalHitLabels = marginal.hits.map((hit) => L.S[hit.surfaceIdx].label);
     const samples = obstructionAwareRayFractionsForDensity(L, L.rayFractions, "normal", L.EP.epSD);
@@ -269,6 +354,9 @@ describe("mirror optics support", () => {
     expect(marginal.reachedImagePlane).toBe(true);
     expect(marginal.clipped).toBe(false);
     expect(marginal.terminalPoint[2]).toBeCloseTo(L.imagePlane.z, 10);
+    expect(offAxisStop.found).toBe(true);
+    expect(offAxisStop.hitIndex).toBe(-1);
+    expect(offAxisStop.y).toBeCloseTo(0, 12);
     expect(samples.every((fraction) => Math.abs(fraction) >= blockedFraction - 1e-9)).toBe(true);
   });
 
@@ -366,6 +454,7 @@ describe("mirror optics support", () => {
     expect(marginal.diagnostics?.hitSurfaceLabels).toEqual(["M1", "SEC"]);
     expect(marginal.reachedImagePlane).toBe(true);
     expect(marginal.clipped).toBe(false);
+    expect(marginal.pts[marginal.pts.length - 1]![0]).toBeCloseTo(L.imagePlane.z, 10);
   });
 
   it("supports an annular blocker that clips a ring while allowing the center through", () => {
@@ -384,6 +473,72 @@ describe("mirror optics support", () => {
       reason: "block-surface",
       failureReason: null,
     });
+  });
+
+  it("selects repeated stop-surface occurrences in generalized stop traces", () => {
+    const L = buildLens({
+      ...mirrorData,
+      key: "reference-repeated-stop-primary",
+      opticalPath: {
+        surfaceOrder: ["STO", "M1", "STO"],
+        imagePlane: { z: 0, label: "IMG" },
+        maxInteractions: 4,
+      },
+    } satisfies LensData);
+    const layout = doLayout(0, 0, L);
+    const firstStop = traceToStopViaGeneralized(L, { y0: 5, uy0: 0 }, L.stopIdx, {
+      zPos: layout.z,
+      leadDistance: 0,
+    });
+    const secondStop = traceToStopViaGeneralized(L, { y0: 5, uy0: 0 }, L.stopIdx, {
+      zPos: layout.z,
+      leadDistance: 0,
+      stopOccurrence: 1,
+    });
+
+    expect(firstStop.found).toBe(true);
+    expect(secondStop.found).toBe(true);
+    expect(firstStop.hitIndex).toBe(0);
+    expect(secondStop.hitIndex).toBeGreaterThan(firstStop.hitIndex);
+    expect(secondStop.point![2]).toBeCloseTo(layout.z[L.stopIdx], 10);
+  });
+
+  it("infers enough launch lead for a tilted flat first surface", () => {
+    const result = traceExactSurfaceStack(
+      {
+        S: [
+          {
+            label: "M1",
+            R: 1e15,
+            d: 0,
+            nd: 1,
+            sd: 10,
+            interaction: { type: "reflect", mirrorKind: "first-surface", normal: { z: 1, y: 1 } },
+          },
+        ],
+        asphByIdx: {},
+        opticalPath: { mode: "sequential", surfaceOrder: [0], surfaceLabels: ["M1"], maxInteractions: 2 },
+        isFoldedOptics: true,
+      },
+      { y0: 10, uy0: 0 },
+    );
+
+    expect(result.failureReason).toBeNull();
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0]!.point[2]).toBeCloseTo(-10, 8);
+  });
+
+  it("preserves representative refractive lens build constants", () => {
+    const L = buildLens(planarData);
+
+    expect(L.EP.epSD).toBeCloseTo(17.856823466425105, 12);
+    expect(L.EP.yRatio).toBeCloseTo(0.6960409629659625, 12);
+    expect(L.B).toBeCloseTo(16.79046967193117, 12);
+    expect(L.halfField).toBeCloseTo(25.81431950150305, 12);
+    expect(L.tracingHalfField).toBeCloseTo(25.81431950150305, 12);
+    expect(L.epZRelStop).toBeCloseTo(4.204818318081482, 12);
+    expect(L.xpZRelLastSurf).toBeCloseTo(-29.615117987357305, 12);
+    expect(L.xpSD).toBeCloseTo(23.254328038906696, 12);
   });
 
   it("computes mirror-safe on-axis spherical aberration against the explicit image plane", () => {

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -11,6 +11,7 @@ import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 const mirrorData = LENS_CATALOG["reference-spherical-primary-mirror"] as LensData;
 const annularData = LENS_CATALOG["reference-annular-obscured-mirror"] as LensData;
 const manginData = LENS_CATALOG["reference-mangin-second-surface-mirror"] as LensData;
+const newtonianData = LENS_CATALOG["reference-newtonian-side-focus"] as LensData;
 
 function reflectYz(incidentY: number, incidentZ: number, normalY: number, normalZ: number): [number, number] {
   const dot = incidentY * normalY + incidentZ * normalZ;
@@ -127,5 +128,23 @@ describe("mirror optics support", () => {
     expect(result.n).toBeCloseTo(1, 12);
     expect(result.terminalPoint[2]).toBeCloseTo(L.imagePlane.z, 10);
     expect(Number.isFinite(result.terminalPoint[1])).toBe(true);
+  });
+
+  it("automatically resolves a folded Newtonian path to a side image plane", () => {
+    const L = buildLens(newtonianData);
+    const layout = doLayout(0, 0, L);
+    const result = traceExactSurfaceStack(L, { y0: 12, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
+    const hitLabels = result.hits.map((hit) => L.S[hit.surfaceIdx].label);
+
+    expect(validateLensData(newtonianData)).toEqual([]);
+    expect(L.opticalPath.mode).toBe("auto");
+    expect(L.opticalPath.surfaceOrder).toBeNull();
+    expect(L.imagePlane.normal).toEqual({ z: 0, y: 1 });
+    expect(hitLabels).toEqual(["M1", "SEC"]);
+    expect(result.reachedImagePlane).toBe(true);
+    expect(result.failureReason).toBeNull();
+    expect(result.clipped).toBe(false);
+    expect(result.terminalPoint[1]).toBeCloseTo(25, 10);
+    expect(Number.isFinite(result.terminalPoint[2])).toBe(true);
   });
 });

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import buildLens from "../../../src/optics/buildLens.js";
+import { traceExactSurfaceStack } from "../../../src/optics/internal/exactSurfaceTrace.js";
+import { doLayout, traceRay } from "../../../src/optics/optics.js";
+import validateLensData from "../../../src/optics/validateLensData.js";
+import type { LensData } from "../../../src/types/optics.js";
+import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
+
+const mirrorData = LENS_CATALOG["reference-spherical-primary-mirror"] as LensData;
+
+function reflectYz(incidentY: number, incidentZ: number, normalY: number, normalZ: number): [number, number] {
+  const dot = incidentY * normalY + incidentZ * normalZ;
+  const y = incidentY - 2 * dot * normalY;
+  const z = incidentZ - 2 * dot * normalZ;
+  const inv = 1 / Math.hypot(y, z);
+  return [y * inv, z * inv];
+}
+
+describe("mirror optics support", () => {
+  it("validates mirror-specific surface and optical path fields", () => {
+    expect(validateLensData(mirrorData)).toEqual([]);
+
+    const badInner = validateLensData({
+      ...mirrorData,
+      surfaces: mirrorData.surfaces.map((surface) =>
+        surface.label === "M1" ? { ...surface, innerSd: surface.sd } : surface,
+      ),
+    });
+    expect(badInner.some((error) => error.includes("innerSd"))).toBe(true);
+
+    const badPath = validateLensData({
+      ...mirrorData,
+      opticalPath: { ...mirrorData.opticalPath, surfaceOrder: ["MISSING"] },
+    });
+    expect(badPath.some((error) => error.includes("opticalPath.surfaceOrder"))).toBe(true);
+  });
+
+  it("builds the hidden spherical mirror fixture as folded optics", () => {
+    const L = buildLens(mirrorData);
+
+    expect(L.isFoldedOptics).toBe(true);
+    expect(L.imagePlane.z).toBe(0);
+    expect(L.imagePlane.normal).toEqual({ z: 1, y: 0 });
+    expect(L.opticalPath.surfaceLabels).toEqual(["STO", "M1"]);
+    expect(L.opticalPath.surfaceOrder).toEqual([0, 1]);
+    expect(L.FOPEN).toBeCloseTo(4, 10);
+  });
+
+  it("reflects a first-surface mirror ray according to the local surface normal", () => {
+    const L = buildLens(mirrorData);
+    const layout = doLayout(0, 0, L);
+    const result = traceExactSurfaceStack(L, { y0: 5, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
+    const mirrorHit = result.hits.find((hit) => hit.surfaceIdx === L.labelIdx.M1);
+
+    expect(mirrorHit).toBeDefined();
+    expect(result.reachedImagePlane).toBe(true);
+    expect(result.failureReason).toBeNull();
+
+    const [expectedY, expectedZ] = reflectYz(0, 1, mirrorHit!.normal[1], mirrorHit!.normal[2]);
+    expect(result.terminalDirection[1]).toBeCloseTo(expectedY, 10);
+    expect(result.terminalDirection[2]).toBeCloseTo(expectedZ, 10);
+  });
+
+  it("traces finite visible rays to the explicit front image plane", () => {
+    const L = buildLens(mirrorData);
+    const layout = doLayout(0, 0, L);
+    const result = traceRay(1, 0, layout.z, 0, 0, L.stopPhysSD, true, L);
+    const lastPoint = result.pts[result.pts.length - 1];
+
+    expect(layout.imgZ).toBe(0);
+    expect(result.reachedImagePlane).toBe(true);
+    expect(result.clipped).toBe(false);
+    expect(result.y).toBeCloseTo(0, 2);
+    expect(lastPoint[0]).toBeCloseTo(L.imagePlane.z, 10);
+    expect(lastPoint[1]).toBeCloseTo(result.y, 10);
+  });
+});

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -10,6 +10,7 @@ import { LENS_CATALOG } from "../../../src/utils/catalog/lensCatalog.js";
 
 const mirrorData = LENS_CATALOG["reference-spherical-primary-mirror"] as LensData;
 const annularData = LENS_CATALOG["reference-annular-obscured-mirror"] as LensData;
+const manginData = LENS_CATALOG["reference-mangin-second-surface-mirror"] as LensData;
 
 function reflectYz(incidentY: number, incidentZ: number, normalY: number, normalZ: number): [number, number] {
   const dot = incidentY * normalY + incidentZ * normalZ;
@@ -109,5 +110,22 @@ describe("mirror optics support", () => {
     expect(mirrorShape).toBeDefined();
     expect(mirrorShape!.fillRule).toBe("evenodd");
     expect((mirrorShape!.d.match(/M/g) ?? []).length).toBeGreaterThan(1);
+  });
+
+  it("supports second-surface mirrors that exit through a repeated front surface", () => {
+    const L = buildLens(manginData);
+    const layout = doLayout(0, 0, L);
+    const result = traceExactSurfaceStack(L, { y0: 4, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
+    const hitLabels = result.hits.map((hit) => L.S[hit.surfaceIdx].label);
+
+    expect(validateLensData(manginData)).toEqual([]);
+    expect(L.isFoldedOptics).toBe(true);
+    expect(hitLabels).toEqual(["STO", "MG1", "MG2", "MG1"]);
+    expect(result.reachedImagePlane).toBe(true);
+    expect(result.failureReason).toBeNull();
+    expect(result.clipped).toBe(false);
+    expect(result.n).toBeCloseTo(1, 12);
+    expect(result.terminalPoint[2]).toBeCloseTo(L.imagePlane.z, 10);
+    expect(Number.isFinite(result.terminalPoint[1])).toBe(true);
   });
 });

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../src/optics/aberrationAnalysis.js";
 import buildLens from "../../../src/optics/buildLens.js";
 import { computeElementShapes } from "../../../src/optics/diagramGeometry.js";
+import { foldedHitOrderLabelsForDisplay } from "../../../src/optics/foldedPathDisplay.js";
 import { traceExactSurfaceStack } from "../../../src/optics/internal/exactSurfaceTrace.js";
 import { doLayout, SVG_PATH_SUBDIVISIONS, traceRay } from "../../../src/optics/optics.js";
 import { obstructionAwareRayFractionsForDensity } from "../../../src/optics/raySampling.js";
@@ -51,6 +52,14 @@ describe("mirror optics support", () => {
       opticalPath: { ...mirrorData.opticalPath, surfaceOrder: ["MISSING"] },
     });
     expect(badPath.some((error) => error.includes("opticalPath.surfaceOrder"))).toBe(true);
+
+    const badBackingNormal = validateLensData({
+      ...newtonianData,
+      surfaces: newtonianData.surfaces.map((surface) =>
+        surface.label === "SECB" ? { ...surface, interaction: { type: "refract" } } : surface,
+      ),
+    });
+    expect(badBackingNormal.some((error) => error.includes("tilted mirror backing plane"))).toBe(true);
   });
 
   it("builds the hidden spherical mirror fixture as folded optics", () => {
@@ -183,6 +192,23 @@ describe("mirror optics support", () => {
         }
       }
     }
+  });
+
+  it("derives display hit-order labels for automatic folded paths", () => {
+    const L = buildLens(newtonianData);
+    const layout = doLayout(0, 0, L);
+
+    expect(
+      foldedHitOrderLabelsForDisplay({
+        L,
+        zPos: layout.z,
+        focusT: 0,
+        zoomT: 0,
+        aberrationT: 0,
+        currentPhysStopSD: L.stopPhysSD,
+        currentEPSD: L.EP.epSD,
+      }),
+    ).toEqual(["M1", "SEC"]);
   });
 
   it("exposes folded-path diagnostics through the public ray trace result", () => {

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -527,6 +527,44 @@ describe("mirror optics support", () => {
     expect(marginal.diagnostics?.finalMedium).toBeCloseTo(1, 12);
   });
 
+  it("continues tracing active mirrors after an explicit folded opening sequence", () => {
+    const lens: ExactTraceLens = {
+      S: [
+        { label: "STO", R: 1e15, d: 100, nd: 1, sd: 30 },
+        {
+          label: "M1",
+          R: -200,
+          d: 2,
+          nd: 1,
+          sd: 30,
+          innerSd: 7,
+          interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
+        },
+        { label: "M1B", R: 1e15, d: -127, nd: 1, sd: 30, innerSd: 7 },
+        {
+          label: "SEC",
+          R: 80,
+          d: 1,
+          nd: 1,
+          sd: 12,
+          interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "block", mirrorKind: "first-surface" },
+        },
+        { label: "SECB", R: 1e15, d: 159, nd: 1, sd: 12 },
+      ],
+      asphByIdx: {},
+      opticalPath: { mode: "sequential", surfaceOrder: [1, 3], surfaceLabels: ["M1", "SEC"], maxInteractions: 6 },
+      imagePlane: { z: 135, y: 0, normal: { z: 1, y: 0 }, label: "IMG" },
+      isFoldedOptics: true,
+    };
+    const result = traceExactSurfaceStack(lens, { y0: 12, uy0: 0 }, { leadDistance: 40, checkSemiDiameter: true });
+    const hitLabels = result.hits.map((hit) => lens.S[hit.surfaceIdx].label);
+    const repeatedPrimary = result.hits.find((hit, index) => index > 1 && hit.surfaceIdx === 1);
+
+    expect(hitLabels.slice(0, 3)).toEqual(["M1", "SEC", "M1"]);
+    expect(repeatedPrimary?.outgoingDirection?.[2]).toBeLessThan(0);
+    expect(result.reachedImagePlane).toBe(false);
+  });
+
   it("supports a Gregorian-style secondary fixture with alternate secondary curvature", () => {
     const L = buildLens(gregorianData);
     const layout = doLayout(0, 0, L);

--- a/__tests__/src/optics/mirrorOptics.test.ts
+++ b/__tests__/src/optics/mirrorOptics.test.ts
@@ -12,6 +12,7 @@ const mirrorData = LENS_CATALOG["reference-spherical-primary-mirror"] as LensDat
 const annularData = LENS_CATALOG["reference-annular-obscured-mirror"] as LensData;
 const manginData = LENS_CATALOG["reference-mangin-second-surface-mirror"] as LensData;
 const newtonianData = LENS_CATALOG["reference-newtonian-side-focus"] as LensData;
+const cassegrainData = LENS_CATALOG["reference-cassegrain-back-focus"] as LensData;
 
 function reflectYz(incidentY: number, incidentZ: number, normalY: number, normalZ: number): [number, number] {
   const dot = incidentY * normalY + incidentZ * normalZ;
@@ -146,5 +147,25 @@ describe("mirror optics support", () => {
     expect(result.clipped).toBe(false);
     expect(result.terminalPoint[1]).toBeCloseTo(25, 10);
     expect(Number.isFinite(result.terminalPoint[2])).toBe(true);
+  });
+
+  it("supports a Cassegrain-style obstruction and back-focus image plane fixture", () => {
+    const L = buildLens(cassegrainData);
+    const layout = doLayout(0, 0, L);
+    const central = traceExactSurfaceStack(L, { y0: 0, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
+    const marginal = traceExactSurfaceStack(L, { y0: 12, uy0: 0 }, { zPos: layout.z, leadDistance: 0 });
+    const centralSecondary = central.hits.find((hit) => hit.surfaceIdx === L.labelIdx.SEC);
+    const marginalHitLabels = marginal.hits.map((hit) => L.S[hit.surfaceIdx].label);
+    const samples = obstructionAwareRayFractionsForDensity(L, L.rayFractions, "normal", L.EP.epSD);
+    const blockedFraction = L.S[L.labelIdx.SEC].sd / L.EP.epSD;
+
+    expect(validateLensData(cassegrainData)).toEqual([]);
+    expect(centralSecondary?.clipped).toBe(true);
+    expect(central.clipped).toBe(true);
+    expect(marginalHitLabels).toEqual(["M1", "SEC"]);
+    expect(marginal.reachedImagePlane).toBe(true);
+    expect(marginal.clipped).toBe(false);
+    expect(marginal.terminalPoint[2]).toBeCloseTo(L.imagePlane.z, 10);
+    expect(samples.every((fraction) => Math.abs(fraction) >= blockedFraction - 1e-9)).toBe(true);
   });
 });

--- a/__tests__/src/pages/lensIndex/lensIndexCatalog.test.ts
+++ b/__tests__/src/pages/lensIndex/lensIndexCatalog.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  ALL_CATALOG_ENTRIES,
   defaultCustomFilter,
+  DEBUG_CATALOG_ENTRIES,
+  catalogEntriesForView,
   groupByImageFormat,
   groupByMount,
   matchesCustomFilter,
 } from "../../../../src/pages/lensIndex/catalog.js";
+import { CATALOG_KEYS } from "../../../../src/utils/catalog/lensCatalog.js";
 import type { CatalogLensEntry, FilterBounds } from "../../../../src/pages/lensIndex/types.js";
 import type { LensData } from "../../../../src/types/optics.js";
 import { IMAGE_FORMAT_BY_ID, LENS_MOUNT_BY_ID } from "../../../../src/utils/catalog/lensTaxonomy.js";
@@ -36,6 +40,15 @@ function entry(
 }
 
 describe("lens index catalog metadata filters", () => {
+  it("exposes visible, all, and debug catalog entry sets", () => {
+    expect(catalogEntriesForView("visible").map((entry) => entry.key)).toEqual(CATALOG_KEYS);
+    expect(catalogEntriesForView("all").length).toBe(ALL_CATALOG_ENTRIES.length);
+    expect(catalogEntriesForView("debug").map((entry) => entry.key)).toEqual(
+      DEBUG_CATALOG_ENTRIES.map((entry) => entry.key),
+    );
+    expect(catalogEntriesForView("debug").some((entry) => entry.key === "reference-newtonian-side-focus")).toBe(true);
+  });
+
   it("matches a multi-mount lens when any selected mount matches", () => {
     const multiMount = entry("multi", {
       lensMounts: [LENS_MOUNT_BY_ID["nikon-z"], LENS_MOUNT_BY_ID["sony-fe"]],

--- a/__tests__/src/pages/lensIndexPage.test.tsx
+++ b/__tests__/src/pages/lensIndexPage.test.tsx
@@ -12,7 +12,9 @@ import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { HelmetProvider } from "react-helmet-async";
 import LensIndexPage from "../../../src/pages/LensIndexPage.js";
 import {
+  ALL_CATALOG_ENTRIES,
   CATALOG_ENTRIES,
+  DEBUG_CATALOG_ENTRIES,
   FILTER_BOUNDS,
   defaultCustomFilter,
   matchesCustomFilter,
@@ -136,6 +138,38 @@ describe("LensIndexPage", () => {
     expect(href).toContain("context=mount");
     expect(href).toContain("id=nikon-z");
     expect(href).toContain("returnTo=%2Flenses%3Fgroup%3Dmount%26mounts%3Dnikon-z");
+  });
+
+  it("shows hidden reference fixtures in the debug URL view", async () => {
+    renderLensIndexPage("/lenses?view=debug");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          new RegExp(`Showing ${DEBUG_CATALOG_ENTRIES.length} of ${DEBUG_CATALOG_ENTRIES.length} interactive`, "i"),
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(screen.getByRole("link", { name: /REFERENCE Newtonian Side Focus/i })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /NIKON NIKKOR Z 26mm f\/2.8/i })).toBeNull();
+  });
+
+  it("preserves the all-files library view in hidden fixture links", async () => {
+    renderLensIndexPage("/lenses?view=all");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          new RegExp(`Showing ${ALL_CATALOG_ENTRIES.length} of ${ALL_CATALOG_ENTRIES.length} interactive`, "i"),
+        ),
+      ).toBeTruthy();
+    });
+
+    const fixtureLink = screen.getByRole("link", { name: /REFERENCE Newtonian Side Focus/i });
+    const href = fixtureLink.getAttribute("href") ?? "";
+    expect(href).toContain("/lens/reference-newtonian-side-focus");
+    expect(href).toContain("returnTo=%2Flenses%3Fview%3Dall");
   });
 
   it("filters by lens mount and image format", () => {

--- a/__tests__/src/pages/pageRenders.test.tsx
+++ b/__tests__/src/pages/pageRenders.test.tsx
@@ -8,6 +8,7 @@ import { Route, Routes, useLocation } from "react-router";
 import HomePage from "../../../src/pages/HomePage.js";
 import ArticlesPage from "../../../src/pages/ArticlesPage.js";
 import ArticlePage from "../../../src/pages/ArticlePage.js";
+import LensPage from "../../../src/pages/LensPage.js";
 import ComparePage from "../../../src/pages/ComparePage.js";
 import NotFoundPage from "../../../src/pages/NotFoundPage.js";
 import { ARTICLE_CONTENT, ARTICLES, HOMEPAGE_ARTICLES } from "../../../src/utils/content/homepageContent.js";
@@ -169,6 +170,20 @@ describe("static page renders", () => {
 
     expect(screen.getByText(`${LENS_CATALOG[slugA].name} vs ${LENS_CATALOG[slugB].name}`)).toBeTruthy();
     expect(screen.getByText(/Interactive side-by-side comparison available in the viewer above/i)).toBeTruthy();
+  });
+
+  it("renders hidden reference lens fallback content for debug library links", () => {
+    const hiddenKey = "reference-newtonian-side-focus";
+
+    renderRoutes(
+      `/lens/${hiddenKey}`,
+      <Routes>
+        <Route path="/lens/:slug" element={<LensPage />} />
+      </Routes>,
+    );
+
+    expect(screen.getByText(LENS_CATALOG[hiddenKey].name)).toBeTruthy();
+    expect(screen.getByText(/Hidden automatic folded-path regression fixture/i)).toBeTruthy();
   });
 
   it("redirects invalid compare slugs to the lenses index", async () => {

--- a/agent_docs/README.md
+++ b/agent_docs/README.md
@@ -20,6 +20,12 @@ Regenerate all glass reports together:
 npm run generate:glass-reports
 ```
 
+Regenerate mirror fixture reports:
+
+```bash
+npm run generate:mirror-reports
+```
+
 Individual report commands:
 
 - [`generated/unresolved-glass.generated.md`](generated/unresolved-glass.generated.md) — `npm test -- unresolvedGlassScan`
@@ -29,3 +35,4 @@ Individual report commands:
 - [`generated/six-digit-glass-codes.generated.md`](generated/six-digit-glass-codes.generated.md) — `npm test -- sixDigitGlassCodeScan`
 - [`generated/six-digit-glass-codes-missing-sellmeier.generated.md`](generated/six-digit-glass-codes-missing-sellmeier.generated.md) — `npm test -- sixDigitGlassCodeScan`
 - [`generated/sellmeier-coverage.generated.md`](generated/sellmeier-coverage.generated.md) — `npm test -- sellmeierCoverageScan`
+- [`generated/mirror-fixtures.generated.md`](generated/mirror-fixtures.generated.md) — `npm test -- mirrorFixtureAuthoringReport`

--- a/agent_docs/README.md
+++ b/agent_docs/README.md
@@ -8,7 +8,9 @@ links outward only when the task crosses boundaries.
 - [`architecture.md`](architecture.md) and [`architecture/`](architecture/) — subsystem map, program flow, public functions, and focused architecture notes.
 - Lens/content workflow docs at the root — lens authoring, patent audits, articles, changelog, comments, and gotchas.
 - Glass catalog workflow docs at the root — catalog buildout, relabel follow-up, and proprietary-glass backfill.
-- Mirror-lens follow-up work is tracked in [`../MIRROR_LENS_FUTURE_ENHANCEMENTS.md`](../MIRROR_LENS_FUTURE_ENHANCEMENTS.md).
+- Mirror/folded off-axis accuracy status is captured in
+  [`../MIRROR_OPTICS_ACCURACY_PLAN.md`](../MIRROR_OPTICS_ACCURACY_PLAN.md); remaining follow-up work is tracked in
+  [`../MIRROR_LENS_FUTURE_ENHANCEMENTS.md`](../MIRROR_LENS_FUTURE_ENHANCEMENTS.md).
 - [`generated/`](generated/) — auto-generated reports and work queues; regenerate these instead of hand-editing them.
 - [`records/`](records/) — historical branch/task notes. Treat these as context, not current source of truth.
 

--- a/agent_docs/README.md
+++ b/agent_docs/README.md
@@ -8,6 +8,7 @@ links outward only when the task crosses boundaries.
 - [`architecture.md`](architecture.md) and [`architecture/`](architecture/) — subsystem map, program flow, public functions, and focused architecture notes.
 - Lens/content workflow docs at the root — lens authoring, patent audits, articles, changelog, comments, and gotchas.
 - Glass catalog workflow docs at the root — catalog buildout, relabel follow-up, and proprietary-glass backfill.
+- Mirror-lens follow-up work is tracked in [`../MIRROR_LENS_FUTURE_ENHANCEMENTS.md`](../MIRROR_LENS_FUTURE_ENHANCEMENTS.md).
 - [`generated/`](generated/) — auto-generated reports and work queues; regenerate these instead of hand-editing them.
 - [`records/`](records/) — historical branch/task notes. Treat these as context, not current source of truth.
 

--- a/agent_docs/adding_a_lens.md
+++ b/agent_docs/adding_a_lens.md
@@ -17,7 +17,7 @@ No manual imports or catalog edits required.
 - **Companion analysis-file format:** `src/lens-data/LENS_ANALYSIS_SPEC.md` — required skeleton, conditional sections, voice and conventions for `*.analysis.md`.
 - **Annotated template:** `src/lens-data/TEMPLATE.data.ts.template`
 - **Shared defaults:** `src/lens-data/defaults.ts`
-- **Mirror/folded reference fixtures:** `src/lens-data/reference/*.data.ts` — hidden synthetic examples for first-surface mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, and Cassegrain-style obstruction/back-focus behavior.
+- **Mirror/folded reference fixtures:** `src/lens-data/reference/*.data.ts` — hidden synthetic examples for first-surface mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, Cassegrain/Gregorian/Maksutov-style folded paths, and annular blocker behavior.
 - **Mirror fixture authoring report:** `agent_docs/generated/mirror-fixtures.generated.md` — regenerate with `npm run generate:mirror-reports` after changing hidden mirror/telescope fixtures.
 - **Mount/format backfill status:** [lens-mount-format-backfill.md](lens-mount-format-backfill.md)
 - **Re-auditing an existing lens against its patent:** [lens-patent-audit.md](lens-patent-audit.md) — use this when revisiting a data file already in the catalog, not when authoring a new one.
@@ -87,15 +87,19 @@ Use `src/lens-data/LENS_DATA_SPEC.md` as the source of truth, and start from the
 - `ReferenceManginSecondSurfaceMirror.data.ts` for a second-surface mirror with an explicit repeated hit order.
 - `ReferenceNewtonianSideFocus.data.ts` for automatic next-surface selection, a tilted diagonal secondary, and a side image plane.
 - `ReferenceCassegrainBackFocus.data.ts` for obstruction plus folded back-focus behavior.
+- `ReferenceGregorianSecondary.data.ts` for Gregorian secondary behavior and declared back focus.
+- `ReferenceMaksutovCassegrainMeniscus.data.ts` for refractive meniscus plus folded mirror path.
+- `ReferenceAnnularRingBlocker.data.ts` for annular blocker behavior.
 
 Authoring rules that matter most:
 
 - Keep `surfaces` in physical axial order. Use `opticalPath.surfaceOrder` when the ray hit order is known and not the same as the list order; labels may repeat.
-- Use `opticalPath.mode: "auto"` only when nearest-valid-surface selection is required. Set a conservative `maxInteractions` so an invalid folded path cannot loop.
+- Use `opticalPath.mode: "auto"` only when nearest-valid-surface selection is required. Set a conservative `maxInteractions` so an invalid folded path cannot loop; for explicit `surfaceOrder`, it must still cover every listed hit plus image-plane termination.
 - Put `opticalPath.imagePlane` wherever the design really images. For side focus, set both `y` and a non-axial `normal` such as `{ z: 0, y: 1 }`.
 - Use `interaction.normal` for tilted flat fold mirrors. Put the same normal on the passive backing plane so the SVG element renders at the physical angle.
 - Use `mirrorKind: "second-surface"` for substrate-backed coatings. The diagram draws those coating surfaces as dashed accents, but ray behavior still comes entirely from `interaction.type`, `incidentSide`, and the resolved optical path.
-- Use `innerSd` for annular active surfaces. Use a separate `interaction: { type: "block" }` surface for a solid central obstruction.
+- Use `innerSd` for annular active surfaces. Keep paired mirror/backing `innerSd` values consistent, and use a separate `interaction: { type: "block" }` surface for a solid central obstruction.
+- Do not hand-tune `rayFractions` or pupil constants to compensate for a folded path. Folded off-axis rays now solve stop and image-plane geometry through the generalized tracer; fix the physical path metadata instead.
 - Run `npm run generate:mirror-reports` after adding or materially changing a hidden mirror fixture so the generated authoring matrix stays current.
 - Expect analysis guardrails: mirror-safe spherical aberration and related blur helpers can run, while tabs that still assume a sequential front-to-rear paraxial model are hidden for folded systems.
 

--- a/agent_docs/adding_a_lens.md
+++ b/agent_docs/adding_a_lens.md
@@ -18,6 +18,7 @@ No manual imports or catalog edits required.
 - **Annotated template:** `src/lens-data/TEMPLATE.data.ts.template`
 - **Shared defaults:** `src/lens-data/defaults.ts`
 - **Mirror/folded reference fixtures:** `src/lens-data/reference/*.data.ts` — hidden synthetic examples for first-surface mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, and Cassegrain-style obstruction/back-focus behavior.
+- **Mirror fixture authoring report:** `agent_docs/generated/mirror-fixtures.generated.md` — regenerate with `npm run generate:mirror-reports` after changing hidden mirror/telescope fixtures.
 - **Mount/format backfill status:** [lens-mount-format-backfill.md](lens-mount-format-backfill.md)
 - **Re-auditing an existing lens against its patent:** [lens-patent-audit.md](lens-patent-audit.md) — use this when revisiting a data file already in the catalog, not when authoring a new one.
 
@@ -93,7 +94,9 @@ Authoring rules that matter most:
 - Use `opticalPath.mode: "auto"` only when nearest-valid-surface selection is required. Set a conservative `maxInteractions` so an invalid folded path cannot loop.
 - Put `opticalPath.imagePlane` wherever the design really images. For side focus, set both `y` and a non-axial `normal` such as `{ z: 0, y: 1 }`.
 - Use `interaction.normal` for tilted flat fold mirrors. Put the same normal on the passive backing plane so the SVG element renders at the physical angle.
+- Use `mirrorKind: "second-surface"` for substrate-backed coatings. The diagram draws those coating surfaces as dashed accents, but ray behavior still comes entirely from `interaction.type`, `incidentSide`, and the resolved optical path.
 - Use `innerSd` for annular active surfaces. Use a separate `interaction: { type: "block" }` surface for a solid central obstruction.
+- Run `npm run generate:mirror-reports` after adding or materially changing a hidden mirror fixture so the generated authoring matrix stays current.
 - Expect analysis guardrails: mirror-safe spherical aberration and related blur helpers can run, while tabs that still assume a sequential front-to-rear paraxial model are hidden for folded systems.
 
 ### Aberration-Control Lenses

--- a/agent_docs/adding_a_lens.md
+++ b/agent_docs/adding_a_lens.md
@@ -17,6 +17,7 @@ No manual imports or catalog edits required.
 - **Companion analysis-file format:** `src/lens-data/LENS_ANALYSIS_SPEC.md` — required skeleton, conditional sections, voice and conventions for `*.analysis.md`.
 - **Annotated template:** `src/lens-data/TEMPLATE.data.ts.template`
 - **Shared defaults:** `src/lens-data/defaults.ts`
+- **Mirror/folded reference fixtures:** `src/lens-data/reference/*.data.ts` — hidden synthetic examples for first-surface mirrors, annular obstructions, Mangin-style second-surface mirrors, Newtonian side focus, and Cassegrain-style obstruction/back-focus behavior.
 - **Mount/format backfill status:** [lens-mount-format-backfill.md](lens-mount-format-backfill.md)
 - **Re-auditing an existing lens against its patent:** [lens-patent-audit.md](lens-patent-audit.md) — use this when revisiting a data file already in the catalog, not when authoring a new one.
 
@@ -71,6 +72,29 @@ perspectiveControl: {
 Ranges must be finite, ascending, and include zero. Use official manufacturer sources when available and leave the source
 URL in a nearby comment. The v1 movement layer is a 2D meridional visualization: it shifts/tilts rendered geometry and
 rays relative to the fixed IMG plane, while analysis drawer diagnostics remain centered-lens calculations.
+
+### Mirror, Telescope, And Folded Lenses
+
+Ordinary refractive camera lenses should omit `opticalPath`, `interaction`, and `innerSd`. Add those fields only when a
+surface actually reflects, blocks, uses an annular active aperture, repeats in the ray path, or images onto a non-default
+plane.
+
+Use `src/lens-data/LENS_DATA_SPEC.md` as the source of truth, and start from the reference fixture closest to the design:
+
+- `ReferenceSphericalPrimaryMirror.data.ts` for a first-surface primary and front image plane.
+- `ReferenceAnnularObscuredMirror.data.ts` for annular clear apertures and central obstruction-aware sampling.
+- `ReferenceManginSecondSurfaceMirror.data.ts` for a second-surface mirror with an explicit repeated hit order.
+- `ReferenceNewtonianSideFocus.data.ts` for automatic next-surface selection, a tilted diagonal secondary, and a side image plane.
+- `ReferenceCassegrainBackFocus.data.ts` for obstruction plus folded back-focus behavior.
+
+Authoring rules that matter most:
+
+- Keep `surfaces` in physical axial order. Use `opticalPath.surfaceOrder` when the ray hit order is known and not the same as the list order; labels may repeat.
+- Use `opticalPath.mode: "auto"` only when nearest-valid-surface selection is required. Set a conservative `maxInteractions` so an invalid folded path cannot loop.
+- Put `opticalPath.imagePlane` wherever the design really images. For side focus, set both `y` and a non-axial `normal` such as `{ z: 0, y: 1 }`.
+- Use `interaction.normal` for tilted flat fold mirrors. Put the same normal on the passive backing plane so the SVG element renders at the physical angle.
+- Use `innerSd` for annular active surfaces. Use a separate `interaction: { type: "block" }` surface for a solid central obstruction.
+- Expect analysis guardrails: mirror-safe spherical aberration and related blur helpers can run, while tabs that still assume a sequential front-to-rear paraxial model are hidden for folded systems.
 
 ### Aberration-Control Lenses
 

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -70,7 +70,8 @@ LensVisualizer is a React + TypeScript app with an SVG-first optical diagram and
 - [`glass-catalog-buildout.md`](glass-catalog-buildout.md) - glass catalog expansion and sourcing playbook.
 - [`glass-relabel-followup.md`](glass-relabel-followup.md) - per-lens glass mismatch relabel queue.
 - [`proprietary-glass-backfill.md`](proprietary-glass-backfill.md) - patent line-index backfill workflow.
-- [`generated/`](generated/) - generated glass reports; regenerate before glass-audit work with `npm run generate:glass-reports`.
+- [`generated/`](generated/) - generated glass and mirror fixture reports; regenerate glass reports with
+  `npm run generate:glass-reports` and hidden mirror fixture reports with `npm run generate:mirror-reports`.
 - [`adding_an_article.md`](adding_an_article.md) - content authoring, frontmatter, TOC, and series behavior.
 - [`workflow.md`](workflow.md) - checks, CI, deployment, and commit flow.
 - [`../MIRROR_LENS_FUTURE_ENHANCEMENTS.md`](../MIRROR_LENS_FUTURE_ENHANCEMENTS.md) - root backlog for future mirror-lens hardening.

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -50,7 +50,8 @@ LensVisualizer is a React + TypeScript app with an SVG-first optical diagram and
   `Math.tan(field)` launch math in analysis modules.
 - Keep mirror/folded optics on the generalized path model: `LensData.opticalPath` resolves hit order and image plane,
   `SurfaceData.interaction` controls refract/reflect/block behavior, `innerSd` controls annular apertures, and ordinary
-  lenses must retain their no-`opticalPath` sequential defaults.
+  lenses must retain their no-`opticalPath` sequential defaults. Folded stop/chief-ray solves must use generalized
+  tracing and path-aware image-plane math rather than sequential `stopAt` shortcuts.
 - Keep analysis computations slider-state-aware. Do not move state-dependent analysis into `buildLens()`, which is build-time
   and infinity/default-state oriented.
 - Keep perspective-control movement in the dedicated 2D movement layer (`src/optics/lensMovement.ts`) unless the analysis
@@ -74,6 +75,7 @@ LensVisualizer is a React + TypeScript app with an SVG-first optical diagram and
   `npm run generate:glass-reports` and hidden mirror fixture reports with `npm run generate:mirror-reports`.
 - [`adding_an_article.md`](adding_an_article.md) - content authoring, frontmatter, TOC, and series behavior.
 - [`workflow.md`](workflow.md) - checks, CI, deployment, and commit flow.
+- [`../MIRROR_OPTICS_ACCURACY_PLAN.md`](../MIRROR_OPTICS_ACCURACY_PLAN.md) - completed folded off-axis accuracy plan and verification status.
 - [`../MIRROR_LENS_FUTURE_ENHANCEMENTS.md`](../MIRROR_LENS_FUTURE_ENHANCEMENTS.md) - root backlog for future mirror-lens hardening.
 - [`architecture/program-flow.md`](architecture/program-flow.md) - high-level Mermaid program flow.
 - [`architecture/public-functions.md`](architecture/public-functions.md) - stable project-internal functions, types, and import boundaries.

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -48,6 +48,9 @@ LensVisualizer is a React + TypeScript app with an SVG-first optical diagram and
   per-lens rollout state.
 - Keep fisheye/ultra-wide launch logic centralized in `src/optics/projection.ts` and `solveChiefRay`; avoid inline
   `Math.tan(field)` launch math in analysis modules.
+- Keep mirror/folded optics on the generalized path model: `LensData.opticalPath` resolves hit order and image plane,
+  `SurfaceData.interaction` controls refract/reflect/block behavior, `innerSd` controls annular apertures, and ordinary
+  lenses must retain their no-`opticalPath` sequential defaults.
 - Keep analysis computations slider-state-aware. Do not move state-dependent analysis into `buildLens()`, which is build-time
   and infinity/default-state oriented.
 - Keep perspective-control movement in the dedicated 2D movement layer (`src/optics/lensMovement.ts`) unless the analysis
@@ -70,6 +73,7 @@ LensVisualizer is a React + TypeScript app with an SVG-first optical diagram and
 - [`generated/`](generated/) - generated glass reports; regenerate before glass-audit work with `npm run generate:glass-reports`.
 - [`adding_an_article.md`](adding_an_article.md) - content authoring, frontmatter, TOC, and series behavior.
 - [`workflow.md`](workflow.md) - checks, CI, deployment, and commit flow.
+- [`../MIRROR_LENS_FUTURE_ENHANCEMENTS.md`](../MIRROR_LENS_FUTURE_ENHANCEMENTS.md) - root backlog for future mirror-lens hardening.
 - [`architecture/program-flow.md`](architecture/program-flow.md) - high-level Mermaid program flow.
 - [`architecture/public-functions.md`](architecture/public-functions.md) - stable project-internal functions, types, and import boundaries.
 - [`code_conventions.md`](code_conventions.md) - TypeScript, naming, formatting, and architecture constraints.

--- a/agent_docs/architecture/optics-engine.md
+++ b/agent_docs/architecture/optics-engine.md
@@ -126,7 +126,8 @@ Folded systems opt into the generalized exact tracer through lens data, not thro
   without reflecting, refracting, or blocking.
 - `SurfaceData.interaction.type` selects `"refract"`, `"reflect"`, or `"block"`. Side-specific `incidentSide` /
   `inactiveSide` controls whether a surface is active from the front, rear, both sides, ignored from the inactive side,
-  or treated as a blocker from the inactive side.
+  or treated as a blocker from the inactive side. Reflective surfaces block inactive-side hits by default unless
+  `inactiveSide: "ignore"` is explicit.
 - `interaction.mirrorKind` documents first-surface vs second-surface mirrors. Refractive-index transitions still come
   from the physical `nd` sequence so explicit repeated orders can enter a Mangin body, reflect, and exit through the
   same front surface.

--- a/agent_docs/architecture/optics-engine.md
+++ b/agent_docs/architecture/optics-engine.md
@@ -45,6 +45,8 @@ lens data; analysis tabs use current focus, zoom, and aperture state.
 - Element/group/doublet/aspheric/variable maps for runtime lookup.
 - Folded-path metadata: resolved `opticalPath`, explicit `imagePlane`, `isFoldedOptics`, and normalized surface/image-plane
   normals when mirror data opts into the generalized model.
+- Folded entrance/exit pupil geometry derived from generalized real-ray stop and full-system basis traces, with finite
+  geometric fallbacks when a folded path cannot produce reliable stop/full traces.
 
 **`halfField` vs `tracingHalfField`.** Rectilinear lenses set both to the same slope-launch-bisected value
 (real chief ray vignetting check) by default. Fisheye lenses set `halfField = projection.maxTraceFieldDeg`
@@ -105,6 +107,9 @@ The exact tracer in `internal/exactSurfaceTrace.ts` exposes two entry points:
   per-surface bracket bound is z-projected; for grazing or backward rays the caller must supply
   `launchBoundT` so the intersection search has a finite parametric bound (typically `2 × launchRadiusMm`
   for bounding-sphere launches). The slope entry is a thin adapter that calls into this core.
+- `traceToStopViaGeneralized(lens, input, stopIdx, options)` — helper for folded callers that need a stop hit.
+  It runs a full generalized trace, scans `hits` for the first unclipped requested stop occurrence by default, and
+  can select a later repeated stop occurrence when the optical path intentionally crosses the same stop more than once.
 
 Both solve each ray/sag intersection via `internal/surfaceIntersection.ts` and project the outgoing ray back
 to the current surface vertex plane before returning `y`/`u` or `x`/`y`/`ux`/`uy`. `surfaceIntersection.ts`
@@ -143,8 +148,10 @@ Folded systems opt into the generalized exact tracer through lens data, not thro
 and whether the explicit image plane was reached.
 
 Analysis support is deliberately incremental. Spherical aberration and mirror-safe blur/bokeh helpers use generalized
-image-plane intersections where valid; sequential paraxial/cardinal/pupil/field tabs are guarded in the UI for
-`L.isFoldedOptics` until each tab is adapted.
+image-plane intersections where valid, folded visible off-axis geometry uses generalized stop/chief-ray solves, and
+axial folded reflective systems can report first-order cardinal overlays. Complex tabs that still need a settled folded
+interpretation, such as coma, distortion, vignetting, field curvature, and pupils, remain guarded in the UI until each
+tab has fixture-backed validation.
 
 ## Field-Launch Convention
 
@@ -192,7 +199,9 @@ helper instead of reimplementing the criteria.
 surface spacings, receives the visible `zPos`/image-plane positions from the diagram computation pipeline, and returns
 all six cardinal points atomically plus EFL, BFD, FFD, Hiatus, and Total track spans. For ordinary same-index
 photographic lenses, H/N and H′/N′ are marked coincident explicitly; non-unity image-side systems compute N/N′
-independently.
+independently. Axial folded reflective systems share the same paraxial transfer/interaction stepper with an enabled
+reflect branch; folded systems with tilted image planes still return no cardinal result until a rotated-frame reporting
+convention exists.
 
 ## Off-Axis Geometry Policy
 
@@ -203,8 +212,10 @@ Use explicit naming:
 - `computeOffAxisFieldGeometry` remains as a legacy compatibility alias for paraxial geometry.
 
 Visible off-axis rays, chromatic off-axis rays, distortion, vignetting, pupil aberration, coma, and bokeh use the
-state-aware solved-chief-ray path where current focus/zoom can move pupil geometry. Keep legacy paraxial behavior only
-where the UI or test explicitly needs first-order comparison.
+state-aware solved-chief-ray path where current focus/zoom can move pupil geometry. Folded callers that need the stop
+height use generalized stop tracing rather than sequential `stopAt`, and folded image-plane coordinates use the same
+plane-normal intersection helper as sequential callers. Keep legacy paraxial behavior only where the UI or test
+explicitly needs first-order comparison.
 
 ## Perspective-Control Movement
 

--- a/agent_docs/architecture/optics-engine.md
+++ b/agent_docs/architecture/optics-engine.md
@@ -43,6 +43,8 @@ lens data; analysis tabs use current focus, zoom, and aperture state.
 - Zoom metadata: positions, EFLs, EPs, half-fields, tracing half-fields, y-ratios, and back focal distances.
 - Stop data: physical stop SD, blade stub fraction, stop housing SD, and f-stop series.
 - Element/group/doublet/aspheric/variable maps for runtime lookup.
+- Folded-path metadata: resolved `opticalPath`, explicit `imagePlane`, `isFoldedOptics`, and normalized surface/image-plane
+  normals when mirror data opts into the generalized model.
 
 **`halfField` vs `tracingHalfField`.** Rectilinear lenses set both to the same slope-launch-bisected value
 (real chief ray vignetting check) by default. Fisheye lenses set `halfField = projection.maxTraceFieldDeg`
@@ -111,6 +113,36 @@ and `isFiniteEvaluation` (additionally requires non-zero derivative, used inside
 grazing meridional ray whose derivative collapses to zero at the optical axis can still anchor a bracket.
 The Newton seed falls back to the bracket midpoint when the z-projected guess is non-finite.
 
+## Mirror And Folded Optical Paths
+
+Folded systems opt into the generalized exact tracer through lens data, not through a trace-mode flag:
+
+- `SurfaceData.innerSd` defines an annular active aperture. Rays interact only inside `[innerSd, sd]`; central holes pass
+  without reflecting, refracting, or blocking.
+- `SurfaceData.interaction.type` selects `"refract"`, `"reflect"`, or `"block"`. Side-specific `incidentSide` /
+  `inactiveSide` controls whether a surface is active from the front, rear, both sides, ignored from the inactive side,
+  or treated as a blocker from the inactive side.
+- `interaction.mirrorKind` documents first-surface vs second-surface mirrors. Refractive-index transitions still come
+  from the physical `nd` sequence so explicit repeated orders can enter a Mangin body, reflect, and exit through the
+  same front surface.
+- `interaction.normal` turns a surface into a tilted meridional plane for both intersection and SVG element rendering.
+  Use it for flat fold mirrors and their passive backing planes; omit it for curved mirrors so sag-derived normals are
+  used.
+- `LensData.opticalPath.surfaceOrder` is an explicit label sequence and may repeat labels. This is the preferred path
+  for known Mangin or Cassegrain hit orders.
+- `LensData.opticalPath.mode: "auto"` uses nearest-valid-surface selection with self-hit tolerance, passive same-index
+  refractive-surface skipping, image-plane termination, and `maxInteractions` protection.
+- `LensData.opticalPath.imagePlane` supplies arbitrary meridional image planes. `doLayout()` reports `imgZ` from this
+  plane for folded systems, and ray traces terminate at the plane rather than assuming the final right-hand BFD.
+
+`traceRay*` remains the public caller surface for diagram rays. Focused optics tests can import
+`internal/exactSurfaceTrace.ts` to inspect generalized-path details such as hit labels, terminal direction, final medium,
+and whether the explicit image plane was reached.
+
+Analysis support is deliberately incremental. Spherical aberration and mirror-safe blur/bokeh helpers use generalized
+image-plane intersections where valid; sequential paraxial/cardinal/pupil/field tabs are guarded in the UI for
+`L.isFoldedOptics` until each tab is adapted.
+
 ## Field-Launch Convention
 
 Every analysis launch slope flows through `projectionLaunchSlopeForField(L, fieldAngleDeg)` in
@@ -141,6 +173,10 @@ Lens data owns the baseline ray fans through `rayFractions` and `offAxisFraction
 those arrays exactly for `normal`, then derives symmetric denser viewport-only samples for `dense` and
 `diagnostic`. Use the helper from display/tracing hooks instead of mutating runtime lens data or adding
 density-specific arrays to lens files.
+
+For folded systems, `obstructionAwareRayFractionsForDensity()` scans usable pupil bands so visible on-axis/off-axis rays
+avoid central blockers and annular mirror holes automatically. Do not work around a secondary obstruction by hand-editing
+`rayFractions`; fix the physical blocker or `innerSd` data instead.
 
 `raySampling.ts` also exports `isHeavyLensForRayWork(L)` — the shared heaviness heuristic. `LensDiagramPanel`
 uses it to downgrade interactive diagram ray density during slider drag; analysis modules use it to halve

--- a/agent_docs/architecture/optics-engine.md
+++ b/agent_docs/architecture/optics-engine.md
@@ -17,7 +17,7 @@ lens data; analysis tabs use current focus, zoom, and aperture state.
 | --- | --- |
 | `buildLens.ts` | Validates lens data and constructs frozen `RuntimeLens` objects. |
 | `optics.ts` | Ray tracing, sag curves, layout, zoom interpolation, pupil geometry, chromatic tracing, chief ray solver. |
-| `diagramGeometry.ts` | SVG coordinate transforms and element shape/render diagnostics. |
+| `diagramGeometry.ts` | SVG coordinate transforms, element shape/render diagnostics, aspheric overlay paths, and second-surface mirror coating accent paths. |
 | `lensMovement.ts` | Pure 2D perspective-control movement helpers for clamping shift/tilt and transforming rendered points/rays. |
 | `groupMovement.ts` | Pure inferred lens-group axial movement profiles for focus, zoom, and combined overlay views. Uses fixed-image-plane anchoring and group-center positions relative to the focus plane. |
 | `validateLensData.ts` | Runtime lens-data validation. |
@@ -125,6 +125,9 @@ Folded systems opt into the generalized exact tracer through lens data, not thro
 - `interaction.mirrorKind` documents first-surface vs second-surface mirrors. Refractive-index transitions still come
   from the physical `nd` sequence so explicit repeated orders can enter a Mangin body, reflect, and exit through the
   same front surface.
+- Second-surface mirrors also emit a diagram surface accent from `computeElementShapes()` so the SVG can draw the
+  coating separately from the glass substrate. This is visual-only; tracing behavior still comes from
+  `SurfaceData.interaction`.
 - `interaction.normal` turns a surface into a tilted meridional plane for both intersection and SVG element rendering.
   Use it for flat fold mirrors and their passive backing planes; omit it for curved mirrors so sag-derived normals are
   used.

--- a/agent_docs/architecture/optics-engine.md
+++ b/agent_docs/architecture/optics-engine.md
@@ -126,8 +126,8 @@ Folded systems opt into the generalized exact tracer through lens data, not thro
   without reflecting, refracting, or blocking.
 - `SurfaceData.interaction.type` selects `"refract"`, `"reflect"`, or `"block"`. Side-specific `incidentSide` /
   `inactiveSide` controls whether a surface is active from the front, rear, both sides, ignored from the inactive side,
-  or treated as a blocker from the inactive side. Reflective surfaces block inactive-side hits by default unless
-  `inactiveSide: "ignore"` is explicit.
+  or treated as a blocker from the inactive side. Reflective reference fixtures annotate inactive-side blocking
+  explicitly so mirror back-side opacity is visible in the data.
 - `interaction.mirrorKind` documents first-surface vs second-surface mirrors. Refractive-index transitions still come
   from the physical `nd` sequence so explicit repeated orders can enter a Mangin body, reflect, and exit through the
   same front surface.

--- a/agent_docs/architecture/program-flow.md
+++ b/agent_docs/architecture/program-flow.md
@@ -114,11 +114,13 @@ flowchart TD
   BuildLens --> Validate[src/optics/validateLensData.ts]
   BuildLens --> Glass[src/optics/glassCatalog.ts and dispersion.ts]
   BuildLens --> Runtime[RuntimeLens]
+  Runtime --> Path[opticalPath imagePlane folded metadata]
   Runtime --> Layout[src/optics/layout.ts]
   Layout --> Geometry[src/optics/diagramGeometry.ts]
   Geometry --> Shapes[SVG-ready lens shapes and scales]
 
   Runtime --> Trace
+  Path --> Trace
   Trace --> OnAxis[src/components/hooks/useOnAxisRays.ts]
   Trace --> OffAxis[src/components/hooks/useOffAxisRays.ts]
   Trace --> Chromatic[src/components/hooks/useChromaticRays.ts]
@@ -152,6 +154,8 @@ flowchart TD
   Runtime --> TraceCore
   TraceCore --> Exact[src/optics/internal exact surface tracing]
   Exact --> Intersections[src/optics/internal surface intersection]
+  Runtime --> Folded[folded optical path image plane annular masks]
+  Folded --> Exact
   Intersections --> RayResults[Ray paths statuses pupils focal data]
 
   Runtime --> AnalysisJobs[src/optics/analysisJobs.ts]

--- a/agent_docs/architecture/public-functions.md
+++ b/agent_docs/architecture/public-functions.md
@@ -42,7 +42,9 @@ optics helpers. Do not store runtime lens state in module globals.
 
 For mirror or telescope data, inspect `L.opticalPath`, `L.imagePlane`, and `L.isFoldedOptics` instead of inferring behavior
 from surface order. Public `traceRay*` helpers report folded termination through `reachedImagePlane`; targeted optics
-tests may import the exact tracer to assert generalized-path `hits`, `terminalPoint`, and `terminalDirection`.
+tests may import the exact tracer to assert generalized-path `hits`, `terminalPoint`, `terminalDirection`, and repeated
+stop behavior. Folded callers that need an intermediate stop hit should use the generalized stop helper internally
+rather than relying on sequential partial tracing.
 
 ## Optics Engine
 

--- a/agent_docs/architecture/public-functions.md
+++ b/agent_docs/architecture/public-functions.md
@@ -24,6 +24,7 @@ implementation details.
 | `src/types/optics.ts` | `OpticalPathData`, `ResolvedOpticalPath`, `ImagePlaneData`, `ResolvedImagePlane`, `ImagePlaneNormal` | Generalized optical path metadata, explicit/repeated surface hit order, automatic path mode, and arbitrary meridional image-plane placement. |
 | `src/types/optics.ts` | `LensProjectionConfig`, `PerspectiveControlConfig` | Fisheye/rectilinear projection metadata and shift/tilt capability metadata. |
 | `src/types/optics.ts` | `RayTraceResult`, `ParaxialTraceResult`, `LayoutResult`, `ChromaticChannel` | Shared optics result shapes. |
+| `src/types/optics.ts` | `ElementShape`, `AsphPathData`, `SurfaceAccentPathData` | SVG-ready element outline, aspheric overlay, and mirror-coating accent path data returned by `computeElementShapes()`. |
 | `src/types/state.ts` | `LensState`, `LensAction`, `Preferences`, `URLState` | Reducer state, actions, persisted preferences, and shareable URL state. |
 | `src/types/state.ts` | `OffAxisMode`, `RayDensity`, `MobileView`, `DesktopView`, `AnalysisTabId` | UI state unions plus `is*` guards for parsing external values. |
 | `src/types/groupMovement.ts` | `GroupMovementMode`, `isGroupMovementMode` | Shared group-movement mode ids and guard. |

--- a/agent_docs/architecture/public-functions.md
+++ b/agent_docs/architecture/public-functions.md
@@ -20,6 +20,8 @@ implementation details.
 | --- | --- | --- |
 | `src/types/optics.ts` | `LensDataInput`, `LensData`, `RuntimeLens` | Raw lens files, defaulted lens data, and the frozen runtime object returned by `buildLens()`. |
 | `src/types/optics.ts` | `SurfaceData`, `ElementData`, `AsphericCoefficients`, `VarRange` | Prescription structure, element metadata, aspheric terms, and focus/zoom variable gaps. |
+| `src/types/optics.ts` | `SurfaceInteraction`, `SurfaceIncidentSide`, `SurfaceInactiveSideBehavior`, `MirrorKind` | Folded-path surface behavior for refract/reflect/block surfaces, side-specific activation, and first/second-surface mirrors. |
+| `src/types/optics.ts` | `OpticalPathData`, `ResolvedOpticalPath`, `ImagePlaneData`, `ResolvedImagePlane`, `ImagePlaneNormal` | Generalized optical path metadata, explicit/repeated surface hit order, automatic path mode, and arbitrary meridional image-plane placement. |
 | `src/types/optics.ts` | `LensProjectionConfig`, `PerspectiveControlConfig` | Fisheye/rectilinear projection metadata and shift/tilt capability metadata. |
 | `src/types/optics.ts` | `RayTraceResult`, `ParaxialTraceResult`, `LayoutResult`, `ChromaticChannel` | Shared optics result shapes. |
 | `src/types/state.ts` | `LensState`, `LensAction`, `Preferences`, `URLState` | Reducer state, actions, persisted preferences, and shareable URL state. |
@@ -36,6 +38,10 @@ implementation details.
 
 Use `buildLens()` once per lens/session state boundary, then pass the returned `RuntimeLens` (`L`) explicitly into pure
 optics helpers. Do not store runtime lens state in module globals.
+
+For mirror or telescope data, inspect `L.opticalPath`, `L.imagePlane`, and `L.isFoldedOptics` instead of inferring behavior
+from surface order. Public `traceRay*` helpers report folded termination through `reachedImagePlane`; targeted optics
+tests may import the exact tracer to assert generalized-path `hits`, `terminalPoint`, and `terminalDirection`.
 
 ## Optics Engine
 

--- a/agent_docs/architecture/testing.md
+++ b/agent_docs/architecture/testing.md
@@ -51,12 +51,14 @@ Existing tests cover:
 - Pure optics functions and edge cases.
 - Lens build and data validation.
 - Mirror/folded optics fixtures: first-surface reflection, annular clipping/rendering, second-surface repeated hit order,
-  automatic Newtonian path resolution, side/front/back image-plane termination, and folded analysis guardrails.
+  automatic Newtonian path resolution, side/front/back image-plane termination, second-surface coating accents, and
+  folded analysis guardrails.
 - Aberration, distortion, vignetting, pupil aberration, bokeh, and diagram geometry.
 - Catalog/metadata utilities.
 - Reducer, preferences, URL sync, feature flags, and page-theme hooks.
 - Component smoke tests for pages, controls, display panels, analysis drawer, and comparison layout.
 - Script regressions for metadata, route sync, lens-data helpers, sitemap/prerender support.
+- Generated authoring reports, including glass queues and the hidden mirror fixture report.
 
 ## Refactor Test Expectations
 

--- a/agent_docs/architecture/testing.md
+++ b/agent_docs/architecture/testing.md
@@ -50,6 +50,8 @@ Existing tests cover:
 
 - Pure optics functions and edge cases.
 - Lens build and data validation.
+- Mirror/folded optics fixtures: first-surface reflection, annular clipping/rendering, second-surface repeated hit order,
+  automatic Newtonian path resolution, side/front/back image-plane termination, and folded analysis guardrails.
 - Aberration, distortion, vignetting, pupil aberration, bokeh, and diagram geometry.
 - Catalog/metadata utilities.
 - Reducer, preferences, URL sync, feature flags, and page-theme hooks.
@@ -65,6 +67,9 @@ When refactoring:
 - Add equality tests when adding optional precomputed inputs to optics helpers.
 - Add reducer guard tests when tightening string state into literal unions.
 - Add script helper tests when changing metadata generation, route expansion, or git freshness lookup.
+- Add fixture-backed optics tests whenever changing `SurfaceData.interaction`, `innerSd`, `opticalPath`, generalized
+  image-plane intersection, obstruction-aware sampling, or folded analysis gating. Prefer hidden reference fixtures under
+  `src/lens-data/reference/` for canonical mirror/telescope behavior.
 
 Run the normal gate before committing:
 

--- a/agent_docs/architecture/testing.md
+++ b/agent_docs/architecture/testing.md
@@ -51,8 +51,9 @@ Existing tests cover:
 - Pure optics functions and edge cases.
 - Lens build and data validation.
 - Mirror/folded optics fixtures: first-surface reflection, annular clipping/rendering, second-surface repeated hit order,
-  automatic Newtonian path resolution, side/front/back image-plane termination, second-surface coating accents, and
-  folded analysis guardrails.
+  automatic Newtonian path resolution, side/front/back image-plane termination, second-surface coating accents, folded
+  analysis guardrails, off-axis chief-ray/image-plane accuracy, meridional symmetry, and analytic focal/back-focus
+  anchors.
 - Aberration, distortion, vignetting, pupil aberration, bokeh, and diagram geometry.
 - Catalog/metadata utilities.
 - Reducer, preferences, URL sync, feature flags, and page-theme hooks.
@@ -70,8 +71,11 @@ When refactoring:
 - Add reducer guard tests when tightening string state into literal unions.
 - Add script helper tests when changing metadata generation, route expansion, or git freshness lookup.
 - Add fixture-backed optics tests whenever changing `SurfaceData.interaction`, `innerSd`, `opticalPath`, generalized
-  image-plane intersection, obstruction-aware sampling, or folded analysis gating. Prefer hidden reference fixtures under
-  `src/lens-data/reference/` for canonical mirror/telescope behavior.
+  stop tracing, generalized image-plane intersection, obstruction-aware sampling, or folded analysis gating. Prefer
+  hidden reference fixtures under `src/lens-data/reference/` for canonical mirror/telescope behavior.
+- For folded off-axis changes, include chief-ray reachability, image-height magnitude against the expected small-field
+  reference, positive/negative field symmetry, and a representative non-folded refractive snapshot so ordinary
+  sequential behavior does not drift.
 
 Run the normal gate before committing:
 

--- a/agent_docs/architecture/ui-components.md
+++ b/agent_docs/architecture/ui-components.md
@@ -72,6 +72,11 @@ panels slice.
 Desktop uses vertical tabs on the left; mobile uses horizontal tabs on top. Tab content unmounts when the drawer is
 closed, preventing hidden analysis work during slider drag.
 
+`AnalysisDrawerContent` owns global analysis notices. It shows a folded-optics notice for `L.isFoldedOptics`, allows the
+mirror-safe aberrations path, and replaces tabs that still assume a sequential front-to-rear paraxial model with an
+explicit unsupported message. When adapting a tab for mirror systems, remove it from the folded unsupported set only
+after its math uses generalized image-plane/ray intersections and has fixture-backed tests.
+
 New analysis tabs require:
 
 1. Add tab metadata in `src/components/layout/lensDiagram/analysisTabs.ts`.

--- a/agent_docs/architecture/ui-components.md
+++ b/agent_docs/architecture/ui-components.md
@@ -73,9 +73,10 @@ Desktop uses vertical tabs on the left; mobile uses horizontal tabs on top. Tab 
 closed, preventing hidden analysis work during slider drag.
 
 `AnalysisDrawerContent` owns global analysis notices. It shows a folded-optics notice for `L.isFoldedOptics`, allows the
-mirror-safe aberrations path, and replaces tabs that still assume a sequential front-to-rear paraxial model with an
-explicit unsupported message. When adapting a tab for mirror systems, remove it from the folded unsupported set only
-after its math uses generalized image-plane/ray intersections and has fixture-backed tests.
+mirror-safe aberrations path, and replaces complex tabs that still assume a sequential front-to-rear paraxial model with
+an explicit unsupported message. When adapting a tab for mirror systems, remove it from the folded unsupported set only
+after its math uses generalized stop/image-plane ray intersections, has fixture-backed tests, and has clear UI copy for
+folded image-plane conventions.
 
 New analysis tabs require:
 

--- a/agent_docs/architecture/viewer-and-diagram.md
+++ b/agent_docs/architecture/viewer-and-diagram.md
@@ -85,7 +85,7 @@ Key responsibilities:
 | `DiagramSVG.tsx` | Top-level SVG renderer. Accepts viewBox override, zoom handlers, optional movement transforms, and the subtle moved-lens axis; wrapped in `React.memo`. |
 | `DiagramDefs.tsx` | Shared SVG defs, gradients, filters, and markers. |
 | `DiagramGridAxisLayer.tsx` | Grid, axis, and image-plane reference elements, including explicit folded-system image planes that may be in front of, behind, or above the axial layout. |
-| `DiagramElementLayer.tsx` | Lens element paths and aspheric overlays. Annular elements use even-odd fill, and tilted flat mirrors render from `interaction.normal`. |
+| `DiagramElementLayer.tsx` | Lens element paths, aspheric overlays, and surface accents. Annular elements use even-odd fill, tilted flat mirrors render from `interaction.normal`, and second-surface mirror coatings render as dashed substrate accents. |
 | `DiagramRayLayers.tsx` | On-axis, off-axis, and chromatic ray layers. When chromatic mode is active, it hides monochrome layers and lets ON-AXIS/OFF-AXIS gate the chromatic axial/off-axis groups. Folded ray polylines follow the generalized tracer rather than surface-list order. |
 | `RayPolylines.tsx` | Consolidated ray segment polyline rendering. |
 | `ApertureStop.tsx` | Aperture stop blades and STO label. |

--- a/agent_docs/architecture/viewer-and-diagram.md
+++ b/agent_docs/architecture/viewer-and-diagram.md
@@ -44,6 +44,8 @@ Key responsibilities:
 - Wires computation hooks for layout, density-controlled rays, chromatic spread, overlays, and slider feedback.
 - Applies optional perspective-control movement for supported lenses, including transformed geometry/rays and fixed
   image-plane reference behavior.
+- Supports folded mirror runtime lenses by consuming `L.imagePlane`, `L.isFoldedOptics`, generalized ray endpoints, and
+  obstruction-aware ray sampling instead of assuming the final surface's right-hand BFD is the only imaging plane.
 - Passes memoized field geometry into analysis drawer tabs.
 - Tracks slider interaction so heavy analysis can defer/freeze inputs while the user drags.
 - Surfaces build, shape, ray, and render errors through the panel error tiers.
@@ -53,9 +55,9 @@ Key responsibilities:
 | Hook | Purpose |
 | --- | --- |
 | `useLensComputation.ts` | Lens building/reuse, layout, transforms, element shapes, aperture, current-state field geometry, and optional perspective-control movement. Stabilizes `zPos` by element-wise comparison. |
-| `useRayTracing.ts` | Orchestrates on-axis, off-axis, and chromatic ray hooks, applies ray density and optional movement transforms, and reports the first ray error. |
-| `useOnAxisRays.ts` | Computes density-derived on-axis ray fan segments. |
-| `useOffAxisRays.ts` | Computes density-derived visible off-axis rays using state-aware field geometry. |
+| `useRayTracing.ts` | Orchestrates on-axis, off-axis, and chromatic ray hooks, applies ray density and optional movement transforms, and reports the first ray error. Folded systems receive generalized trace results terminating on `L.imagePlane`. |
+| `useOnAxisRays.ts` | Computes density-derived on-axis ray fan segments, using obstruction-aware sampling for folded mirror systems. |
+| `useOffAxisRays.ts` | Computes density-derived visible off-axis rays using state-aware field geometry and folded image-plane termination where applicable. |
 | `offAxisRayUtils.ts` | Shared off-axis tracing geometry and optional edge-projection endpoint logic for monochrome and chromatic fans. |
 | `useChromaticRays.ts` | Computes density-derived axial and off-axis chromatic R/G/B tracing plus axial LCA/TCA spread. |
 | `useFlashOverlay.ts` | Sticky-slider flash animation state. |
@@ -72,7 +74,7 @@ Key responsibilities:
 | `LensDiagramLoadedState.tsx` | Loaded panel composition after build/layout succeeds. |
 | `LensDiagramErrorState.tsx` | Build/shape/ray error presentation. |
 | `DiagramViewport.tsx` | SVG viewport wrapper with LCA/Petzval/group-movement overlay gating, zoom/pan toggle, and keyboard shortcut handling. |
-| `AnalysisDrawerContent.tsx` | Tab-to-panel router for analysis drawer content. Defers slider-derived inputs and freezes last settled analysis inputs during active slider interaction. Shows a notice when PC movement is active because v1 analysis tabs remain centered-lens diagnostics. |
+| `AnalysisDrawerContent.tsx` | Tab-to-panel router for analysis drawer content. Defers slider-derived inputs and freezes last settled analysis inputs during active slider interaction. Shows notices when PC movement is active or folded mirror optics are detected; folded systems gate tabs that still assume sequential front-to-rear paraxial math. |
 | `DiagramControlPanel.tsx` | Sliders, inspector, legend, and analysis launch button. |
 | `analysisTabs.ts` | Typed analysis tab metadata shared by trigger and drawer. |
 
@@ -82,9 +84,9 @@ Key responsibilities:
 | --- | --- |
 | `DiagramSVG.tsx` | Top-level SVG renderer. Accepts viewBox override, zoom handlers, optional movement transforms, and the subtle moved-lens axis; wrapped in `React.memo`. |
 | `DiagramDefs.tsx` | Shared SVG defs, gradients, filters, and markers. |
-| `DiagramGridAxisLayer.tsx` | Grid, axis, and image-plane reference elements. |
-| `DiagramElementLayer.tsx` | Lens element paths and aspheric overlays. |
-| `DiagramRayLayers.tsx` | On-axis, off-axis, and chromatic ray layers. When chromatic mode is active, it hides monochrome layers and lets ON-AXIS/OFF-AXIS gate the chromatic axial/off-axis groups. |
+| `DiagramGridAxisLayer.tsx` | Grid, axis, and image-plane reference elements, including explicit folded-system image planes that may be in front of, behind, or above the axial layout. |
+| `DiagramElementLayer.tsx` | Lens element paths and aspheric overlays. Annular elements use even-odd fill, and tilted flat mirrors render from `interaction.normal`. |
+| `DiagramRayLayers.tsx` | On-axis, off-axis, and chromatic ray layers. When chromatic mode is active, it hides monochrome layers and lets ON-AXIS/OFF-AXIS gate the chromatic axial/off-axis groups. Folded ray polylines follow the generalized tracer rather than surface-list order. |
 | `RayPolylines.tsx` | Consolidated ray segment polyline rendering. |
 | `ApertureStop.tsx` | Aperture stop blades and STO label. |
 | `CardinalElementsOverlay.tsx` | Feature-flagged F/F′, H/H′, N/N′ and axial span overlay. |

--- a/agent_docs/code_conventions.md
+++ b/agent_docs/code_conventions.md
@@ -25,6 +25,8 @@
 ## Architecture Constraints
 
 - **Pure-function modules** (`optics.ts`, `buildLens.ts`, `validateLensData.ts`, `diagramGeometry.ts`, `lcaScaling.ts`) have no React dependencies
+- **Folded mirror behavior stays data-driven** — use `LensData.opticalPath`, `SurfaceData.interaction`, and `innerSd`
+  instead of adding per-lens trace flags or special-case code paths for individual fixtures
 - **Inline styles only** — color palettes defined in theme objects; no CSS files or UI libraries
 - **Monospace font stack** for UI: `'JetBrains Mono','SF Mono','Fira Code'`
 - **Theme color tokens** prefixed with `_` are internal to the `createTheme()` factory — update all 4 themes when changing colors

--- a/agent_docs/generated/catalog-mismatches.generated.md
+++ b/agent_docs/generated/catalog-mismatches.generated.md
@@ -13,9 +13,9 @@ with words like "probable" or "approx").
 
 ## Summary
 
-- **258** lenses scanned
-- **2973** glass surfaces examined
-- **2967** surfaces with non-empty `glass` strings
+- **266** lenses scanned
+- **2975** glass surfaces examined
+- **2969** surfaces with non-empty `glass` strings
 - **2315** of those resolved to a catalog entry
 - **49** mismatches found (2.1% of resolved surfaces)
 - **22** distinct lens files affected

--- a/agent_docs/generated/mirror-fixtures.generated.md
+++ b/agent_docs/generated/mirror-fixtures.generated.md
@@ -1,0 +1,134 @@
+# Mirror Fixture Authoring Report (auto-generated)
+
+Hidden/reference fixtures that exercise mirror, folded-path, annular, blocker, and image-plane metadata.
+
+**Regenerate this file** by running `npm test -- mirrorFixtureAuthoringReport`.
+Regenerate the mirror report set with `npm run generate:mirror-reports`.
+
+## Summary
+
+- **8** hidden/reference fixtures scanned
+- **1** fixtures include second-surface mirror metadata
+- **1** fixtures include tilted meridional plane metadata
+- **5** fixtures include annular aperture or obstruction metadata
+- **0** fixtures currently report validation errors
+
+## Fixture Matrix
+
+| Fixture | Path | Hit order | Image plane | Reflect | Block | Annular | Second surface | Validation |
+|---|---|---|---|---|---|---|---|---|
+| [REFERENCE Annular Obscured Mirror](../../src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts) | explicit | `STO` -> `OBS` -> `M1` | IMG: z=0, y=0, n=(1, 0) | `M1` | `OBS` | `M1` -> `M1B` | None | OK |
+| [REFERENCE Annular Ring Blocker](../../src/lens-data/reference/ReferenceAnnularRingBlocker.data.ts) | auto | `RING` | IMG: z=120, y=0, n=(1, 0) | None | `RING` | `RING` -> `RINGB` | None | OK |
+| [REFERENCE Cassegrain Back Focus](../../src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts) | auto | `M1` -> `SEC` | IMG: z=135, y=0, n=(1, 0) | `SEC` -> `M1` | None | `M1` -> `M1B` | None | OK |
+| [REFERENCE Gregorian Secondary](../../src/lens-data/reference/ReferenceGregorianSecondary.data.ts) | explicit | `M1` -> `SEC` | IMG: z=135, y=0, n=(1, 0) | `M1` -> `SEC` | None | `M1` -> `M1B` | None | OK |
+| [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) | explicit | `MEN1` -> `MEN2` -> `M1` -> `SEC` | IMG: z=135, y=0, n=(1, 0) | `SEC` -> `M1` | None | `M1` -> `M1B` | None | OK |
+| [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) | explicit | `STO` -> `MG1` -> `MG2` -> `MG1` | IMG: z=35, y=0, n=(1, 0) | `MG2` | None | None | `MG2` | OK |
+| [REFERENCE Newtonian Side Focus](../../src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts) | auto | `M1` -> `SEC` | IMG: z=35, y=25, n=(0, 1) | `SEC` -> `M1` | None | None | None | OK |
+| [REFERENCE Spherical Primary Mirror](../../src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts) | explicit | `STO` -> `M1` | IMG: z=0, y=0, n=(1, 0) | `M1` | None | None | None | OK |
+
+## Fixture Details
+
+### [REFERENCE Annular Obscured Mirror](../../src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts)
+
+- Key: `reference-annular-obscured-mirror`
+- Path mode: explicit
+- Hit order: `STO` -> `OBS` -> `M1`
+- Image plane: IMG: z=0, y=0, n=(1, 0)
+- Reflective surfaces: `M1`
+- Blocking surfaces: `OBS`
+- Annular surfaces: `M1` -> `M1B`
+- Second-surface coatings: None
+- Tilted planes: None
+- Validation: OK
+
+### [REFERENCE Annular Ring Blocker](../../src/lens-data/reference/ReferenceAnnularRingBlocker.data.ts)
+
+- Key: `reference-annular-ring-blocker`
+- Path mode: auto
+- Hit order: `RING`
+- Image plane: IMG: z=120, y=0, n=(1, 0)
+- Reflective surfaces: None
+- Blocking surfaces: `RING`
+- Annular surfaces: `RING` -> `RINGB`
+- Second-surface coatings: None
+- Tilted planes: None
+- Validation: OK
+
+### [REFERENCE Cassegrain Back Focus](../../src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts)
+
+- Key: `reference-cassegrain-back-focus`
+- Path mode: auto
+- Hit order: `M1` -> `SEC`
+- Image plane: IMG: z=135, y=0, n=(1, 0)
+- Reflective surfaces: `SEC` -> `M1`
+- Blocking surfaces: None
+- Annular surfaces: `M1` -> `M1B`
+- Second-surface coatings: None
+- Tilted planes: None
+- Validation: OK
+
+### [REFERENCE Gregorian Secondary](../../src/lens-data/reference/ReferenceGregorianSecondary.data.ts)
+
+- Key: `reference-gregorian-secondary`
+- Path mode: explicit
+- Hit order: `M1` -> `SEC`
+- Image plane: IMG: z=135, y=0, n=(1, 0)
+- Reflective surfaces: `M1` -> `SEC`
+- Blocking surfaces: None
+- Annular surfaces: `M1` -> `M1B`
+- Second-surface coatings: None
+- Tilted planes: None
+- Validation: OK
+
+### [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts)
+
+- Key: `reference-maksutov-cassegrain-meniscus`
+- Path mode: explicit
+- Hit order: `MEN1` -> `MEN2` -> `M1` -> `SEC`
+- Image plane: IMG: z=135, y=0, n=(1, 0)
+- Reflective surfaces: `SEC` -> `M1`
+- Blocking surfaces: None
+- Annular surfaces: `M1` -> `M1B`
+- Second-surface coatings: None
+- Tilted planes: None
+- Validation: OK
+
+### [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts)
+
+- Key: `reference-mangin-second-surface-mirror`
+- Path mode: explicit
+- Hit order: `STO` -> `MG1` -> `MG2` -> `MG1`
+- Image plane: IMG: z=35, y=0, n=(1, 0)
+- Reflective surfaces: `MG2`
+- Blocking surfaces: None
+- Annular surfaces: None
+- Second-surface coatings: `MG2`
+- Tilted planes: None
+- Validation: OK
+
+### [REFERENCE Newtonian Side Focus](../../src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts)
+
+- Key: `reference-newtonian-side-focus`
+- Path mode: auto
+- Hit order: `M1` -> `SEC`
+- Image plane: IMG: z=35, y=25, n=(0, 1)
+- Reflective surfaces: `SEC` -> `M1`
+- Blocking surfaces: None
+- Annular surfaces: None
+- Second-surface coatings: None
+- Tilted planes: `SEC` -> `SECB`
+- Validation: OK
+
+### [REFERENCE Spherical Primary Mirror](../../src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts)
+
+- Key: `reference-spherical-primary-mirror`
+- Path mode: explicit
+- Hit order: `STO` -> `M1`
+- Image plane: IMG: z=0, y=0, n=(1, 0)
+- Reflective surfaces: `M1`
+- Blocking surfaces: None
+- Annular surfaces: None
+- Second-surface coatings: None
+- Tilted planes: None
+- Validation: OK
+

--- a/agent_docs/generated/sellmeier-coverage.generated.md
+++ b/agent_docs/generated/sellmeier-coverage.generated.md
@@ -9,11 +9,11 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **258** lenses scanned
+- **266** lenses scanned
 - **258** visible lenses scanned
 - **51** lenses fully covered
 - **51** visible lenses fully covered
-- **2266 / 2973** non-air surfaces use trusted Sellmeier data
+- **2266 / 2975** non-air surfaces use trusted Sellmeier data
 - **76.2%** surface coverage overall
 
 ## Fully Covered Lenses
@@ -293,16 +293,18 @@ Fully covered lenses are listed above; this table focuses on the remaining catal
 | 196 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
 | 197 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
 |  | **0-4.9% coverage** |  |  |  |  |  |
-| 198 | [Nikon Fuwatto Soft 90mm f/4.8](../../src/lens-data/nikon/NikonFuwattoSoft90mmf48.data.ts) | 0.0% | 0/2 | 0/2 | 2 | abbe: 2 |
-| 199 | [CARL ZEISS TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 200 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 201 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 202 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 203 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 204 | [Nikon AI Nikkor 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 205 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 206 | [CARL ZEISS SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 207 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
+| 198 | [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) *(hidden)* | 0.0% | 0/1 | 0/3 | 1 | abbe: 1 |
+| 199 | [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) *(hidden)* | 0.0% | 0/1 | 0/1 | 1 | abbe: 1 |
+| 200 | [Nikon Fuwatto Soft 90mm f/4.8](../../src/lens-data/nikon/NikonFuwattoSoft90mmf48.data.ts) | 0.0% | 0/2 | 0/2 | 2 | abbe: 2 |
+| 201 | [CARL ZEISS TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 202 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 203 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 204 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 205 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 206 | [Nikon AI Nikkor 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 207 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 208 | [CARL ZEISS SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 209 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
 
 ## Missing Surface Details
 

--- a/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
@@ -9,7 +9,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **258** lenses scanned
+- **266** lenses scanned
 - **254** total code-only elements found
 - **183** elements in this report
 - **75** distinct lens files affected

--- a/agent_docs/generated/six-digit-glass-codes.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes.generated.md
@@ -9,7 +9,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **258** lenses scanned
+- **266** lenses scanned
 - **254** total code-only elements found
 - **254** elements in this report
 - **92** distinct lens files affected

--- a/agent_docs/generated/unresolved-glass.generated.md
+++ b/agent_docs/generated/unresolved-glass.generated.md
@@ -8,10 +8,10 @@ or per-lens patent backfills.
 
 ## Summary
 
-- **258** lenses scanned
-- **2973** non-air surfaces examined
-- **2966** element glass declarations examined
-- **584** non-explicit-unmatched annotations did not resolve
+- **266** lenses scanned
+- **2975** non-air surfaces examined
+- **2979** element glass declarations examined
+- **597** non-explicit-unmatched annotations did not resolve
 - **218** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency

--- a/agent_docs/gotchas.md
+++ b/agent_docs/gotchas.md
@@ -12,6 +12,8 @@
   `{ z: 0, y: 1 }` is a horizontal side-focus plane. Do not assume folded systems image at the last surface's BFD
 - `interaction.normal` makes a surface a tilted meridional plane for tracing and SVG rendering. For a flat fold mirror
   with a visible backing plane, put the same normal on the backing surface or it will render as an untilted plate
+- Second-surface mirrors with `mirrorKind: "second-surface"` render a dashed coating accent in the SVG. That accent is
+  visual-only; reflection/refraction behavior still comes from `SurfaceData.interaction` and the resolved path
 - `innerSd` means a central hole in the active aperture; rays inside the hole pass through. Solid central obstructions
   should be separate `interaction: { type: "block" }` surfaces
 - Every analysis launch slope should flow through `projectionLaunchSlopeForField` in `src/optics/projection.ts` rather

--- a/agent_docs/gotchas.md
+++ b/agent_docs/gotchas.md
@@ -3,6 +3,17 @@
 - Optical calculations use paraxial approximation (small-angle) — standard for patent data
 - Exact surface tracing is the only trace path. The legacy vertex-plane tracer has been removed; do not
   reintroduce a per-lens rollout, a `traceMode` option, or trace-mode state in lens data files
+- Mirror and telescope prescriptions opt into folded behavior with `opticalPath`, `SurfaceData.interaction`, and
+  `innerSd`. Ordinary refractive lenses should omit those fields so they keep the default sequential front-to-rear model
+- `opticalPath.surfaceOrder` is a hit order, not a physical ordering requirement, and labels may repeat. Use it for
+  Mangin/second-surface or known folded paths; use `mode: "auto"` only when nearest-valid-surface selection is needed and
+  set a conservative `maxInteractions`
+- `opticalPath.imagePlane.normal` is a meridional normal. `{ z: 1, y: 0 }` is the ordinary vertical IMG plane, while
+  `{ z: 0, y: 1 }` is a horizontal side-focus plane. Do not assume folded systems image at the last surface's BFD
+- `interaction.normal` makes a surface a tilted meridional plane for tracing and SVG rendering. For a flat fold mirror
+  with a visible backing plane, put the same normal on the backing surface or it will render as an untilted plate
+- `innerSd` means a central hole in the active aperture; rays inside the hole pass through. Solid central obstructions
+  should be separate `interaction: { type: "block" }` surfaces
 - Every analysis launch slope should flow through `projectionLaunchSlopeForField` in `src/optics/projection.ts` rather
   than inline `-Math.tan(θ)`. The helper applies the shared `MAX_FIELD_LAUNCH_DEG = 89` guard; fisheye chief-ray solves
   route through the bounding-sphere vector path via `solveChiefRay`, and vector-aware callers should consume
@@ -30,6 +41,9 @@
 - Perspective-control movement is opt-in via `perspectiveControl`. Do not add SHIFT/TILT controls to ordinary lenses.
   The v1 movement layer is a 2D meridional visualization against a fixed IMG plane; analysis tabs remain centered-lens
   diagnostics and show a notice when movement is active
+- Folded mirror analysis is intentionally guarded by tab. Spherical aberration and mirror-safe blur helpers can use the
+  explicit image plane; cardinal, pupil, field, distortion, vignetting, and focus-breathing paths must stay hidden for
+  `L.isFoldedOptics` until their math is explicitly adapted and fixture-tested
 - Ray density is a persisted preference (`normal`, `dense`, `diagnostic`), not a URL field. `normal` must preserve the
   lens-authored `rayFractions` / `offAxisFractions` exactly; denser modes should go through `src/optics/raySampling.ts`
   so symmetry and chief rays stay predictable

--- a/agents.md
+++ b/agents.md
@@ -57,6 +57,8 @@ npm run organize:lens-data # Move stray root-level lens files into maker folders
 npm run preview
 npm run test
 npm run test:coverage
+npm run generate:glass-reports
+npm run generate:mirror-reports
 npm run typecheck
 npm run lint
 npm run lint:fix
@@ -83,7 +85,8 @@ Read only the relevant focused doc before changing that area:
 - `agent_docs/glass-catalog-buildout.md` - chromatic dispersion catalog, resolver, and how to add Sellmeier entries safely
 - `agent_docs/glass-relabel-followup.md` - per-lens catalog mismatch relabel queue and audit workflow pointers
 - `agent_docs/proprietary-glass-backfill.md` - patent line-index backfill workflow for unresolved proprietary glasses
-- `agent_docs/generated/` - generated glass reports and queues; refresh all with `npm run generate:glass-reports`
+- `agent_docs/generated/` - generated glass and mirror fixture reports; refresh glass reports with
+  `npm run generate:glass-reports` and hidden mirror fixture reports with `npm run generate:mirror-reports`
 - `agent_docs/records/exact-surface-trace.md` - historical staged implementation notes for the exact trace rollout
 - `TRACE_MODEL_IMPROVEMENT_PLAN.md` - current/historical fisheye projection, vector launch, and bounding-sphere trace status
 - `MIRROR_LENS_FUTURE_ENHANCEMENTS.md` - follow-up backlog for mirror-lens analysis, tracing, UI, and authoring improvements
@@ -130,7 +133,8 @@ Read only the relevant focused doc before changing that area:
 For a lens: start from `src/lens-data/TEMPLATE.data.ts.template`, use `satisfies LensDataInput`, optionally add a matching
 `*.analysis.md`, and populate `lensMounts` / `imageFormat` when the mount and format are unambiguous. For mirror or
 telescope designs, use the hidden fixtures under `src/lens-data/reference/` and the folded-path section of
-`src/lens-data/LENS_DATA_SPEC.md` as examples. Track backfill status in `agent_docs/lens-mount-format-backfill.md`.
+`src/lens-data/LENS_DATA_SPEC.md` as examples, then run `npm run generate:mirror-reports` if a hidden mirror fixture
+changed. Track backfill status in `agent_docs/lens-mount-format-backfill.md`.
 `npm run generate:metadata` or `npm run build` will move root-level draft lens files into maker folders and fix nested
 imports.
 

--- a/agents.md
+++ b/agents.md
@@ -115,8 +115,11 @@ Read only the relevant focused doc before changing that area:
 - Fisheye and ultra-wide field launch must go through `src/optics/projection.ts` and `solveChiefRay`; do not inline
   `Math.tan(field)` or bypass the bounding-sphere vector path.
 - Mirror/folded systems opt into `LensData.opticalPath` and per-surface `interaction` / `innerSd`. Preserve ordinary
-  sequential defaults for refractive lenses, use explicit `surfaceOrder` when hit order is known, and keep folded-system
-  paraxial analysis guarded until the specific tab is mirror-safe.
+  sequential defaults for refractive lenses, use explicit `surfaceOrder` when hit order is known, and route folded
+  stop/chief-ray solves through the generalized tracer instead of sequential `stopAt` partial traces.
+- Keep folded-system complex analysis tabs guarded until the specific tab is mirror-safe. Axial cardinal overlays and
+  mirror-safe spherical/blur paths are adapted; do not assume that for coma, distortion, vignetting, field curvature, or
+  pupil tabs without fixture-backed validation.
 - Keep slider-state-dependent analysis out of `buildLens()`; analysis tabs compute from current focus/zoom/aperture state.
 - Use existing shared utilities/components before adding new abstractions.
 - Use `src/components/markdown/ThemedMarkdown.tsx` for article and lens-description markdown.

--- a/agents.md
+++ b/agents.md
@@ -4,8 +4,9 @@
 
 LensVisualizer (public site: Surface & Stop) is an interactive React + TypeScript optical lens cross-section visualizer.
 It renders patent-derived camera lens sections as inline SVG, traces rays in real time, and exposes analysis tools for
-aberrations, pupils, distortion, vignetting, bokeh, chromatic behavior, glass, lens comparison, and perspective-control
-movement, including projection-aware fisheye tracing. The site is prerendered for SEO and deployed to Cloudflare Pages.
+aberrations, pupils, distortion, vignetting, bokeh, chromatic behavior, glass, lens comparison, perspective-control
+movement, folded mirror paths, annular apertures/obstructions, arbitrary image planes, and projection-aware fisheye
+tracing. The site is prerendered for SEO and deployed to Cloudflare Pages.
 
 ## Tech Stack
 
@@ -85,6 +86,7 @@ Read only the relevant focused doc before changing that area:
 - `agent_docs/generated/` - generated glass reports and queues; refresh all with `npm run generate:glass-reports`
 - `agent_docs/records/exact-surface-trace.md` - historical staged implementation notes for the exact trace rollout
 - `TRACE_MODEL_IMPROVEMENT_PLAN.md` - current/historical fisheye projection, vector launch, and bounding-sphere trace status
+- `MIRROR_LENS_FUTURE_ENHANCEMENTS.md` - follow-up backlog for mirror-lens analysis, tracing, UI, and authoring improvements
 - `agent_docs/adding_a_lens.md` - lens data workflow and validation troubleshooting
 - `agent_docs/lens-mount-format-backfill.md` - mount/format metadata backfill status and review queue
 - `agent_docs/lens-patent-audit.md` - standard procedure for re-checking a lens against its patent and logging the result
@@ -109,6 +111,9 @@ Read only the relevant focused doc before changing that area:
   or thread `mode` / `traceMode` options through new helpers.
 - Fisheye and ultra-wide field launch must go through `src/optics/projection.ts` and `solveChiefRay`; do not inline
   `Math.tan(field)` or bypass the bounding-sphere vector path.
+- Mirror/folded systems opt into `LensData.opticalPath` and per-surface `interaction` / `innerSd`. Preserve ordinary
+  sequential defaults for refractive lenses, use explicit `surfaceOrder` when hit order is known, and keep folded-system
+  paraxial analysis guarded until the specific tab is mirror-safe.
 - Keep slider-state-dependent analysis out of `buildLens()`; analysis tabs compute from current focus/zoom/aperture state.
 - Use existing shared utilities/components before adding new abstractions.
 - Use `src/components/markdown/ThemedMarkdown.tsx` for article and lens-description markdown.
@@ -123,9 +128,11 @@ Read only the relevant focused doc before changing that area:
 ## Adding Content
 
 For a lens: start from `src/lens-data/TEMPLATE.data.ts.template`, use `satisfies LensDataInput`, optionally add a matching
-`*.analysis.md`, and populate `lensMounts` / `imageFormat` when the mount and format are unambiguous. Track backfill
-status in `agent_docs/lens-mount-format-backfill.md`. `npm run generate:metadata` or `npm run build` will move
-root-level draft lens files into maker folders and fix nested imports.
+`*.analysis.md`, and populate `lensMounts` / `imageFormat` when the mount and format are unambiguous. For mirror or
+telescope designs, use the hidden fixtures under `src/lens-data/reference/` and the folded-path section of
+`src/lens-data/LENS_DATA_SPEC.md` as examples. Track backfill status in `agent_docs/lens-mount-format-backfill.md`.
+`npm run generate:metadata` or `npm run build` will move root-level draft lens files into maker folders and fix nested
+imports.
 
 For an article: create `src/content/**/*.md` with required `slug` and `title` frontmatter. Use `series` and
 `seriesOrder` for article series, and `toc: true` for long pieces. Run `npm run build` when route metadata should be

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run --testTimeout 30000",
     "test:coverage": "vitest run --coverage --testTimeout 30000",
     "generate:glass-reports": "vitest run --testTimeout 30000 unresolvedGlassScan catalogMismatchScan glassRelabelCandidatesScan glassRelabelByLensScan sixDigitGlassCodeScan sellmeierCoverageScan",
+    "generate:mirror-reports": "vitest run --testTimeout 30000 mirrorFixtureAuthoringReport",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/src/components/diagram/DiagramElementLayer.tsx
+++ b/src/components/diagram/DiagramElementLayer.tsx
@@ -86,6 +86,22 @@ const DiagramElementLayer = memo(function DiagramElementLayer({
         )),
       )}
 
+      {shapes.flatMap(({ surfaceAccentPaths }) =>
+        (surfaceAccentPaths || []).map(({ surfIdx, pathD, kind }) => (
+          <path
+            key={`surface-accent-${kind}-${surfIdx}`}
+            data-testid={`surface-accent-${kind}-${surfIdx}`}
+            d={pathD}
+            fill="none"
+            stroke={t.imgLine}
+            strokeWidth={Math.max(t.asphStrokeWidth, t.imgLineWidth + 0.4)}
+            strokeDasharray="3,2"
+            strokeLinecap="round"
+            style={{ pointerEvents: "none" }}
+          />
+        )),
+      )}
+
       {shapes.flatMap(({ asphPaths }) =>
         (asphPaths || []).map(({ surfIdx, labelX, labelY }) => (
           <text

--- a/src/components/diagram/DiagramElementLayer.tsx
+++ b/src/components/diagram/DiagramElementLayer.tsx
@@ -35,7 +35,7 @@ const DiagramElementLayer = memo(function DiagramElementLayer({
 }: DiagramElementLayerProps) {
   return (
     <>
-      {shapes.map(({ eid, d: path }) => {
+      {shapes.map(({ eid, d: path, fillRule }) => {
         const element = L.elements.find((candidate) => candidate.id === eid)!;
         const highlighted = act === eid;
         return (
@@ -43,6 +43,7 @@ const DiagramElementLayer = memo(function DiagramElementLayer({
             key={eid}
             d={path}
             fill={t.elemFill(element, highlighted)}
+            fillRule={fillRule}
             stroke={t.elemStroke(element, highlighted)}
             strokeWidth={highlighted ? t.elemStrokeActive : t.elemStrokeIdle}
             style={{

--- a/src/components/diagram/DiagramOverlayLayer.tsx
+++ b/src/components/diagram/DiagramOverlayLayer.tsx
@@ -45,6 +45,7 @@ interface DiagramOverlayLayerProps {
   showCardinalHiatus?: boolean;
   showCardinalTotalTrack?: boolean;
   cardinalElements?: CardinalElements | null;
+  foldedHitOrderLabels?: string[];
   zoomT: number;
   act: number | null;
   flashVisible: boolean;
@@ -83,6 +84,7 @@ export default function DiagramOverlayLayer({
   showCardinalHiatus = true,
   showCardinalTotalTrack = true,
   cardinalElements,
+  foldedHitOrderLabels = [],
   zoomT,
   act,
   flashVisible,
@@ -171,6 +173,36 @@ export default function DiagramOverlayLayer({
         act={act}
         showChromatic={showChromatic}
       />
+
+      {foldedHitOrderLabels.length > 0 &&
+        (() => {
+          const seen = new Map<string, number>();
+          return foldedHitOrderLabels.map((label, index) => {
+            const surfaceIdx = L.labelIdx[label];
+            if (surfaceIdx === undefined) return null;
+            const previousCount = seen.get(label) ?? 0;
+            seen.set(label, previousCount + 1);
+            const surface = L.S[surfaceIdx];
+            const labelOffset = previousCount * 8;
+            const [x, y] = screenPoint(zPos[surfaceIdx], -(surface.sd + 8 + labelOffset));
+            return (
+              <text
+                key={`folded-hit-${index}-${label}`}
+                x={x}
+                y={y}
+                textAnchor="middle"
+                fill={t.groupLabel}
+                fontSize={8.5}
+                fontFamily="inherit"
+                fontWeight={600}
+                opacity={0.92}
+                style={{ pointerEvents: "none", letterSpacing: "0.06em" }}
+              >
+                {index + 1} {label}
+              </text>
+            );
+          });
+        })()}
 
       {showPupils && (
         <>

--- a/src/components/diagram/DiagramOverlayLayer.tsx
+++ b/src/components/diagram/DiagramOverlayLayer.tsx
@@ -95,6 +95,20 @@ export default function DiagramOverlayLayer({
     const [zz, yy] = pointTransform ? pointTransform(z, y) : [z, y];
     return [sx(zz), sy(yy)];
   };
+  const imageNormal = L.imagePlane.normal;
+  const imageTangent = { z: imageNormal.y, y: -imageNormal.z };
+  const imageLineStart = screenPoint(
+    L.imagePlane.z - imageTangent.z * L.lyImgLine,
+    L.imagePlane.y - imageTangent.y * L.lyImgLine,
+  );
+  const imageLineEnd = screenPoint(
+    L.imagePlane.z + imageTangent.z * L.lyImgLine,
+    L.imagePlane.y + imageTangent.y * L.lyImgLine,
+  );
+  const imageLabel = screenPoint(
+    L.imagePlane.z + imageTangent.z * L.lyImgLabel,
+    L.imagePlane.y + imageTangent.y * L.lyImgLabel,
+  );
 
   return (
     <>
@@ -112,24 +126,24 @@ export default function DiagramOverlayLayer({
       />
 
       <line
-        x1={IX}
-        y1={sy(-L.lyImgLine)}
-        x2={IX}
-        y2={sy(L.lyImgLine)}
+        x1={imageLineStart[0]}
+        y1={imageLineStart[1]}
+        x2={imageLineEnd[0]}
+        y2={imageLineEnd[1]}
         stroke={t.imgLine}
         strokeWidth={t.imgLineWidth}
         strokeDasharray="4,3"
       />
       <text
-        x={IX}
-        y={sy(L.lyImgLabel)}
+        x={imageLabel[0]}
+        y={imageLabel[1]}
         textAnchor="middle"
         fill={t.imgLabel}
         fontSize={9.5}
         fontFamily="inherit"
         style={{ letterSpacing: "0.12em" }}
       >
-        IMG
+        {L.imagePlane.label}
       </text>
 
       {showChromatic && chromSpread && Object.keys(chromSpread.intercepts).length >= 2 && (

--- a/src/components/diagram/DiagramSVG.tsx
+++ b/src/components/diagram/DiagramSVG.tsx
@@ -61,6 +61,7 @@ interface DiagramSVGProps {
   showCardinalHiatus?: boolean;
   showCardinalTotalTrack?: boolean;
   cardinalElements?: CardinalElements | null;
+  foldedHitOrderLabels?: string[];
   zoomT: number;
   act: number | null;
   onHover: (eid: number | null) => void;
@@ -128,6 +129,7 @@ const DiagramSVG = memo(function DiagramSVG({
   showCardinalHiatus = true,
   showCardinalTotalTrack = true,
   cardinalElements,
+  foldedHitOrderLabels = [],
   zoomT,
   act,
   onHover,
@@ -242,6 +244,7 @@ const DiagramSVG = memo(function DiagramSVG({
         showCardinalHiatus={showCardinalHiatus}
         showCardinalTotalTrack={showCardinalTotalTrack}
         cardinalElements={cardinalElements}
+        foldedHitOrderLabels={foldedHitOrderLabels}
         zoomT={zoomT}
         act={act}
         flashVisible={flashVisible}

--- a/src/components/display/ElementInspector.tsx
+++ b/src/components/display/ElementInspector.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { CSSProperties } from "react";
-import type { RuntimeLens, ElementData } from "../../types/optics.js";
+import type { RuntimeLens, ElementData, ImagePlaneNormal, SurfaceData } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
 
 interface ElementInspectorProps {
@@ -26,7 +26,57 @@ const INSPECTOR_GRID: CSSProperties = {
   lineHeight: 1.8,
 };
 
+function fmtNumber(value: number): string {
+  if (Math.abs(value) < 1e-9) return "0";
+  return Number(value.toFixed(3)).toString();
+}
+
+function fmtMm(value: number): string {
+  return `${fmtNumber(value)} mm`;
+}
+
+function fmtNormal(normal: ImagePlaneNormal): string {
+  return `z=${fmtNumber(normal.z)} y=${fmtNumber(normal.y)}`;
+}
+
+function surfaceIndexesForElement(info: ElementData, L: RuntimeLens): number[] {
+  if (!L.S) return [];
+  const indexes = new Set<number>();
+  const span = L.ES?.find(([id]) => id === info.id);
+  if (span) {
+    for (let idx = span[1]; idx <= span[2]; idx++) {
+      if (L.S[idx]) indexes.add(idx);
+    }
+  }
+  L.S.forEach((surface, idx) => {
+    if (surface.elemId === info.id) indexes.add(idx);
+  });
+  return [...indexes].sort((a, b) => a - b);
+}
+
+function surfaceSummary(surface: SurfaceData): string | null {
+  const interaction = surface.interaction;
+  const pieces: string[] = [];
+  if (interaction) {
+    pieces.push(interaction.type);
+    if (interaction.mirrorKind) pieces.push(interaction.mirrorKind);
+    pieces.push(`active ${interaction.incidentSide ?? "both"}`);
+    if ((interaction.incidentSide ?? "both") !== "both") {
+      pieces.push(`inactive ${interaction.inactiveSide ?? "ignore"}`);
+    }
+    if (interaction.normal) pieces.push(`normal ${fmtNormal(interaction.normal)}`);
+  }
+  if (surface.innerSd !== undefined) pieces.push(`innerSd ${fmtMm(surface.innerSd)}`);
+  if (pieces.length === 0) return null;
+  return pieces.join(", ");
+}
+
 export default function ElementInspector({ info, L, t, showChromatic, onOpenAsphericCompare }: ElementInspectorProps) {
+  const foldedSurfaceRows = surfaceIndexesForElement(info, L)
+    .map((idx) => ({ surface: L.S[idx], summary: surfaceSummary(L.S[idx]) }))
+    .filter((row): row is { surface: SurfaceData; summary: string } => Boolean(row.summary));
+  const imagePlane = L.isFoldedOptics && L.data.opticalPath?.imagePlane ? L.imagePlane : null;
+
   return (
     <div>
       <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 6, flexWrap: "wrap" }}>
@@ -160,6 +210,24 @@ export default function ElementInspector({ info, L, t, showChromatic, onOpenAsph
           ));
         })()}
       </div>
+      {(foldedSurfaceRows.length > 0 || imagePlane) && (
+        <div style={{ ...INSPECTOR_GRID, marginTop: 6, paddingTop: 5, borderTop: `1px solid ${t.panelBorder}` }}>
+          {foldedSurfaceRows.map(({ surface, summary }) => (
+            <div key={surface.label} style={{ gridColumn: "1 / -1" }}>
+              <span style={{ color: t.propLabel }}>{surface.label}: </span>
+              <span style={{ color: t.value }}>{summary}</span>
+            </div>
+          ))}
+          {imagePlane && (
+            <div style={{ gridColumn: "1 / -1" }}>
+              <span style={{ color: t.propLabel }}>Image plane {imagePlane.label}: </span>
+              <span style={{ color: t.value }}>
+                z={fmtMm(imagePlane.z)} y={fmtMm(imagePlane.y)} normal {fmtNormal(imagePlane.normal)}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
       {showChromatic && info.vd && (
         <div style={{ ...INSPECTOR_GRID, marginTop: 4 }}>
           <div>

--- a/src/components/display/analysis/AberrationsPanel.tsx
+++ b/src/components/display/analysis/AberrationsPanel.tsx
@@ -87,19 +87,37 @@ export default function AberrationsPanel({
           theme={t}
         />
 
-        <FieldCurvatureSection
-          result={chromaticFieldCurvatureResult ?? fieldCurvatureResult}
-          expanded={fieldCurvatureExpanded}
-          onToggle={() => setFieldCurvatureExpanded((value) => !value)}
-          theme={t}
-        />
+        {L.isFoldedOptics ? (
+          <div
+            style={{
+              padding: "8px 10px",
+              border: `1px solid ${t.panelDivider}`,
+              borderRadius: 6,
+              color: t.desc,
+              background: t.panelBg,
+              lineHeight: 1.5,
+            }}
+          >
+            Field curvature and astigmatism remain hidden for folded mirror systems because those sections still assume
+            a sequential paraxial field model.
+          </div>
+        ) : (
+          <>
+            <FieldCurvatureSection
+              result={chromaticFieldCurvatureResult ?? fieldCurvatureResult}
+              expanded={fieldCurvatureExpanded}
+              onToggle={() => setFieldCurvatureExpanded((value) => !value)}
+              theme={t}
+            />
 
-        <AstigmatismSection
-          result={chromaticFieldCurvatureResult ?? fieldCurvatureResult}
-          expanded={astigmatismExpanded}
-          onToggle={() => setAstigmatismExpanded((value) => !value)}
-          theme={t}
-        />
+            <AstigmatismSection
+              result={chromaticFieldCurvatureResult ?? fieldCurvatureResult}
+              expanded={astigmatismExpanded}
+              onToggle={() => setAstigmatismExpanded((value) => !value)}
+              theme={t}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/hooks/raySegmentUtils.ts
+++ b/src/components/hooks/raySegmentUtils.ts
@@ -32,6 +32,7 @@ export function compileRaySegment(
   clampedRayEnd: (lastZ: number, lastY: number, u: number, targetZ: number) => [number, number],
   IMG_MM: number,
   endOverride?: number[],
+  reachedImagePlane = false,
 ): RaySegment {
   const sp: number[][] = pts.map(([z, yy]) => [sx(z), sy(yy)]);
   let gp: number[][] = [];
@@ -45,7 +46,7 @@ export function compileRaySegment(
       gp.push(endOverride ?? clampedRayEnd(lastGhost[0], lastGhost[1], u, IMG_MM));
     }
   }
-  if (!clipped) {
+  if (!clipped && !reachedImagePlane) {
     const last = pts[pts.length - 1];
     if (last) {
       sp.push(endOverride ?? clampedRayEnd(last[0], last[1], u, IMG_MM));

--- a/src/components/hooks/useChromaticRays.ts
+++ b/src/components/hooks/useChromaticRays.ts
@@ -13,7 +13,7 @@ import {
   traceRayChromatic,
   traceRayVectorChromatic,
 } from "../../optics/optics.js";
-import { rayFractionsForDensity } from "../../optics/raySampling.js";
+import { obstructionAwareRayFractionsForDensity } from "../../optics/raySampling.js";
 import type { RuntimeLens, ChromaticChannel, ChromaticSpread, ChromaticSpreadByAxis } from "../../types/optics.js";
 import type { LensMovementTransform } from "../../optics/lensMovement.js";
 import type { OffAxisMode, RayDensity } from "../../types/state.js";
@@ -127,7 +127,7 @@ export default function useChromaticRays({
     try {
       const out: ChromaticRaySegment[] = [];
       if (showOnAxis) {
-        for (const f of rayFractionsForDensity(L.rayFractions, rayDensity)) {
+        for (const f of obstructionAwareRayFractionsForDensity(L, L.rayFractions, rayDensity, currentEPSD)) {
           const h = f * currentEPSD;
           const uIn = rayTracksF ? h * focusK : 0;
           for (const ch of channels) {
@@ -182,7 +182,7 @@ export default function useChromaticRays({
           showOffAxis,
         });
         if (geometry) {
-          for (const f of rayFractionsForDensity(L.offAxisFractions, rayDensity)) {
+          for (const f of obstructionAwareRayFractionsForDensity(L, L.offAxisFractions, rayDensity, currentEPSD)) {
             const h = f * currentEPSD;
             const uConverge = rayTracksF ? h * focusK : 0;
             for (const ch of channels) {

--- a/src/components/hooks/useChromaticRays.ts
+++ b/src/components/hooks/useChromaticRays.ts
@@ -153,6 +153,8 @@ export default function useChromaticRays({
               sy,
               clampedRayEnd,
               IMG_MM,
+              undefined,
+              result.reachedImagePlane,
             );
             out.push({
               ...seg,
@@ -217,6 +219,7 @@ export default function useChromaticRays({
                 clampedRayEnd,
                 IMG_MM,
                 geometry.useEdge ? geometry.edgeEnd : undefined,
+                result.reachedImagePlane,
               );
               out.push({
                 ...seg,

--- a/src/components/hooks/useLensComputation.ts
+++ b/src/components/hooks/useLensComputation.ts
@@ -135,7 +135,7 @@ export default function useLensComputation({
   );
 
   const cardinalElements = useMemo(
-    () => (L ? computeCardinalElementsAtState(L, focusT, zoomT, zPos, IMG_MM, aberrationT) : null),
+    () => (L && !L.isFoldedOptics ? computeCardinalElementsAtState(L, focusT, zoomT, zPos, IMG_MM, aberrationT) : null),
     [L, focusT, zoomT, zPos, IMG_MM, aberrationT],
   );
 

--- a/src/components/hooks/useLensComputation.ts
+++ b/src/components/hooks/useLensComputation.ts
@@ -140,11 +140,18 @@ export default function useLensComputation({
   );
 
   const cardinalZExtent = useMemo(() => {
-    if (!includeCardinalExtents || !cardinalElements) return null;
+    const foldedExtent =
+      L && L.isFoldedOptics && zPos.length > 0
+        ? { min: Math.min(IMG_MM, ...zPos), max: Math.max(IMG_MM, ...zPos) }
+        : null;
+    if (!includeCardinalExtents || !cardinalElements) return foldedExtent;
     const pointZ = Object.values(cardinalElements.points).map((point) => point.z);
     const distanceZ = Object.values(cardinalElements.distances).flatMap((distance) => [distance.fromZ, distance.toZ]);
-    return { min: Math.min(...pointZ, ...distanceZ), max: Math.max(...pointZ, ...distanceZ) };
-  }, [includeCardinalExtents, cardinalElements]);
+    return {
+      min: Math.min(foldedExtent?.min ?? Infinity, ...pointZ, ...distanceZ),
+      max: Math.max(foldedExtent?.max ?? -Infinity, ...pointZ, ...distanceZ),
+    };
+  }, [includeCardinalExtents, cardinalElements, L, zPos, IMG_MM]);
 
   /* ── Coordinate transforms (optical mm → SVG pixels) ── */
   const { sx, sy, clampedRayEnd, CX, IX, effectiveSC } = useMemo(

--- a/src/components/hooks/useLensComputation.ts
+++ b/src/components/hooks/useLensComputation.ts
@@ -135,7 +135,7 @@ export default function useLensComputation({
   );
 
   const cardinalElements = useMemo(
-    () => (L && !L.isFoldedOptics ? computeCardinalElementsAtState(L, focusT, zoomT, zPos, IMG_MM, aberrationT) : null),
+    () => (L ? computeCardinalElementsAtState(L, focusT, zoomT, zPos, IMG_MM, aberrationT) : null),
     [L, focusT, zoomT, zPos, IMG_MM, aberrationT],
   );
 

--- a/src/components/hooks/useOffAxisRays.ts
+++ b/src/components/hooks/useOffAxisRays.ts
@@ -111,6 +111,7 @@ export default function useOffAxisRays({
             clampedRayEnd,
             IMG_MM,
             geometry.useEdge ? geometry.edgeEnd : undefined,
+            result.reachedImagePlane,
           ),
         );
       }

--- a/src/components/hooks/useOffAxisRays.ts
+++ b/src/components/hooks/useOffAxisRays.ts
@@ -8,7 +8,7 @@
  */
 import { useMemo } from "react";
 import { offsetVectorFieldRay, traceRay, traceRayVector } from "../../optics/optics.js";
-import { rayFractionsForDensity } from "../../optics/raySampling.js";
+import { obstructionAwareRayFractionsForDensity } from "../../optics/raySampling.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { LensMovementTransform } from "../../optics/lensMovement.js";
 import type { RaySegment } from "./useOnAxisRays.js";
@@ -76,7 +76,7 @@ export default function useOffAxisRays({
         showOffAxis,
       });
       if (geometry === null) return { segments: [], error: null };
-      for (const f of rayFractionsForDensity(L.offAxisFractions, rayDensity)) {
+      for (const f of obstructionAwareRayFractionsForDensity(L, L.offAxisFractions, rayDensity, currentEPSD)) {
         const h = f * currentEPSD;
         const uConverge = rayTracksF ? h * focusK : 0;
         const rawResult =

--- a/src/components/hooks/useOnAxisRays.ts
+++ b/src/components/hooks/useOnAxisRays.ts
@@ -8,7 +8,7 @@
  */
 import { useMemo } from "react";
 import { traceRay } from "../../optics/optics.js";
-import { rayFractionsForDensity } from "../../optics/raySampling.js";
+import { obstructionAwareRayFractionsForDensity } from "../../optics/raySampling.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { RayDensity } from "../../types/state.js";
 import type { LensMovementTransform } from "../../optics/lensMovement.js";
@@ -65,7 +65,7 @@ export default function useOnAxisRays({
     if (!L) return { segments: [], error: null };
     try {
       const out: RaySegment[] = [];
-      for (const f of rayFractionsForDensity(L.rayFractions, rayDensity)) {
+      for (const f of obstructionAwareRayFractionsForDensity(L, L.rayFractions, rayDensity, currentEPSD)) {
         const h = f * currentEPSD;
         const uIn = rayTracksF ? h * focusK : 0;
         const rawResult = traceRay(h, uIn, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT);

--- a/src/components/hooks/useOnAxisRays.ts
+++ b/src/components/hooks/useOnAxisRays.ts
@@ -71,7 +71,18 @@ export default function useOnAxisRays({
         const rawResult = traceRay(h, uIn, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT);
         const result = movementTransform ? movementTransform.trace(rawResult) : rawResult;
         out.push(
-          compileRaySegment(result.pts, result.ghostPts, result.u, result.clipped, sx, sy, clampedRayEnd, IMG_MM),
+          compileRaySegment(
+            result.pts,
+            result.ghostPts,
+            result.u,
+            result.clipped,
+            sx,
+            sy,
+            clampedRayEnd,
+            IMG_MM,
+            undefined,
+            result.reachedImagePlane,
+          ),
         );
       }
       return { segments: out, error: null };

--- a/src/components/layout/LensDiagramPanel.tsx
+++ b/src/components/layout/LensDiagramPanel.tsx
@@ -40,6 +40,7 @@ import LensGroupMovementOverlay from "../display/overlays/LensGroupMovementOverl
 import LensDiagramErrorState from "./lensDiagram/LensDiagramErrorState.js";
 import LensDiagramLoadedState from "./lensDiagram/LensDiagramLoadedState.js";
 import type { RuntimeLens } from "../../types/optics.js";
+import { foldedHitOrderLabelsForDisplay } from "../../optics/foldedPathDisplay.js";
 import { isHeavyLensForRayWork } from "../../optics/raySampling.js";
 import { normalizePanelId, selectedElementKeyForPanel } from "../../types/state.js";
 
@@ -208,6 +209,19 @@ export default function LensDiagramPanel({
     includeCardinalExtents: ENABLE_CARDINAL_ELEMENTS && (showCardinals || showCardinalDimensions),
   });
   const resolvedMovement = movement ?? { shiftMm: 0, tiltDeg: 0, active: false };
+  const foldedHitOrderLabels = useMemo(
+    () =>
+      foldedHitOrderLabelsForDisplay({
+        L,
+        zPos,
+        focusT,
+        zoomT,
+        aberrationT,
+        currentPhysStopSD,
+        currentEPSD,
+      }),
+    [L, zPos, focusT, zoomT, aberrationT, currentPhysStopSD, currentEPSD],
+  );
 
   useEffect(() => {
     if (!L || sel == null) return;
@@ -365,6 +379,7 @@ export default function LensDiagramPanel({
             act,
             sel,
             cardinalElements,
+            foldedHitOrderLabels,
           }}
           rayData={{
             chromSpread: chromSpread ?? null,

--- a/src/components/layout/LensViewer.tsx
+++ b/src/components/layout/LensViewer.tsx
@@ -19,7 +19,7 @@
 import { useMemo, useCallback } from "react";
 import { useNavigate } from "react-router";
 
-import { LENS_CATALOG, CATALOG_KEYS, mdForKey } from "../../utils/catalog/lensCatalog.js";
+import { ALL_CATALOG_KEYS, LENS_CATALOG, CATALOG_KEYS, mdForKey } from "../../utils/catalog/lensCatalog.js";
 import usePreferences from "../../utils/state/usePreferences.js";
 import useURLSync from "../../utils/state/useURLSync.js";
 import { LensStateContext, LensDispatchContext, PanelStateContext } from "../../utils/state/LensContext.js";
@@ -70,7 +70,13 @@ export default function LensVisualization({ initialLensKey, initialLensKeyB }: L
   const navigate = useNavigate();
   const isComparePage = !!initialLensKey && !!initialLensKeyB;
   const isLensPage = !!initialLensKey && !initialLensKeyB;
-  const [state, dispatch, isWide] = useLensState(CATALOG_KEYS, initialLensKey, initialLensKeyB);
+  const viewerCatalogKeys = useMemo(() => {
+    const needsHiddenCatalog =
+      (initialLensKey !== undefined && !CATALOG_KEYS.includes(initialLensKey)) ||
+      (initialLensKeyB !== undefined && !CATALOG_KEYS.includes(initialLensKeyB));
+    return needsHiddenCatalog ? ALL_CATALOG_KEYS : CATALOG_KEYS;
+  }, [initialLensKey, initialLensKeyB]);
+  const [state, dispatch, isWide] = useLensState(viewerCatalogKeys, initialLensKey, initialLensKeyB);
 
   /* ── Destructure state slices for convenient access ── */
   const { lens, display, rays, sharedSliders, panels, overlays } = state;
@@ -119,7 +125,7 @@ export default function LensVisualization({ initialLensKey, initialLensKeyB }: L
     handleFocusPointerDown,
     handleAperturePointerDown,
     toggleCompare,
-  } = useComparisonOrchestration({ state, dispatch, navigate, catalogKeys: CATALOG_KEYS });
+  } = useComparisonOrchestration({ state, dispatch, navigate, catalogKeys: viewerCatalogKeys });
 
   /* ── Overlay management: primer level, escape key, open/close callbacks ── */
   const {
@@ -169,7 +175,10 @@ export default function LensVisualization({ initialLensKey, initialLensKeyB }: L
   const t = resolveTheme(resolvedDark, highContrast);
 
   /* ── Catalog names map for TopBar (avoids passing full LENS_CATALOG) ── */
-  const catalogNames = useMemo(() => Object.fromEntries(CATALOG_KEYS.map((k) => [k, LENS_CATALOG[k].name])), []);
+  const catalogNames = useMemo(
+    () => Object.fromEntries(viewerCatalogKeys.map((k) => [k, LENS_CATALOG[k].name])),
+    [viewerCatalogKeys],
+  );
 
   /* ── Lens switching (single-lens mode resets sliders, comparison mode does not) ── */
   const switchLensA = useCallback(
@@ -271,7 +280,7 @@ export default function LensVisualization({ initialLensKey, initialLensKeyB }: L
               onOpenAboutAuthor={openAboutAuthor}
               onOpenOpticsPrimer={openOpticsPrimer}
               onOpenAberrationsPrimer={openAberrationsPrimer}
-              catalogKeys={CATALOG_KEYS}
+              catalogKeys={viewerCatalogKeys}
               catalogNames={catalogNames}
               controlsBarProps={controlsBarProps}
               mobileView={mobileView}

--- a/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
+++ b/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
@@ -25,7 +25,6 @@ interface AnalysisDrawerContentProps {
 }
 
 const FOLDED_OPTICS_UNSUPPORTED_TABS = new Set<AnalysisTabId>([
-  "aberrations",
   "coma",
   "distortion",
   "breathing",

--- a/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
+++ b/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
@@ -3,6 +3,7 @@ import { ANALYSIS_TAB_RENDERERS } from "./analysisTabRenderers.js";
 import type { RuntimeLens } from "../../../types/optics.js";
 import type { Theme } from "../../../types/theme.js";
 import type { FieldGeometryState } from "../../../optics/optics.js";
+import { traceRay } from "../../../optics/optics.js";
 import { isFisheyeProjection, projectionValueAtZoom } from "../../../optics/projection.js";
 import type { AnalysisTabId } from "../../../types/state.js";
 
@@ -24,13 +25,7 @@ interface AnalysisDrawerContentProps {
   onAberrationsExpandedChange: (expanded: boolean) => void;
 }
 
-const FOLDED_OPTICS_UNSUPPORTED_TABS = new Set<AnalysisTabId>([
-  "coma",
-  "distortion",
-  "breathing",
-  "vignetting",
-  "pupils",
-]);
+const FOLDED_OPTICS_UNSUPPORTED_TABS = new Set<AnalysisTabId>(["coma", "distortion", "vignetting", "pupils"]);
 
 export default function AnalysisDrawerContent({
   activeTab,
@@ -100,18 +95,48 @@ export default function AnalysisDrawerContent({
   const foldedOpticsText = L.isFoldedOptics
     ? "Folded mirror optical path detected. Ray drawing uses the generalized folded tracer; sequential paraxial diagnostics are guarded until mirror-safe analysis is enabled for each tab."
     : null;
+  const foldedTraceDiagnostics = useMemo(() => {
+    const env = (import.meta as { env?: { DEV?: boolean } }).env;
+    if (!env?.DEV || !L.isFoldedOptics || !Array.isArray(L.S) || zPos.length < L.N) return null;
+
+    try {
+      return traceRay(
+        0,
+        0,
+        zPos,
+        analysisInputs.focusT,
+        analysisInputs.zoomT,
+        analysisInputs.currentPhysStopSD,
+        true,
+        L,
+      ).diagnostics;
+    } catch {
+      return null;
+    }
+  }, [L, zPos, analysisInputs.focusT, analysisInputs.zoomT, analysisInputs.currentPhysStopSD]);
+  const foldedTraceDiagnosticsText = foldedTraceDiagnostics
+    ? `Trace diagnostics: ${foldedTraceDiagnostics.expectedPathMode} path, hits ${
+        foldedTraceDiagnostics.hitSurfaceLabels.length > 0
+          ? foldedTraceDiagnostics.hitSurfaceLabels.join(" -> ")
+          : "none"
+      }, image plane ${foldedTraceDiagnostics.reachedImagePlane ? "reached" : "not reached"}, final n=${foldedTraceDiagnostics.finalMedium.toFixed(3)}${
+        foldedTraceDiagnostics.clipEvents.length > 0
+          ? `, clips ${foldedTraceDiagnostics.clipEvents.map((event) => event.reason).join(", ")}`
+          : ""
+      }.`
+    : null;
   const foldedUnsupported = L.isFoldedOptics && FOLDED_OPTICS_UNSUPPORTED_TABS.has(activeTab);
   const foldedUnsupportedContent = (
     <div style={noticeStyle}>
       This analysis tab is not available for folded mirror systems yet. Its current math assumes a front-to-rear
-      refractive sequence, so the tab is hidden here instead of showing misleading cardinal, pupil, field, or focus
-      results.
+      refractive sequence, so the tab is hidden here instead of showing misleading pupil, field, or off-axis results.
     </div>
   );
   const withAnalysisNotices = (content: ReactNode) => (
     <>
       {fisheyeProjectionText && <div style={noticeStyle}>{fisheyeProjectionText}</div>}
       {foldedOpticsText && <div style={noticeStyle}>{foldedOpticsText}</div>}
+      {foldedTraceDiagnosticsText && <div style={noticeStyle}>{foldedTraceDiagnosticsText}</div>}
       {movementActive && (
         <div style={noticeStyle}>
           Tilt/shift is active. Analysis tabs use the centered-lens diagnostics in this first movement pass.

--- a/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
+++ b/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
@@ -24,6 +24,15 @@ interface AnalysisDrawerContentProps {
   onAberrationsExpandedChange: (expanded: boolean) => void;
 }
 
+const FOLDED_OPTICS_UNSUPPORTED_TABS = new Set<AnalysisTabId>([
+  "aberrations",
+  "coma",
+  "distortion",
+  "breathing",
+  "vignetting",
+  "pupils",
+]);
+
 export default function AnalysisDrawerContent({
   activeTab,
   L,
@@ -71,6 +80,16 @@ export default function AnalysisDrawerContent({
 
   const analysisInputs = sliderInteracting ? lastSettledInputsRef.current : deferredInputs;
   const projection = L.projection ?? { kind: "rectilinear" };
+  const noticeStyle = {
+    margin: "0 0 12px",
+    padding: "8px 10px",
+    border: `1px solid ${t.panelDivider}`,
+    borderRadius: 6,
+    color: t.desc,
+    background: t.panelBg,
+    fontSize: 10,
+    lineHeight: 1.5,
+  };
   const fisheyeProjectionText = (() => {
     if (!isFisheyeProjection(projection)) return null;
     const fullFieldDeg = projectionValueAtZoom(projection.fullFieldDeg, analysisInputs.zoomT);
@@ -79,37 +98,23 @@ export default function AnalysisDrawerContent({
       imageCircleMm ? ` over a ${imageCircleMm.toFixed(1)} mm image circle` : ""
     }. Analysis tabs use the central forward-traced cone; the full field is projection metadata, not a rectilinear trace.`;
   })();
+  const foldedOpticsText = L.isFoldedOptics
+    ? "Folded mirror optical path detected. Ray drawing uses the generalized folded tracer; sequential paraxial diagnostics are guarded until mirror-safe analysis is enabled for each tab."
+    : null;
+  const foldedUnsupported = L.isFoldedOptics && FOLDED_OPTICS_UNSUPPORTED_TABS.has(activeTab);
+  const foldedUnsupportedContent = (
+    <div style={noticeStyle}>
+      This analysis tab is not available for folded mirror systems yet. Its current math assumes a front-to-rear
+      refractive sequence, so the tab is hidden here instead of showing misleading cardinal, pupil, field, or focus
+      results.
+    </div>
+  );
   const withAnalysisNotices = (content: ReactNode) => (
     <>
-      {fisheyeProjectionText && (
-        <div
-          style={{
-            margin: "0 0 12px",
-            padding: "8px 10px",
-            border: `1px solid ${t.panelDivider}`,
-            borderRadius: 6,
-            color: t.desc,
-            background: t.panelBg,
-            fontSize: 10,
-            lineHeight: 1.5,
-          }}
-        >
-          {fisheyeProjectionText}
-        </div>
-      )}
+      {fisheyeProjectionText && <div style={noticeStyle}>{fisheyeProjectionText}</div>}
+      {foldedOpticsText && <div style={noticeStyle}>{foldedOpticsText}</div>}
       {movementActive && (
-        <div
-          style={{
-            margin: "0 0 12px",
-            padding: "8px 10px",
-            border: `1px solid ${t.panelDivider}`,
-            borderRadius: 6,
-            color: t.desc,
-            background: t.panelBg,
-            fontSize: 10,
-            lineHeight: 1.5,
-          }}
-        >
+        <div style={noticeStyle}>
           Tilt/shift is active. Analysis tabs use the centered-lens diagnostics in this first movement pass.
         </div>
       )}
@@ -118,13 +123,15 @@ export default function AnalysisDrawerContent({
   );
 
   return withAnalysisNotices(
-    ANALYSIS_TAB_RENDERERS[activeTab]({
-      L,
-      t,
-      zPos,
-      inputs: analysisInputs,
-      aberrationsExpanded,
-      onAberrationsExpandedChange,
-    }),
+    foldedUnsupported
+      ? foldedUnsupportedContent
+      : ANALYSIS_TAB_RENDERERS[activeTab]({
+          L,
+          t,
+          zPos,
+          inputs: analysisInputs,
+          aberrationsExpanded,
+          onAberrationsExpandedChange,
+        }),
   );
 }

--- a/src/components/layout/lensDiagram/DiagramViewport.tsx
+++ b/src/components/layout/lensDiagram/DiagramViewport.tsx
@@ -92,6 +92,7 @@ export default function DiagramViewport({
   showCardinalHiatus,
   showCardinalTotalTrack,
   cardinalElements,
+  foldedHitOrderLabels,
   act,
   onHover,
   onSelect,
@@ -227,6 +228,7 @@ export default function DiagramViewport({
         showCardinalHiatus={showCardinalHiatus}
         showCardinalTotalTrack={showCardinalTotalTrack}
         cardinalElements={cardinalElements}
+        foldedHitOrderLabels={foldedHitOrderLabels}
         zoomT={zoomT}
         act={act}
         onHover={onHover}

--- a/src/components/layout/lensDiagram/LensDiagramLoadedState.tsx
+++ b/src/components/layout/lensDiagram/LensDiagramLoadedState.tsx
@@ -58,6 +58,7 @@ export default function LensDiagramLoadedState({
     act,
     sel,
     cardinalElements,
+    foldedHitOrderLabels,
   } = computed;
   const { chromSpread, chromaticSpreads, rays, offAxisRays, chromaticRays } = rayData;
   const {
@@ -147,6 +148,7 @@ export default function LensDiagramLoadedState({
             showCardinalHiatus={showCardinalHiatus}
             showCardinalTotalTrack={showCardinalTotalTrack}
             cardinalElements={cardinalElements}
+            foldedHitOrderLabels={foldedHitOrderLabels}
             zoomT={zoomT}
             act={act}
             onHover={onHover}

--- a/src/components/layout/lensDiagram/panelModel.ts
+++ b/src/components/layout/lensDiagram/panelModel.ts
@@ -51,6 +51,7 @@ export interface PanelComputedModel {
   act: number | null;
   sel: number | null;
   cardinalElements: CardinalElements | null;
+  foldedHitOrderLabels: string[];
 }
 
 export interface PanelRayDataModel {

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -242,6 +242,7 @@ Field meanings:
 
 - `type: "refract"` applies normal Snell refraction. It is also useful for a passive backing plane that needs the same tilted visual geometry as a mirror face.
 - `type: "reflect"` reflects the ray using the solved surface normal. Use `mirrorKind: "first-surface"` for front-coated mirrors and `mirrorKind: "second-surface"` for substrate-backed reflective surfaces.
+- `mirrorKind: "second-surface"` also tells the SVG renderer to draw a dashed coating accent on that surface so the coating is visible apart from the glass substrate. The accent is display-only; tracing follows `type`, `incidentSide`, `inactiveSide`, and the optical path.
 - `type: "block"` clips rays within the surface's active aperture. It is intended for central obstructions, baffles, and synthetic regression fixtures.
 - `incidentSide` limits which side of the surface is active. The side is relative to the solved surface normal, not the list position in `surfaces`. If a ray hits the inactive side, `inactiveSide: "ignore"` lets it pass and `inactiveSide: "block"` clips it inside the active disk or annulus.
 - `normal` converts the surface into a tilted meridional plane for both tracing and SVG element rendering. Use this for flat fold mirrors. Curved mirrors should normally omit `normal` so the spherical/aspherical sag and local normal come from `R` and `asph`.
@@ -344,6 +345,9 @@ Mirror/telescope regression fixtures live under `src/lens-data/reference/`. They
 - `ReferenceCassegrainBackFocus.data.ts` — obstruction plus folded back-focus behavior.
 
 Use these as authoring examples and regression anchors, not as polished public catalog entries.
+
+For a compact audit of hidden mirror fixture metadata, run `npm run generate:mirror-reports` and review
+`agent_docs/generated/mirror-fixtures.generated.md`.
 
 ---
 

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -231,7 +231,7 @@ Surfaces default to `interaction: { type: "refract" }`. Add `interaction` only w
   interaction: {
     type: "reflect",                   // "refract" | "reflect" | "block"
     incidentSide: "rear",              // optional: "front" | "rear" | "both"; default both
-    inactiveSide: "ignore",            // optional override: reflect defaults block, others ignore
+    inactiveSide: "block",             // reference mirrors should block inactive-side hits
     mirrorKind: "first-surface",       // optional: "first-surface" | "second-surface"
     normal: { z: 1, y: 1 },             // optional tilted meridional plane normal
   },
@@ -244,7 +244,7 @@ Field meanings:
 - `type: "reflect"` reflects the ray using the solved surface normal. Use `mirrorKind: "first-surface"` for front-coated mirrors and `mirrorKind: "second-surface"` for substrate-backed reflective surfaces.
 - `mirrorKind: "second-surface"` also tells the SVG renderer to draw a dashed coating accent on that surface so the coating is visible apart from the glass substrate. The accent is display-only; tracing follows `type`, `incidentSide`, `inactiveSide`, and the optical path.
 - `type: "block"` clips rays within the surface's active aperture. It is intended for central obstructions, baffles, and synthetic regression fixtures.
-- `incidentSide` limits which side of the surface is active. The side is relative to the solved surface normal, not the list position in `surfaces`. If a ray hits a reflective surface from its inactive side, it blocks by default inside the active disk or annulus. Set `inactiveSide: "ignore"` only for intentional pass-through cases such as a Newtonian diagonal's first pass. Refractive and blocker surfaces keep the historical inactive-side default of ignore unless `inactiveSide: "block"` is explicit.
+- `incidentSide` limits which side of the surface is active. The side is relative to the solved surface normal, not the list position in `surfaces`. If a ray hits a reflective surface from its inactive side, it blocks by default inside the active disk or annulus. Reference mirror fixtures should declare `inactiveSide: "block"` explicitly so back-side opacity is clear in the data. Refractive and blocker surfaces keep the historical inactive-side default of ignore unless `inactiveSide: "block"` is explicit.
 - `normal` converts the surface into a tilted meridional plane for both tracing and SVG element rendering. Use this for flat fold mirrors. Curved mirrors should normally omit `normal` so the spherical/aspherical sag and local normal come from `R` and `asph`.
 
 Choosing `incidentSide`:
@@ -252,7 +252,8 @@ Choosing `incidentSide`:
 - For an incoming beam traveling left-to-right into a concave primary whose sag-derived normal faces the object side,
   start with `incidentSide: "front"`. This is the usual first-surface primary case.
 - For a beam returning right-to-left toward a diagonal flat after the primary reflection, use `incidentSide: "rear"` and
-  `inactiveSide: "ignore"` on the diagonal so the first pass goes through and the return pass reflects.
+  `inactiveSide: "block"` on the diagonal so the incoming beam is obstructed inside the secondary aperture and the
+  returning beam reflects from the active side.
 - For a Mangin or other second-surface mirror, set `incidentSide` on the reflective coating side reached after the ray
   enters the substrate. Keep the refractive front surface ordinary, then repeat that front label in `surfaceOrder` for
   the exit path.
@@ -288,7 +289,7 @@ First-surface concave primary with an image plane in front:
 ```javascript
 surfaces: [
   { label: "STO", R: 1e15, d: 100, nd: 1.0, elemId: 0, sd: 25 },
-  { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 25, interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" } },
+  { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 25, interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" } },
 ],
 opticalPath: {
   surfaceOrder: ["STO", "M1"],
@@ -301,7 +302,7 @@ Second-surface Mangin-style path through a glass front surface, reflective rear 
 ```javascript
 surfaces: [
   { label: "MG1", R: 120, d: 8, nd: 1.5168, elemId: 1, sd: 22 },
-  { label: "MG2", R: -100, d: 0, nd: 1.0, elemId: 0, sd: 22, interaction: { type: "reflect", incidentSide: "front", mirrorKind: "second-surface" } },
+  { label: "MG2", R: -100, d: 0, nd: 1.0, elemId: 0, sd: 22, interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "second-surface" } },
 ],
 opticalPath: {
   surfaceOrder: ["MG1", "MG2", "MG1"],
@@ -326,10 +327,10 @@ surfaces: [
     nd: 1.0,
     elemId: 2,
     sd: 10,
-    interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "ignore", mirrorKind: "first-surface", normal: { z: 1, y: 1 } },
+    interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "block", mirrorKind: "first-surface", normal: { z: 1, y: 1 } },
   },
   { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 10, interaction: { type: "refract", normal: { z: 1, y: 1 } } },
-  { label: "M1", R: -200, d: 2, nd: 1.0, elemId: 1, sd: 30, interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" } },
+  { label: "M1", R: -200, d: 2, nd: 1.0, elemId: 1, sd: 30, interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" } },
   { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30 },
 ],
 ```
@@ -511,7 +512,7 @@ Each entry in the `surfaces` array describes one optical surface, in physical fr
   sd:     14.5,       // REQUIRED: outer semi-diameter (half clear aperture) in mm
   innerSd: 4.0,       // optional: inner semi-diameter for annular active apertures
   stopPlacement: "inside-element", // optional: only valid on an embedded STO surface
-  interaction: { type: "reflect", mirrorKind: "first-surface" }, // optional folded-path behavior
+  interaction: { type: "reflect", inactiveSide: "block", mirrorKind: "first-surface" }, // optional folded-path behavior
 }
 ```
 

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -246,6 +246,18 @@ Field meanings:
 - `incidentSide` limits which side of the surface is active. The side is relative to the solved surface normal, not the list position in `surfaces`. If a ray hits the inactive side, `inactiveSide: "ignore"` lets it pass and `inactiveSide: "block"` clips it inside the active disk or annulus.
 - `normal` converts the surface into a tilted meridional plane for both tracing and SVG element rendering. Use this for flat fold mirrors. Curved mirrors should normally omit `normal` so the spherical/aspherical sag and local normal come from `R` and `asph`.
 
+Choosing `incidentSide`:
+
+- For an incoming beam traveling left-to-right into a concave primary whose sag-derived normal faces the object side,
+  start with `incidentSide: "front"`. This is the usual first-surface primary case.
+- For a beam returning right-to-left toward a diagonal flat after the primary reflection, use `incidentSide: "rear"` on
+  the diagonal so the first pass can ignore the inactive face and the return pass reflects.
+- For a Mangin or other second-surface mirror, set `incidentSide` on the reflective coating side reached after the ray
+  enters the substrate. Keep the refractive front surface ordinary, then repeat that front label in `surfaceOrder` for
+  the exit path.
+- When the SVG looks correct but every ray is blocked or ignored, flip only `incidentSide` first. If the design then
+  works, leave the surface normal alone unless it is a flat fold plane whose visual tilt is wrong.
+
 ### Annular Apertures And Obstructions
 
 Any surface may declare `innerSd` to define an annular active aperture:
@@ -785,7 +797,7 @@ doublets: [
 14. Conic height limit: for aspherical surfaces with K > 0, sd ≤ 0.98 × |R| / √(1+K)
 15. Element render diagnostics: production lenses must not require material hidden trim (>0.25 mm) from slope, conic, or cross-gap limits
 16. `innerSd` must be finite, non-negative, and smaller than `sd`
-17. `interaction.type` must be `"refract"`, `"reflect"`, or `"block"`; side fields must be valid enum values; `normal` vectors must have finite `z` and `y` components
+17. `interaction.type` must be `"refract"`, `"reflect"`, or `"block"`; side fields must be valid enum values; `normal` vectors must have finite `z` and `y` components; tilted flat mirror backing planes must repeat the reflective face normal
 18. `opticalPath.mode` must be `"sequential"` or `"auto"`; `surfaceOrder` labels must exist; `imagePlane` point/normal fields must be finite; `maxInteractions` must be a positive integer
 
 On failure, `buildLens()` throws with all errors listed.

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -203,7 +203,7 @@ opticalPath: {
 - `mode: "sequential"` preserves the historical behavior unless `surfaceOrder` is present. With a `surfaceOrder`, the generalized tracer follows that label list exactly and then intersects the configured image plane. This is the safest choice for Mangin mirrors and other designs where the physical surface order is not the optical hit order.
 - `mode: "auto"` asks the generalized tracer to choose the nearest valid optical surface at each step. It skips passive same-index refractive surfaces, respects side-specific reflection/blocking behavior, avoids immediate self-hits, stops at the image plane when it is the next intersection, and stops at `maxInteractions` if a path does not terminate.
 - `surfaceOrder` entries are surface labels, not indices. Labels must exist, and labels may repeat when a ray intentionally re-enters or exits through the same physical surface.
-- `maxInteractions` should be high enough for the expected path plus the image plane, but not so high that an invalid folded system can loop for many interactions.
+- `maxInteractions` should be high enough for the expected path plus the image plane, but not so high that an invalid folded system can loop for many interactions. For an explicit `surfaceOrder`, validation requires enough interactions to cover every listed surface hit plus image-plane termination.
 
 ### Image Plane
 
@@ -214,7 +214,7 @@ opticalPath: {
 - Side-focus Newtonian: use a horizontal plane such as `normal: { z: 0, y: 1 }` with `y` above or below the optical axis.
 - The normal is normalized by `buildLens()`. `{ z: 1, y: 0 }` means a vertical plane of constant z. `{ z: 0, y: 1 }` means a horizontal side plane of constant y.
 
-Diagram layout, ray termination, and mirror-safe spherical aberration use this explicit plane for folded systems. Sequential paraxial analysis tabs that still assume a right-hand image plane are guarded in the UI instead of showing misleading results.
+Diagram layout, ray termination, off-axis folded pupil/chief-ray geometry, and mirror-safe spherical aberration use this explicit plane for folded systems. Complex analysis tabs that still assume a sequential right-hand image plane remain guarded in the UI instead of showing misleading results.
 
 ### Surface Interactions
 
@@ -278,6 +278,8 @@ For a solid central obstruction, omit `innerSd` and use a `block` surface:
 For an annular blocker, combine `innerSd` with `type: "block"`; only the ring clips and the hole passes.
 
 Visible on-axis and off-axis ray sampling is obstruction-aware for folded systems. The sampler scans the usable pupil bands and avoids the central blocked region automatically, so mirror fixtures should not hand-tune `rayFractions` just to route around a secondary obstruction.
+
+If a tilted or paired backing surface belongs to the same annular mirror element, keep `innerSd` consistent between the reflective face and its backing plane. Validation rejects mismatched paired annular faces because the SVG element and active optical aperture would otherwise disagree.
 
 ### Authoring Patterns
 
@@ -343,6 +345,9 @@ Mirror/telescope regression fixtures live under `src/lens-data/reference/`. They
 - `ReferenceManginSecondSurfaceMirror.data.ts` — repeated front-surface hit around a second-surface mirror.
 - `ReferenceNewtonianSideFocus.data.ts` — auto path selection, tilted secondary, and side image plane.
 - `ReferenceCassegrainBackFocus.data.ts` — obstruction plus folded back-focus behavior.
+- `ReferenceGregorianSecondary.data.ts` — Gregorian-style secondary and declared back focus.
+- `ReferenceMaksutovCassegrainMeniscus.data.ts` — refractive meniscus plus folded mirror path.
+- `ReferenceAnnularRingBlocker.data.ts` — annular blocker behavior that clips the ring while passing the center.
 
 Use these as authoring examples and regression anchors, not as polished public catalog entries.
 

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -231,7 +231,7 @@ Surfaces default to `interaction: { type: "refract" }`. Add `interaction` only w
   interaction: {
     type: "reflect",                   // "refract" | "reflect" | "block"
     incidentSide: "rear",              // optional: "front" | "rear" | "both"; default both
-    inactiveSide: "ignore",            // optional: "ignore" | "block"; default ignore
+    inactiveSide: "ignore",            // optional override: reflect defaults block, others ignore
     mirrorKind: "first-surface",       // optional: "first-surface" | "second-surface"
     normal: { z: 1, y: 1 },             // optional tilted meridional plane normal
   },
@@ -244,15 +244,15 @@ Field meanings:
 - `type: "reflect"` reflects the ray using the solved surface normal. Use `mirrorKind: "first-surface"` for front-coated mirrors and `mirrorKind: "second-surface"` for substrate-backed reflective surfaces.
 - `mirrorKind: "second-surface"` also tells the SVG renderer to draw a dashed coating accent on that surface so the coating is visible apart from the glass substrate. The accent is display-only; tracing follows `type`, `incidentSide`, `inactiveSide`, and the optical path.
 - `type: "block"` clips rays within the surface's active aperture. It is intended for central obstructions, baffles, and synthetic regression fixtures.
-- `incidentSide` limits which side of the surface is active. The side is relative to the solved surface normal, not the list position in `surfaces`. If a ray hits the inactive side, `inactiveSide: "ignore"` lets it pass and `inactiveSide: "block"` clips it inside the active disk or annulus.
+- `incidentSide` limits which side of the surface is active. The side is relative to the solved surface normal, not the list position in `surfaces`. If a ray hits a reflective surface from its inactive side, it blocks by default inside the active disk or annulus. Set `inactiveSide: "ignore"` only for intentional pass-through cases such as a Newtonian diagonal's first pass. Refractive and blocker surfaces keep the historical inactive-side default of ignore unless `inactiveSide: "block"` is explicit.
 - `normal` converts the surface into a tilted meridional plane for both tracing and SVG element rendering. Use this for flat fold mirrors. Curved mirrors should normally omit `normal` so the spherical/aspherical sag and local normal come from `R` and `asph`.
 
 Choosing `incidentSide`:
 
 - For an incoming beam traveling left-to-right into a concave primary whose sag-derived normal faces the object side,
   start with `incidentSide: "front"`. This is the usual first-surface primary case.
-- For a beam returning right-to-left toward a diagonal flat after the primary reflection, use `incidentSide: "rear"` on
-  the diagonal so the first pass can ignore the inactive face and the return pass reflects.
+- For a beam returning right-to-left toward a diagonal flat after the primary reflection, use `incidentSide: "rear"` and
+  `inactiveSide: "ignore"` on the diagonal so the first pass goes through and the return pass reflects.
 - For a Mangin or other second-surface mirror, set `incidentSide` on the reflective coating side reached after the ray
   enters the substrate. Keep the refractive front surface ordinary, then repeat that front label in `surfaceOrder` for
   the exit path.
@@ -267,7 +267,7 @@ Any surface may declare `innerSd` to define an annular active aperture:
 { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 30, innerSd: 8, interaction: { type: "reflect" } }
 ```
 
-The active radial band is `[innerSd, sd]`. Rays below `innerSd` pass through the central hole without interacting with that surface. Rays above `sd` clip when semi-diameter checking is active. This supports annular primary mirrors, annular stops, and ring-shaped blockers.
+The active radial band is `[innerSd, sd]`. Rays below `innerSd` pass through the central hole without interacting with that surface, including from an inactive mirror side that would otherwise block. Rays above `sd` clip when semi-diameter checking is active. This supports annular primary mirrors, annular stops, and ring-shaped blockers.
 
 For a solid central obstruction, omit `innerSd` and use a `block` surface:
 

--- a/src/lens-data/LENS_DATA_SPEC.md
+++ b/src/lens-data/LENS_DATA_SPEC.md
@@ -11,6 +11,8 @@ Reference for creating new `*.data.ts` files in `lens-data/`.
 
 File naming: `lens-data/**/*.data.ts` (glob pattern used for auto-discovery). Each file imports and uses `satisfies LensDataInput` for compile-time type checking. Optional analysis files use the same relative stem path with a `.analysis.md` suffix.
 
+Ordinary photographic lenses still use the historical front-to-rear sequential prescription by default. Mirror lenses and telescope-style reference fixtures opt into the generalized optical-path model with `opticalPath` and per-surface `interaction` fields, described below.
+
 Per-lens patent audit logs use `*.audit.md` alongside the data file. They are not consumed by any build script, runtime catalog, or test scanner — all of those filter strictly on `.data.ts` and `.analysis.md`. See [../../agent_docs/lens-patent-audit.md](../../agent_docs/lens-patent-audit.md) for the audit procedure and log format.
 
 ## Scope: What to Include
@@ -20,12 +22,16 @@ Per-lens patent audit logs use `*.audit.md` alongside the data file. They are no
 - All optical surfaces from front lens element to final image plane
 - Aperture stop (diaphragm)
 - Variable air gaps for focus and zoom
+- Mirror or blocking surfaces that participate in a folded path
+- Annular clear apertures or central obstructions when they are optically meaningful
 
 **Do NOT include:**
 - **Sensor glass / cover glass** — the protective or thermal compensation glass plate on the camera sensor (rear of the assembly)
 - **Filters** — UV, ND, polarizing, or other filters mounted on the lens or in front of the sensor
 - **Mechanical components** — focus motors, aperture blades (mechanical detail), barrel, mounts
 - **Parent/donor designs** — if the lens is a descendant of another design, transcribe only the final production or patent design shown, not intermediate parent elements
+
+For telescope and mirror-lens fixtures, include the optical surfaces that rays can hit, not the full mechanical tube. A secondary baffle or obstruction that clips rays belongs in `surfaces`; a spider vane, cell, barrel, or mount detail does not.
 
 ---
 
@@ -92,6 +98,7 @@ These must be specified in every lens file — they have no defaults.
 | `groupCount` | `number` | | Total number of air-separated groups in the design. |
 | `perspectiveControl` | `object` | | Optional tilt/shift movement limits for perspective-control lenses. Omit for all ordinary lenses. |
 | `projection` | `object` | `{ kind: "rectilinear" }` | Optional projection metadata. Use for non-rectilinear lenses, or for rare rectilinear designs whose published coverage should override the paraxial field estimate. |
+| `opticalPath` | `object` | | Optional generalized path metadata for mirror, folded, annular, or non-right-side image-plane systems. Omit for ordinary front-to-rear refractive lenses. |
 | `focusDescription` | `string` | | Human-readable focus mechanism description |
 | `asph` | `object` | | Aspherical coefficients (see below) |
 | `var` | `object` | | Variable air gaps for focus (see below) |
@@ -166,6 +173,165 @@ projection: {
 - Zoom fisheyes may provide arrays for `focalLengthMm`, `fullFieldDeg`, `imageCircleMm`, and `maxTraceFieldDeg`; values are interpolated across the zoom range just like `zoomPositions`.
 - `fullFieldDeg` and `imageCircleMm` describe the published circular fisheye projection.
 - `maxTraceFieldDeg` sets the lens's authoritative half-field for fisheyes. The validator accepts values up to (but not including) 180°; chief rays past `MAX_FIELD_LAUNCH_DEG = 89°` route through the bounding-sphere launch arm. The diagram's off-axis ray rendering respects a separate, bisected `tracingHalfField` so bundle rays land safely on the image plane regardless of the declared coverage.
+
+---
+
+## Folded And Mirror Optical Paths (`opticalPath`)
+
+Use `opticalPath` only when the default sequential model is insufficient: first-surface mirrors, second-surface mirrors, repeated surface hits, annular mirrors, central obstructions, automatically resolved folded paths, or image planes that are not the ordinary right-hand `IMG` plane.
+
+If `opticalPath` is omitted, the lens remains an ordinary sequential refractive system. Existing refractive lenses should not add `opticalPath`, `interaction`, or `innerSd` unless the physical design needs those fields.
+
+When `opticalPath` is present, provide either a non-empty `surfaceOrder` or `mode: "auto"`. Do not set only `imagePlane` on an otherwise ordinary lens; that opts into the generalized tracer without telling it which surfaces to visit.
+
+```javascript
+opticalPath: {
+  mode: "auto",                         // optional: "sequential" (default) or "auto"
+  surfaceOrder: ["STO", "MG1", "MG2", "MG1"], // optional explicit hit order; repeated labels are allowed
+  imagePlane: {
+    z: 35,                              // point on the plane, in lens-data millimeters
+    y: 25,                              // optional; defaults to 0
+    normal: { z: 0, y: 1 },             // optional; defaults to { z: 1, y: 0 }
+    label: "IMG",                      // optional; defaults to "IMG"
+  },
+  maxInteractions: 8,                   // optional safety cap; defaults to surfaces.length + 1
+},
+```
+
+### Path Modes
+
+- `mode: "sequential"` preserves the historical behavior unless `surfaceOrder` is present. With a `surfaceOrder`, the generalized tracer follows that label list exactly and then intersects the configured image plane. This is the safest choice for Mangin mirrors and other designs where the physical surface order is not the optical hit order.
+- `mode: "auto"` asks the generalized tracer to choose the nearest valid optical surface at each step. It skips passive same-index refractive surfaces, respects side-specific reflection/blocking behavior, avoids immediate self-hits, stops at the image plane when it is the next intersection, and stops at `maxInteractions` if a path does not terminate.
+- `surfaceOrder` entries are surface labels, not indices. Labels must exist, and labels may repeat when a ray intentionally re-enters or exits through the same physical surface.
+- `maxInteractions` should be high enough for the expected path plus the image plane, but not so high that an invalid folded system can loop for many interactions.
+
+### Image Plane
+
+`opticalPath.imagePlane` defines the imaging plane for folded systems. It is a point plus a meridional normal vector:
+
+- Default image plane: `{ z: totalTrack, y: 0, normal: { z: 1, y: 0 }, label: "IMG" }`, the ordinary vertical right-hand plane.
+- Front-focus mirror: set `z` in front of the mirror, usually near or before the aperture stop.
+- Side-focus Newtonian: use a horizontal plane such as `normal: { z: 0, y: 1 }` with `y` above or below the optical axis.
+- The normal is normalized by `buildLens()`. `{ z: 1, y: 0 }` means a vertical plane of constant z. `{ z: 0, y: 1 }` means a horizontal side plane of constant y.
+
+Diagram layout, ray termination, and mirror-safe spherical aberration use this explicit plane for folded systems. Sequential paraxial analysis tabs that still assume a right-hand image plane are guarded in the UI instead of showing misleading results.
+
+### Surface Interactions
+
+Surfaces default to `interaction: { type: "refract" }`. Add `interaction` only when the surface does something other than ordinary refraction, has side-specific behavior, or is a tilted meridional plane.
+
+```javascript
+{
+  label: "SEC",
+  R: 1e15,
+  d: 0.5,
+  nd: 1.0,
+  elemId: 2,
+  sd: 10,
+  interaction: {
+    type: "reflect",                   // "refract" | "reflect" | "block"
+    incidentSide: "rear",              // optional: "front" | "rear" | "both"; default both
+    inactiveSide: "ignore",            // optional: "ignore" | "block"; default ignore
+    mirrorKind: "first-surface",       // optional: "first-surface" | "second-surface"
+    normal: { z: 1, y: 1 },             // optional tilted meridional plane normal
+  },
+}
+```
+
+Field meanings:
+
+- `type: "refract"` applies normal Snell refraction. It is also useful for a passive backing plane that needs the same tilted visual geometry as a mirror face.
+- `type: "reflect"` reflects the ray using the solved surface normal. Use `mirrorKind: "first-surface"` for front-coated mirrors and `mirrorKind: "second-surface"` for substrate-backed reflective surfaces.
+- `type: "block"` clips rays within the surface's active aperture. It is intended for central obstructions, baffles, and synthetic regression fixtures.
+- `incidentSide` limits which side of the surface is active. The side is relative to the solved surface normal, not the list position in `surfaces`. If a ray hits the inactive side, `inactiveSide: "ignore"` lets it pass and `inactiveSide: "block"` clips it inside the active disk or annulus.
+- `normal` converts the surface into a tilted meridional plane for both tracing and SVG element rendering. Use this for flat fold mirrors. Curved mirrors should normally omit `normal` so the spherical/aspherical sag and local normal come from `R` and `asph`.
+
+### Annular Apertures And Obstructions
+
+Any surface may declare `innerSd` to define an annular active aperture:
+
+```javascript
+{ label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 30, innerSd: 8, interaction: { type: "reflect" } }
+```
+
+The active radial band is `[innerSd, sd]`. Rays below `innerSd` pass through the central hole without interacting with that surface. Rays above `sd` clip when semi-diameter checking is active. This supports annular primary mirrors, annular stops, and ring-shaped blockers.
+
+For a solid central obstruction, omit `innerSd` and use a `block` surface:
+
+```javascript
+{ label: "OBS", R: 1e15, d: 10, nd: 1.0, elemId: 0, sd: 6, interaction: { type: "block" } }
+```
+
+For an annular blocker, combine `innerSd` with `type: "block"`; only the ring clips and the hole passes.
+
+Visible on-axis and off-axis ray sampling is obstruction-aware for folded systems. The sampler scans the usable pupil bands and avoids the central blocked region automatically, so mirror fixtures should not hand-tune `rayFractions` just to route around a secondary obstruction.
+
+### Authoring Patterns
+
+First-surface concave primary with an image plane in front:
+
+```javascript
+surfaces: [
+  { label: "STO", R: 1e15, d: 100, nd: 1.0, elemId: 0, sd: 25 },
+  { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 25, interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" } },
+],
+opticalPath: {
+  surfaceOrder: ["STO", "M1"],
+  imagePlane: { z: 0, label: "IMG" },
+},
+```
+
+Second-surface Mangin-style path through a glass front surface, reflective rear surface, then back out the front:
+
+```javascript
+surfaces: [
+  { label: "MG1", R: 120, d: 8, nd: 1.5168, elemId: 1, sd: 22 },
+  { label: "MG2", R: -100, d: 0, nd: 1.0, elemId: 0, sd: 22, interaction: { type: "reflect", incidentSide: "front", mirrorKind: "second-surface" } },
+],
+opticalPath: {
+  surfaceOrder: ["MG1", "MG2", "MG1"],
+  imagePlane: { z: 30 },
+},
+```
+
+Newtonian-style automatic folded path with a diagonal secondary and side image plane:
+
+```javascript
+opticalPath: {
+  mode: "auto",
+  imagePlane: { z: 35, y: 25, normal: { z: 0, y: 1 }, label: "IMG" },
+  maxInteractions: 8,
+},
+surfaces: [
+  { label: "STO", R: 1e15, d: 35, nd: 1.0, elemId: 0, sd: 30 },
+  {
+    label: "SEC",
+    R: 1e15,
+    d: 0.5,
+    nd: 1.0,
+    elemId: 2,
+    sd: 10,
+    interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "ignore", mirrorKind: "first-surface", normal: { z: 1, y: 1 } },
+  },
+  { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 10, interaction: { type: "refract", normal: { z: 1, y: 1 } } },
+  { label: "M1", R: -200, d: 2, nd: 1.0, elemId: 1, sd: 30, interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" } },
+  { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30 },
+],
+```
+
+The backing plane (`SECB`) is optically passive but carries the same `normal` as the reflective face so the SVG element shape renders as a tilted flat mirror instead of a vertical plate.
+
+### Reference Fixtures
+
+Mirror/telescope regression fixtures live under `src/lens-data/reference/`. They are normally hidden with `visible: false` unless temporarily exposed for visual testing:
+
+- `ReferenceSphericalPrimaryMirror.data.ts` — first-surface mirror and front image plane.
+- `ReferenceAnnularObscuredMirror.data.ts` — annular primary plus central obstruction-aware sampling.
+- `ReferenceManginSecondSurfaceMirror.data.ts` — repeated front-surface hit around a second-surface mirror.
+- `ReferenceNewtonianSideFocus.data.ts` — auto path selection, tilted secondary, and side image plane.
+- `ReferenceCassegrainBackFocus.data.ts` — obstruction plus folded back-focus behavior.
+
+Use these as authoring examples and regression anchors, not as polished public catalog entries.
 
 ---
 
@@ -312,7 +478,7 @@ When a patent does not specify the vendor, prefer the vendor whose name matches 
 
 ## Surface Object
 
-Each entry in the `surfaces` array describes one optical surface, in strict front-to-rear order.
+Each entry in the `surfaces` array describes one optical surface, in physical front-to-rear axial order. Folded systems still keep this physical order; `opticalPath` controls the ray hit order.
 
 ```javascript
 {
@@ -321,8 +487,10 @@ Each entry in the `surfaces` array describes one optical surface, in strict fron
   d:      3.46,       // REQUIRED: axial thickness to next surface in mm
   nd:     1.85249,    // REQUIRED: refractive index of medium AFTER this surface
   elemId: 2,          // REQUIRED: element ID (0 = air interface)
-  sd:     14.5,       // REQUIRED: semi-diameter (half clear aperture) in mm
+  sd:     14.5,       // REQUIRED: outer semi-diameter (half clear aperture) in mm
+  innerSd: 4.0,       // optional: inner semi-diameter for annular active apertures
   stopPlacement: "inside-element", // optional: only valid on an embedded STO surface
+  interaction: { type: "reflect", mirrorKind: "first-surface" }, // optional folded-path behavior
 }
 ```
 
@@ -336,12 +504,14 @@ Each entry in the `surfaces` array describes one optical surface, in strict fron
 | `d > 0` | Always positive (distance to next surface) |
 | `nd = 1.0` | Air gap |
 | `nd > 1.0` | Glass medium (use the glass's refractive index) |
+| `innerSd` | Inner inactive radius for annular surfaces; must be non-negative and smaller than `sd` |
 
 ### Surface Label Convention
 
 - Sequential numbers: `"1"`, `"2"`, `"3"`, ...
 - Append `"A"` for aspherical surfaces: `"1A"`, `"3A"`, `"18A"`
 - The aperture stop MUST be labeled `"STO"` (exactly one required)
+- Mirror fixtures may use descriptive labels such as `"M1"`, `"SEC"`, `"MG1"`, or `"OBS"` when those labels make explicit `surfaceOrder` easier to read. Keep labels unique and stable.
 
 ### Pairing Rules
 
@@ -364,6 +534,9 @@ Each entry in the `surfaces` array describes one optical surface, in strict fron
   { label: "11A", R: -16.276, d: ...,  nd: 1.0,     elemId: 0, sd: ... },  // Resin rear (asph) → air
   ```
 - **Embedded stop inside glass:** Rare designs may put the aperture stop inside a glass element. In that case the `STO` surface stays optically neutral and flat, uses the same `nd` and `elemId` as the containing element, and sets `stopPlacement: "inside-element"`. The containing element must declare `fromSurface` and `toSurface` so the renderer uses the real outer glass surfaces as the element silhouette.
+- **Mirror element:** A first-surface mirror can use one reflective face with a passive backing surface for SVG thickness. The reflective face carries the mirror element's `elemId`; the backing surface typically uses `elemId: 0` unless it is needed as the first surface of a distinct physical element. A tilted flat fold mirror should put the same `interaction.normal` on both the reflective face and backing plane so the rendered element is visibly tilted.
+- **Annular mirror or aperture:** Add `innerSd` to the active surface. For a physical mirror element with a central hole, add `innerSd` to both front/back surfaces if both surfaces should render as annular; the element path will use even-odd fill.
+- **Blocker:** Use `interaction: { type: "block" }` and `elemId: 0` for a pure aperture obstruction. Use a non-zero `elemId` only if the blocker should be rendered as a physical element with a front/back surface span.
 - **Last surface:** `d` = back focal distance to image plane
 
 ### Aperture Stop
@@ -374,6 +547,7 @@ Exactly one surface must have `label: "STO"`. This is typically a flat surface (
 - **Patent specifies stop:** Use the exact surface index or gap from the patent table.
 - **Patent does not specify (common in older patents):** Estimate from the patent figure drawing. Split the air gap at the inferred iris location — the preceding surface's `d` is the distance from that surface to the stop, and the STO surface's `d` is the remaining distance to the next surface. Document the estimate in a code comment (e.g., "STO position inferred from Fig. 1 iris placement").
 - **Patent places stop inside a glass element:** Use `stopPlacement: "inside-element"` on `STO`, keep the stop flat, set `STO.nd` to the containing glass index, set `STO.elemId` to the containing element id, and add `fromSurface`/`toSurface` to that element. Do not use this flag for ordinary air stops.
+- **Annular or obstructed stop:** Use `innerSd` only when the stop itself has a real central hole. For a separate secondary obstruction, prefer a distinct `block` surface so ray clipping and sampling can identify the obstruction independently.
 
 ---
 
@@ -610,6 +784,9 @@ doublets: [
 13. Cross-gap surface overlap: combined sag intrusion from the two boundary surfaces that face each other doesn't exceed `gapSagFrac × gap` — checked at all zoom positions for zoom lenses
 14. Conic height limit: for aspherical surfaces with K > 0, sd ≤ 0.98 × |R| / √(1+K)
 15. Element render diagnostics: production lenses must not require material hidden trim (>0.25 mm) from slope, conic, or cross-gap limits
+16. `innerSd` must be finite, non-negative, and smaller than `sd`
+17. `interaction.type` must be `"refract"`, `"reflect"`, or `"block"`; side fields must be valid enum values; `normal` vectors must have finite `z` and `y` components
+18. `opticalPath.mode` must be `"sequential"` or `"auto"`; `surfaceOrder` labels must exist; `imagePlane` point/normal fields must be finite; `maxInteractions` must be a positive integer
 
 On failure, `buildLens()` throws with all errors listed.
 

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -174,7 +174,7 @@ const LENS_DATA = {
    *    interaction (object, optional)  Folded-path behavior:
    *      type: "refract" | "reflect" | "block"   (default "refract")
    *      incidentSide?: "front" | "rear" | "both"  (default both)
-   *      inactiveSide?: "ignore" | "block"         (reflect defaults block, others ignore)
+   *      inactiveSide?: "ignore" | "block"         (reference mirrors should use "block")
    *      mirrorKind?: "first-surface" | "second-surface"
    *      normal?: { z: number, y: number }          tilted meridional plane normal
    *
@@ -238,9 +238,9 @@ const LENS_DATA = {
    *    - Mirror elements: tag the reflective face with the mirror element's elemId and
    *      use a passive backing surface with elemId: 0 unless modeling a distinct physical
    *      element. A reflective face blocks inactive-side hits by default; set
-   *      inactiveSide: "ignore" only when an intentional first pass must go through it.
-   *      For tilted flat mirrors, put the same interaction.normal on the backing surface
-   *      so the SVG element renders at the correct angle.
+   *      inactiveSide: "block" explicitly on reference mirrors so back-side opacity is
+   *      clear in the data. For tilted flat mirrors, put the same interaction.normal on
+   *      the backing surface so the SVG element renders at the correct angle.
    *    - Blocker surfaces normally use elemId: 0. Give them an element only when they
    *      should draw as a physical rendered part.
    *
@@ -278,15 +278,15 @@ const LENS_DATA = {
    *  Folded mirror examples:
    *    First-surface mirror:
    *      { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 25,
-   *        interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" } }
+   *        interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" } }
    *
    *    Annular mirror:
    *      { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 30, innerSd: 8,
-   *        interaction: { type: "reflect", mirrorKind: "first-surface" } }
+   *        interaction: { type: "reflect", inactiveSide: "block", mirrorKind: "first-surface" } }
    *
    *    Tilted Newtonian secondary (mirror face + passive backing):
    *      { label: "SEC", R: 1e15, d: 0.5, nd: 1.0, elemId: 2, sd: 10,
-   *        interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "ignore", mirrorKind: "first-surface", normal: { z: 1, y: 1 } } }
+   *        interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "block", mirrorKind: "first-surface", normal: { z: 1, y: 1 } } }
    *      { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 10,
    *        interaction: { type: "refract", normal: { z: 1, y: 1 } } }
    */

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -174,7 +174,7 @@ const LENS_DATA = {
    *    interaction (object, optional)  Folded-path behavior:
    *      type: "refract" | "reflect" | "block"   (default "refract")
    *      incidentSide?: "front" | "rear" | "both"  (default both)
-   *      inactiveSide?: "ignore" | "block"         (default ignore)
+   *      inactiveSide?: "ignore" | "block"         (reflect defaults block, others ignore)
    *      mirrorKind?: "first-surface" | "second-surface"
    *      normal?: { z: number, y: number }          tilted meridional plane normal
    *
@@ -237,8 +237,10 @@ const LENS_DATA = {
    *      and STO.elemId to the containing glass, and add fromSurface/toSurface to that element.
    *    - Mirror elements: tag the reflective face with the mirror element's elemId and
    *      use a passive backing surface with elemId: 0 unless modeling a distinct physical
-   *      element. For tilted flat mirrors, put the same interaction.normal on the backing
-   *      surface so the SVG element renders at the correct angle.
+   *      element. A reflective face blocks inactive-side hits by default; set
+   *      inactiveSide: "ignore" only when an intentional first pass must go through it.
+   *      For tilted flat mirrors, put the same interaction.normal on the backing surface
+   *      so the SVG element renders at the correct angle.
    *    - Blocker surfaces normally use elemId: 0. Give them an element only when they
    *      should draw as a physical rendered part.
    *

--- a/src/lens-data/TEMPLATE.data.ts.template
+++ b/src/lens-data/TEMPLATE.data.ts.template
@@ -24,9 +24,15 @@ import type { LensDataInput } from "../types/optics.js";
  * ║    [Describe how SDs were determined — patent-listed, estimated    ║
  * ║    from EP geometry, etc.]                                         ║
  * ║                                                                    ║
+ * ║  NOTE ON MIRROR/FOLDED PATHS (if applicable):                       ║
+ * ║    [Document first/second-surface mirrors, annular apertures,       ║
+ * ║    central obstructions, opticalPath.surfaceOrder or auto mode,     ║
+ * ║    tilted mirror normals, and explicit image-plane placement.]      ║
+ * ║                                                                    ║
  * ║  IMPORTANT: This file describes ONLY the optical design:           ║
  * ║    ✓ Glass elements and surfaces (front element to image plane)   ║
  * ║    ✓ Aperture stop and variable focus/zoom gaps                   ║
+ * ║    ✓ Optical mirror/blocking surfaces that rays can hit           ║
  * ║    ✗ DO NOT include: sensor glass, filters, mechanical parts      ║
  * ║    ✗ DO NOT include: parent/donor designs (use final design only) ║
  * ╚══════════════════════════════════════════════════════════════════════╝
@@ -71,6 +77,8 @@ const LENS_DATA = {
    *                        when the published focal length is a projection constant, or for
    *                        unusual rectilinear ultrawides whose published coverage should
    *                        override the paraxial field estimate.
+   *  opticalPath           Optional generalized path metadata for folded/mirror systems.
+   *                        Omit for ordinary front-to-rear refractive lenses.
    */
   focalLengthMarketing: 50,             // or [70, 200] for zooms
   focalLengthDesign:    51.2,           // omit if same as focalLengthMarketing
@@ -104,6 +112,20 @@ const LENS_DATA = {
   //   maxTraceFieldDeg: 80,
   // },
 
+  // Optional: folded/mirror optical path support.
+  // Omit this entire block for ordinary sequential refractive lenses.
+  // Use surfaceOrder for known hit sequences, including repeated labels.
+  // Use mode: "auto" when the nearest valid next surface should be determined
+  // geometrically. imagePlane is a point plus meridional normal; default is the
+  // ordinary right-hand IMG plane at the final axial track. Do not set only
+  // imagePlane without either surfaceOrder or mode: "auto".
+  // opticalPath: {
+  //   mode: "auto",                                      // "sequential" (default) or "auto"
+  //   surfaceOrder: ["STO", "MG1", "MG2", "MG1"],       // optional; labels may repeat
+  //   imagePlane: { z: 35, y: 25, normal: { z: 0, y: 1 }, label: "IMG" },
+  //   maxInteractions: 8,
+  // },
+
   /* ── Elements ──
    *  One entry per physical glass element, front to rear.
    *  Each element must have a unique `id` and be referenced by at least one surface.
@@ -135,8 +157,9 @@ const LENS_DATA = {
   ],
 
   /* ── Surface prescription ──
-   *  One entry per optical surface, in strict front-to-rear order.
-   *  Includes glass surfaces AND air gaps.
+   *  One entry per optical surface, in physical front-to-rear axial order.
+   *  Folded systems still keep this physical order; opticalPath controls hit order.
+   *  Includes glass surfaces, mirror surfaces, blocker surfaces, AND air gaps.
    *  Exactly one surface must have label "STO" (the aperture stop).
    *
    *  Fields:
@@ -146,7 +169,14 @@ const LENS_DATA = {
    *    nd      (number, REQUIRED)  Refractive index of the medium FOLLOWING this surface
    *                                (1.0 for air, glass nd for entering a glass element)
    *    elemId  (number, REQUIRED)  Element ID this surface belongs to — 0 for air interfaces
-   *    sd      (number, REQUIRED)  Semi-diameter (half clear aperture) in mm
+   *    sd      (number, REQUIRED)  Outer semi-diameter (half clear aperture) in mm
+   *    innerSd (number, optional)  Inner inactive radius for annular apertures/holes; must be < sd
+   *    interaction (object, optional)  Folded-path behavior:
+   *      type: "refract" | "reflect" | "block"   (default "refract")
+   *      incidentSide?: "front" | "rear" | "both"  (default both)
+   *      inactiveSide?: "ignore" | "block"         (default ignore)
+   *      mirrorKind?: "first-surface" | "second-surface"
+   *      normal?: { z: number, y: number }          tilted meridional plane normal
    *
    *  Semi-diameter constraints (1–5 validated automatically, 6–8 are guidance):
    *    1. Edge thickness: For each element, sag(sd, R_front) − sag(sd, R_rear) must
@@ -186,6 +216,10 @@ const LENS_DATA = {
    *    9. Hidden render trim: If `computeElementRenderDiagnostics()` reports >0.25 mm
    *       trim for a production lens, reduce the relevant SD or document and test an
    *       intentional exception.  Renderer-only clipping can create artificial "wings".
+   *   10. Annular surfaces: `innerSd` defines the central hole. Rays interact only in
+   *       the radial band [innerSd, sd]. Use `innerSd` for mirror holes or annular
+   *       stops, and a separate `interaction: { type: "block" }` surface for solid
+   *       central obstructions.
    *
    *  Sign conventions:
    *    R > 0  →  center of curvature to the RIGHT of the surface
@@ -201,6 +235,12 @@ const LENS_DATA = {
    *    - The last surface's d is the back focal distance (BFD) to the image plane.
    *    - Embedded glass stop exception: use stopPlacement: "inside-element" on STO, set STO.nd
    *      and STO.elemId to the containing glass, and add fromSurface/toSurface to that element.
+   *    - Mirror elements: tag the reflective face with the mirror element's elemId and
+   *      use a passive backing surface with elemId: 0 unless modeling a distinct physical
+   *      element. For tilted flat mirrors, put the same interaction.normal on the backing
+   *      surface so the SVG element renders at the correct angle.
+   *    - Blocker surfaces normally use elemId: 0. Give them an element only when they
+   *      should draw as a physical rendered part.
    *
    *  Standalone element pattern:
    *    { label: "1",  R: ..., d: ..., nd: 1.xxxxx, elemId: 1, sd: ... },  // L1 front — elemId: 1
@@ -232,6 +272,21 @@ const LENS_DATA = {
    *  Why: buildLens.ts finds the FIRST surface with each elemId and uses (index, index+1)
    *  as the element's front/rear pair for rendering. Tagging rear or air surfaces with
    *  non-zero elemId will cause rendering errors or crashes.
+   *
+   *  Folded mirror examples:
+   *    First-surface mirror:
+   *      { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 25,
+   *        interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" } }
+   *
+   *    Annular mirror:
+   *      { label: "M1", R: -200, d: 0, nd: 1.0, elemId: 1, sd: 30, innerSd: 8,
+   *        interaction: { type: "reflect", mirrorKind: "first-surface" } }
+   *
+   *    Tilted Newtonian secondary (mirror face + passive backing):
+   *      { label: "SEC", R: 1e15, d: 0.5, nd: 1.0, elemId: 2, sd: 10,
+   *        interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "ignore", mirrorKind: "first-surface", normal: { z: 1, y: 1 } } }
+   *      { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 10,
+   *        interaction: { type: "refract", normal: { z: 1, y: 1 } } }
    */
   surfaces: [
     { label: "1",   R:   00.000, d: 0.00, nd: 1.00000, elemId: 1, sd: 00.0 },

--- a/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
+++ b/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
@@ -1,0 +1,82 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Hidden regression fixture for annular pupils and central obstructions.
+ *
+ * This is the spherical-primary fixture with a 6 mm central baffle ahead of an
+ * annular first-surface mirror. Visible ray sampling should skip the blocked
+ * pupil core, while a deliberately central trace should clip on the baffle.
+ */
+
+const LENS_DATA = {
+  key: "reference-annular-obscured-mirror",
+  maker: "Reference",
+  visible: false,
+  name: "REFERENCE Annular Obscured Mirror",
+  subtitle: "Hidden annular-pupil regression fixture",
+  specs: ["ANNULAR FIRST-SURFACE MIRROR", "CENTRAL OBSTRUCTION", "f = 100 mm", "F/4"],
+
+  focalLengthMarketing: 100,
+  focalLengthDesign: 100,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  patentYear: 2026,
+  elementCount: 1,
+  groupCount: 1,
+  nominalFno: 4,
+  closeFocusM: 10,
+  yScFill: 0.55,
+  scFill: 0.62,
+  rayLeadFrac: 0.3,
+  maxFstop: 16,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 10,
+    maxTraceFieldDeg: 5,
+  },
+  opticalPath: {
+    surfaceOrder: ["STO", "OBS", "M1"],
+    imagePlane: { z: 0, label: "IMG" },
+    maxInteractions: 4,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "M1",
+      label: "Annular primary mirror",
+      type: "Annular Concave First-Surface Mirror",
+      nd: 1.0,
+      vd: 0,
+      fl: 100,
+      glass: "Aluminized annular front surface",
+      apd: false,
+      role: "Spherical mirror with a central hole masked by an upstream obstruction.",
+    },
+  ],
+
+  surfaces: [
+    { label: "STO", R: 1e15, d: 20, nd: 1.0, elemId: 0, sd: 30 },
+    { label: "OBS", R: 1e15, d: 80, nd: 1.0, elemId: 0, sd: 6, interaction: { type: "block" } },
+    {
+      label: "M1",
+      R: -200,
+      d: 2,
+      nd: 1.0,
+      elemId: 1,
+      sd: 30,
+      innerSd: 6,
+      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+    },
+    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30, innerSd: 6 },
+  ],
+
+  asph: {},
+  var: {},
+  varLabels: [],
+  groups: [{ text: "M1", fromSurface: "M1", toSurface: "M1B" }],
+  doublets: [],
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
+++ b/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
@@ -11,7 +11,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-annular-obscured-mirror",
   maker: "Reference",
-  visible: false,
+  visible: true,
   name: "REFERENCE Annular Obscured Mirror",
   subtitle: "Hidden annular-pupil regression fixture",
   specs: ["ANNULAR FIRST-SURFACE MIRROR", "CENTRAL OBSTRUCTION", "f = 100 mm", "F/4"],

--- a/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
+++ b/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
@@ -11,7 +11,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-annular-obscured-mirror",
   maker: "Reference",
-  visible: true,
+  visible: false,
   name: "REFERENCE Annular Obscured Mirror",
   subtitle: "Hidden annular-pupil regression fixture",
   specs: ["ANNULAR FIRST-SURFACE MIRROR", "CENTRAL OBSTRUCTION", "f = 100 mm", "F/4"],

--- a/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
+++ b/src/lens-data/reference/ReferenceAnnularObscuredMirror.data.ts
@@ -67,7 +67,7 @@ const LENS_DATA = {
       elemId: 1,
       sd: 30,
       innerSd: 6,
-      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+      interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
     { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30, innerSd: 6 },
   ],

--- a/src/lens-data/reference/ReferenceAnnularRingBlocker.data.ts
+++ b/src/lens-data/reference/ReferenceAnnularRingBlocker.data.ts
@@ -1,0 +1,70 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Hidden regression fixture for annular blocking geometry where the center
+ * passes through the hole but a surrounding ring is stopped.
+ */
+
+const LENS_DATA = {
+  key: "reference-annular-ring-blocker",
+  maker: "Reference",
+  visible: false,
+  name: "REFERENCE Annular Ring Blocker",
+  subtitle: "Hidden annular blocker fixture",
+  specs: ["ANNULAR BLOCKER", "CENTER PASSES", "RING CLIPS"],
+
+  focalLengthMarketing: 100,
+  focalLengthDesign: 100,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  patentYear: 2026,
+  elementCount: 1,
+  groupCount: 1,
+  nominalFno: 4,
+  closeFocusM: 10,
+  yScFill: 0.5,
+  scFill: 0.62,
+  rayLeadFrac: 0.2,
+  maxFstop: 16,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 8,
+    maxTraceFieldDeg: 4,
+  },
+  opticalPath: {
+    mode: "auto",
+    imagePlane: { z: 120, label: "IMG" },
+    maxInteractions: 5,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "MASK",
+      label: "Annular blocker",
+      type: "Annular Blocker",
+      nd: 1.0,
+      vd: 0,
+      glass: "Opaque mask",
+      apd: false,
+      fromSurface: "RING",
+      toSurface: "RINGB",
+      role: "Blocks a ring zone while leaving the central opening and outside clear aperture inactive.",
+    },
+  ],
+
+  surfaces: [
+    { label: "STO", R: 1e15, d: 25, nd: 1.0, elemId: 0, sd: 30 },
+    { label: "RING", R: 1e15, d: 0.5, nd: 1.0, elemId: 1, sd: 14, innerSd: 6, interaction: { type: "block" } },
+    { label: "RINGB", R: 1e15, d: 94.5, nd: 1.0, elemId: 1, sd: 14, innerSd: 6 },
+  ],
+
+  asph: {},
+  var: {},
+  varLabels: [],
+  groups: [{ text: "Mask", fromSurface: "RING", toSurface: "RINGB" }],
+  doublets: [],
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts
+++ b/src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts
@@ -1,0 +1,113 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Hidden regression fixture for guarded folded-system analysis.
+ *
+ * This synthetic Cassegrain-style prescription uses an annular primary and a
+ * centrally blocking secondary. Off-axis pupil samples pass around the
+ * secondary, reflect from the primary, reflect from the secondary, then pass
+ * through the primary hole to a back-focus image plane.
+ */
+
+const LENS_DATA = {
+  key: "reference-cassegrain-back-focus",
+  maker: "Reference",
+  visible: false,
+  name: "REFERENCE Cassegrain Back Focus",
+  subtitle: "Hidden folded-analysis guard fixture",
+  specs: ["CASSEGRAIN-STYLE", "CENTRAL SECONDARY", "ANNULAR PRIMARY", "BACK FOCUS"],
+
+  focalLengthMarketing: 100,
+  focalLengthDesign: 100,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  patentYear: 2026,
+  elementCount: 2,
+  groupCount: 2,
+  nominalFno: 4,
+  closeFocusM: 10,
+  yScFill: 0.5,
+  scFill: 0.62,
+  rayLeadFrac: 0.25,
+  maxFstop: 16,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 8,
+    maxTraceFieldDeg: 4,
+  },
+  opticalPath: {
+    mode: "auto",
+    imagePlane: { z: 135, label: "IMG" },
+    maxInteractions: 10,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "M2",
+      label: "Secondary mirror",
+      type: "Flat First-Surface Mirror",
+      nd: 1.0,
+      vd: 0,
+      glass: "Aluminized front surface",
+      apd: false,
+      fromSurface: "SEC",
+      toSurface: "SECB",
+      role: "Central secondary that blocks incoming core rays and reflects the returning primary beam.",
+    },
+    {
+      id: 2,
+      name: "M1",
+      label: "Annular primary mirror",
+      type: "Annular Concave First-Surface Mirror",
+      nd: 1.0,
+      vd: 0,
+      fl: 100,
+      glass: "Aluminized annular front surface",
+      apd: false,
+      role: "Spherical primary mirror with a central hole for the back-focus beam.",
+    },
+  ],
+
+  surfaces: [
+    { label: "STO", R: 1e15, d: 35, nd: 1.0, elemId: 0, sd: 30 },
+    {
+      label: "SEC",
+      R: 1e15,
+      d: 0.5,
+      nd: 1.0,
+      elemId: 1,
+      sd: 8,
+      interaction: {
+        type: "reflect",
+        incidentSide: "rear",
+        inactiveSide: "block",
+        mirrorKind: "first-surface",
+      },
+    },
+    { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 8 },
+    {
+      label: "M1",
+      R: -200,
+      d: 2,
+      nd: 1.0,
+      elemId: 2,
+      sd: 30,
+      innerSd: 8,
+      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+    },
+    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30, innerSd: 8 },
+  ],
+
+  asph: {},
+  var: {},
+  varLabels: [],
+  groups: [
+    { text: "M2", fromSurface: "SEC", toSurface: "SECB" },
+    { text: "M1", fromSurface: "M1", toSurface: "M1B" },
+  ],
+  doublets: [],
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts
+++ b/src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts
@@ -95,7 +95,7 @@ const LENS_DATA = {
       elemId: 2,
       sd: 30,
       innerSd: 8,
-      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+      interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
     { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30, innerSd: 8 },
   ],

--- a/src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts
+++ b/src/lens-data/reference/ReferenceCassegrainBackFocus.data.ts
@@ -12,7 +12,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-cassegrain-back-focus",
   maker: "Reference",
-  visible: false,
+  visible: true,
   name: "REFERENCE Cassegrain Back Focus",
   subtitle: "Hidden folded-analysis guard fixture",
   specs: ["CASSEGRAIN-STYLE", "CENTRAL SECONDARY", "ANNULAR PRIMARY", "BACK FOCUS"],

--- a/src/lens-data/reference/ReferenceGregorianSecondary.data.ts
+++ b/src/lens-data/reference/ReferenceGregorianSecondary.data.ts
@@ -1,0 +1,107 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Hidden regression fixture for a Gregorian-style secondary path. The secondary
+ * is positioned beyond the primary focus on the object side, exercising a
+ * different secondary curvature/sign convention than the Cassegrain fixtures.
+ */
+
+const LENS_DATA = {
+  key: "reference-gregorian-secondary",
+  maker: "Reference",
+  visible: false,
+  name: "REFERENCE Gregorian Secondary",
+  subtitle: "Hidden alternate-secondary folded fixture",
+  specs: ["GREGORIAN-STYLE", "CONCAVE SECONDARY", "ANNULAR PRIMARY", "BACK FOCUS"],
+
+  focalLengthMarketing: 100,
+  focalLengthDesign: 100,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  patentYear: 2026,
+  elementCount: 2,
+  groupCount: 2,
+  nominalFno: 4,
+  closeFocusM: 10,
+  yScFill: 0.5,
+  scFill: 0.62,
+  rayLeadFrac: 0.25,
+  maxFstop: 16,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 8,
+    maxTraceFieldDeg: 4,
+  },
+  opticalPath: {
+    surfaceOrder: ["M1", "SEC"],
+    imagePlane: { z: 135, label: "IMG" },
+    maxInteractions: 10,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "M1",
+      label: "Annular primary mirror",
+      type: "Annular Concave First-Surface Mirror",
+      nd: 1.0,
+      vd: 0,
+      fl: 100,
+      glass: "Aluminized annular front surface",
+      apd: false,
+      fromSurface: "M1",
+      toSurface: "M1B",
+      role: "Primary mirror whose returning beam crosses the front focus before reaching the Gregorian secondary.",
+    },
+    {
+      id: 2,
+      name: "M2",
+      label: "Gregorian secondary",
+      type: "Concave First-Surface Mirror",
+      nd: 1.0,
+      vd: 0,
+      glass: "Aluminized front surface",
+      apd: false,
+      fromSurface: "SEC",
+      toSurface: "SECB",
+      role: "Concave secondary beyond the primary focus, returning the beam through the primary hole.",
+    },
+  ],
+
+  surfaces: [
+    { label: "STO", R: 1e15, d: 100, nd: 1.0, elemId: 0, sd: 30 },
+    {
+      label: "M1",
+      R: -200,
+      d: 2,
+      nd: 1.0,
+      elemId: 1,
+      sd: 30,
+      innerSd: 7,
+      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+    },
+    { label: "M1B", R: 1e15, d: -127, nd: 1.0, elemId: 1, sd: 30, innerSd: 7 },
+    {
+      label: "SEC",
+      R: 80,
+      d: 1,
+      nd: 1.0,
+      elemId: 2,
+      sd: 12,
+      interaction: { type: "reflect", incidentSide: "rear", mirrorKind: "first-surface" },
+    },
+    { label: "SECB", R: 1e15, d: 159, nd: 1.0, elemId: 2, sd: 12 },
+  ],
+
+  asph: {},
+  var: {},
+  varLabels: [],
+  groups: [
+    { text: "M1", fromSurface: "M1", toSurface: "M1B" },
+    { text: "M2", fromSurface: "SEC", toSurface: "SECB" },
+  ],
+  doublets: [],
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/reference/ReferenceGregorianSecondary.data.ts
+++ b/src/lens-data/reference/ReferenceGregorianSecondary.data.ts
@@ -79,7 +79,7 @@ const LENS_DATA = {
       elemId: 1,
       sd: 30,
       innerSd: 7,
-      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+      interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
     { label: "M1B", R: 1e15, d: -127, nd: 1.0, elemId: 1, sd: 30, innerSd: 7 },
     {
@@ -89,7 +89,7 @@ const LENS_DATA = {
       nd: 1.0,
       elemId: 2,
       sd: 12,
-      interaction: { type: "reflect", incidentSide: "rear", mirrorKind: "first-surface" },
+      interaction: { type: "reflect", incidentSide: "rear", inactiveSide: "block", mirrorKind: "first-surface" },
     },
     { label: "SECB", R: 1e15, d: 159, nd: 1.0, elemId: 2, sd: 12 },
   ],

--- a/src/lens-data/reference/ReferenceGregorianSecondary.data.ts
+++ b/src/lens-data/reference/ReferenceGregorianSecondary.data.ts
@@ -78,10 +78,10 @@ const LENS_DATA = {
       nd: 1.0,
       elemId: 1,
       sd: 30,
-      innerSd: 7,
+      innerSd: 9,
       interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
-    { label: "M1B", R: 1e15, d: -127, nd: 1.0, elemId: 1, sd: 30, innerSd: 7 },
+    { label: "M1B", R: 1e15, d: -127, nd: 1.0, elemId: 1, sd: 30, innerSd: 9 },
     {
       label: "SEC",
       R: 80,

--- a/src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts
+++ b/src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts
@@ -107,10 +107,10 @@ const LENS_DATA = {
       nd: 1.0,
       elemId: 3,
       sd: 30,
-      innerSd: 7,
+      innerSd: 8.1,
       interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
-    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 3, sd: 30, innerSd: 7 },
+    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 3, sd: 30, innerSd: 8.1 },
   ],
 
   asph: {},

--- a/src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts
+++ b/src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts
@@ -108,7 +108,7 @@ const LENS_DATA = {
       elemId: 3,
       sd: 30,
       innerSd: 7,
-      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+      interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
     { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 3, sd: 30, innerSd: 7 },
   ],

--- a/src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts
+++ b/src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts
@@ -1,29 +1,25 @@
 import type { LensDataInput } from "../../types/optics.js";
 
 /**
- * Hidden regression fixture for guarded folded-system analysis.
- *
- * This synthetic Cassegrain-style prescription uses an annular primary and a
- * centrally blocking secondary. Off-axis pupil samples pass around the
- * secondary, reflect from the primary, reflect from the secondary, then pass
- * through the primary hole to a back-focus image plane.
+ * Hidden regression fixture for folded systems with a refractive meniscus
+ * ahead of a Cassegrain-style primary/secondary mirror pair.
  */
 
 const LENS_DATA = {
-  key: "reference-cassegrain-back-focus",
+  key: "reference-maksutov-cassegrain-meniscus",
   maker: "Reference",
   visible: false,
-  name: "REFERENCE Cassegrain Back Focus",
-  subtitle: "Hidden folded-analysis guard fixture",
-  specs: ["CASSEGRAIN-STYLE", "CENTRAL SECONDARY", "ANNULAR PRIMARY", "BACK FOCUS"],
+  name: "REFERENCE Maksutov Cassegrain Meniscus",
+  subtitle: "Hidden folded-path meniscus fixture",
+  specs: ["MENISCUS CORRECTOR", "CASSEGRAIN-STYLE", "ANNULAR PRIMARY", "BACK FOCUS"],
 
   focalLengthMarketing: 100,
   focalLengthDesign: 100,
   apertureMarketing: 4,
   apertureDesign: 4,
   patentYear: 2026,
-  elementCount: 2,
-  groupCount: 2,
+  elementCount: 3,
+  groupCount: 3,
   nominalFno: 4,
   closeFocusM: 10,
   yScFill: 0.5,
@@ -37,16 +33,29 @@ const LENS_DATA = {
     maxTraceFieldDeg: 4,
   },
   opticalPath: {
-    mode: "auto",
+    surfaceOrder: ["MEN1", "MEN2", "M1", "SEC"],
     imagePlane: { z: 135, label: "IMG" },
-    maxInteractions: 10,
+    maxInteractions: 12,
   },
 
   elements: [
     {
       id: 1,
+      name: "MEN",
+      label: "Weak meniscus corrector",
+      type: "Meniscus Corrector",
+      nd: 1.5168,
+      vd: 64.2,
+      glass: "Reference crown",
+      apd: false,
+      fromSurface: "MEN1",
+      toSurface: "MEN2",
+      role: "Weak refractive corrector placed ahead of the folded mirror train.",
+    },
+    {
+      id: 2,
       name: "M2",
-      label: "Secondary mirror",
+      label: "Central secondary mirror",
       type: "Flat First-Surface Mirror",
       nd: 1.0,
       vd: 0,
@@ -54,10 +63,10 @@ const LENS_DATA = {
       apd: false,
       fromSurface: "SEC",
       toSurface: "SECB",
-      role: "Central secondary that blocks incoming core rays and reflects the returning primary beam.",
+      role: "Central secondary that blocks the incoming core and reflects the returning primary beam.",
     },
     {
-      id: 2,
+      id: 3,
       name: "M1",
       label: "Annular primary mirror",
       type: "Annular Concave First-Surface Mirror",
@@ -66,19 +75,23 @@ const LENS_DATA = {
       fl: 100,
       glass: "Aluminized annular front surface",
       apd: false,
+      fromSurface: "M1",
+      toSurface: "M1B",
       role: "Spherical primary mirror with a central hole for the back-focus beam.",
     },
   ],
 
   surfaces: [
-    { label: "STO", R: 1e15, d: 35, nd: 1.0, elemId: 0, sd: 30 },
+    { label: "STO", R: 1e15, d: 10, nd: 1.0, elemId: 0, sd: 30 },
+    { label: "MEN1", R: 300, d: 4, nd: 1.5168, elemId: 1, sd: 30 },
+    { label: "MEN2", R: -300, d: 21, nd: 1.0, elemId: 1, sd: 30 },
     {
       label: "SEC",
       R: 1e15,
       d: 0.5,
       nd: 1.0,
-      elemId: 1,
-      sd: 8,
+      elemId: 2,
+      sd: 7,
       interaction: {
         type: "reflect",
         incidentSide: "rear",
@@ -86,24 +99,25 @@ const LENS_DATA = {
         mirrorKind: "first-surface",
       },
     },
-    { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 8 },
+    { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 2, sd: 7 },
     {
       label: "M1",
       R: -200,
       d: 2,
       nd: 1.0,
-      elemId: 2,
+      elemId: 3,
       sd: 30,
-      innerSd: 8,
+      innerSd: 7,
       interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
     },
-    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30, innerSd: 8 },
+    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 3, sd: 30, innerSd: 7 },
   ],
 
   asph: {},
   var: {},
   varLabels: [],
   groups: [
+    { text: "Corrector", fromSurface: "MEN1", toSurface: "MEN2" },
     { text: "M2", fromSurface: "SEC", toSurface: "SECB" },
     { text: "M1", fromSurface: "M1", toSurface: "M1B" },
   ],

--- a/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
+++ b/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
@@ -11,7 +11,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-mangin-second-surface-mirror",
   maker: "Reference",
-  visible: false,
+  visible: true,
   name: "REFERENCE Mangin Second-Surface Mirror",
   subtitle: "Hidden repeated-surface regression fixture",
   specs: ["SECOND-SURFACE MIRROR", "REPEATED FRONT SURFACE", "n = 1.5"],

--- a/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
+++ b/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
@@ -1,0 +1,80 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Hidden regression fixture for second-surface mirror tracing.
+ *
+ * A simple plano-concave Mangin-style mirror: rays enter a glass body through
+ * the flat front surface, reflect from the silvered rear surface, and exit
+ * through the same front surface from the rear side.
+ */
+
+const LENS_DATA = {
+  key: "reference-mangin-second-surface-mirror",
+  maker: "Reference",
+  visible: false,
+  name: "REFERENCE Mangin Second-Surface Mirror",
+  subtitle: "Hidden repeated-surface regression fixture",
+  specs: ["SECOND-SURFACE MIRROR", "REPEATED FRONT SURFACE", "n = 1.5"],
+
+  focalLengthMarketing: 90,
+  focalLengthDesign: 90,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  patentYear: 2026,
+  elementCount: 1,
+  groupCount: 1,
+  nominalFno: 4,
+  closeFocusM: 10,
+  yScFill: 0.55,
+  scFill: 0.62,
+  rayLeadFrac: 0.3,
+  maxFstop: 16,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 8,
+    maxTraceFieldDeg: 4,
+  },
+  opticalPath: {
+    surfaceOrder: ["STO", "MG1", "MG2", "MG1"],
+    imagePlane: { z: 35, label: "IMG" },
+    maxInteractions: 5,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "MG",
+      label: "Mangin mirror",
+      type: "Plano-Concave Second-Surface Mirror",
+      nd: 1.5,
+      vd: 60,
+      fl: 90,
+      glass: "Reference crown glass",
+      apd: false,
+      role: "Glass body whose rear surface reflects rays back through the entrance surface.",
+    },
+  ],
+
+  surfaces: [
+    { label: "STO", R: 1e15, d: 100, nd: 1.0, elemId: 0, sd: 25 },
+    { label: "MG1", R: 1e15, d: 10, nd: 1.5, elemId: 1, sd: 25 },
+    {
+      label: "MG2",
+      R: -220,
+      d: 0,
+      nd: 1.0,
+      elemId: 0,
+      sd: 25,
+      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "second-surface" },
+    },
+  ],
+
+  asph: {},
+  var: {},
+  varLabels: [],
+  groups: [{ text: "MG", fromSurface: "MG1", toSurface: "MG2" }],
+  doublets: [],
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
+++ b/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
@@ -66,7 +66,7 @@ const LENS_DATA = {
       nd: 1.0,
       elemId: 0,
       sd: 25,
-      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "second-surface" },
+      interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "second-surface" },
     },
   ],
 

--- a/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
+++ b/src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts
@@ -11,7 +11,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-mangin-second-surface-mirror",
   maker: "Reference",
-  visible: true,
+  visible: false,
   name: "REFERENCE Mangin Second-Surface Mirror",
   subtitle: "Hidden repeated-surface regression fixture",
   specs: ["SECOND-SURFACE MIRROR", "REPEATED FRONT SURFACE", "n = 1.5"],

--- a/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
+++ b/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
@@ -14,7 +14,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-newtonian-side-focus",
   maker: "Reference",
-  visible: false,
+  visible: true,
   name: "REFERENCE Newtonian Side Focus",
   subtitle: "Hidden automatic folded-path regression fixture",
   specs: ["AUTO PATH", "DIAGONAL SECONDARY", "SIDE IMAGE PLANE", "f = 100 mm"],
@@ -89,7 +89,7 @@ const LENS_DATA = {
         normal: { z: 1, y: 1 },
       },
     },
-    { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 10 },
+    { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 10, interaction: { type: "refract", normal: { z: 1, y: 1 } } },
     {
       label: "M1",
       R: -200,

--- a/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
+++ b/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
@@ -84,7 +84,7 @@ const LENS_DATA = {
       interaction: {
         type: "reflect",
         incidentSide: "rear",
-        inactiveSide: "ignore",
+        inactiveSide: "block",
         mirrorKind: "first-surface",
         normal: { z: 1, y: 1 },
       },
@@ -97,7 +97,7 @@ const LENS_DATA = {
       nd: 1.0,
       elemId: 1,
       sd: 30,
-      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+      interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
     { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30 },
   ],

--- a/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
+++ b/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
@@ -1,0 +1,115 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Hidden regression fixture for automatically resolved folded mirror paths.
+ *
+ * A synthetic Newtonian-style layout: incoming collimated rays pass the diagonal
+ * secondary from its inactive side, reflect from a concave spherical primary,
+ * then hit the same diagonal from the rear side and terminate on a side image
+ * plane above the axis. The geometry is intentionally compact and hidden from
+ * the public catalog; it exists to verify automatic next-surface selection and
+ * non-axial image-plane handling.
+ */
+
+const LENS_DATA = {
+  key: "reference-newtonian-side-focus",
+  maker: "Reference",
+  visible: false,
+  name: "REFERENCE Newtonian Side Focus",
+  subtitle: "Hidden automatic folded-path regression fixture",
+  specs: ["AUTO PATH", "DIAGONAL SECONDARY", "SIDE IMAGE PLANE", "f = 100 mm"],
+
+  focalLengthMarketing: 100,
+  focalLengthDesign: 100,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  patentYear: 2026,
+  elementCount: 2,
+  groupCount: 2,
+  nominalFno: 4,
+  closeFocusM: 10,
+  yScFill: 0.5,
+  scFill: 0.62,
+  rayLeadFrac: 0.25,
+  maxFstop: 16,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 8,
+    maxTraceFieldDeg: 4,
+  },
+  opticalPath: {
+    mode: "auto",
+    imagePlane: { z: 35, y: 25, normal: { z: 0, y: 1 }, label: "IMG" },
+    maxInteractions: 8,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "M1",
+      label: "Primary mirror",
+      type: "Concave First-Surface Mirror",
+      nd: 1.0,
+      vd: 0,
+      fl: 100,
+      glass: "Aluminized front surface",
+      apd: false,
+      role: "Spherical primary mirror that sends the beam back toward the diagonal secondary.",
+    },
+    {
+      id: 2,
+      name: "M2",
+      label: "Diagonal secondary",
+      type: "Flat Fold Mirror",
+      nd: 1.0,
+      vd: 0,
+      glass: "Aluminized flat surface",
+      apd: false,
+      fromSurface: "SEC",
+      toSurface: "SECB",
+      role: "Meridional fold mirror active only from the rear side after primary reflection.",
+    },
+  ],
+
+  surfaces: [
+    { label: "STO", R: 1e15, d: 35, nd: 1.0, elemId: 0, sd: 30 },
+    {
+      label: "SEC",
+      R: 1e15,
+      d: 0.5,
+      nd: 1.0,
+      elemId: 2,
+      sd: 10,
+      interaction: {
+        type: "reflect",
+        incidentSide: "rear",
+        inactiveSide: "ignore",
+        mirrorKind: "first-surface",
+        normal: { z: 1, y: 1 },
+      },
+    },
+    { label: "SECB", R: 1e15, d: 64.5, nd: 1.0, elemId: 0, sd: 10 },
+    {
+      label: "M1",
+      R: -200,
+      d: 2,
+      nd: 1.0,
+      elemId: 1,
+      sd: 30,
+      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+    },
+    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30 },
+  ],
+
+  asph: {},
+  var: {},
+  varLabels: [],
+  groups: [
+    { text: "M2", fromSurface: "SEC", toSurface: "SECB" },
+    { text: "M1", fromSurface: "M1", toSurface: "M1B" },
+  ],
+  doublets: [],
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
+++ b/src/lens-data/reference/ReferenceNewtonianSideFocus.data.ts
@@ -14,7 +14,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-newtonian-side-focus",
   maker: "Reference",
-  visible: true,
+  visible: false,
   name: "REFERENCE Newtonian Side Focus",
   subtitle: "Hidden automatic folded-path regression fixture",
   specs: ["AUTO PATH", "DIAGONAL SECONDARY", "SIDE IMAGE PLANE", "f = 100 mm"],

--- a/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
+++ b/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
@@ -12,7 +12,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-spherical-primary-mirror",
   maker: "Reference",
-  visible: true,
+  visible: false,
   name: "REFERENCE Spherical Primary Mirror",
   subtitle: "Hidden folded-optics regression fixture",
   specs: ["FIRST-SURFACE MIRROR", "f = 100 mm", "F/4", "FRONT IMAGE PLANE"],

--- a/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
+++ b/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
@@ -1,0 +1,81 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Hidden regression fixture for folded-optics tracing.
+ *
+ * A concave first-surface spherical primary mirror with R = -200 mm focuses
+ * collimated on-axis rays at z = 0 mm after reflection from the vertex at
+ * z = 100 mm. The fixture is intentionally simple and hidden from the public
+ * catalog; it exists to verify mirror reflection and front-side image planes.
+ */
+
+const LENS_DATA = {
+  key: "reference-spherical-primary-mirror",
+  maker: "Reference",
+  visible: false,
+  name: "REFERENCE Spherical Primary Mirror",
+  subtitle: "Hidden folded-optics regression fixture",
+  specs: ["FIRST-SURFACE MIRROR", "f = 100 mm", "F/4", "FRONT IMAGE PLANE"],
+
+  focalLengthMarketing: 100,
+  focalLengthDesign: 100,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  patentYear: 2026,
+  elementCount: 1,
+  groupCount: 1,
+  nominalFno: 4,
+  closeFocusM: 10,
+  yScFill: 0.55,
+  scFill: 0.62,
+  rayLeadFrac: 0.3,
+  maxFstop: 16,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 10,
+    maxTraceFieldDeg: 5,
+  },
+  opticalPath: {
+    surfaceOrder: ["STO", "M1"],
+    imagePlane: { z: 0, label: "IMG" },
+    maxInteractions: 3,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "M1",
+      label: "Primary mirror",
+      type: "Concave First-Surface Mirror",
+      nd: 1.0,
+      vd: 0,
+      fl: 100,
+      glass: "Aluminized front surface",
+      apd: false,
+      role: "Single spherical mirror focusing collimated rays back toward the front focal plane.",
+    },
+  ],
+
+  surfaces: [
+    { label: "STO", R: 1e15, d: 100, nd: 1.0, elemId: 0, sd: 30 },
+    {
+      label: "M1",
+      R: -200,
+      d: 2,
+      nd: 1.0,
+      elemId: 1,
+      sd: 30,
+      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+    },
+    { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30 },
+  ],
+
+  asph: {},
+  var: {},
+  varLabels: [],
+  groups: [{ text: "M1", fromSurface: "M1", toSurface: "M1B" }],
+  doublets: [],
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
+++ b/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
@@ -66,7 +66,7 @@ const LENS_DATA = {
       nd: 1.0,
       elemId: 1,
       sd: 30,
-      interaction: { type: "reflect", incidentSide: "front", mirrorKind: "first-surface" },
+      interaction: { type: "reflect", incidentSide: "front", inactiveSide: "block", mirrorKind: "first-surface" },
     },
     { label: "M1B", R: 1e15, d: 0, nd: 1.0, elemId: 0, sd: 30 },
   ],

--- a/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
+++ b/src/lens-data/reference/ReferenceSphericalPrimaryMirror.data.ts
@@ -12,7 +12,7 @@ import type { LensDataInput } from "../../types/optics.js";
 const LENS_DATA = {
   key: "reference-spherical-primary-mirror",
   maker: "Reference",
-  visible: false,
+  visible: true,
   name: "REFERENCE Spherical Primary Mirror",
   subtitle: "Hidden folded-optics regression fixture",
   specs: ["FIRST-SURFACE MIRROR", "f = 100 mm", "F/4", "FRONT IMAGE PLANE"],

--- a/src/optics/aberration/shared.ts
+++ b/src/optics/aberration/shared.ts
@@ -44,10 +44,40 @@ export function imagePlaneIntercept(y: number, u: number, lastSurfZ: number, ima
   return isFinite(imageHeight) ? imageHeight : null;
 }
 
-export function meridionalImagePlaneCoordinate(z: number, y: number, L: RuntimeLens): number {
-  const tangentZ = -L.imagePlane.normal.y;
-  const tangentY = L.imagePlane.normal.z;
-  return (z - L.imagePlane.z) * tangentZ + (y - L.imagePlane.y) * tangentY;
+export function meridionalImagePlaneCoordinate(
+  z: number,
+  y: number,
+  L: RuntimeLens,
+  planeZ = L.imagePlane?.z ?? z,
+): number {
+  const normal = L.imagePlane?.normal ?? { z: 1, y: 0 };
+  const imageY = L.imagePlane?.y ?? 0;
+  const tangentZ = -normal.y;
+  const tangentY = normal.z;
+  return (z - planeZ) * tangentZ + (y - imageY) * tangentY;
+}
+
+export function imagePlaneCoordinate(
+  y: number,
+  u: number,
+  referenceZ: number,
+  L: RuntimeLens,
+  planeZ = L.imagePlane?.z ?? referenceZ,
+): number | null {
+  const normal = L.imagePlane?.normal ?? { z: 1, y: 0 };
+  const imageY = L.imagePlane?.y ?? 0;
+  const normalY = normal.y;
+  const normalZ = normal.z;
+  const numer = normalY * (y - imageY) + normalZ * (referenceZ - planeZ);
+  const denom = normalY * u + normalZ;
+  if (Math.abs(denom) <= 1e-12) {
+    return Math.abs(numer) <= 1e-9 ? meridionalImagePlaneCoordinate(referenceZ, y, L, planeZ) : null;
+  }
+  const dz = -numer / denom;
+  const zHit = referenceZ + dz;
+  const yHit = y + u * dz;
+  if (!isFinite(zHit) || !isFinite(yHit)) return null;
+  return meridionalImagePlaneCoordinate(zHit, yHit, L, planeZ);
 }
 
 export function generalizedImagePlaneIntercept(
@@ -56,18 +86,7 @@ export function generalizedImagePlaneIntercept(
   referenceZ: number,
   L: RuntimeLens,
 ): number | null {
-  const normalY = L.imagePlane.normal.y;
-  const normalZ = L.imagePlane.normal.z;
-  const numer = normalY * (y - L.imagePlane.y) + normalZ * (referenceZ - L.imagePlane.z);
-  const denom = normalY * u + normalZ;
-  if (Math.abs(denom) <= 1e-12) {
-    return Math.abs(numer) <= 1e-9 ? meridionalImagePlaneCoordinate(referenceZ, y, L) : null;
-  }
-  const dz = -numer / denom;
-  const zHit = referenceZ + dz;
-  const yHit = y + u * dz;
-  if (!isFinite(zHit) || !isFinite(yHit)) return null;
-  return meridionalImagePlaneCoordinate(zHit, yHit, L);
+  return imagePlaneCoordinate(y, u, referenceZ, L, L.imagePlane?.z ?? referenceZ);
 }
 
 export function computeRealRayHit(
@@ -90,9 +109,7 @@ export function computeRealRayHit(
   const referenceZ = terminalPoint ? terminalPoint[0] : lastSurfZ;
   const referenceY = terminalPoint ? terminalPoint[1] : ray.y;
   const intercept = axialIntercept(referenceY, ray.u, referenceZ);
-  const imageHeight = L.isFoldedOptics
-    ? generalizedImagePlaneIntercept(referenceY, ray.u, referenceZ, L)
-    : imagePlaneIntercept(referenceY, ray.u, referenceZ, imagePlaneZ);
+  const imageHeight = imagePlaneCoordinate(referenceY, ray.u, referenceZ, L, imagePlaneZ);
   if (intercept === null || imageHeight === null) return null;
 
   return {

--- a/src/optics/aberration/shared.ts
+++ b/src/optics/aberration/shared.ts
@@ -21,6 +21,7 @@ export interface SymmetricRealSample {
 export interface TransverseFocusHit {
   coordinate: number;
   slope: number;
+  referenceZ?: number;
 }
 
 export interface RealRayHit extends TransverseFocusHit {
@@ -43,6 +44,32 @@ export function imagePlaneIntercept(y: number, u: number, lastSurfZ: number, ima
   return isFinite(imageHeight) ? imageHeight : null;
 }
 
+export function meridionalImagePlaneCoordinate(z: number, y: number, L: RuntimeLens): number {
+  const tangentZ = -L.imagePlane.normal.y;
+  const tangentY = L.imagePlane.normal.z;
+  return (z - L.imagePlane.z) * tangentZ + (y - L.imagePlane.y) * tangentY;
+}
+
+export function generalizedImagePlaneIntercept(
+  y: number,
+  u: number,
+  referenceZ: number,
+  L: RuntimeLens,
+): number | null {
+  const normalY = L.imagePlane.normal.y;
+  const normalZ = L.imagePlane.normal.z;
+  const numer = normalY * (y - L.imagePlane.y) + normalZ * (referenceZ - L.imagePlane.z);
+  const denom = normalY * u + normalZ;
+  if (Math.abs(denom) <= 1e-12) {
+    return Math.abs(numer) <= 1e-9 ? meridionalImagePlaneCoordinate(referenceZ, y, L) : null;
+  }
+  const dz = -numer / denom;
+  const zHit = referenceZ + dz;
+  const yHit = y + u * dz;
+  if (!isFinite(zHit) || !isFinite(yHit)) return null;
+  return meridionalImagePlaneCoordinate(zHit, yHit, L);
+}
+
 export function computeRealRayHit(
   L: RuntimeLens,
   zPos: number[],
@@ -59,16 +86,22 @@ export function computeRealRayHit(
   const ray = traceRay(h, 0, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT);
   if (ray.clipped) return null;
 
-  const intercept = axialIntercept(ray.y, ray.u, lastSurfZ);
-  const imageHeight = imagePlaneIntercept(ray.y, ray.u, lastSurfZ, imagePlaneZ);
+  const terminalPoint = ray.reachedImagePlane ? ray.pts[ray.pts.length - 1] : undefined;
+  const referenceZ = terminalPoint ? terminalPoint[0] : lastSurfZ;
+  const referenceY = terminalPoint ? terminalPoint[1] : ray.y;
+  const intercept = axialIntercept(referenceY, ray.u, referenceZ);
+  const imageHeight = L.isFoldedOptics
+    ? generalizedImagePlaneIntercept(referenceY, ray.u, referenceZ, L)
+    : imagePlaneIntercept(referenceY, ray.u, referenceZ, imagePlaneZ);
   if (intercept === null || imageHeight === null) return null;
 
   return {
-    coordinate: ray.y,
+    coordinate: referenceY,
     fraction: Math.abs(signedFraction),
     signedFraction,
     slope: ray.u,
-    y: ray.y,
+    referenceZ,
+    y: referenceY,
     u: ray.u,
     intercept,
     imageHeight,
@@ -121,7 +154,7 @@ export function computeSymmetricRealSample(
 }
 
 export function transverseCoordinateAtPlane(hit: TransverseFocusHit, lastSurfZ: number, planeZ: number): number {
-  return hit.coordinate + hit.slope * (planeZ - lastSurfZ);
+  return hit.coordinate + hit.slope * (planeZ - (hit.referenceZ ?? lastSurfZ));
 }
 
 export function rmsAtPlane(hits: TransverseFocusHit[], lastSurfZ: number, planeZ: number): number {
@@ -140,8 +173,11 @@ export function peakAtPlane(hits: TransverseFocusHit[], lastSurfZ: number, plane
 export function bestFocusPlane(hits: TransverseFocusHit[], lastSurfZ: number): number {
   const denom = hits.reduce((sum, hit) => sum + hit.slope * hit.slope, 0);
   if (denom <= 1e-12) return lastSurfZ;
-  const numer = hits.reduce((sum, hit) => sum + hit.coordinate * hit.slope, 0);
-  return lastSurfZ - numer / denom;
+  const numer = hits.reduce((sum, hit) => {
+    const referenceZ = hit.referenceZ ?? lastSurfZ;
+    return sum + hit.slope * hit.slope * referenceZ - hit.coordinate * hit.slope;
+  }, 0);
+  return numer / denom;
 }
 
 export function bestRelativeFocusPlane(
@@ -156,10 +192,13 @@ export function bestRelativeFocusPlane(
   if (denom <= 1e-12) return lastSurfZ;
 
   const numer = hits.reduce((sum, hit) => {
-    const dy = hit.coordinate - referenceHit.coordinate;
     const du = hit.slope - referenceHit.slope;
-    return sum + dy * du;
+    const referenceZ = hit.referenceZ ?? lastSurfZ;
+    const referenceHitZ = referenceHit.referenceZ ?? lastSurfZ;
+    const offset =
+      hit.coordinate - hit.slope * referenceZ - referenceHit.coordinate + referenceHit.slope * referenceHitZ;
+    return sum + offset * du;
   }, 0);
 
-  return lastSurfZ - numer / denom;
+  return -numer / denom;
 }

--- a/src/optics/aberration/spherical.ts
+++ b/src/optics/aberration/spherical.ts
@@ -19,6 +19,7 @@ import {
   computeSymmetricRealSample,
   peakAtPlane,
   rmsAtPlane,
+  transverseCoordinateAtPlane,
 } from "./shared.js";
 
 const SA_BLUR_CHARACTER_MIN_VALID_SAMPLES = 5;
@@ -37,7 +38,7 @@ export function computeSphericalAberration(
   if (currentEPSD <= 0 || L.N < 1) return null;
 
   const lastSurfZ = zPos[L.N - 1];
-  const imagePlaneZ = lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
+  const imagePlaneZ = L.isFoldedOptics ? L.imagePlane.z : lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
   if (!isFinite(imagePlaneZ)) return null;
 
   const nearAxisSample = computeSymmetricRealSample(
@@ -145,7 +146,7 @@ export function computeSAProfile(
   if (currentEPSD <= 0 || L.N < 1) return [];
 
   const lastSurfZ = zPos[L.N - 1];
-  const imagePlaneZ = lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
+  const imagePlaneZ = L.isFoldedOptics ? L.imagePlane.z : lastSurfZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
   if (!isFinite(imagePlaneZ)) return [];
 
   const hits = PROFILE_FRACS.flatMap((fraction) => {
@@ -182,7 +183,7 @@ export function computeSAProfile(
   const nearAxisPlusHit = hits.find((hit) => hit.signedFraction === NEAR_AXIS_REAL_FRAC) ?? null;
   if (nearAxisPlusHit === null) return [];
 
-  const nearAxisHeightAtBestFocus = nearAxisPlusHit.y + nearAxisPlusHit.u * (bestFocusZ - lastSurfZ);
+  const nearAxisHeightAtBestFocus = transverseCoordinateAtPlane(nearAxisPlusHit, lastSurfZ, bestFocusZ);
   const points: SAProfilePoint[] = [];
 
   for (const fraction of PROFILE_FRACS) {
@@ -191,7 +192,7 @@ export function computeSAProfile(
 
     points.push({
       fraction,
-      transverseSaMm: plusHit.y + plusHit.u * (bestFocusZ - lastSurfZ) - nearAxisHeightAtBestFocus,
+      transverseSaMm: transverseCoordinateAtPlane(plusHit, lastSurfZ, bestFocusZ) - nearAxisHeightAtBestFocus,
     });
   }
 

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -25,7 +25,8 @@ import {
   type ParaxialSurfaceTraceOptions,
   type RealSurfaceTraceResult,
 } from "./internal/traceSurfaces.js";
-import { traceExactSurfaceStack } from "./internal/exactSurfaceTrace.js";
+import { traceExactSurfaceStack, traceToStopViaGeneralized } from "./internal/exactSurfaceTrace.js";
+import type { ExactTraceLens, ExactSurfaceTraceResult } from "./internal/exactSurfaceTrace.js";
 import {
   fisheyeProjectionFocalLengthAtZoom,
   fisheyeProjectionMaxTraceFieldAtZoom,
@@ -122,6 +123,82 @@ function realTraceToStop(
 interface RealTraceFullResult extends RealTraceToStopResult {
   heights: number[];
   clipped: boolean; /* true if |y| exceeded any surface SD */
+}
+
+interface PupilBasisRay {
+  y: number;
+  u: number;
+  z: number;
+}
+
+interface PupilGeometryFallback {
+  xpZRelLastSurf: number;
+  xpSD: number;
+}
+
+interface PupilGeometryResult {
+  epZRelStop: number;
+  xpZRelLastSurf: number;
+  xpSD: number;
+}
+
+function finitePupilBasisRay(ray: PupilBasisRay): boolean {
+  return isFinite(ray.y) && isFinite(ray.u) && isFinite(ray.z);
+}
+
+function pupilBasisAtZ(ray: PupilBasisRay, scale: number, z: number): { y: number; u: number } {
+  return {
+    y: (ray.y + ray.u * (z - ray.z)) / scale,
+    u: ray.u / scale,
+  };
+}
+
+function computePupilGeometry({
+  realYRatio,
+  realB,
+  margFull,
+  chiefFull,
+  epSD,
+  delta,
+  zStop,
+  zLast,
+  fallback,
+}: {
+  realYRatio: number;
+  realB: number;
+  margFull: PupilBasisRay;
+  chiefFull: PupilBasisRay;
+  epSD: number;
+  delta: number;
+  zStop: number;
+  zLast: number;
+  fallback: PupilGeometryFallback;
+}): PupilGeometryResult {
+  const epZRelStop = Math.abs(realYRatio) > 1e-9 ? realB / realYRatio - zStop : 0;
+  if (!finitePupilBasisRay(margFull) || !finitePupilBasisRay(chiefFull) || !isFinite(zLast)) {
+    return { epZRelStop, ...fallback };
+  }
+
+  const marginal = pupilBasisAtZ(margFull, delta, zLast);
+  const chief = pupilBasisAtZ(chiefFull, delta, zLast);
+  const xpY = realYRatio * chief.y - realB * marginal.y;
+  const xpU = realYRatio * chief.u - realB * marginal.u;
+  const xpZRelLastSurf = Math.abs(xpU) > 1e-9 ? -xpY / xpU : Infinity;
+  const xpSD = isFinite(xpZRelLastSurf) ? Math.abs(marginal.y + marginal.u * xpZRelLastSurf) * epSD : Infinity;
+  return { epZRelStop, xpZRelLastSurf, xpSD };
+}
+
+function foldedPupilBasisRay(result: ExactSurfaceTraceResult): PupilBasisRay {
+  if (result.failureReason !== null || result.clipped) return { y: NaN, u: NaN, z: NaN };
+  const lastHit = [...result.hits].reverse().find((hit) => !hit.fallback && hit.failureReason === null);
+  if (!lastHit) return { y: NaN, u: NaN, z: NaN };
+  const direction = lastHit.outgoingDirection ?? result.terminalDirection;
+  if (Math.abs(direction[2]) <= 1e-12) return { y: NaN, u: NaN, z: NaN };
+  return {
+    y: lastHit.point[1],
+    u: direction[1] / direction[2],
+    z: lastHit.point[2],
+  };
 }
 
 /**
@@ -332,10 +409,71 @@ export default function buildLens(data: LensData): RuntimeLens {
       firstFiniteScalar(data.focalLengthDesign) ?? firstFiniteScalar(data.focalLengthMarketing) ?? axialExtent;
     const baseNomFno = Array.isArray(data.nominalFno) ? data.nominalFno[0] : data.nominalFno!;
     const stopPhysSD = S[stopIdx].sd;
-    const EP: EntrancePupil = {
-      epSD: referenceFocalLength / (2 * baseNomFno),
-      yRatio: stopPhysSD > 0 ? stopPhysSD / Math.max(referenceFocalLength / (2 * baseNomFno), 1e-12) : 1,
+    const nominalEPSD = referenceFocalLength / (2 * baseNomFno);
+    const fallbackYRatio = stopPhysSD > 0 ? stopPhysSD / Math.max(nominalEPSD, 1e-12) : 1;
+    const foldedTraceLens: ExactTraceLens = {
+      S,
+      asphByIdx,
+      stopIdx,
+      clipMargin: data.clipMargin,
+      opticalPath,
+      imagePlane,
+      isFoldedOptics: true,
     };
+    let EP: EntrancePupil = { epSD: nominalEPSD, yRatio: fallbackYRatio };
+    let B = 0;
+    let epZRelStop = 0;
+    let xpZRelLastSurf = 0;
+    let xpSD = EP.epSD;
+    const realEpDelta = 1e-4;
+    const foldedMarginalStop = traceToStopViaGeneralized(foldedTraceLens, { y0: realEpDelta, uy0: 0 }, stopIdx, {
+      zPos: z,
+      leadDistance: 0,
+    });
+    const foldedChiefStop = traceToStopViaGeneralized(foldedTraceLens, { y0: 0, uy0: realEpDelta }, stopIdx, {
+      zPos: z,
+      leadDistance: 0,
+    });
+    if (
+      foldedMarginalStop.found &&
+      foldedChiefStop.found &&
+      isFinite(foldedMarginalStop.y) &&
+      isFinite(foldedChiefStop.y) &&
+      Math.abs(foldedMarginalStop.y) > 1e-15
+    ) {
+      const realYRatio = foldedMarginalStop.y / realEpDelta;
+      const realB = foldedChiefStop.y / realEpDelta;
+      const foldedMarginalFull = foldedPupilBasisRay(
+        traceExactSurfaceStack(foldedTraceLens, { y0: realEpDelta, uy0: 0 }, { zPos: z, leadDistance: 0 }),
+      );
+      const foldedChiefFull = foldedPupilBasisRay(
+        traceExactSurfaceStack(foldedTraceLens, { y0: 0, uy0: realEpDelta }, { zPos: z, leadDistance: 0 }),
+      );
+      const foldedLastZ = finitePupilBasisRay(foldedMarginalFull)
+        ? foldedMarginalFull.z
+        : finitePupilBasisRay(foldedChiefFull)
+          ? foldedChiefFull.z
+          : z[N - 1];
+      const pupilGeometry = computePupilGeometry({
+        realYRatio,
+        realB,
+        margFull: foldedMarginalFull,
+        chiefFull: foldedChiefFull,
+        epSD: EP.epSD,
+        delta: realEpDelta,
+        zStop: foldedMarginalStop.point?.[2] ?? z[stopIdx] ?? 0,
+        zLast: foldedLastZ,
+        fallback: {
+          xpZRelLastSurf: 0,
+          xpSD: EP.epSD,
+        },
+      });
+      EP = { epSD: nominalEPSD, yRatio: realYRatio };
+      B = realB;
+      epZRelStop = pupilGeometry.epZRelStop;
+      xpZRelLastSurf = pupilGeometry.xpZRelLastSurf;
+      xpSD = pupilGeometry.xpSD;
+    }
     const FOPEN = baseNomFno;
     const halfField =
       rectilinearProjectionMaxTraceField(projection) ??
@@ -402,7 +540,7 @@ export default function buildLens(data: LensData): RuntimeLens {
       EFL: referenceFocalLength,
       apertureReferenceFocalLength: referenceFocalLength,
       EP,
-      B: 0,
+      B,
       FOPEN,
       halfField,
       tracingHalfField,
@@ -450,9 +588,9 @@ export default function buildLens(data: LensData): RuntimeLens {
       zoomTracingHalfFields: null,
       zoomYRatios: null,
       zoomBs: null,
-      epZRelStop: 0,
-      xpZRelLastSurf: 0,
-      xpSD: EP.epSD,
+      epZRelStop,
+      xpZRelLastSurf,
+      xpSD,
       zoomEpZRelStops: null,
       zoomXpZRelLastSurfs: null,
       zoomXpSDs: null,
@@ -525,7 +663,6 @@ export default function buildLens(data: LensData): RuntimeLens {
   const realChief = realTraceToStopFull(S, asphByIdx, 0, realEpDelta, stopIdx);
   const realYRatio = isFinite(realMarginal.y) ? realMarginal.y / realEpDelta : epTrace.y;
   const realB = isFinite(realChief.y) ? realChief.y / realEpDelta : B;
-  const epZRelStop = Math.abs(realYRatio) > 1e-9 ? realB / realYRatio - zStopBaseline : 0;
 
   /* Exit pupil: use real (Snell's law) two-ray decomposition through the
    * full system.  Trace small marginal (y=δ, u=0) and chief (y=0, u=δ)
@@ -534,28 +671,27 @@ export default function buildLens(data: LensData): RuntimeLens {
    * to find XP position and size.  Falls back to paraxial on TIR. */
   const realMargFull = realTraceFullSystem(S, asphByIdx, realEpDelta, 0);
   const realChiefFull = realTraceFullSystem(S, asphByIdx, 0, realEpDelta);
-  let xpZRelLastSurf: number;
-  let xpSD: number;
-  if (isFinite(realMargFull.y) && isFinite(realChiefFull.y)) {
-    /* Normalize to unit-input basis rays (divide out δ) */
-    const mY = realMargFull.y / realEpDelta,
-      mU = realMargFull.u / realEpDelta;
-    const cY = realChiefFull.y / realEpDelta,
-      cU = realChiefFull.u / realEpDelta;
-    /* Two-ray decomposition: stop-center chief = yRatio·chief − B·marginal
-     * (using real yRatio and B from the front-group traces above) */
-    const xpY = realYRatio * cY - realB * mY;
-    const xpU = realYRatio * cU - realB * mU;
-    xpZRelLastSurf = Math.abs(xpU) > 1e-9 ? -xpY / xpU : Infinity;
-    xpSD = isFinite(xpZRelLastSurf) ? Math.abs(mY + mU * xpZRelLastSurf) * EP.epSD : Infinity;
-  } else {
-    /* Fallback: paraxial exit pupil */
-    const chiefFull = paraxialTrace(S, 0, 1, { skipLastTransfer: true });
-    const xpNumer = -(epTrace.y * chiefFull.y - eflTrace.y * B);
-    const xpDenom = epTrace.y * chiefFull.u - eflTrace.u * B;
-    xpZRelLastSurf = Math.abs(xpDenom) > 1e-9 ? xpNumer / xpDenom : Infinity;
-    xpSD = isFinite(xpZRelLastSurf) ? Math.abs(eflTrace.y + eflTrace.u * xpZRelLastSurf) * EP.epSD : Infinity;
-  }
+  const chiefFull = paraxialTrace(S, 0, 1, { skipLastTransfer: true });
+  const xpNumer = -(epTrace.y * chiefFull.y - eflTrace.y * B);
+  const xpDenom = epTrace.y * chiefFull.u - eflTrace.u * B;
+  const fallbackXpZRelLastSurf = Math.abs(xpDenom) > 1e-9 ? xpNumer / xpDenom : Infinity;
+  const lastSurfaceZ = sumSurfaceThicknesses(S, N - 1);
+  const { epZRelStop, xpZRelLastSurf, xpSD } = computePupilGeometry({
+    realYRatio,
+    realB,
+    margFull: { ...realMargFull, z: lastSurfaceZ },
+    chiefFull: { ...realChiefFull, z: lastSurfaceZ },
+    epSD: EP.epSD,
+    delta: realEpDelta,
+    zStop: zStopBaseline,
+    zLast: lastSurfaceZ,
+    fallback: {
+      xpZRelLastSurf: fallbackXpZRelLastSurf,
+      xpSD: isFinite(fallbackXpZRelLastSurf)
+        ? Math.abs(eflTrace.y + eflTrace.u * fallbackXpZRelLastSurf) * EP.epSD
+        : Infinity,
+    },
+  });
 
   const stopPhysSD = S[stopIdx].sd;
   const FOPEN = apertureReferenceFocalLength / (2 * EP.epSD); /* wide-open f-number */

--- a/src/optics/buildLens.ts
+++ b/src/optics/buildLens.ts
@@ -39,6 +39,8 @@ import type {
   AsphericCoefficients,
   EntrancePupil,
   LensProjectionConfig,
+  ResolvedImagePlane,
+  ResolvedOpticalPath,
   RuntimeLens,
   ParaxialTraceResult,
 } from "../types/optics.js";
@@ -222,6 +224,41 @@ function assertRectilinearFocalReference(data: LensData, projection: LensProject
   }
 }
 
+function normalizeImagePlaneNormal(normal: { z: number; y: number } | undefined): { z: number; y: number } {
+  const candidate = normal ?? { z: 1, y: 0 };
+  const length = Math.hypot(candidate.z, candidate.y);
+  if (!isFinite(length) || length <= 1e-12) return { z: 1, y: 0 };
+  return { z: candidate.z / length, y: candidate.y / length };
+}
+
+function resolveImagePlane(data: LensData, fallbackZ: number): ResolvedImagePlane {
+  const configured = data.opticalPath?.imagePlane;
+  return {
+    z: configured?.z ?? fallbackZ,
+    y: configured?.y ?? 0,
+    normal: normalizeImagePlaneNormal(configured?.normal),
+    label: configured?.label ?? "IMG",
+  };
+}
+
+function resolveOpticalPath(data: LensData, labelIdx: Record<string, number>): ResolvedOpticalPath {
+  const surfaceLabels = data.opticalPath?.surfaceOrder ?? null;
+  return {
+    mode: data.opticalPath?.mode ?? "sequential",
+    surfaceOrder: surfaceLabels
+      ? surfaceLabels.map((label) => labelIdx[label]).filter((idx) => idx !== undefined)
+      : null,
+    surfaceLabels,
+    maxInteractions: data.opticalPath?.maxInteractions ?? Math.max(data.surfaces.length + 1, 1),
+  };
+}
+
+function hasFoldedOptics(data: LensData): boolean {
+  return Boolean(
+    data.opticalPath || data.surfaces.some((surface) => surface.interaction && surface.interaction.type !== "refract"),
+  );
+}
+
 /**
  * Build a frozen runtime lens object from validated LENS_DATA.
  *
@@ -278,8 +315,153 @@ export default function buildLens(data: LensData): RuntimeLens {
   const doublets = resolveAnnotations(data.doublets, labelIdx);
 
   const stopIdx = S.findIndex((row) => row.label === "STO");
+  const opticalPath = resolveOpticalPath(data, labelIdx);
 
   const preserveAuthoredStopSD = S[stopIdx]?.stopPlacement === "inside-element";
+
+  if (hasFoldedOptics(data)) {
+    const z = [0];
+    for (let i = 0; i < N - 1; i++) z.push(z[i] + S[i].d);
+    const fallbackImageZ = z[N - 1] + S[N - 1].d;
+    const imagePlane = resolveImagePlane(data, fallbackImageZ);
+    const zMin = Math.min(imagePlane.z, ...z);
+    const zMax = Math.max(imagePlane.z, ...z);
+    const axialExtent = Math.max(1, zMax - zMin);
+    const maxSD = Math.max(...S.map((s) => s.sd));
+    const referenceFocalLength =
+      firstFiniteScalar(data.focalLengthDesign) ?? firstFiniteScalar(data.focalLengthMarketing) ?? axialExtent;
+    const baseNomFno = Array.isArray(data.nominalFno) ? data.nominalFno[0] : data.nominalFno!;
+    const stopPhysSD = S[stopIdx].sd;
+    const EP: EntrancePupil = {
+      epSD: referenceFocalLength / (2 * baseNomFno),
+      yRatio: stopPhysSD > 0 ? stopPhysSD / Math.max(referenceFocalLength / (2 * baseNomFno), 1e-12) : 1,
+    };
+    const FOPEN = baseNomFno;
+    const halfField =
+      rectilinearProjectionMaxTraceField(projection) ??
+      Math.max(1, (Math.atan(Math.max(1, maxSD) / Math.max(referenceFocalLength, 1)) * 180) / Math.PI);
+    const tracingHalfField = halfField;
+    const totalTrack = axialExtent;
+
+    const { svgW, svgH, scFill, yScFill, maxRimAngleDeg, gapSagFrac, clipMargin } = data;
+    const SC = (svgW * scFill) / totalTrack;
+    let YSC: number;
+    let effectiveSvgH: number;
+    if (ENABLE_UNIFORM_SCALING) {
+      YSC = SC;
+      const verticalMargin = 1.45 * maxSD;
+      effectiveSvgH = Math.round(Math.max(2 * verticalMargin * SC + 20, 290));
+    } else {
+      YSC = (svgH * yScFill) / maxSD;
+      const maxAR = data.maxAspectRatio;
+      if (maxAR > 0 && YSC / SC > maxAR) YSC = SC * maxAR;
+      effectiveSvgH = svgH;
+    }
+    const maxRimSin = Math.sin((maxRimAngleDeg * Math.PI) / 180);
+    const maxRimTan = Math.tan((maxRimAngleDeg * Math.PI) / 180);
+    const gridPitch = totalTrack / 15;
+    const gridCount = Math.ceil(svgW / (gridPitch * SC)) + 4;
+    const lyDoublet = -1.1 * maxSD;
+    const lyImgLine = 1.133 * maxSD;
+    const lyImgLabel = -1.233 * maxSD;
+    const lyElemNum = 1.2 * maxSD;
+    const lyVdBadge = 1.36 * maxSD;
+    const lyGroup = 1.37 * maxSD;
+    const lyStoPad = 0.12 * maxSD;
+    const rayHeights = data.rayFractions.map((f: number) => f * EP.epSD);
+    const rayLead = totalTrack * data.rayLeadFrac;
+    const bladeStubFrac = 0.1;
+    const prevSD = stopIdx > 0 ? S[stopIdx - 1].sd : stopPhysSD;
+    const nextSD = stopIdx < N - 1 ? S[stopIdx + 1].sd : stopPhysSD;
+    const stopHousingSD = Math.max(stopPhysSD, Math.min(prevSD, nextSD));
+    const offAxisFieldDeg = halfField * data.offAxisFieldFrac;
+    const offAxisHeights = data.offAxisFractions.map((f: number) => f * EP.epSD);
+
+    return Object.freeze({
+      data,
+      S,
+      N,
+      ES,
+      elements: data.elements,
+      asphByIdx,
+      varByIdx,
+      vdByIdx,
+      spectralByIdx,
+      indexByIdx,
+      varLabels,
+      groups,
+      doublets,
+      perspectiveControl: data.perspectiveControl ?? null,
+      aberrationControl,
+      projection,
+      opticalPath,
+      imagePlane,
+      isFoldedOptics: true,
+      stopIdx,
+      stopPhysSD,
+      EFL: referenceFocalLength,
+      apertureReferenceFocalLength: referenceFocalLength,
+      EP,
+      B: 0,
+      FOPEN,
+      halfField,
+      tracingHalfField,
+      petzvalSum: 0,
+      totalTrack,
+      maxSD,
+      svgW: data.svgW,
+      svgH: effectiveSvgH,
+      SC,
+      YSC,
+      maxRimSin,
+      maxRimTan,
+      gapSagFrac,
+      clipMargin,
+      gridPitch,
+      gridCount,
+      lyDoublet,
+      lyImgLine,
+      lyImgLabel,
+      lyElemNum,
+      lyVdBadge,
+      lyGroup,
+      lyStoPad,
+      lensShiftFrac: data.lensShiftFrac || 0,
+      rayFractions: data.rayFractions,
+      rayHeights,
+      rayLead,
+      bladeStubFrac,
+      stopHousingSD,
+      offAxisFieldDeg,
+      offAxisFieldFrac: data.offAxisFieldFrac,
+      offAxisFractions: data.offAxisFractions,
+      offAxisHeights,
+      closeFocusM: data.closeFocusM,
+      focusStep: data.focusStep,
+      focusDescription: data.focusDescription,
+      maxFstop: data.maxFstop,
+      apertureStep: data.apertureStep,
+      fstopSeries: data.fstopSeries,
+      isZoom: false,
+      zoomPositions: null,
+      zoomEFLs: null,
+      zoomEPs: null,
+      zoomHalfFields: null,
+      zoomTracingHalfFields: null,
+      zoomYRatios: null,
+      zoomBs: null,
+      epZRelStop: 0,
+      xpZRelLastSurf: 0,
+      xpSD: EP.epSD,
+      zoomEpZRelStops: null,
+      zoomXpZRelLastSurfs: null,
+      zoomXpSDs: null,
+      zoomFOPENs: null,
+      zoomStep: data.zoomStep || 0.004,
+      zoomLabels: null,
+      labelIdx,
+    }) as RuntimeLens;
+  }
 
   /* ── Derive stop SD and entrance pupil from nominal f-number ──
    *  nominalFno is a required field (validated).  We back-compute:
@@ -486,6 +668,7 @@ export default function buildLens(data: LensData): RuntimeLens {
     for (let i = 0; i < N - 1; i++) z.push(z[i] + S[i].d);
     totalTrack = z[N - 1] + S[N - 1].d;
   }
+  const imagePlane = resolveImagePlane(data, totalTrack);
   const maxSD = Math.max(...S.map((s) => s.sd));
 
   const { svgW, svgH, scFill, yScFill, maxRimAngleDeg, gapSagFrac, clipMargin } = data;
@@ -688,6 +871,9 @@ export default function buildLens(data: LensData): RuntimeLens {
     perspectiveControl: data.perspectiveControl ?? null,
     aberrationControl,
     projection,
+    opticalPath,
+    imagePlane,
+    isFoldedOptics: false,
     stopIdx,
     stopPhysSD,
     EFL,

--- a/src/optics/cardinalElements.ts
+++ b/src/optics/cardinalElements.ts
@@ -1,8 +1,12 @@
 import type { RuntimeLens } from "../types/optics.js";
 import { traceExactSurfaceStack } from "./internal/exactSurfaceTrace.js";
 import { buildStateSurfaces } from "./internal/lensState.js";
-import { FLAT_R_THRESHOLD } from "./internal/surfaceMath.js";
-import { traceSurfacesParaxial } from "./internal/traceSurfaces.js";
+import {
+  interactParaxialSurface,
+  traceSurfacesParaxial,
+  transferParaxialRay,
+  type ParaxialRayState,
+} from "./internal/traceSurfaces.js";
 
 const CARDINAL_EPSILON = 1e-12;
 const FOLDED_PARAXIAL_SAMPLE_FRACTIONS = [0.04, 0.08, 0.16, 0.32, 0.5, 0.7, 0.9] as const;
@@ -232,10 +236,8 @@ function traceFoldedReflectiveParaxialPath(
   order: readonly number[],
   y0: number,
   u0: number,
-): { y: number; u: number; n: number } | null {
-  let y = y0;
-  let u = u0;
-  let n = 1;
+): ParaxialRayState | null {
+  let state: ParaxialRayState = { y: y0, u: u0, n: 1 };
   let currentZ = zPos[0];
 
   for (const surfaceIdx of order) {
@@ -243,18 +245,16 @@ function traceFoldedReflectiveParaxialPath(
     const targetZ = zPos[surfaceIdx];
     if (!surface || !isFinite(targetZ)) return null;
 
-    y += (targetZ - currentZ) * u;
+    state = transferParaxialRay(state, targetZ - currentZ);
     currentZ = targetZ;
 
-    if (surface.interaction?.type === "reflect") {
-      u = Math.abs(surface.R) < FLAT_R_THRESHOLD ? -u - (2 * y) / surface.R : -u;
-      continue;
-    }
-
-    const nextIndex = surface.nd === 1.0 ? 1.0 : surface.nd;
-    if (Math.abs(nextIndex - n) > 1e-12) return null;
-    n = nextIndex;
+    const nextState = interactParaxialSurface(state, surface, {
+      allowReflect: true,
+      requireSameIndexRefraction: true,
+    });
+    if (nextState === null) return null;
+    state = nextState;
   }
 
-  return { y, u, n };
+  return state;
 }

--- a/src/optics/cardinalElements.ts
+++ b/src/optics/cardinalElements.ts
@@ -1,8 +1,11 @@
 import type { RuntimeLens } from "../types/optics.js";
+import { traceExactSurfaceStack } from "./internal/exactSurfaceTrace.js";
 import { buildStateSurfaces } from "./internal/lensState.js";
+import { FLAT_R_THRESHOLD } from "./internal/surfaceMath.js";
 import { traceSurfacesParaxial } from "./internal/traceSurfaces.js";
 
 const CARDINAL_EPSILON = 1e-12;
+const FOLDED_PARAXIAL_SAMPLE_FRACTIONS = [0.04, 0.08, 0.16, 0.32, 0.5, 0.7, 0.9] as const;
 
 export interface CardinalPoint {
   id: "F" | "F'" | "H" | "H'" | "N" | "N'";
@@ -48,6 +51,10 @@ export function computeCardinalElementsAtState(
   imagePlaneZ: number,
   aberrationT = 0,
 ): CardinalElements | null {
+  if (L.isFoldedOptics) {
+    return computeFoldedReflectiveCardinalElementsAtState(L, zPos, imagePlaneZ);
+  }
+
   if (zPos.length < L.N) return null;
 
   const S = buildStateSurfaces(
@@ -64,15 +71,41 @@ export function computeCardinalElementsAtState(
   const objectIndex = 1;
   const imageIndex = marginal.n;
 
-  const A = marginal.y;
-  const B = chief.y;
-  const C = imageIndex * marginal.u;
-  const D = imageIndex * chief.u;
+  return buildCardinalElementsFromMatrix({
+    A: marginal.y,
+    B: chief.y,
+    C: imageIndex * marginal.u,
+    D: imageIndex * chief.u,
+    frontVertexZ: zPos[0],
+    rearVertexZ: zPos[L.N - 1],
+    imagePlaneZ,
+    objectIndex,
+    imageIndex,
+  });
+}
 
+function buildCardinalElementsFromMatrix({
+  A,
+  B,
+  C,
+  D,
+  frontVertexZ,
+  rearVertexZ,
+  imagePlaneZ,
+  objectIndex,
+  imageIndex,
+}: {
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+  frontVertexZ: number;
+  rearVertexZ: number;
+  imagePlaneZ: number;
+  objectIndex: number;
+  imageIndex: number;
+}): CardinalElements | null {
   if (!isFinite(C) || Math.abs(C) < CARDINAL_EPSILON) return null;
-
-  const frontVertexZ = zPos[0];
-  const rearVertexZ = zPos[L.N - 1];
   const frontFocalZ = frontVertexZ + (objectIndex * D) / C;
   const rearFocalZ = rearVertexZ - (imageIndex * A) / C;
   const frontPrincipalZ = frontVertexZ + (objectIndex * (D - 1)) / C;
@@ -112,4 +145,116 @@ export function computeCardinalElementsAtState(
     imageIndex,
     nodalPrincipalCoincident,
   };
+}
+
+function computeFoldedReflectiveCardinalElementsAtState(
+  L: RuntimeLens,
+  zPos: number[],
+  imagePlaneZ: number,
+): CardinalElements | null {
+  if (zPos.length < L.N) return null;
+  if (Math.abs(L.imagePlane.normal.y) > 1e-9) return null;
+
+  const order = resolveFoldedParaxialSurfaceOrder(L, zPos);
+  if (order.length === 0) return null;
+  if (!order.every((surfaceIdx) => isFoldedParaxialSurfaceSupported(L, surfaceIdx))) return null;
+
+  const marginal = traceFoldedReflectiveParaxialPath(L, zPos, order, 1, 0);
+  const chief = traceFoldedReflectiveParaxialPath(L, zPos, order, 0, 1);
+  if (marginal === null || chief === null) return null;
+
+  const objectIndex = 1;
+  const imageIndex = marginal.n;
+
+  return buildCardinalElementsFromMatrix({
+    A: marginal.y,
+    B: chief.y,
+    C: imageIndex * marginal.u,
+    D: imageIndex * chief.u,
+    frontVertexZ: zPos[0],
+    rearVertexZ: zPos[order[order.length - 1]],
+    imagePlaneZ,
+    objectIndex,
+    imageIndex,
+  });
+}
+
+function resolveFoldedParaxialSurfaceOrder(L: RuntimeLens, zPos: number[]): number[] {
+  if (L.opticalPath.surfaceOrder?.length) return L.opticalPath.surfaceOrder;
+
+  const candidateFractions = new Set<number>([0, ...L.rayFractions.map((fraction) => Math.abs(fraction))]);
+  for (const fraction of FOLDED_PARAXIAL_SAMPLE_FRACTIONS) candidateFractions.add(fraction);
+
+  const candidateHeights = [...candidateFractions]
+    .filter((fraction) => isFinite(fraction) && fraction >= 0)
+    .sort((a, b) => a - b)
+    .map((fraction) => fraction * L.EP.epSD);
+
+  for (const y0 of candidateHeights) {
+    const result = traceExactSurfaceStack(
+      L,
+      { y0, uy0: 0 },
+      {
+        zPos,
+        checkSemiDiameter: true,
+        stopSemiDiameter: L.stopPhysSD,
+        leadDistance: 0,
+        stopOnClip: true,
+      },
+    );
+    if (!result.reachedImagePlane || result.clipped) continue;
+    const opticalHits = result.hits
+      .map((hit) => hit.surfaceIdx)
+      .filter((surfaceIdx) => {
+        const interaction = L.S[surfaceIdx]?.interaction;
+        return interaction?.type === "reflect" || (interaction?.type ?? "refract") === "refract";
+      });
+    if (opticalHits.some((surfaceIdx) => L.S[surfaceIdx]?.interaction?.type === "reflect")) return opticalHits;
+  }
+
+  return [];
+}
+
+function isFoldedParaxialSurfaceSupported(L: RuntimeLens, surfaceIdx: number): boolean {
+  const surface = L.S[surfaceIdx];
+  if (!surface) return false;
+  if (surface.interaction?.normal) return false;
+  if (surface.interaction?.type === "block") return false;
+  if (surface.interaction?.type === "reflect") return true;
+
+  const nextIndex = surface.nd === 1.0 ? 1.0 : surface.nd;
+  return Math.abs(nextIndex - 1) <= 1e-12;
+}
+
+function traceFoldedReflectiveParaxialPath(
+  L: RuntimeLens,
+  zPos: number[],
+  order: readonly number[],
+  y0: number,
+  u0: number,
+): { y: number; u: number; n: number } | null {
+  let y = y0;
+  let u = u0;
+  let n = 1;
+  let currentZ = zPos[0];
+
+  for (const surfaceIdx of order) {
+    const surface = L.S[surfaceIdx];
+    const targetZ = zPos[surfaceIdx];
+    if (!surface || !isFinite(targetZ)) return null;
+
+    y += (targetZ - currentZ) * u;
+    currentZ = targetZ;
+
+    if (surface.interaction?.type === "reflect") {
+      u = Math.abs(surface.R) < FLAT_R_THRESHOLD ? -u - (2 * y) / surface.R : -u;
+      continue;
+    }
+
+    const nextIndex = surface.nd === 1.0 ? 1.0 : surface.nd;
+    if (Math.abs(nextIndex - n) > 1e-12) return null;
+    n = nextIndex;
+  }
+
+  return { y, u, n };
 }

--- a/src/optics/diagramGeometry.ts
+++ b/src/optics/diagramGeometry.ts
@@ -265,6 +265,19 @@ export function computeElementShapes(
       const y = -trim2 + (2 * trim2 * i) / NN;
       d += `L${pathPoint(z2 + renderSag(Math.abs(y), s2, L), y)} `;
     }
+    const inner = Math.min(Math.min(trim1, trim2), Math.max(L.S[s1].innerSd ?? 0, L.S[s2].innerSd ?? 0));
+    const fillRule = inner > 0 ? "evenodd" : undefined;
+    if (inner > 0) {
+      d += "Z ";
+      for (let i = 0; i <= NN; i++) {
+        const y = -inner + (2 * inner * i) / NN;
+        d += `${i ? "L" : "M"}${pathPoint(z1 + renderSag(Math.abs(y), s1, L), y)} `;
+      }
+      for (let i = NN; i >= 0; i--) {
+        const y = -inner + (2 * inner * i) / NN;
+        d += `L${pathPoint(z2 + renderSag(Math.abs(y), s2, L), y)} `;
+      }
+    }
     /* Aspheric surface overlay paths + diamond half-fill paths */
     const asphPaths: AsphPathData[] = [];
     const midZ = (z1 + z2) / 2;
@@ -307,6 +320,6 @@ export function computeElementShapes(
         labelY: labelY - 4,
       });
     }
-    return { eid, d: d + "Z", z1, z2, asphPaths };
+    return { eid, d: d + "Z", z1, z2, fillRule, asphPaths };
   });
 }

--- a/src/optics/diagramGeometry.ts
+++ b/src/optics/diagramGeometry.ts
@@ -10,6 +10,7 @@ import type {
   CoordinateTransforms,
   ElementShape,
   AsphPathData,
+  SurfaceAccentPathData,
   ElementSpan,
   SurfaceRenderDiagnostics,
   ElementRenderDiagnostics,
@@ -260,6 +261,14 @@ export function computeElementShapes(
     const z1 = zPos[s1],
       z2 = zPos[s2],
       NN = SVG_PATH_SUBDIVISIONS;
+    const surfacePath = (surfaceIndex: number, vertexZ: number, trim: number): string => {
+      let path = "";
+      for (let i = 0; i <= NN; i++) {
+        const y = -trim + (2 * trim * i) / NN;
+        path += `${i ? "L" : "M"}${pathPoint(renderedSurfaceZ(surfaceIndex, vertexZ, y, L), y)} `;
+      }
+      return path;
+    };
     /* Element outline path — each surface rendered to its own SD.
      * Front sweeps from −trim1 to +trim1, rear from +trim2 to −trim2.
      * SVG path commands create straight connecting edges at top/bottom
@@ -288,13 +297,10 @@ export function computeElementShapes(
     }
     /* Aspheric surface overlay paths + diamond half-fill paths */
     const asphPaths: AsphPathData[] = [];
+    const surfaceAccentPaths: SurfaceAccentPathData[] = [];
     const midZ = (z1 + z2) / 2;
     if (L.asphByIdx[s1]) {
-      let p = "";
-      for (let i = 0; i <= NN; i++) {
-        const y = -trim1 + (2 * trim1 * i) / NN;
-        p += `${i ? "L" : "M"}${pathPoint(renderedSurfaceZ(s1, z1, y, L), y)} `;
-      }
+      const p = surfacePath(s1, z1, trim1);
       /* Half-path: front surface top-to-bottom, then straight line back at midpoint */
       const hp = p + `L${pathPoint(midZ, trim1)} L${pathPoint(midZ, -trim1)} Z`;
       const [labelX, labelY] = screenPoint(renderedSurfaceZ(s1, z1, -trim1, L), -trim1);
@@ -307,11 +313,7 @@ export function computeElementShapes(
       });
     }
     if (L.asphByIdx[s2]) {
-      let p = "";
-      for (let i = 0; i <= NN; i++) {
-        const y = -trim2 + (2 * trim2 * i) / NN;
-        p += `${i ? "L" : "M"}${pathPoint(renderedSurfaceZ(s2, z2, y, L), y)} `;
-      }
+      const p = surfacePath(s2, z2, trim2);
       /* Half-path: straight line at midpoint top-to-bottom, then rear surface bottom-to-top */
       let hp = `M${pathPoint(midZ, -trim2)} L${pathPoint(midZ, trim2)} `;
       for (let i = NN; i >= 0; i--) {
@@ -328,6 +330,19 @@ export function computeElementShapes(
         labelY: labelY - 4,
       });
     }
-    return { eid, d: d + "Z", z1, z2, fillRule, asphPaths };
+    for (const { surfaceIndex, vertexZ, trim } of [
+      { surfaceIndex: s1, vertexZ: z1, trim: trim1 },
+      { surfaceIndex: s2, vertexZ: z2, trim: trim2 },
+    ]) {
+      const interaction = L.S[surfaceIndex].interaction;
+      if (interaction?.type === "reflect" && interaction.mirrorKind === "second-surface") {
+        surfaceAccentPaths.push({
+          surfIdx: surfaceIndex,
+          pathD: surfacePath(surfaceIndex, vertexZ, trim),
+          kind: "second-surface-coating",
+        });
+      }
+    }
+    return { eid, d: d + "Z", z1, z2, fillRule, asphPaths, surfaceAccentPaths };
   });
 }

--- a/src/optics/diagramGeometry.ts
+++ b/src/optics/diagramGeometry.ts
@@ -145,6 +145,14 @@ function boundaryIntrusion(
   return renderSag(height, rearSurfaceIndex, L) - renderSag(height, frontSurfaceIndex, L);
 }
 
+function renderedSurfaceZ(surfaceIndex: number, vertexZ: number, y: number, L: RuntimeLens): number {
+  const normal = L.S[surfaceIndex].interaction?.normal;
+  if (normal && Math.abs(normal.z) > 1e-12) {
+    return vertexZ - (normal.y * y) / normal.z;
+  }
+  return vertexZ + renderSag(Math.abs(y), surfaceIndex, L);
+}
+
 function boundaryTrimHeight(
   rearSurfaceIndex: number,
   frontSurfaceIndex: number,
@@ -259,11 +267,11 @@ export function computeElementShapes(
     let d = "";
     for (let i = 0; i <= NN; i++) {
       const y = -trim1 + (2 * trim1 * i) / NN;
-      d += `${i ? "L" : "M"}${pathPoint(z1 + renderSag(Math.abs(y), s1, L), y)} `;
+      d += `${i ? "L" : "M"}${pathPoint(renderedSurfaceZ(s1, z1, y, L), y)} `;
     }
     for (let i = NN; i >= 0; i--) {
       const y = -trim2 + (2 * trim2 * i) / NN;
-      d += `L${pathPoint(z2 + renderSag(Math.abs(y), s2, L), y)} `;
+      d += `L${pathPoint(renderedSurfaceZ(s2, z2, y, L), y)} `;
     }
     const inner = Math.min(Math.min(trim1, trim2), Math.max(L.S[s1].innerSd ?? 0, L.S[s2].innerSd ?? 0));
     const fillRule = inner > 0 ? "evenodd" : undefined;
@@ -271,11 +279,11 @@ export function computeElementShapes(
       d += "Z ";
       for (let i = 0; i <= NN; i++) {
         const y = -inner + (2 * inner * i) / NN;
-        d += `${i ? "L" : "M"}${pathPoint(z1 + renderSag(Math.abs(y), s1, L), y)} `;
+        d += `${i ? "L" : "M"}${pathPoint(renderedSurfaceZ(s1, z1, y, L), y)} `;
       }
       for (let i = NN; i >= 0; i--) {
         const y = -inner + (2 * inner * i) / NN;
-        d += `L${pathPoint(z2 + renderSag(Math.abs(y), s2, L), y)} `;
+        d += `L${pathPoint(renderedSurfaceZ(s2, z2, y, L), y)} `;
       }
     }
     /* Aspheric surface overlay paths + diamond half-fill paths */
@@ -285,11 +293,11 @@ export function computeElementShapes(
       let p = "";
       for (let i = 0; i <= NN; i++) {
         const y = -trim1 + (2 * trim1 * i) / NN;
-        p += `${i ? "L" : "M"}${pathPoint(z1 + renderSag(Math.abs(y), s1, L), y)} `;
+        p += `${i ? "L" : "M"}${pathPoint(renderedSurfaceZ(s1, z1, y, L), y)} `;
       }
       /* Half-path: front surface top-to-bottom, then straight line back at midpoint */
       const hp = p + `L${pathPoint(midZ, trim1)} L${pathPoint(midZ, -trim1)} Z`;
-      const [labelX, labelY] = screenPoint(z1 + renderSag(trim1, s1, L), -trim1);
+      const [labelX, labelY] = screenPoint(renderedSurfaceZ(s1, z1, -trim1, L), -trim1);
       asphPaths.push({
         surfIdx: s1,
         pathD: p,
@@ -302,16 +310,16 @@ export function computeElementShapes(
       let p = "";
       for (let i = 0; i <= NN; i++) {
         const y = -trim2 + (2 * trim2 * i) / NN;
-        p += `${i ? "L" : "M"}${pathPoint(z2 + renderSag(Math.abs(y), s2, L), y)} `;
+        p += `${i ? "L" : "M"}${pathPoint(renderedSurfaceZ(s2, z2, y, L), y)} `;
       }
       /* Half-path: straight line at midpoint top-to-bottom, then rear surface bottom-to-top */
       let hp = `M${pathPoint(midZ, -trim2)} L${pathPoint(midZ, trim2)} `;
       for (let i = NN; i >= 0; i--) {
         const y = -trim2 + (2 * trim2 * i) / NN;
-        hp += `L${pathPoint(z2 + renderSag(Math.abs(y), s2, L), y)} `;
+        hp += `L${pathPoint(renderedSurfaceZ(s2, z2, y, L), y)} `;
       }
       hp += "Z";
-      const [labelX, labelY] = screenPoint(z2 + renderSag(trim2, s2, L), -trim2);
+      const [labelX, labelY] = screenPoint(renderedSurfaceZ(s2, z2, -trim2, L), -trim2);
       asphPaths.push({
         surfIdx: s2,
         pathD: p,

--- a/src/optics/fieldGeometry.ts
+++ b/src/optics/fieldGeometry.ts
@@ -6,8 +6,12 @@ import {
   type RealSurfaceTraceOptions,
   type RealSurfaceTraceResult,
 } from "./internal/traceSurfaces.js";
-import { traceExactSurfaceStack, traceExactSurfaceStackVector } from "./internal/exactSurfaceTrace.js";
-import type { Vector3 } from "./internal/exactSurfaceTrace.js";
+import {
+  traceExactSurfaceStack,
+  traceExactSurfaceStackVector,
+  traceToStopViaGeneralized,
+} from "./internal/exactSurfaceTrace.js";
+import type { ExactTraceLens, Vector3 } from "./internal/exactSurfaceTrace.js";
 import {
   ABSOLUTE_HALF_FIELD_CEILING,
   boundingSphereLaunchVector,
@@ -73,6 +77,29 @@ const OBJECT_PLANE_BRACKET_SCAN_SAMPLES = 96;
 const BOUNDING_SPHERE_BRACKET_SCAN_SAMPLES = 96;
 
 const chiefRaySolveCache: WeakMap<RuntimeLens, Map<string, ChiefRaySolveResult>> = new WeakMap();
+
+function exactTraceLensForState(S: ReturnType<typeof stateSurfaces>, L: RuntimeLens): ExactTraceLens {
+  return L.isFoldedOptics
+    ? {
+        S,
+        asphByIdx: L.asphByIdx,
+        stopIdx: L.stopIdx,
+        clipMargin: L.clipMargin,
+        opticalPath: L.opticalPath,
+        imagePlane: L.imagePlane,
+        isFoldedOptics: true,
+      }
+    : { S, asphByIdx: L.asphByIdx, stopIdx: L.stopIdx, clipMargin: L.clipMargin };
+}
+
+function foldedRayImagePlaneCoordinate(trace: RayTraceResult, L: RuntimeLens): number {
+  const point = trace.pts[trace.pts.length - 1];
+  if (!point) return NaN;
+  const [z, y] = point;
+  const tangentZ = -L.imagePlane.normal.y;
+  const tangentY = L.imagePlane.normal.z;
+  return (z - L.imagePlane.z) * tangentZ + (y - L.imagePlane.y) * tangentY;
+}
 
 function chiefRaySolveCacheKey(
   L: RuntimeLens,
@@ -263,6 +290,7 @@ export function chiefRayImageHeight(
   aberrationT = 0,
 ): number {
   const trace = traceChiefRayAtAngle(fieldAngleDeg, zPos, focusT, zoomT, L, geometry, aberrationT);
+  if (L.isFoldedOptics && trace.reachedImagePlane) return foldedRayImagePlaneCoordinate(trace, L);
   return trace.y + trace.u * thick(L.N - 1, focusT, zoomT, L, aberrationT);
 }
 
@@ -562,8 +590,16 @@ export function solveChiefRayBoundingSphere(
 
   const heightAtStop = (yEP: number): number | null => {
     const origin: Vector3 = [baseOrigin[0], baseOrigin[1] + yEP * perpY, baseOrigin[2] + yEP * perpZ];
+    if (L.isFoldedOptics) {
+      const result = traceToStopViaGeneralized(exactTraceLensForState(S, L), { origin, direction }, stopIdx, {
+        launchBoundT,
+        checkSemiDiameter: true,
+      });
+      if (!result.found) return null;
+      return result.y;
+    }
     const result = traceExactSurfaceStackVector(
-      { S, asphByIdx: L.asphByIdx, stopIdx: L.stopIdx },
+      exactTraceLensForState(S, L),
       { origin, direction },
       { stopAt: stopIdx, launchBoundT, checkSemiDiameter: true },
     );
@@ -715,11 +751,13 @@ export function chiefRayImageHeightAccurate(
   if (solve.vectorLaunch) {
     const trace = traceRayVector(solve.vectorLaunch, zPos, undefined, false, L);
     if (trace.clipped) return NaN;
+    if (L.isFoldedOptics && trace.reachedImagePlane) return foldedRayImagePlaneCoordinate(trace, L);
     return trace.y + trace.u * thick(L.N - 1, focusT, zoomT, L, aberrationT);
   }
   const uField = launch.uField;
   const yChief = solve.yLaunch;
   const trace = traceRay(yChief, uField, zPos, focusT, zoomT, undefined, true, L, aberrationT);
+  if (L.isFoldedOptics && trace.reachedImagePlane) return foldedRayImagePlaneCoordinate(trace, L);
   return trace.y + trace.u * thick(L.N - 1, focusT, zoomT, L, aberrationT);
 }
 
@@ -875,8 +913,22 @@ function traceStateSurfacesReal(
   u0: number,
   traceOptions: RealSurfaceTraceOptions = {},
 ): RealSurfaceTraceResult {
+  const traceLens = exactTraceLensForState(S, L);
+  if (L.isFoldedOptics && traceOptions.stopAt !== undefined) {
+    const stopResult = traceToStopViaGeneralized(traceLens, { y0, uy0: u0 }, traceOptions.stopAt, {
+      checkSemiDiameter: traceOptions.checkSemiDiameter,
+    });
+    return {
+      y: stopResult.found ? stopResult.y : NaN,
+      u: stopResult.found ? stopResult.uy : NaN,
+      n: stopResult.n,
+      clipped: !stopResult.found,
+      heights: null,
+    };
+  }
+
   const result = traceExactSurfaceStack(
-    { S, asphByIdx: L.asphByIdx, stopIdx: L.stopIdx },
+    traceLens,
     { y0, uy0: u0 },
     {
       stopAt: traceOptions.stopAt,

--- a/src/optics/foldedPathDisplay.ts
+++ b/src/optics/foldedPathDisplay.ts
@@ -1,0 +1,63 @@
+import type { RuntimeLens } from "../types/optics.js";
+import { traceRay } from "./optics.js";
+import { obstructionAwareRayFractionsForDensity } from "./raySampling.js";
+
+interface FoldedHitOrderParams {
+  L: RuntimeLens | undefined;
+  zPos: number[];
+  focusT: number;
+  zoomT: number;
+  aberrationT: number;
+  currentPhysStopSD: number;
+  currentEPSD: number;
+}
+
+function uniqueHeightsByMagnitude(heights: number[]): number[] {
+  const seen = new Set<string>();
+  return heights
+    .filter((height) => Number.isFinite(height))
+    .sort((a, b) => Math.abs(b) - Math.abs(a))
+    .filter((height) => {
+      const key = height.toFixed(6);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+export function foldedHitOrderLabelsForDisplay({
+  L,
+  zPos,
+  focusT,
+  zoomT,
+  aberrationT,
+  currentPhysStopSD,
+  currentEPSD,
+}: FoldedHitOrderParams): string[] {
+  if (!L?.isFoldedOptics) return [];
+  if (L.opticalPath.surfaceLabels && L.opticalPath.surfaceLabels.length > 0) {
+    return L.opticalPath.surfaceLabels;
+  }
+
+  const rayHeights = uniqueHeightsByMagnitude([
+    ...obstructionAwareRayFractionsForDensity(L, L.rayFractions, "normal", currentEPSD).map(
+      (fraction) => fraction * currentEPSD,
+    ),
+    currentEPSD * 0.5,
+    -currentEPSD * 0.5,
+    0,
+  ]);
+
+  let fallbackLabels: string[] = [];
+  for (const height of rayHeights) {
+    try {
+      const trace = traceRay(height, 0, zPos, focusT, zoomT, currentPhysStopSD, true, L, aberrationT);
+      const labels = trace.diagnostics?.hitSurfaceLabels ?? [];
+      if (labels.length > 0 && fallbackLabels.length === 0) fallbackLabels = labels;
+      if (!trace.clipped && trace.reachedImagePlane && labels.length > 0) return labels;
+    } catch {
+      continue;
+    }
+  }
+  return fallbackLabels;
+}

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -616,7 +616,8 @@ function traceGeneralizedSurfaceStackVector(
     const withinAperture = apertureState === "inside";
 
     if (!sideActive) {
-      const inactiveClipped = interaction.inactiveSide === "block" && withinAperture;
+      const inactiveSideBehavior = interaction.inactiveSide ?? (interaction.type === "reflect" ? "block" : "ignore");
+      const inactiveClipped = inactiveSideBehavior === "block" && withinAperture;
       if (inactiveClipped) {
         clipped = true;
         pushClipEvent(clipEvents, lens, nextSurfaceIdx, "inactive-side-block");

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -456,11 +456,13 @@ function traceGeneralizedSurfaceStackVector(
       interaction.incidentSide === "both" ||
       interaction.incidentSide === incidentSide;
     const apertureClip = apertureSemiDiameter(nextSurfaceIdx, surface, lens, stopSemiDiameter);
-    const withinAperture = apertureClip === null || radiusWithinTraceAperture(radius, surface, apertureClip);
+    const apertureState = traceApertureState(radius, surface, apertureClip);
+    const withinAperture = apertureState === "inside";
 
     if (!sideActive) {
-      if (interaction.inactiveSide === "block") clipped = true;
-      if (clipped) {
+      const inactiveClipped = interaction.inactiveSide === "block" && withinAperture;
+      if (inactiveClipped) {
+        clipped = true;
         hits.push({
           surfaceIdx: nextSurfaceIdx,
           point,
@@ -494,7 +496,25 @@ function traceGeneralizedSurfaceStackVector(
       continue;
     }
 
-    if (checkSemiDiameter && !withinAperture) clipped = true;
+    if (!withinAperture) {
+      const apertureClipped = checkSemiDiameter && apertureState === "outside";
+      if (apertureClipped) {
+        clipped = true;
+        hits.push({
+          surfaceIdx: nextSurfaceIdx,
+          point,
+          normal,
+          radius,
+          clipped: true,
+          fallback: false,
+          failureReason: null,
+        });
+        if (stopOnClip && !ghost) break;
+      }
+      origin = advanceOrigin(point, direction);
+      continue;
+    }
+
     hits.push({
       surfaceIdx: nextSurfaceIdx,
       point,
@@ -589,11 +609,19 @@ function apertureSemiDiameter(
 }
 
 function radiusWithinTraceAperture(radius: number, surface: ExactTraceSurface, semiDiameter: number): boolean {
-  if (exceedsTraceAperture(radius, semiDiameter)) return false;
+  return traceApertureState(radius, surface, semiDiameter) === "inside";
+}
+
+function traceApertureState(
+  radius: number,
+  surface: ExactTraceSurface,
+  semiDiameter: number | null,
+): "inside" | "inside-hole" | "outside" {
+  if (semiDiameter !== null && exceedsTraceAperture(radius, semiDiameter)) return "outside";
   const inner = surface.innerSd ?? 0;
-  if (inner <= 0) return true;
+  if (inner <= 0) return "inside";
   const tolerance = Math.max(TRACE_CLIP_ABS_TOLERANCE, Math.abs(inner) * 1e-12);
-  return radius >= inner - tolerance;
+  return radius >= inner - tolerance ? "inside" : "inside-hole";
 }
 
 function exceedsTraceAperture(radius: number, semiDiameter: number): boolean {

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -90,6 +90,8 @@ export interface ExactSurfaceTraceHit {
   surfaceIdx: number;
   point: Vector3;
   normal: Vector3;
+  incidentDirection?: Vector3;
+  outgoingDirection?: Vector3;
   radius: number;
   clipped: boolean;
   fallback: boolean;
@@ -121,6 +123,24 @@ export interface ExactSurfaceTraceResult {
 }
 
 const TRACE_CLIP_ABS_TOLERANCE = 1e-9;
+
+export type GeneralizedStopTraceInput = ExactSurfaceTraceInput | VectorRayInput;
+
+export interface TraceToStopViaGeneralizedOptions extends Omit<ExactSurfaceTraceOptions, "stopAt"> {
+  stopOccurrence?: number;
+}
+
+export interface TraceToStopViaGeneralizedResult {
+  found: boolean;
+  x: number;
+  y: number;
+  ux: number;
+  uy: number;
+  n: number;
+  point: Vector3 | null;
+  hitIndex: number;
+  trace: ExactSurfaceTraceResult;
+}
 
 export function buildSurfaceZPositions(surfaces: readonly Pick<ExactTraceSurface, "d">[]): number[] {
   const z = [0];
@@ -263,6 +283,7 @@ export function traceExactSurfaceStackVector(
       heights!.push(projectCoordinateToZ(point[1], point[2], direction[1], direction[2], vertexZ));
     }
 
+    const incidentDirection: Vector3 = [direction[0], direction[1], direction[2]];
     const apertureClip = apertureSemiDiameter(i, surface, lens, stopSemiDiameter);
     let clipReason: FoldedPathClipReason | undefined;
     if (checkSemiDiameter && apertureClip !== null && !radiusWithinTraceAperture(radius, surface, apertureClip)) {
@@ -276,6 +297,7 @@ export function traceExactSurfaceStackVector(
       surfaceIdx: i,
       point,
       normal,
+      incidentDirection,
       radius,
       clipped: hitClipped,
       fallback,
@@ -309,6 +331,10 @@ export function traceExactSurfaceStackVector(
     }
 
     n = nn;
+    hits[hits.length - 1] = {
+      ...hits[hits.length - 1],
+      outgoingDirection: [direction[0], direction[1], direction[2]],
+    };
     origin = point;
   }
 
@@ -346,6 +372,73 @@ export function traceExactSurfaceStackVector(
       autoSteps: [],
       loopKey: null,
     }),
+  };
+}
+
+export function traceToStopViaGeneralized(
+  lens: ExactTraceLens,
+  input: GeneralizedStopTraceInput,
+  stopIdx: number,
+  {
+    zPos = buildSurfaceZPositions(lens.S),
+    stopOccurrence = 0,
+    recordHeights = false,
+    checkSemiDiameter = false,
+    stopSemiDiameter,
+    ghost = false,
+    stopOnClip = false,
+    leadDistance,
+    launchBoundT,
+    indexAtSurface,
+  }: TraceToStopViaGeneralizedOptions = {},
+): TraceToStopViaGeneralizedResult {
+  const ray = vectorRayFromStopTraceInput(lens, input, zPos, leadDistance);
+  const trace = traceExactSurfaceStackVector(lens, ray, {
+    zPos,
+    recordHeights,
+    checkSemiDiameter,
+    stopSemiDiameter,
+    ghost,
+    stopOnClip,
+    launchBoundT,
+    indexAtSurface,
+  });
+
+  let occurrence = 0;
+  for (let hitIndex = 0; hitIndex < trace.hits.length; hitIndex++) {
+    const hit = trace.hits[hitIndex];
+    if (hit.surfaceIdx !== stopIdx || hit.clipped || hit.fallback || hit.failureReason !== null) continue;
+    if (occurrence === stopOccurrence) {
+      const direction = hit.incidentDirection ?? trace.terminalDirection;
+      return stopTraceResult(true, hit.point, direction, trace.n, hitIndex, trace);
+    }
+    occurrence++;
+  }
+
+  const launchPlaneStop = stopTraceLaunchPlaneCandidate(
+    lens,
+    ray.origin,
+    ray.direction,
+    zPos,
+    stopIdx,
+    trace,
+    checkSemiDiameter,
+    stopSemiDiameter,
+  );
+  if (stopOccurrence === 0 && launchPlaneStop !== null) {
+    return stopTraceResult(true, launchPlaneStop, ray.direction, trace.n, -1, trace);
+  }
+
+  return {
+    found: false,
+    x: NaN,
+    y: NaN,
+    ux: NaN,
+    uy: NaN,
+    n: trace.n,
+    point: null,
+    hitIndex: -1,
+    trace,
   };
 }
 
@@ -488,6 +581,7 @@ function traceGeneralizedSurfaceStackVector(
         surfaceIdx: nextSurfaceIdx,
         point: fallbackPoint.point,
         normal: fallbackPoint.normal,
+        incidentDirection: [direction[0], direction[1], direction[2]],
         radius,
         clipped: true,
         fallback: true,
@@ -504,6 +598,7 @@ function traceGeneralizedSurfaceStackVector(
     const point = nextSurfaceHit.point;
     const normal = nextSurfaceHit.normal;
     const radius = nextSurfaceHit.radius;
+    const incidentDirection: Vector3 = [direction[0], direction[1], direction[2]];
     terminalPoint = point;
     terminalSurfaceIdx = nextSurfaceIdx;
     if (recordHeights) {
@@ -529,6 +624,7 @@ function traceGeneralizedSurfaceStackVector(
           surfaceIdx: nextSurfaceIdx,
           point,
           normal,
+          incidentDirection,
           radius,
           clipped: true,
           fallback: false,
@@ -550,6 +646,7 @@ function traceGeneralizedSurfaceStackVector(
           surfaceIdx: nextSurfaceIdx,
           point,
           normal,
+          incidentDirection,
           radius,
           clipped: true,
           fallback: false,
@@ -572,6 +669,7 @@ function traceGeneralizedSurfaceStackVector(
           surfaceIdx: nextSurfaceIdx,
           point,
           normal,
+          incidentDirection,
           radius,
           clipped: true,
           fallback: false,
@@ -589,6 +687,7 @@ function traceGeneralizedSurfaceStackVector(
       surfaceIdx: nextSurfaceIdx,
       point,
       normal,
+      incidentDirection,
       radius,
       clipped,
       fallback: false,
@@ -621,6 +720,11 @@ function traceGeneralizedSurfaceStackVector(
       }
       n = nn;
     }
+
+    hits[hits.length - 1] = {
+      ...hits[hits.length - 1],
+      outgoingDirection: [direction[0], direction[1], direction[2]],
+    };
 
     if (path?.mode === "auto") {
       const stateKey = autoLoopStateKey(nextSurfaceIdx, point, direction, n);
@@ -738,9 +842,115 @@ function exceedsTraceAperture(radius: number, semiDiameter: number): boolean {
   return radius > semiDiameter + tolerance;
 }
 
+function vectorRayFromStopTraceInput(
+  lens: ExactTraceLens,
+  input: GeneralizedStopTraceInput,
+  zPos: readonly number[],
+  leadDistance: number | undefined,
+): VectorRayInput {
+  if ("origin" in input) {
+    return {
+      origin: [input.origin[0], input.origin[1], input.origin[2]],
+      direction: [input.direction[0], input.direction[1], input.direction[2]],
+    };
+  }
+
+  const { x0 = 0, y0, ux0 = 0, uy0 } = input;
+  const lead = Math.max(0, leadDistance ?? inferLeadDistance(lens));
+  return {
+    origin: [x0 - ux0 * lead, y0 - uy0 * lead, (zPos[0] ?? 0) - lead],
+    direction: normalizeDirection(ux0, uy0),
+  };
+}
+
+function stopTraceResult(
+  found: boolean,
+  point: Vector3,
+  direction: Vector3,
+  n: number,
+  hitIndex: number,
+  trace: ExactSurfaceTraceResult,
+): TraceToStopViaGeneralizedResult {
+  const invDz = Math.abs(direction[2]) > 1e-12 ? 1 / direction[2] : Infinity;
+  return {
+    found,
+    x: point[0],
+    y: point[1],
+    ux: direction[0] * invDz,
+    uy: direction[1] * invDz,
+    n,
+    point,
+    hitIndex,
+    trace,
+  };
+}
+
+function rayParameterAtPoint(origin: Vector3, direction: Vector3, point: Vector3): number {
+  return (
+    (point[0] - origin[0]) * direction[0] +
+    (point[1] - origin[1]) * direction[1] +
+    (point[2] - origin[2]) * direction[2]
+  );
+}
+
+function stopTraceLaunchPlaneCandidate(
+  lens: ExactTraceLens,
+  origin: Vector3,
+  direction: Vector3,
+  zPos: readonly number[],
+  stopIdx: number,
+  trace: ExactSurfaceTraceResult,
+  checkSemiDiameter: boolean,
+  stopSemiDiameter: number | undefined,
+): Vector3 | null {
+  const surface = lens.S[stopIdx];
+  if (!surface) return null;
+
+  const configuredNormal = surface.interaction?.normal;
+  const normal: Vector3 = [0, configuredNormal?.y ?? 0, configuredNormal?.z ?? 1];
+  const normalLength = Math.hypot(normal[0], normal[1], normal[2]);
+  if (!isFinite(normalLength) || normalLength <= 1e-12) return null;
+  normal[0] /= normalLength;
+  normal[1] /= normalLength;
+  normal[2] /= normalLength;
+
+  const vertex: Vector3 = [0, 0, zPos[stopIdx] ?? 0];
+  const denom = direction[0] * normal[0] + direction[1] * normal[1] + direction[2] * normal[2];
+  if (Math.abs(denom) <= 1e-12) return null;
+  const t =
+    ((vertex[0] - origin[0]) * normal[0] + (vertex[1] - origin[1]) * normal[1] + (vertex[2] - origin[2]) * normal[2]) /
+    denom;
+  if (!isFinite(t) || t < -1e-7) return null;
+
+  const firstHit = trace.hits[0];
+  if (firstHit) {
+    const firstHitT = rayParameterAtPoint(origin, direction, firstHit.point);
+    if (isFinite(firstHitT) && t > firstHitT + generalizedHitTolerance(firstHitT)) return null;
+  }
+
+  const point: Vector3 = [origin[0] + direction[0] * t, origin[1] + direction[1] * t, origin[2] + direction[2] * t];
+  if (!point.every(Number.isFinite)) return null;
+
+  if (checkSemiDiameter) {
+    const radius = Math.hypot(point[0], point[1]);
+    const aperture = apertureSemiDiameter(stopIdx, surface, lens, stopSemiDiameter);
+    if (traceApertureState(radius, surface, aperture) !== "inside") return null;
+  }
+
+  return point;
+}
+
 function inferLeadDistance(lens: ExactTraceLens): number {
   const first = lens.S[0];
   if (!first) return 0;
+  const tiltedNormal = first.interaction?.normal;
+  if (tiltedNormal) {
+    const sd = first.sd ?? 0;
+    if (Math.abs(tiltedNormal.z) > 1e-12) {
+      return Math.max(1, Math.abs((sd * tiltedNormal.y) / tiltedNormal.z) + 1);
+    }
+    return Math.max(1, 2 * sd + 1);
+  }
   const firstSag = Math.abs(conicPolySag(first.sd ?? 0, first.R, lens.asphByIdx[0]));
   return Math.max(1, firstSag + 1);
 }

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -1,4 +1,9 @@
-import type { AsphericCoefficients } from "../../types/optics.js";
+import type {
+  AsphericCoefficients,
+  ResolvedImagePlane,
+  ResolvedOpticalPath,
+  SurfaceInteraction,
+} from "../../types/optics.js";
 import { FLAT_R_THRESHOLD, conicPolySag } from "./surfaceMath.js";
 import {
   intersectSagSurface,
@@ -15,6 +20,8 @@ export interface ExactTraceSurface {
   nd: number;
   d: number;
   sd?: number;
+  innerSd?: number;
+  interaction?: SurfaceInteraction;
 }
 
 export interface ExactTraceLens {
@@ -22,6 +29,9 @@ export interface ExactTraceLens {
   asphByIdx: Record<number, AsphericCoefficients>;
   stopIdx?: number;
   clipMargin?: number;
+  opticalPath?: ResolvedOpticalPath;
+  imagePlane?: ResolvedImagePlane;
+  isFoldedOptics?: boolean;
 }
 
 export interface ExactSurfaceTraceInput {
@@ -91,6 +101,7 @@ export interface ExactSurfaceTraceResult {
   terminalSurfaceIdx: number;
   returnVertexIdx: number;
   failureReason: SurfaceIntersectionFailureReason | "totalInternalReflection" | null;
+  reachedImagePlane?: boolean;
 }
 
 const TRACE_CLIP_ABS_TOLERANCE = 1e-9;
@@ -165,6 +176,24 @@ export function traceExactSurfaceStackVector(
     indexAtSurface,
   }: ExactSurfaceTraceOptions = {},
 ): ExactSurfaceTraceResult {
+  if (shouldUseGeneralizedTrace(lens, stopAt)) {
+    return traceGeneralizedSurfaceStackVector(
+      lens,
+      { origin: originIn, direction: directionIn },
+      {
+        zPos,
+        stopAt,
+        recordHeights,
+        checkSemiDiameter,
+        stopSemiDiameter,
+        ghost,
+        stopOnClip,
+        launchBoundT,
+        indexAtSurface,
+      },
+    );
+  }
+
   const total = lens.S.length;
   const tracedCount = clampTraceCount(stopAt ?? total, total);
   const heights: number[] | null = recordHeights ? [] : null;
@@ -217,7 +246,7 @@ export function traceExactSurfaceStackVector(
     }
 
     const apertureClip = apertureSemiDiameter(i, surface, lens, stopSemiDiameter);
-    if (checkSemiDiameter && apertureClip !== null && exceedsTraceAperture(radius, apertureClip)) {
+    if (checkSemiDiameter && apertureClip !== null && !radiusWithinTraceAperture(radius, surface, apertureClip)) {
       clipped = true;
     }
 
@@ -276,6 +305,253 @@ export function traceExactSurfaceStackVector(
     terminalSurfaceIdx,
     returnVertexIdx,
     failureReason,
+    reachedImagePlane: false,
+  };
+}
+
+interface GeneralizedTraceOptions {
+  zPos: readonly number[];
+  stopAt?: number;
+  recordHeights: boolean;
+  checkSemiDiameter: boolean;
+  stopSemiDiameter?: number;
+  ghost: boolean;
+  stopOnClip: boolean;
+  launchBoundT?: number;
+  indexAtSurface?: (surfaceIdx: number, nd: number) => number;
+}
+
+interface ImagePlaneIntersection {
+  point: Vector3;
+  t: number;
+}
+
+function shouldUseGeneralizedTrace(lens: ExactTraceLens, stopAt: number | undefined): boolean {
+  if (!lens.isFoldedOptics && !lens.opticalPath && !lens.imagePlane) return false;
+  if (stopAt !== undefined) return false;
+  return (
+    Boolean(lens.isFoldedOptics) ||
+    Boolean(lens.opticalPath?.surfaceOrder?.length) ||
+    lens.opticalPath?.mode === "auto" ||
+    lens.S.some((surface) => surface.interaction && surface.interaction.type !== "refract")
+  );
+}
+
+function traceGeneralizedSurfaceStackVector(
+  lens: ExactTraceLens,
+  { origin: originIn, direction: directionIn }: VectorRayInput,
+  {
+    zPos,
+    recordHeights,
+    checkSemiDiameter,
+    stopSemiDiameter,
+    ghost,
+    stopOnClip,
+    launchBoundT,
+    indexAtSurface,
+  }: GeneralizedTraceOptions,
+): ExactSurfaceTraceResult {
+  const path = lens.opticalPath;
+  const explicitOrder = path?.surfaceOrder ?? null;
+  const maxInteractions = path?.maxInteractions ?? Math.max(lens.S.length + 1, 1);
+  const heights: number[] | null = recordHeights ? [] : null;
+  const hits: ExactSurfaceTraceHit[] = [];
+  let origin: Vector3 = [originIn[0], originIn[1], originIn[2]];
+  let direction: Vector3 = [directionIn[0], directionIn[1], directionIn[2]];
+  let n = 1.0;
+  let clipped = false;
+  let terminalPoint: Vector3 = origin;
+  let terminalSurfaceIdx = -1;
+  let failureReason: ExactSurfaceTraceResult["failureReason"] = null;
+  let reachedImagePlane = false;
+  let explicitCursor = 0;
+
+  for (let interactionCount = 0; interactionCount < maxInteractions; interactionCount++) {
+    const imageHit =
+      !explicitOrder || explicitCursor >= explicitOrder.length
+        ? intersectImagePlane(origin, direction, lens.imagePlane)
+        : null;
+    let nextSurfaceIdx: number | null = null;
+    let nextSurfaceHit: ReturnType<typeof intersectSagSurface> | null = null;
+
+    if (explicitOrder && explicitCursor < explicitOrder.length) {
+      nextSurfaceIdx = explicitOrder[explicitCursor++];
+      const maxT = surfaceIntersectionMaxTForTarget(nextSurfaceIdx, origin, direction, zPos, lens, launchBoundT);
+      nextSurfaceHit = intersectSagSurface(
+        { origin, direction } satisfies SurfaceIntersectionRay,
+        nextSurfaceIdx,
+        zPos[nextSurfaceIdx] ?? 0,
+        lens,
+        { maxT, refractiveIndex: n },
+      );
+    } else if (path?.mode === "auto") {
+      const next = findNearestGeneralizedSurfaceHit(origin, direction, zPos, lens, launchBoundT, n);
+      nextSurfaceIdx = next?.surfaceIdx ?? null;
+      nextSurfaceHit = next?.hit ?? null;
+    }
+
+    if (
+      imageHit &&
+      (!nextSurfaceHit?.ok || imageHit.t <= Math.max(0, nextSurfaceHit.t - generalizedHitTolerance(nextSurfaceHit.t)))
+    ) {
+      terminalPoint = imageHit.point;
+      reachedImagePlane = true;
+      break;
+    }
+
+    if (nextSurfaceIdx === null || nextSurfaceHit === null) {
+      if (imageHit) {
+        terminalPoint = imageHit.point;
+        reachedImagePlane = true;
+      }
+      break;
+    }
+
+    if (!nextSurfaceHit.ok) {
+      clipped = true;
+      failureReason = nextSurfaceHit.failureReason;
+      if (!ghost) break;
+
+      const fallbackPoint = fallbackSurfacePoint(
+        origin,
+        direction,
+        zPos[nextSurfaceIdx] ?? 0,
+        nextSurfaceIdx,
+        lens,
+        surfaceIntersectionMaxTForTarget(nextSurfaceIdx, origin, direction, zPos, lens, launchBoundT),
+      );
+      if (fallbackPoint === null) continue;
+      const radius = Math.hypot(fallbackPoint.point[0], fallbackPoint.point[1]);
+      hits.push({
+        surfaceIdx: nextSurfaceIdx,
+        point: fallbackPoint.point,
+        normal: fallbackPoint.normal,
+        radius,
+        clipped: true,
+        fallback: true,
+        failureReason: nextSurfaceHit.failureReason,
+      });
+      terminalPoint = fallbackPoint.point;
+      terminalSurfaceIdx = nextSurfaceIdx;
+      if (stopOnClip) break;
+      continue;
+    }
+
+    const surface = lens.S[nextSurfaceIdx];
+    const point = nextSurfaceHit.point;
+    const normal = nextSurfaceHit.normal;
+    const radius = nextSurfaceHit.radius;
+    terminalPoint = point;
+    terminalSurfaceIdx = nextSurfaceIdx;
+    if (recordHeights) {
+      heights!.push(projectCoordinateToZ(point[1], point[2], direction[1], direction[2], zPos[nextSurfaceIdx] ?? 0));
+    }
+
+    const interaction = surface.interaction ?? { type: "refract" as const };
+    const incidentSide = incidentSideFor(direction, normal);
+    const sideActive =
+      interaction.incidentSide === undefined ||
+      interaction.incidentSide === "both" ||
+      interaction.incidentSide === incidentSide;
+    const apertureClip = apertureSemiDiameter(nextSurfaceIdx, surface, lens, stopSemiDiameter);
+    const withinAperture = apertureClip === null || radiusWithinTraceAperture(radius, surface, apertureClip);
+
+    if (!sideActive) {
+      if (interaction.inactiveSide === "block") clipped = true;
+      if (clipped) {
+        hits.push({
+          surfaceIdx: nextSurfaceIdx,
+          point,
+          normal,
+          radius,
+          clipped: true,
+          fallback: false,
+          failureReason: null,
+        });
+        if (stopOnClip && !ghost) break;
+      }
+      origin = advanceOrigin(point, direction);
+      continue;
+    }
+
+    if (interaction.type === "block") {
+      if (withinAperture) {
+        clipped = true;
+        hits.push({
+          surfaceIdx: nextSurfaceIdx,
+          point,
+          normal,
+          radius,
+          clipped: true,
+          fallback: false,
+          failureReason: null,
+        });
+        if (stopOnClip && !ghost) break;
+      }
+      origin = advanceOrigin(point, direction);
+      continue;
+    }
+
+    if (checkSemiDiameter && !withinAperture) clipped = true;
+    hits.push({
+      surfaceIdx: nextSurfaceIdx,
+      point,
+      normal,
+      radius,
+      clipped,
+      fallback: false,
+      failureReason: null,
+    });
+    if (clipped && stopOnClip && !ghost) break;
+
+    if (interaction.type === "reflect") {
+      direction = reflectDirection(direction, normal);
+    } else {
+      const nn = resolvedNextIndex(nextSurfaceIdx, incidentSide, surface, lens, indexAtSurface);
+      if (nn !== n) {
+        const orientedNormal = incidentSide === "front" ? normal : ([-normal[0], -normal[1], -normal[2]] as Vector3);
+        const refracted = refractDirection(direction, orientedNormal, n, nn);
+        if (refracted === null) {
+          clipped = true;
+          failureReason = "totalInternalReflection";
+          hits[hits.length - 1] = { ...hits[hits.length - 1], clipped: true, failureReason };
+          if (!ghost) break;
+        } else {
+          direction = refracted;
+        }
+      }
+      n = nn;
+    }
+
+    origin = advanceOrigin(point, direction);
+  }
+
+  const returnVertexIdx = terminalSurfaceIdx >= 0 ? terminalSurfaceIdx : 0;
+  const returnZ = reachedImagePlane ? terminalPoint[2] : (zPos[returnVertexIdx] ?? 0);
+  const directionZ = direction[2];
+  const invDz = Math.abs(directionZ) > 1e-12 ? 1 / directionZ : Infinity;
+  const x = reachedImagePlane
+    ? terminalPoint[0]
+    : projectCoordinateToZ(terminalPoint[0], terminalPoint[2], direction[0], directionZ, returnZ);
+  const y = reachedImagePlane
+    ? terminalPoint[1]
+    : projectCoordinateToZ(terminalPoint[1], terminalPoint[2], direction[1], directionZ, returnZ);
+
+  return {
+    x,
+    y,
+    ux: direction[0] * invDz,
+    uy: direction[1] * invDz,
+    n,
+    clipped,
+    heights,
+    hits,
+    terminalPoint,
+    terminalDirection: direction,
+    terminalSurfaceIdx,
+    returnVertexIdx,
+    failureReason,
+    reachedImagePlane,
   };
 }
 
@@ -308,6 +584,14 @@ function apertureSemiDiameter(
   if (surfaceIdx === lens.stopIdx && stopSemiDiameter !== undefined) return stopSemiDiameter;
   if (typeof surface.sd !== "number") return null;
   return surface.sd * (lens.clipMargin ?? 1);
+}
+
+function radiusWithinTraceAperture(radius: number, surface: ExactTraceSurface, semiDiameter: number): boolean {
+  if (exceedsTraceAperture(radius, semiDiameter)) return false;
+  const inner = surface.innerSd ?? 0;
+  if (inner <= 0) return true;
+  const tolerance = Math.max(TRACE_CLIP_ABS_TOLERANCE, Math.abs(inner) * 1e-12);
+  return radius >= inner - tolerance;
 }
 
 function exceedsTraceAperture(radius: number, semiDiameter: number): boolean {
@@ -344,6 +628,108 @@ function surfaceIntersectionMaxT(
   // meaningless; fall back to the caller-supplied launch bound. Returning 0 when
   // unset preserves the original reject-and-fail behavior.
   return launchBoundT && launchBoundT > 0 ? launchBoundT : 0;
+}
+
+function generalizedHitTolerance(t: number): number {
+  return Math.max(1e-7, Math.abs(t) * 1e-9);
+}
+
+function surfaceIntersectionMaxTForTarget(
+  surfIdx: number,
+  origin: Vector3,
+  direction: Vector3,
+  zPos: readonly number[],
+  lens: ExactTraceLens,
+  launchBoundT: number | undefined,
+): number {
+  const vertexZ = zPos[surfIdx] ?? 0;
+  const surfaceSag = Math.abs(conicPolySag(lens.S[surfIdx]?.sd ?? 0, lens.S[surfIdx]?.R ?? 0, lens.asphByIdx[surfIdx]));
+  if (Math.abs(direction[2]) > 1e-12) {
+    const projectedT = (vertexZ - origin[2]) / direction[2];
+    if (isFinite(projectedT) && projectedT > 0) {
+      return Math.max(1e-6, projectedT + (surfaceSag + 2) / Math.abs(direction[2]));
+    }
+  }
+  if (launchBoundT && launchBoundT > 0) return launchBoundT;
+  const extent = lens.S.reduce((sum, surface) => sum + Math.abs(surface.d ?? 0), 0);
+  const maxSD = lens.S.reduce((max, surface) => Math.max(max, surface.sd ?? 0), 0);
+  return Math.max(10, extent + 4 * maxSD + surfaceSag);
+}
+
+function findNearestGeneralizedSurfaceHit(
+  origin: Vector3,
+  direction: Vector3,
+  zPos: readonly number[],
+  lens: ExactTraceLens,
+  launchBoundT: number | undefined,
+  refractiveIndex: number,
+): { surfaceIdx: number; hit: ReturnType<typeof intersectSagSurface> } | null {
+  let best: { surfaceIdx: number; hit: ReturnType<typeof intersectSagSurface> } | null = null;
+  for (let i = 0; i < lens.S.length; i++) {
+    const maxT = surfaceIntersectionMaxTForTarget(i, origin, direction, zPos, lens, launchBoundT);
+    const hit = intersectSagSurface({ origin, direction } satisfies SurfaceIntersectionRay, i, zPos[i] ?? 0, lens, {
+      minT: 1e-6,
+      maxT,
+      refractiveIndex,
+    });
+    if (!hit.ok) continue;
+    if (!best || hit.t < (best.hit.ok ? best.hit.t : Infinity)) {
+      best = { surfaceIdx: i, hit };
+    }
+  }
+  return best;
+}
+
+function intersectImagePlane(
+  origin: Vector3,
+  direction: Vector3,
+  imagePlane: ResolvedImagePlane | undefined,
+): ImagePlaneIntersection | null {
+  if (!imagePlane) return null;
+  const normalY = imagePlane.normal.y;
+  const normalZ = imagePlane.normal.z;
+  const denom = normalY * direction[1] + normalZ * direction[2];
+  if (Math.abs(denom) <= 1e-12) return null;
+  const numer = normalY * (origin[1] - imagePlane.y) + normalZ * (origin[2] - imagePlane.z);
+  const t = -numer / denom;
+  if (!isFinite(t) || t <= 1e-7) return null;
+  return {
+    t,
+    point: [origin[0] + direction[0] * t, origin[1] + direction[1] * t, origin[2] + direction[2] * t],
+  };
+}
+
+function incidentSideFor(direction: Vector3, normal: Vector3): "front" | "rear" {
+  const dot = direction[0] * normal[0] + direction[1] * normal[1] + direction[2] * normal[2];
+  return dot >= 0 ? "front" : "rear";
+}
+
+function advanceOrigin(point: Vector3, direction: Vector3): Vector3 {
+  const eps = 1e-7;
+  return [point[0] + direction[0] * eps, point[1] + direction[1] * eps, point[2] + direction[2] * eps];
+}
+
+function reflectDirection(direction: Vector3, normal: Vector3): Vector3 {
+  const dot = direction[0] * normal[0] + direction[1] * normal[1] + direction[2] * normal[2];
+  const reflected: Vector3 = [
+    direction[0] - 2 * dot * normal[0],
+    direction[1] - 2 * dot * normal[1],
+    direction[2] - 2 * dot * normal[2],
+  ];
+  const invMag = 1 / Math.hypot(reflected[0], reflected[1], reflected[2]);
+  return [reflected[0] * invMag, reflected[1] * invMag, reflected[2] * invMag];
+}
+
+function resolvedNextIndex(
+  surfaceIdx: number,
+  incidentSide: "front" | "rear",
+  surface: ExactTraceSurface,
+  lens: ExactTraceLens,
+  indexAtSurface: ((surfaceIdx: number, nd: number) => number) | undefined,
+): number {
+  const physicalNextNd = incidentSide === "front" ? surface.nd : surfaceIdx > 0 ? lens.S[surfaceIdx - 1].nd : 1.0;
+  if (!indexAtSurface) return physicalNextNd === 1.0 ? 1.0 : physicalNextNd;
+  return physicalNextNd === 1.0 ? 1.0 : indexAtSurface(surfaceIdx, physicalNextNd);
 }
 
 // Only reached on the ghost-render path for grazing or backward rays from

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -1,5 +1,11 @@
 import type {
   AsphericCoefficients,
+  FoldedPathAutoCandidateSkip,
+  FoldedPathAutoStepDiagnostics,
+  FoldedPathClipEvent,
+  FoldedPathClipReason,
+  FoldedPathTraceDiagnostics,
+  FoldedPathTraceTermination,
   ResolvedImagePlane,
   ResolvedOpticalPath,
   SurfaceInteraction,
@@ -18,6 +24,7 @@ import {
 export type { Vector3 } from "./surfaceIntersection.js";
 
 export interface ExactTraceSurface {
+  label?: string;
   R: number;
   nd: number;
   d: number;
@@ -87,6 +94,7 @@ export interface ExactSurfaceTraceHit {
   clipped: boolean;
   fallback: boolean;
   failureReason: SurfaceIntersectionFailureReason | "totalInternalReflection" | null;
+  clipReason?: FoldedPathClipReason;
 }
 
 export interface ExactSurfaceTraceResult {
@@ -102,8 +110,14 @@ export interface ExactSurfaceTraceResult {
   terminalDirection: Vector3;
   terminalSurfaceIdx: number;
   returnVertexIdx: number;
-  failureReason: SurfaceIntersectionFailureReason | "totalInternalReflection" | null;
+  failureReason:
+    | SurfaceIntersectionFailureReason
+    | "totalInternalReflection"
+    | "loopDetected"
+    | "maxInteractions"
+    | null;
   reachedImagePlane?: boolean;
+  diagnostics: FoldedPathTraceDiagnostics;
 }
 
 const TRACE_CLIP_ABS_TOLERANCE = 1e-9;
@@ -200,6 +214,7 @@ export function traceExactSurfaceStackVector(
   const tracedCount = clampTraceCount(stopAt ?? total, total);
   const heights: number[] | null = recordHeights ? [] : null;
   const hits: ExactSurfaceTraceHit[] = [];
+  const clipEvents: FoldedPathClipEvent[] = [];
   let origin: Vector3 = [originIn[0], originIn[1], originIn[2]];
   let direction: Vector3 = [directionIn[0], directionIn[1], directionIn[2]];
   let n = 1.0;
@@ -230,6 +245,7 @@ export function traceExactSurfaceStackVector(
     } else {
       clipped = true;
       failureReason = hit.failureReason;
+      pushClipEvent(clipEvents, lens, i, "intersection-failure", hit.failureReason);
       if (!ghost) break;
 
       const fallbackPoint = fallbackSurfacePoint(origin, direction, vertexZ, i, lens, maxT);
@@ -248,8 +264,11 @@ export function traceExactSurfaceStackVector(
     }
 
     const apertureClip = apertureSemiDiameter(i, surface, lens, stopSemiDiameter);
+    let clipReason: FoldedPathClipReason | undefined;
     if (checkSemiDiameter && apertureClip !== null && !radiusWithinTraceAperture(radius, surface, apertureClip)) {
       clipped = true;
+      clipReason = traceApertureState(radius, surface, apertureClip) === "inside-hole" ? "inner-hole" : "semi-diameter";
+      pushClipEvent(clipEvents, lens, i, clipReason);
     }
 
     const hitClipped = clipped;
@@ -261,6 +280,7 @@ export function traceExactSurfaceStackVector(
       clipped: hitClipped,
       fallback,
       failureReason: hitFailure,
+      clipReason,
     });
 
     if (hitClipped && stopOnClip && !ghost) break;
@@ -274,7 +294,13 @@ export function traceExactSurfaceStackVector(
         if (refracted === null) {
           clipped = true;
           failureReason = "totalInternalReflection";
-          hits[hits.length - 1] = { ...hits[hits.length - 1], clipped: true, failureReason };
+          pushClipEvent(clipEvents, lens, i, "total-internal-reflection", failureReason);
+          hits[hits.length - 1] = {
+            ...hits[hits.length - 1],
+            clipped: true,
+            failureReason,
+            clipReason: "total-internal-reflection",
+          };
           if (!ghost) break;
         } else {
           direction = refracted;
@@ -308,6 +334,18 @@ export function traceExactSurfaceStackVector(
     returnVertexIdx,
     failureReason,
     reachedImagePlane: false,
+    diagnostics: buildFoldedPathDiagnostics(lens, {
+      hits,
+      finalMedium: n,
+      reachedImagePlane: false,
+      terminalSurfaceIdx,
+      clipped,
+      failureReason,
+      terminationReason: "sequential-return",
+      clipEvents,
+      autoSteps: [],
+      loopKey: null,
+    }),
   };
 }
 
@@ -358,6 +396,9 @@ function traceGeneralizedSurfaceStackVector(
   const maxInteractions = path?.maxInteractions ?? Math.max(lens.S.length + 1, 1);
   const heights: number[] | null = recordHeights ? [] : null;
   const hits: ExactSurfaceTraceHit[] = [];
+  const clipEvents: FoldedPathClipEvent[] = [];
+  const autoSteps: FoldedPathAutoStepDiagnostics[] = [];
+  const seenAutoStates = new Set<string>();
   let origin: Vector3 = [originIn[0], originIn[1], originIn[2]];
   let direction: Vector3 = [directionIn[0], directionIn[1], directionIn[2]];
   let n = 1.0;
@@ -367,6 +408,8 @@ function traceGeneralizedSurfaceStackVector(
   let failureReason: ExactSurfaceTraceResult["failureReason"] = null;
   let reachedImagePlane = false;
   let explicitCursor = 0;
+  let terminationReason: FoldedPathTraceTermination = "max-interactions";
+  let loopKey: string | null = null;
 
   for (let interactionCount = 0; interactionCount < maxInteractions; interactionCount++) {
     const imageHit =
@@ -387,7 +430,17 @@ function traceGeneralizedSurfaceStackVector(
         { maxT, refractiveIndex: n },
       );
     } else if (path?.mode === "auto") {
-      const next = findNearestGeneralizedSurfaceHit(origin, direction, zPos, lens, launchBoundT, n, indexAtSurface);
+      const next = findNearestGeneralizedSurfaceHit(
+        origin,
+        direction,
+        zPos,
+        lens,
+        launchBoundT,
+        n,
+        indexAtSurface,
+        terminalSurfaceIdx,
+      );
+      autoSteps.push({ step: interactionCount, skippedCandidates: next.skippedCandidates });
       nextSurfaceIdx = next?.surfaceIdx ?? null;
       nextSurfaceHit = next?.hit ?? null;
     }
@@ -398,6 +451,7 @@ function traceGeneralizedSurfaceStackVector(
     ) {
       terminalPoint = imageHit.point;
       reachedImagePlane = true;
+      terminationReason = "image-plane";
       break;
     }
 
@@ -405,6 +459,10 @@ function traceGeneralizedSurfaceStackVector(
       if (imageHit) {
         terminalPoint = imageHit.point;
         reachedImagePlane = true;
+        terminationReason = "image-plane";
+      } else {
+        terminationReason =
+          explicitOrder && explicitCursor >= explicitOrder.length ? "explicit-path-complete" : "no-next-surface";
       }
       break;
     }
@@ -412,6 +470,8 @@ function traceGeneralizedSurfaceStackVector(
     if (!nextSurfaceHit.ok) {
       clipped = true;
       failureReason = nextSurfaceHit.failureReason;
+      terminationReason = "trace-failure";
+      pushClipEvent(clipEvents, lens, nextSurfaceIdx, "intersection-failure", nextSurfaceHit.failureReason);
       if (!ghost) break;
 
       const fallbackPoint = fallbackSurfacePoint(
@@ -432,6 +492,7 @@ function traceGeneralizedSurfaceStackVector(
         clipped: true,
         fallback: true,
         failureReason: nextSurfaceHit.failureReason,
+        clipReason: "intersection-failure",
       });
       terminalPoint = fallbackPoint.point;
       terminalSurfaceIdx = nextSurfaceIdx;
@@ -463,6 +524,7 @@ function traceGeneralizedSurfaceStackVector(
       const inactiveClipped = interaction.inactiveSide === "block" && withinAperture;
       if (inactiveClipped) {
         clipped = true;
+        pushClipEvent(clipEvents, lens, nextSurfaceIdx, "inactive-side-block");
         hits.push({
           surfaceIdx: nextSurfaceIdx,
           point,
@@ -471,7 +533,9 @@ function traceGeneralizedSurfaceStackVector(
           clipped: true,
           fallback: false,
           failureReason: null,
+          clipReason: "inactive-side-block",
         });
+        terminationReason = "clipped";
         if (stopOnClip && !ghost) break;
       }
       origin = advanceOrigin(point, direction);
@@ -481,6 +545,7 @@ function traceGeneralizedSurfaceStackVector(
     if (interaction.type === "block") {
       if (withinAperture) {
         clipped = true;
+        pushClipEvent(clipEvents, lens, nextSurfaceIdx, "block-surface");
         hits.push({
           surfaceIdx: nextSurfaceIdx,
           point,
@@ -489,7 +554,9 @@ function traceGeneralizedSurfaceStackVector(
           clipped: true,
           fallback: false,
           failureReason: null,
+          clipReason: "block-surface",
         });
+        terminationReason = "clipped";
         if (stopOnClip && !ghost) break;
       }
       origin = advanceOrigin(point, direction);
@@ -500,6 +567,7 @@ function traceGeneralizedSurfaceStackVector(
       const apertureClipped = checkSemiDiameter && apertureState === "outside";
       if (apertureClipped) {
         clipped = true;
+        pushClipEvent(clipEvents, lens, nextSurfaceIdx, "semi-diameter");
         hits.push({
           surfaceIdx: nextSurfaceIdx,
           point,
@@ -508,7 +576,9 @@ function traceGeneralizedSurfaceStackVector(
           clipped: true,
           fallback: false,
           failureReason: null,
+          clipReason: "semi-diameter",
         });
+        terminationReason = "clipped";
         if (stopOnClip && !ghost) break;
       }
       origin = advanceOrigin(point, direction);
@@ -536,7 +606,14 @@ function traceGeneralizedSurfaceStackVector(
         if (refracted === null) {
           clipped = true;
           failureReason = "totalInternalReflection";
-          hits[hits.length - 1] = { ...hits[hits.length - 1], clipped: true, failureReason };
+          terminationReason = "trace-failure";
+          pushClipEvent(clipEvents, lens, nextSurfaceIdx, "total-internal-reflection", failureReason);
+          hits[hits.length - 1] = {
+            ...hits[hits.length - 1],
+            clipped: true,
+            failureReason,
+            clipReason: "total-internal-reflection",
+          };
           if (!ghost) break;
         } else {
           direction = refracted;
@@ -545,7 +622,27 @@ function traceGeneralizedSurfaceStackVector(
       n = nn;
     }
 
+    if (path?.mode === "auto") {
+      const stateKey = autoLoopStateKey(nextSurfaceIdx, point, direction, n);
+      if (seenAutoStates.has(stateKey)) {
+        clipped = true;
+        failureReason = "loopDetected";
+        terminationReason = "loop-detected";
+        loopKey = stateKey;
+        pushClipEvent(clipEvents, lens, nextSurfaceIdx, "loop-detected");
+        hits[hits.length - 1] = { ...hits[hits.length - 1], clipped: true, clipReason: "loop-detected" };
+        break;
+      }
+      seenAutoStates.add(stateKey);
+    }
+
     origin = advanceOrigin(point, direction);
+  }
+
+  if (terminationReason === "max-interactions") {
+    clipped = true;
+    failureReason = failureReason ?? "maxInteractions";
+    pushClipEvent(clipEvents, lens, terminalSurfaceIdx >= 0 ? terminalSurfaceIdx : null, "max-interactions");
   }
 
   const returnVertexIdx = terminalSurfaceIdx >= 0 ? terminalSurfaceIdx : 0;
@@ -574,6 +671,18 @@ function traceGeneralizedSurfaceStackVector(
     returnVertexIdx,
     failureReason,
     reachedImagePlane,
+    diagnostics: buildFoldedPathDiagnostics(lens, {
+      hits,
+      finalMedium: n,
+      reachedImagePlane,
+      terminalSurfaceIdx,
+      clipped,
+      failureReason,
+      terminationReason,
+      clipEvents,
+      autoSteps,
+      loopKey,
+    }),
   };
 }
 
@@ -664,6 +773,10 @@ function generalizedHitTolerance(t: number): number {
   return Math.max(1e-7, Math.abs(t) * 1e-9);
 }
 
+function selfHitTolerance(t: number): number {
+  return Math.max(1e-5, Math.abs(t) * 1e-7);
+}
+
 function surfaceIntersectionMaxTForTarget(
   surfIdx: number,
   origin: Vector3,
@@ -695,8 +808,14 @@ function findNearestGeneralizedSurfaceHit(
   launchBoundT: number | undefined,
   refractiveIndex: number,
   indexAtSurface: ((surfaceIdx: number, nd: number) => number) | undefined,
-): { surfaceIdx: number; hit: SurfaceIntersectionResult } | null {
+  previousSurfaceIdx: number,
+): {
+  surfaceIdx: number | null;
+  hit: SurfaceIntersectionResult | null;
+  skippedCandidates: FoldedPathAutoCandidateSkip[];
+} {
   let best: { surfaceIdx: number; hit: SurfaceIntersectionResult } | null = null;
+  const skippedCandidates: FoldedPathAutoCandidateSkip[] = [];
   for (let i = 0; i < lens.S.length; i++) {
     const maxT = surfaceIntersectionMaxTForTarget(i, origin, direction, zPos, lens, launchBoundT);
     const hit = intersectGeneralizedSurface(
@@ -710,13 +829,42 @@ function findNearestGeneralizedSurfaceHit(
         refractiveIndex,
       },
     );
-    if (!hit.ok) continue;
-    if (isPassiveAutoSurface(i, hit, direction, lens, refractiveIndex, indexAtSurface)) continue;
+    if (!hit.ok) {
+      skippedCandidates.push({
+        surfaceIdx: i,
+        surfaceLabel: surfaceLabel(lens, i),
+        reason: "intersection-failed",
+        failureReason: hit.failureReason,
+      });
+      continue;
+    }
+    if (hit.t <= 0) {
+      skippedCandidates.push({
+        surfaceIdx: i,
+        surfaceLabel: surfaceLabel(lens, i),
+        reason: "non-forward-hit",
+        t: hit.t,
+      });
+      continue;
+    }
+    if (i === previousSurfaceIdx && hit.t <= selfHitTolerance(hit.t)) {
+      skippedCandidates.push({ surfaceIdx: i, surfaceLabel: surfaceLabel(lens, i), reason: "self-hit", t: hit.t });
+      continue;
+    }
+    if (isPassiveAutoSurface(i, hit, direction, lens, refractiveIndex, indexAtSurface)) {
+      skippedCandidates.push({
+        surfaceIdx: i,
+        surfaceLabel: surfaceLabel(lens, i),
+        reason: "passive-same-index",
+        t: hit.t,
+      });
+      continue;
+    }
     if (!best || hit.t < (best.hit.ok ? best.hit.t : Infinity)) {
       best = { surfaceIdx: i, hit };
     }
   }
-  return best;
+  return { surfaceIdx: best?.surfaceIdx ?? null, hit: best?.hit ?? null, skippedCandidates };
 }
 
 function isPassiveAutoSurface(
@@ -867,6 +1015,88 @@ function resolvedNextIndex(
   const physicalNextNd = incidentSide === "front" ? surface.nd : surfaceIdx > 0 ? lens.S[surfaceIdx - 1].nd : 1.0;
   if (!indexAtSurface) return physicalNextNd === 1.0 ? 1.0 : physicalNextNd;
   return physicalNextNd === 1.0 ? 1.0 : indexAtSurface(surfaceIdx, physicalNextNd);
+}
+
+function surfaceLabel(lens: ExactTraceLens, surfaceIdx: number | null): string {
+  if (surfaceIdx === null || surfaceIdx < 0) return "";
+  return lens.S[surfaceIdx]?.label ?? `S${surfaceIdx + 1}`;
+}
+
+function pushClipEvent(
+  events: FoldedPathClipEvent[],
+  lens: ExactTraceLens,
+  surfaceIdx: number | null,
+  reason: FoldedPathClipReason,
+  failureReason: string | null = null,
+): void {
+  events.push({
+    surfaceIdx,
+    surfaceLabel: surfaceIdx === null ? null : surfaceLabel(lens, surfaceIdx),
+    reason,
+    failureReason,
+  });
+}
+
+function autoLoopStateKey(surfaceIdx: number, point: Vector3, direction: Vector3, n: number): string {
+  const bucket = (value: number, scale: number) => Math.round(value / scale);
+  return [
+    surfaceIdx,
+    bucket(point[0], 1e-5),
+    bucket(point[1], 1e-5),
+    bucket(point[2], 1e-5),
+    bucket(direction[0], 1e-7),
+    bucket(direction[1], 1e-7),
+    bucket(direction[2], 1e-7),
+    bucket(n, 1e-9),
+  ].join(":");
+}
+
+function buildFoldedPathDiagnostics(
+  lens: ExactTraceLens,
+  {
+    hits,
+    finalMedium,
+    reachedImagePlane,
+    terminalSurfaceIdx,
+    clipped,
+    failureReason,
+    terminationReason,
+    clipEvents,
+    autoSteps,
+    loopKey,
+  }: {
+    hits: readonly ExactSurfaceTraceHit[];
+    finalMedium: number;
+    reachedImagePlane: boolean;
+    terminalSurfaceIdx: number;
+    clipped: boolean;
+    failureReason: ExactSurfaceTraceResult["failureReason"];
+    terminationReason: FoldedPathTraceTermination;
+    clipEvents: FoldedPathClipEvent[];
+    autoSteps: FoldedPathAutoStepDiagnostics[];
+    loopKey: string | null;
+  },
+): FoldedPathTraceDiagnostics {
+  const hitSurfaceIndexes = hits.map((hit) => hit.surfaceIdx);
+  return {
+    expectedPathMode: lens.opticalPath?.mode ?? "sequential",
+    expectedSurfaceLabels: lens.opticalPath?.surfaceLabels ?? null,
+    maxInteractions: lens.opticalPath?.maxInteractions ?? Math.max(lens.S.length + 1, 1),
+    hitSurfaceIndexes,
+    hitSurfaceLabels: hitSurfaceIndexes.map((idx) => surfaceLabel(lens, idx)),
+    finalMedium,
+    reachedImagePlane,
+    imagePlaneLabel: lens.imagePlane?.label ?? null,
+    terminalSurfaceIndex: terminalSurfaceIdx,
+    terminalSurfaceLabel: terminalSurfaceIdx >= 0 ? surfaceLabel(lens, terminalSurfaceIdx) : null,
+    clipped,
+    failureReason,
+    terminationReason,
+    clipEvents,
+    autoSteps,
+    loopDetected: terminationReason === "loop-detected",
+    loopKey,
+  };
 }
 
 // Only reached on the ghost-render path for grazing or backward rays from

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -492,6 +492,9 @@ function traceGeneralizedSurfaceStackVector(
   const clipEvents: FoldedPathClipEvent[] = [];
   const autoSteps: FoldedPathAutoStepDiagnostics[] = [];
   const seenAutoStates = new Set<string>();
+  const reflectiveSurfaceIndexes = new Set(
+    lens.S.flatMap((surface, index) => (surface.interaction?.type === "reflect" ? [index] : [])),
+  );
   let origin: Vector3 = [originIn[0], originIn[1], originIn[2]];
   let direction: Vector3 = [directionIn[0], directionIn[1], directionIn[2]];
   let n = 1.0;
@@ -522,7 +525,7 @@ function traceGeneralizedSurfaceStackVector(
         lens,
         { maxT, refractiveIndex: n },
       );
-    } else if (path?.mode === "auto") {
+    } else if (path?.mode === "auto" || (explicitOrder !== null && explicitCursor >= explicitOrder.length)) {
       const next = findNearestGeneralizedSurfaceHit(
         origin,
         direction,
@@ -532,6 +535,7 @@ function traceGeneralizedSurfaceStackVector(
         n,
         indexAtSurface,
         terminalSurfaceIdx,
+        path?.mode === "auto" ? undefined : reflectiveSurfaceIndexes,
       );
       autoSteps.push({ step: interactionCount, skippedCandidates: next.skippedCandidates });
       nextSurfaceIdx = next?.surfaceIdx ?? null;
@@ -555,7 +559,9 @@ function traceGeneralizedSurfaceStackVector(
         terminationReason = "image-plane";
       } else {
         terminationReason =
-          explicitOrder && explicitCursor >= explicitOrder.length ? "explicit-path-complete" : "no-next-surface";
+          explicitOrder && explicitCursor >= explicitOrder.length && path?.mode !== "auto"
+            ? "explicit-path-complete"
+            : "no-next-surface";
       }
       break;
     }
@@ -1020,6 +1026,7 @@ function findNearestGeneralizedSurfaceHit(
   refractiveIndex: number,
   indexAtSurface: ((surfaceIdx: number, nd: number) => number) | undefined,
   previousSurfaceIdx: number,
+  allowedSurfaceIndexes?: ReadonlySet<number>,
 ): {
   surfaceIdx: number | null;
   hit: SurfaceIntersectionResult | null;
@@ -1028,6 +1035,7 @@ function findNearestGeneralizedSurfaceHit(
   let best: { surfaceIdx: number; hit: SurfaceIntersectionResult } | null = null;
   const skippedCandidates: FoldedPathAutoCandidateSkip[] = [];
   for (let i = 0; i < lens.S.length; i++) {
+    if (allowedSurfaceIndexes && !allowedSurfaceIndexes.has(i)) continue;
     const maxT = surfaceIntersectionMaxTForTarget(i, origin, direction, zPos, lens, launchBoundT);
     const hit = intersectGeneralizedSurface(
       { origin, direction } satisfies SurfaceIntersectionRay,

--- a/src/optics/internal/exactSurfaceTrace.ts
+++ b/src/optics/internal/exactSurfaceTrace.ts
@@ -9,7 +9,9 @@ import {
   intersectSagSurface,
   surfaceNormalAtHit,
   type SurfaceIntersectionFailureReason,
+  type SurfaceIntersectionOptions,
   type SurfaceIntersectionRay,
+  type SurfaceIntersectionResult,
   type Vector3,
 } from "./surfaceIntersection.js";
 
@@ -372,12 +374,12 @@ function traceGeneralizedSurfaceStackVector(
         ? intersectImagePlane(origin, direction, lens.imagePlane)
         : null;
     let nextSurfaceIdx: number | null = null;
-    let nextSurfaceHit: ReturnType<typeof intersectSagSurface> | null = null;
+    let nextSurfaceHit: SurfaceIntersectionResult | null = null;
 
     if (explicitOrder && explicitCursor < explicitOrder.length) {
       nextSurfaceIdx = explicitOrder[explicitCursor++];
       const maxT = surfaceIntersectionMaxTForTarget(nextSurfaceIdx, origin, direction, zPos, lens, launchBoundT);
-      nextSurfaceHit = intersectSagSurface(
+      nextSurfaceHit = intersectGeneralizedSurface(
         { origin, direction } satisfies SurfaceIntersectionRay,
         nextSurfaceIdx,
         zPos[nextSurfaceIdx] ?? 0,
@@ -385,7 +387,7 @@ function traceGeneralizedSurfaceStackVector(
         { maxT, refractiveIndex: n },
       );
     } else if (path?.mode === "auto") {
-      const next = findNearestGeneralizedSurfaceHit(origin, direction, zPos, lens, launchBoundT, n);
+      const next = findNearestGeneralizedSurfaceHit(origin, direction, zPos, lens, launchBoundT, n, indexAtSurface);
       nextSurfaceIdx = next?.surfaceIdx ?? null;
       nextSurfaceHit = next?.hit ?? null;
     }
@@ -644,7 +646,8 @@ function surfaceIntersectionMaxTForTarget(
 ): number {
   const vertexZ = zPos[surfIdx] ?? 0;
   const surfaceSag = Math.abs(conicPolySag(lens.S[surfIdx]?.sd ?? 0, lens.S[surfIdx]?.R ?? 0, lens.asphByIdx[surfIdx]));
-  if (Math.abs(direction[2]) > 1e-12) {
+  const hasTiltedPlaneNormal = Boolean(lens.S[surfIdx]?.interaction?.normal);
+  if (!hasTiltedPlaneNormal && Math.abs(direction[2]) > 1e-12) {
     const projectedT = (vertexZ - origin[2]) / direction[2];
     if (isFinite(projectedT) && projectedT > 0) {
       return Math.max(1e-6, projectedT + (surfaceSag + 2) / Math.abs(direction[2]));
@@ -663,21 +666,127 @@ function findNearestGeneralizedSurfaceHit(
   lens: ExactTraceLens,
   launchBoundT: number | undefined,
   refractiveIndex: number,
-): { surfaceIdx: number; hit: ReturnType<typeof intersectSagSurface> } | null {
-  let best: { surfaceIdx: number; hit: ReturnType<typeof intersectSagSurface> } | null = null;
+  indexAtSurface: ((surfaceIdx: number, nd: number) => number) | undefined,
+): { surfaceIdx: number; hit: SurfaceIntersectionResult } | null {
+  let best: { surfaceIdx: number; hit: SurfaceIntersectionResult } | null = null;
   for (let i = 0; i < lens.S.length; i++) {
     const maxT = surfaceIntersectionMaxTForTarget(i, origin, direction, zPos, lens, launchBoundT);
-    const hit = intersectSagSurface({ origin, direction } satisfies SurfaceIntersectionRay, i, zPos[i] ?? 0, lens, {
-      minT: 1e-6,
-      maxT,
-      refractiveIndex,
-    });
+    const hit = intersectGeneralizedSurface(
+      { origin, direction } satisfies SurfaceIntersectionRay,
+      i,
+      zPos[i] ?? 0,
+      lens,
+      {
+        minT: 1e-6,
+        maxT,
+        refractiveIndex,
+      },
+    );
     if (!hit.ok) continue;
+    if (isPassiveAutoSurface(i, hit, direction, lens, refractiveIndex, indexAtSurface)) continue;
     if (!best || hit.t < (best.hit.ok ? best.hit.t : Infinity)) {
       best = { surfaceIdx: i, hit };
     }
   }
   return best;
+}
+
+function isPassiveAutoSurface(
+  surfaceIdx: number,
+  hit: SurfaceIntersectionResult,
+  direction: Vector3,
+  lens: ExactTraceLens,
+  refractiveIndex: number,
+  indexAtSurface: ((surfaceIdx: number, nd: number) => number) | undefined,
+): boolean {
+  if (!hit.ok) return true;
+  const surface = lens.S[surfaceIdx];
+  if (surface.interaction && surface.interaction.type !== "refract") return false;
+  const incidentSide = incidentSideFor(direction, hit.normal);
+  const nextIndex = resolvedNextIndex(surfaceIdx, incidentSide, surface, lens, indexAtSurface);
+  return Math.abs(nextIndex - refractiveIndex) <= 1e-12;
+}
+
+function intersectGeneralizedSurface(
+  ray: SurfaceIntersectionRay,
+  surfaceIdx: number,
+  vertexZ: number,
+  lens: ExactTraceLens,
+  options: SurfaceIntersectionOptions = {},
+): SurfaceIntersectionResult {
+  const normal = lens.S[surfaceIdx]?.interaction?.normal;
+  if (!normal) return intersectSagSurface(ray, surfaceIdx, vertexZ, lens, options);
+  return intersectTiltedMeridionalPlane(ray, surfaceIdx, vertexZ, normal, options);
+}
+
+function intersectTiltedMeridionalPlane(
+  ray: SurfaceIntersectionRay,
+  surfaceIdx: number,
+  vertexZ: number,
+  normal: { z: number; y: number },
+  {
+    minT = 0,
+    maxT = Infinity,
+    tolerance = 1e-9,
+    refractiveIndex,
+  }: Pick<SurfaceIntersectionOptions, "minT" | "maxT" | "tolerance" | "refractiveIndex"> = {},
+): SurfaceIntersectionResult {
+  const directionLength = Math.hypot(ray.direction[0], ray.direction[1], ray.direction[2]);
+  if (!isFinite(directionLength) || directionLength <= 0) {
+    return surfaceIntersectionFailure(surfaceIdx, "invalidRayDirection", null, 0);
+  }
+  if (!isFinite(minT) || minT < 0 || maxT < minT || (!isFinite(maxT) && maxT !== Infinity)) {
+    return surfaceIntersectionFailure(surfaceIdx, "invalidBounds", null, 0);
+  }
+
+  const normalLength = Math.hypot(normal.z, normal.y);
+  if (!isFinite(normalLength) || normalLength <= 1e-12) {
+    return surfaceIntersectionFailure(surfaceIdx, "invalidRayDirection", null, 0);
+  }
+  const normalY = normal.y / normalLength;
+  const normalZ = normal.z / normalLength;
+  const direction: Vector3 = [
+    ray.direction[0] / directionLength,
+    ray.direction[1] / directionLength,
+    ray.direction[2] / directionLength,
+  ];
+  const denom = normalY * direction[1] + normalZ * direction[2];
+  if (Math.abs(denom) <= 1e-12) return surfaceIntersectionFailure(surfaceIdx, "noBracket", null, 0);
+
+  const numer = normalY * ray.origin[1] + normalZ * (ray.origin[2] - vertexZ);
+  const t = -numer / denom;
+  if (!isFinite(t) || t < minT - tolerance || t > maxT + tolerance) {
+    return surfaceIntersectionFailure(surfaceIdx, "noBracket", null, 0);
+  }
+
+  const clampedT = Math.min(Math.max(t, minT), maxT);
+  const point: Vector3 = [
+    ray.origin[0] + direction[0] * clampedT,
+    ray.origin[1] + direction[1] * clampedT,
+    ray.origin[2] + direction[2] * clampedT,
+  ];
+  const residual = normalY * point[1] + normalZ * (point[2] - vertexZ);
+  return {
+    ok: true,
+    surfaceIdx,
+    t: clampedT,
+    point,
+    radius: Math.hypot(point[0], point[1]),
+    normal: [0, normalY, normalZ],
+    residual,
+    iterations: 0,
+    segmentLength: clampedT,
+    opticalPathLength: refractiveIndex === undefined ? null : refractiveIndex * clampedT,
+  };
+}
+
+function surfaceIntersectionFailure(
+  surfaceIdx: number,
+  failureReason: SurfaceIntersectionFailureReason,
+  residual: number | null,
+  iterations: number,
+): SurfaceIntersectionResult {
+  return { ok: false, surfaceIdx, failureReason, residual, iterations };
 }
 
 function intersectImagePlane(

--- a/src/optics/internal/traceSurfaces.ts
+++ b/src/optics/internal/traceSurfaces.ts
@@ -6,6 +6,13 @@ interface TraceSurface {
   nd: number;
   d: number;
   sd?: number;
+  interaction?: { type?: "refract" | "reflect" | "block" };
+}
+
+export interface ParaxialRayState {
+  y: number;
+  u: number;
+  n: number;
 }
 
 export interface ParaxialSurfaceTraceOptions {
@@ -26,6 +33,36 @@ export interface RealSurfaceTraceResult {
   heights: number[] | null;
 }
 
+export function transferParaxialRay({ y, u, n }: ParaxialRayState, distance: number): ParaxialRayState {
+  return { y: y + distance * u, u, n };
+}
+
+export function interactParaxialSurface(
+  { y, u, n }: ParaxialRayState,
+  surface: TraceSurface,
+  {
+    allowReflect = false,
+    requireSameIndexRefraction = false,
+  }: { allowReflect?: boolean; requireSameIndexRefraction?: boolean } = {},
+): ParaxialRayState | null {
+  const interactionType = surface.interaction?.type ?? "refract";
+  if (interactionType === "block") return null;
+
+  if (interactionType === "reflect") {
+    if (!allowReflect) return null;
+    const reflectedU = Math.abs(surface.R) < FLAT_R_THRESHOLD ? -u - (2 * y) / surface.R : -u;
+    return { y, u: reflectedU, n };
+  }
+
+  const nextN = surface.nd === 1.0 ? 1.0 : surface.nd;
+  if (requireSameIndexRefraction && Math.abs(nextN - n) > 1e-12) return null;
+  if (nextN === n) return { y, u, n };
+
+  const refractedU =
+    Math.abs(surface.R) < FLAT_R_THRESHOLD ? (n * u - (y * (nextN - n)) / surface.R) / nextN : (n * u) / nextN;
+  return { y, u: refractedU, n: nextN };
+}
+
 export function traceSurfacesParaxial(
   surfaces: TraceSurface[],
   y0: number,
@@ -35,22 +72,18 @@ export function traceSurfacesParaxial(
   const tracedCount = stopAt !== undefined ? stopAt : surfaces.length;
   const total = surfaces.length;
   const heights: number[] | null = recordHeights ? [] : null;
-  let y = y0;
-  let u = u0;
-  let n = 1.0;
+  let state: ParaxialRayState = { y: y0, u: u0, n: 1.0 };
   for (let i = 0; i < tracedCount; i++) {
-    if (recordHeights) heights!.push(y);
-    const { R, nd, d } = surfaces[i];
-    const nextN = nd === 1.0 ? 1.0 : nd;
-    if (nextN !== n) {
-      u = Math.abs(R) < FLAT_R_THRESHOLD ? (n * u - (y * (nextN - n)) / R) / nextN : (n * u) / nextN;
-    }
-    n = nextN;
+    if (recordHeights) heights!.push(state.y);
+    const surface = surfaces[i];
+    const nextState = interactParaxialSurface(state, surface);
+    if (nextState === null) return { ...state, heights };
+    state = nextState;
     const isLast = i === tracedCount - 1;
     if (isLast && skipLastTransfer) {
       continue;
     }
-    if (i < total - 1) y += d * u;
+    if (i < total - 1) state = transferParaxialRay(state, surface.d);
   }
-  return { y, u, n, heights };
+  return { ...state, heights };
 }

--- a/src/optics/layout.ts
+++ b/src/optics/layout.ts
@@ -61,7 +61,7 @@ export function doLayout(focusT: number, zoomT: number, L: RuntimeLens, aberrati
   const z = [0];
   for (let i = 0; i < th.length - 1; i++) z.push(z[i] + th[i]);
   const defaultImgZ = z[z.length - 1] + th[th.length - 1];
-  return { z, th, imgZ: L.imagePlane?.z ?? defaultImgZ };
+  return { z, th, imgZ: L.isFoldedOptics ? L.imagePlane.z : defaultImgZ };
 }
 
 export function stateSurfaces(focusT: number, zoomT: number, L: RuntimeLens, aberrationT = 0) {

--- a/src/optics/layout.ts
+++ b/src/optics/layout.ts
@@ -60,7 +60,8 @@ export function doLayout(focusT: number, zoomT: number, L: RuntimeLens, aberrati
   const th = L.S.map((_: unknown, i: number) => thick(i, focusT, zoomT, L, aberrationT));
   const z = [0];
   for (let i = 0; i < th.length - 1; i++) z.push(z[i] + th[i]);
-  return { z, th, imgZ: z[z.length - 1] + th[th.length - 1] };
+  const defaultImgZ = z[z.length - 1] + th[th.length - 1];
+  return { z, th, imgZ: L.imagePlane?.z ?? defaultImgZ };
 }
 
 export function stateSurfaces(focusT: number, zoomT: number, L: RuntimeLens, aberrationT = 0) {

--- a/src/optics/pupilAberration.ts
+++ b/src/optics/pupilAberration.ts
@@ -40,7 +40,8 @@ import {
 import type { FieldGeometryState } from "./optics.js";
 import { stateSurfaces } from "./layout.js";
 import { type RealSurfaceTraceOptions, type RealSurfaceTraceResult } from "./internal/traceSurfaces.js";
-import { traceExactSurfaceStack } from "./internal/exactSurfaceTrace.js";
+import { traceExactSurfaceStack, traceToStopViaGeneralized } from "./internal/exactSurfaceTrace.js";
+import type { ExactTraceLens } from "./internal/exactSurfaceTrace.js";
 import { projectionLaunchSlopeForField } from "./projection.js";
 import type { RuntimeLens } from "../types/optics.js";
 
@@ -141,6 +142,20 @@ export interface ExitPupilAberrationProfile {
 
 /** Default number of field samples (0° through halfField). */
 export const PUPIL_ABERRATION_SAMPLE_COUNT = 17;
+
+function exactTraceLensForState(S: ReturnType<typeof stateSurfaces>, L: RuntimeLens): ExactTraceLens {
+  return L.isFoldedOptics
+    ? {
+        S,
+        asphByIdx: L.asphByIdx,
+        stopIdx: L.stopIdx,
+        clipMargin: L.clipMargin,
+        opticalPath: L.opticalPath,
+        imagePlane: L.imagePlane,
+        isFoldedOptics: true,
+      }
+    : { S, asphByIdx: L.asphByIdx, stopIdx: L.stopIdx, clipMargin: L.clipMargin };
+}
 
 function computeStatePupilBaselines(
   focusT: number,
@@ -477,8 +492,22 @@ function traceStateSurfacesReal(
   u0: number,
   traceOptions: RealSurfaceTraceOptions = {},
 ): RealSurfaceTraceResult {
+  const traceLens = exactTraceLensForState(S, L);
+  if (L.isFoldedOptics && traceOptions.stopAt !== undefined) {
+    const stopResult = traceToStopViaGeneralized(traceLens, { y0, uy0: u0 }, traceOptions.stopAt, {
+      checkSemiDiameter: traceOptions.checkSemiDiameter,
+    });
+    return {
+      y: stopResult.found ? stopResult.y : NaN,
+      u: stopResult.found ? stopResult.uy : NaN,
+      n: stopResult.n,
+      clipped: !stopResult.found,
+      heights: null,
+    };
+  }
+
   const result = traceExactSurfaceStack(
-    { S, asphByIdx: L.asphByIdx, stopIdx: L.stopIdx },
+    traceLens,
     { y0, uy0: u0 },
     {
       stopAt: traceOptions.stopAt,

--- a/src/optics/raySampling.ts
+++ b/src/optics/raySampling.ts
@@ -73,7 +73,10 @@ export function obstructionAwareRayFractionsForDensity(
   if (!L.isFoldedOptics || entrancePupilSemiDiameter <= 0) return samples;
 
   const blockedRadius = L.S.reduce((max, surface) => {
-    if (surface.interaction?.type === "block" && (surface.innerSd ?? 0) <= 0) return Math.max(max, surface.sd);
+    const centralBlocker =
+      surface.interaction?.type === "block" ||
+      (surface.interaction?.type === "reflect" && surface.interaction.inactiveSide === "block");
+    if (centralBlocker && (surface.innerSd ?? 0) <= 0) return Math.max(max, surface.sd);
     if (surface.interaction?.type === "reflect" && (surface.innerSd ?? 0) > 0) return Math.max(max, surface.innerSd!);
     return max;
   }, 0);

--- a/src/optics/raySampling.ts
+++ b/src/optics/raySampling.ts
@@ -63,6 +63,30 @@ export function rayFractionsForDensity(fractions: readonly number[], density: Ra
   return Array.from({ length: count }, (_, i) => -maxAbs + i * step).map((f) => (Math.abs(f) < 1e-12 ? 0 : f));
 }
 
+export function obstructionAwareRayFractionsForDensity(
+  L: Pick<RuntimeLens, "isFoldedOptics" | "S">,
+  fractions: readonly number[],
+  density: RayDensity,
+  entrancePupilSemiDiameter: number,
+): number[] {
+  const samples = rayFractionsForDensity(fractions, density);
+  if (!L.isFoldedOptics || entrancePupilSemiDiameter <= 0) return samples;
+
+  const blockedRadius = L.S.reduce((max, surface) => {
+    if (surface.interaction?.type === "block" && (surface.innerSd ?? 0) <= 0) return Math.max(max, surface.sd);
+    if (surface.interaction?.type === "reflect" && (surface.innerSd ?? 0) > 0) return Math.max(max, surface.innerSd!);
+    return max;
+  }, 0);
+  if (blockedRadius <= 0) return samples;
+
+  const minFraction = blockedRadius / entrancePupilSemiDiameter;
+  const filtered = samples.filter((fraction) => Math.abs(fraction) >= minFraction - 1e-9);
+  if (filtered.length > 0) return filtered;
+
+  const maxAbs = Math.max(...samples.map((fraction) => Math.abs(fraction)), 0);
+  return maxAbs > 0 ? [-maxAbs, maxAbs] : [];
+}
+
 export function raySampleCountForDensity(fractions: readonly number[], density: RayDensity): number {
   return rayFractionsForDensity(fractions, density).length;
 }

--- a/src/optics/rayTrace.ts
+++ b/src/optics/rayTrace.ts
@@ -96,7 +96,15 @@ function traceRayExactCore(
   );
 
   appendExactTracePoints(result.hits, pts, ghostPts, ghost);
-  return { pts, ghostPts, y: result.y, u: result.uy, clipped: result.clipped };
+  appendImagePlanePoint(result, pts);
+  return {
+    pts,
+    ghostPts,
+    y: result.y,
+    u: result.uy,
+    clipped: result.clipped,
+    reachedImagePlane: result.reachedImagePlane,
+  };
 }
 
 function appendExactTracePoints(
@@ -114,6 +122,18 @@ function appendExactTracePoints(
       pts.push(pt);
     }
   }
+}
+
+function appendImagePlanePoint(
+  result: { reachedImagePlane?: boolean; terminalPoint: Vector3; clipped: boolean },
+  pts: number[][],
+): void {
+  if (!result.reachedImagePlane || result.clipped) return;
+  const point = [result.terminalPoint[2], result.terminalPoint[1]];
+  if (!isFinite(point[0]) || !isFinite(point[1])) return;
+  const last = pts[pts.length - 1];
+  if (last && Math.hypot(last[0] - point[0], last[1] - point[1]) < 1e-9) return;
+  pts.push(point);
 }
 
 function vectorLeadPoint(
@@ -443,7 +463,15 @@ function traceRayVectorExactCore(
   const lead = L.rayLead ?? 0;
   pts.push(vectorLeadPoint(input, result.hits[0], lead));
   appendExactTracePoints(result.hits, pts, ghostPts, ghost);
-  return { pts, ghostPts, y: result.y, u: result.uy, clipped: result.clipped };
+  appendImagePlanePoint(result, pts);
+  return {
+    pts,
+    ghostPts,
+    y: result.y,
+    u: result.uy,
+    clipped: result.clipped,
+    reachedImagePlane: result.reachedImagePlane,
+  };
 }
 
 export function traceRayVector(

--- a/src/optics/rayTrace.ts
+++ b/src/optics/rayTrace.ts
@@ -104,6 +104,7 @@ function traceRayExactCore(
     u: result.uy,
     clipped: result.clipped,
     reachedImagePlane: result.reachedImagePlane,
+    diagnostics: result.diagnostics,
   };
 }
 
@@ -471,6 +472,7 @@ function traceRayVectorExactCore(
     u: result.uy,
     clipped: result.clipped,
     reachedImagePlane: result.reachedImagePlane,
+    diagnostics: result.diagnostics,
   };
 }
 

--- a/src/optics/validateLensData.ts
+++ b/src/optics/validateLensData.ts
@@ -261,6 +261,60 @@ function validateYzNormal(value: unknown, label: string, errors: string[]): void
   }
 }
 
+function normalizedNormal(value: unknown): { z: number; y: number } | null {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    typeof (value as Record<string, unknown>).z !== "number" ||
+    typeof (value as Record<string, unknown>).y !== "number"
+  ) {
+    return null;
+  }
+  const normal = value as { z: number; y: number };
+  const len = Math.hypot(normal.z, normal.y);
+  if (!isFinite(len) || len <= 1e-12) return null;
+  return { z: normal.z / len, y: normal.y / len };
+}
+
+function samePlaneNormal(a: unknown, b: unknown): boolean {
+  const na = normalizedNormal(a);
+  const nb = normalizedNormal(b);
+  if (!na || !nb) return false;
+  return Math.abs(Math.abs(na.z * nb.z + na.y * nb.y) - 1) < 1e-6;
+}
+
+function validateTiltedMirrorBackingNormals(
+  S: UntrustedLensData[],
+  explicitSpans: Map<number, { from: number; to: number; element: UntrustedLensData }>,
+  errors: string[],
+): void {
+  const spanForElement = (elemId: number): { from: number; to: number } | null => {
+    const explicit = explicitSpans.get(elemId);
+    if (explicit) return explicit;
+    const from = S.findIndex((surface) => surface.elemId === elemId);
+    if (from < 0 || from + 1 >= S.length) return null;
+    return { from, to: from + 1 };
+  };
+
+  for (let i = 0; i < S.length; i++) {
+    const surface = S[i];
+    if (surface.elemId === 0 || surface.interaction?.type !== "reflect" || !surface.interaction.normal) continue;
+    if (typeof surface.R !== "number" || Math.abs(surface.R) <= FLAT_R_THRESHOLD) continue;
+
+    const span = spanForElement(surface.elemId);
+    if (!span || i < span.from || i > span.to) continue;
+    const backingIdx = i === span.from ? span.to : span.from;
+    if (backingIdx === i || backingIdx < 0 || backingIdx >= S.length) continue;
+    const backing = S[backingIdx];
+    if (typeof backing.R !== "number" || Math.abs(backing.R) <= FLAT_R_THRESHOLD) continue;
+    if (samePlaneNormal(surface.interaction.normal, backing.interaction?.normal)) continue;
+
+    errors.push(
+      `surfaces[${backingIdx}] ("${backing.label}"): tilted mirror backing plane should repeat interaction.normal from reflective surface "${surface.label}"`,
+    );
+  }
+}
+
 function validateImageFormat(value: unknown, errors: string[]): void {
   if (!isImageFormatId(value)) {
     errors.push(`"imageFormat" must be a known canonical format id when provided`);
@@ -559,6 +613,8 @@ export default function validateLensData(data: UntrustedLensData): string[] {
       }
     }
   }
+
+  validateTiltedMirrorBackingNormals(S, explicitSpans, errors);
 
   const stopIdx = typeof labelToIdx.STO === "number" ? labelToIdx.STO : -1;
   if (stopIdx >= 0) {

--- a/src/optics/validateLensData.ts
+++ b/src/optics/validateLensData.ts
@@ -9,7 +9,7 @@
  * rather than throwing on the first problem.
  */
 
-import type { AsphericCoefficients, PerspectiveControlConfig, SurfaceData } from "../types/optics.js";
+import type { AsphericCoefficients, ImagePlaneData, PerspectiveControlConfig, SurfaceData } from "../types/optics.js";
 import { isImageFormatId, isLensMountId } from "../utils/catalog/lensTaxonomy.js";
 import { buildAsphereIndex, buildLabelIndex, firstInfinityThickness } from "./internal/lensState.js";
 import { conicPolySag, FLAT_R_THRESHOLD, MAX_RIM_SLOPE_TAN, sagSlopeRaw } from "./internal/surfaceMath.js";
@@ -162,6 +162,78 @@ function validateProjection(value: unknown, errors: string[]): void {
   );
 }
 
+function validateImagePlane(value: unknown, errors: string[]): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`"opticalPath.imagePlane" must be an object when provided`);
+    return;
+  }
+
+  const imagePlane = value as ImagePlaneData;
+  if (typeof imagePlane.z !== "number" || !isFinite(imagePlane.z)) {
+    errors.push(`"opticalPath.imagePlane.z" must be a finite number`);
+  }
+  if (imagePlane.y !== undefined && (typeof imagePlane.y !== "number" || !isFinite(imagePlane.y))) {
+    errors.push(`"opticalPath.imagePlane.y" must be a finite number when provided`);
+  }
+  if (imagePlane.label !== undefined && typeof imagePlane.label !== "string") {
+    errors.push(`"opticalPath.imagePlane.label" must be a string when provided`);
+  }
+  if (imagePlane.normal !== undefined) {
+    const normal = imagePlane.normal;
+    if (
+      !normal ||
+      typeof normal !== "object" ||
+      Array.isArray(normal) ||
+      typeof normal.z !== "number" ||
+      typeof normal.y !== "number" ||
+      !isFinite(normal.z) ||
+      !isFinite(normal.y)
+    ) {
+      errors.push(`"opticalPath.imagePlane.normal" must contain finite z and y numbers`);
+      return;
+    }
+    if (Math.hypot(normal.z, normal.y) <= 1e-12) {
+      errors.push(`"opticalPath.imagePlane.normal" must not be the zero vector`);
+    }
+  }
+}
+
+function validateOpticalPath(value: unknown, surfaceLabels: Set<string>, errors: string[]): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`"opticalPath" must be an object when provided`);
+    return;
+  }
+
+  const path = value as Record<string, unknown>;
+  if (path.mode !== undefined && path.mode !== "sequential" && path.mode !== "auto") {
+    errors.push(`"opticalPath.mode" must be "sequential" or "auto" when provided`);
+  }
+
+  if (path.surfaceOrder !== undefined) {
+    if (!Array.isArray(path.surfaceOrder) || path.surfaceOrder.length === 0) {
+      errors.push(`"opticalPath.surfaceOrder" must be a non-empty array of surface labels when provided`);
+    } else {
+      path.surfaceOrder.forEach((label, index) => {
+        if (typeof label !== "string" || !surfaceLabels.has(label)) {
+          errors.push(`"opticalPath.surfaceOrder[${index}]" must match a surface label`);
+        }
+      });
+    }
+  }
+
+  if (path.imagePlane !== undefined) validateImagePlane(path.imagePlane, errors);
+
+  if (
+    path.maxInteractions !== undefined &&
+    (typeof path.maxInteractions !== "number" ||
+      !isFinite(path.maxInteractions) ||
+      path.maxInteractions < 1 ||
+      Math.round(path.maxInteractions) !== path.maxInteractions)
+  ) {
+    errors.push(`"opticalPath.maxInteractions" must be a positive integer when provided`);
+  }
+}
+
 function validateLensMounts(value: unknown, errors: string[]): void {
   if (!Array.isArray(value)) {
     errors.push(`"lensMounts" must be a non-empty array of canonical mount ids when provided`);
@@ -290,6 +362,47 @@ export default function validateLensData(data: UntrustedLensData): string[] {
     if (typeof s.d !== "number") errors.push(`surfaces[${i}] ("${s.label}"): missing or invalid d`);
     if (typeof s.nd !== "number") errors.push(`surfaces[${i}] ("${s.label}"): missing or invalid nd`);
     if (typeof s.sd !== "number") errors.push(`surfaces[${i}] ("${s.label}"): missing or invalid sd`);
+    if (s.innerSd !== undefined) {
+      if (typeof s.innerSd !== "number" || !isFinite(s.innerSd) || s.innerSd < 0) {
+        errors.push(`surfaces[${i}] ("${s.label}"): innerSd must be a finite non-negative number when provided`);
+      } else if (typeof s.sd === "number" && isFinite(s.sd) && s.innerSd >= s.sd) {
+        errors.push(`surfaces[${i}] ("${s.label}"): innerSd must be smaller than sd`);
+      }
+    }
+    if (s.interaction !== undefined) {
+      if (!s.interaction || typeof s.interaction !== "object" || Array.isArray(s.interaction)) {
+        errors.push(`surfaces[${i}] ("${s.label}"): interaction must be an object when provided`);
+      } else {
+        const interaction = s.interaction as Record<string, unknown>;
+        if (interaction.type !== "refract" && interaction.type !== "reflect" && interaction.type !== "block") {
+          errors.push(`surfaces[${i}] ("${s.label}"): interaction.type must be "refract", "reflect", or "block"`);
+        }
+        if (
+          interaction.incidentSide !== undefined &&
+          interaction.incidentSide !== "front" &&
+          interaction.incidentSide !== "rear" &&
+          interaction.incidentSide !== "both"
+        ) {
+          errors.push(`surfaces[${i}] ("${s.label}"): interaction.incidentSide must be "front", "rear", or "both"`);
+        }
+        if (
+          interaction.inactiveSide !== undefined &&
+          interaction.inactiveSide !== "ignore" &&
+          interaction.inactiveSide !== "block"
+        ) {
+          errors.push(`surfaces[${i}] ("${s.label}"): interaction.inactiveSide must be "ignore" or "block"`);
+        }
+        if (
+          interaction.mirrorKind !== undefined &&
+          interaction.mirrorKind !== "first-surface" &&
+          interaction.mirrorKind !== "second-surface"
+        ) {
+          errors.push(
+            `surfaces[${i}] ("${s.label}"): interaction.mirrorKind must be "first-surface" or "second-surface"`,
+          );
+        }
+      }
+    }
     if (s.stopPlacement !== undefined && s.stopPlacement !== "inside-element") {
       errors.push(`surfaces[${i}] ("${s.label}"): stopPlacement must be "inside-element" when provided`);
     }
@@ -299,6 +412,7 @@ export default function validateLensData(data: UntrustedLensData): string[] {
   }
   if (stoCount === 0) errors.push('No surface with label "STO" found');
   if (stoCount > 1) errors.push(`Multiple surfaces with label "STO" found (${stoCount})`);
+  if (data.opticalPath !== undefined) validateOpticalPath(data.opticalPath, surfaceLabels, errors);
 
   /* ── Element IDs: unique ── */
   const elemIds = new Set<number>();

--- a/src/optics/validateLensData.ts
+++ b/src/optics/validateLensData.ts
@@ -178,24 +178,7 @@ function validateImagePlane(value: unknown, errors: string[]): void {
   if (imagePlane.label !== undefined && typeof imagePlane.label !== "string") {
     errors.push(`"opticalPath.imagePlane.label" must be a string when provided`);
   }
-  if (imagePlane.normal !== undefined) {
-    const normal = imagePlane.normal;
-    if (
-      !normal ||
-      typeof normal !== "object" ||
-      Array.isArray(normal) ||
-      typeof normal.z !== "number" ||
-      typeof normal.y !== "number" ||
-      !isFinite(normal.z) ||
-      !isFinite(normal.y)
-    ) {
-      errors.push(`"opticalPath.imagePlane.normal" must contain finite z and y numbers`);
-      return;
-    }
-    if (Math.hypot(normal.z, normal.y) <= 1e-12) {
-      errors.push(`"opticalPath.imagePlane.normal" must not be the zero vector`);
-    }
-  }
+  validateYzNormal(imagePlane.normal, `"opticalPath.imagePlane.normal"`, errors);
 }
 
 function validateOpticalPath(value: unknown, surfaceLabels: Set<string>, errors: string[]): void {
@@ -255,6 +238,26 @@ function validateLensMounts(value: unknown, errors: string[]): void {
       errors.push(`"lensMounts" must not contain duplicate mount id "${mount}"`);
     }
     seen.add(mount);
+  }
+}
+
+function validateYzNormal(value: unknown, label: string, errors: string[]): void {
+  if (value === undefined) return;
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    typeof (value as Record<string, unknown>).z !== "number" ||
+    typeof (value as Record<string, unknown>).y !== "number" ||
+    !isFinite((value as { z: number }).z) ||
+    !isFinite((value as { y: number }).y)
+  ) {
+    errors.push(`${label} must contain finite z and y numbers`);
+    return;
+  }
+  const normal = value as { z: number; y: number };
+  if (Math.hypot(normal.z, normal.y) <= 1e-12) {
+    errors.push(`${label} must not be the zero vector`);
   }
 }
 
@@ -401,6 +404,7 @@ export default function validateLensData(data: UntrustedLensData): string[] {
             `surfaces[${i}] ("${s.label}"): interaction.mirrorKind must be "first-surface" or "second-surface"`,
           );
         }
+        validateYzNormal(interaction.normal, `surfaces[${i}] ("${s.label}"): interaction.normal`, errors);
       }
     }
     if (s.stopPlacement !== undefined && s.stopPlacement !== "inside-element") {

--- a/src/optics/validateLensData.ts
+++ b/src/optics/validateLensData.ts
@@ -13,6 +13,8 @@ import type { AsphericCoefficients, ImagePlaneData, PerspectiveControlConfig, Su
 import { isImageFormatId, isLensMountId } from "../utils/catalog/lensTaxonomy.js";
 import { buildAsphereIndex, buildLabelIndex, firstInfinityThickness } from "./internal/lensState.js";
 import { conicPolySag, FLAT_R_THRESHOLD, MAX_RIM_SLOPE_TAN, sagSlopeRaw } from "./internal/surfaceMath.js";
+import { traceExactSurfaceStack } from "./internal/exactSurfaceTrace.js";
+import type { ExactTraceLens } from "./internal/exactSurfaceTrace.js";
 
 /* Validation operates on untrusted data — use a permissive record type
  * so dynamic-key checks compile without casts on every property access. */
@@ -215,6 +217,20 @@ function validateOpticalPath(value: unknown, surfaceLabels: Set<string>, errors:
   ) {
     errors.push(`"opticalPath.maxInteractions" must be a positive integer when provided`);
   }
+
+  if (
+    Array.isArray(path.surfaceOrder) &&
+    typeof path.maxInteractions === "number" &&
+    isFinite(path.maxInteractions) &&
+    Math.round(path.maxInteractions) === path.maxInteractions
+  ) {
+    const requiredInteractions = path.surfaceOrder.length + (path.imagePlane !== undefined ? 1 : 0);
+    if (path.maxInteractions < requiredInteractions) {
+      errors.push(
+        `"opticalPath.maxInteractions" must be at least surfaceOrder length plus image-plane termination (${requiredInteractions})`,
+      );
+    }
+  }
 }
 
 function validateLensMounts(value: unknown, errors: string[]): void {
@@ -312,6 +328,99 @@ function validateTiltedMirrorBackingNormals(
     errors.push(
       `surfaces[${backingIdx}] ("${backing.label}"): tilted mirror backing plane should repeat interaction.normal from reflective surface "${surface.label}"`,
     );
+  }
+}
+
+function validatePairedInnerSdConsistency(
+  S: UntrustedLensData[],
+  explicitSpans: Map<number, { from: number; to: number; element: UntrustedLensData }>,
+  errors: string[],
+): void {
+  const pairs = new Map<string, [number, number]>();
+  const addPair = (a: number, b: number): void => {
+    if (a === b || a < 0 || b < 0 || a >= S.length || b >= S.length) return;
+    const lo = Math.min(a, b);
+    const hi = Math.max(a, b);
+    pairs.set(`${lo}:${hi}`, [lo, hi]);
+  };
+
+  for (const span of explicitSpans.values()) addPair(span.from, span.to);
+  for (let i = 0; i < S.length - 1; i++) {
+    if (typeof S[i]?.label === "string" && S[i + 1]?.label === `${S[i].label}B`) addPair(i, i + 1);
+  }
+
+  for (const [aIdx, bIdx] of pairs.values()) {
+    const a = S[aIdx];
+    const b = S[bIdx];
+    const aInner = typeof a.innerSd === "number" && isFinite(a.innerSd) ? a.innerSd : null;
+    const bInner = typeof b.innerSd === "number" && isFinite(b.innerSd) ? b.innerSd : null;
+    if (aInner === null && bInner === null) continue;
+    if (aInner !== null && bInner !== null && Math.abs(aInner - bInner) <= 1e-9) continue;
+    errors.push(
+      `surfaces[${aIdx}] ("${a.label}") and surfaces[${bIdx}] ("${b.label}"): paired annular surfaces must use matching innerSd values`,
+    );
+  }
+}
+
+function validateFoldedImagePlaneReachability(
+  data: UntrustedLensData,
+  S: UntrustedLensData[],
+  labelToIdx: Record<string, number>,
+  errors: string[],
+): void {
+  const pathData = data.opticalPath as Record<string, unknown> | undefined;
+  const imagePlaneData = pathData?.imagePlane as ImagePlaneData | undefined;
+  if (!pathData || !imagePlaneData || typeof imagePlaneData.z !== "number" || !isFinite(imagePlaneData.z)) return;
+  if (pathData.mode === "auto") return;
+  if (typeof labelToIdx.STO !== "number") return;
+
+  const surfaceLabels = Array.isArray(pathData.surfaceOrder) ? pathData.surfaceOrder : null;
+  if (surfaceLabels && new Set(surfaceLabels).size !== surfaceLabels.length) return;
+  const surfaceOrder =
+    surfaceLabels && surfaceLabels.every((label) => typeof label === "string" && typeof labelToIdx[label] === "number")
+      ? surfaceLabels.map((label) => labelToIdx[label])
+      : null;
+  const normal = normalizedNormal(imagePlaneData.normal) ?? { z: 1, y: 0 };
+  const maxInteractions =
+    typeof pathData.maxInteractions === "number" && isFinite(pathData.maxInteractions)
+      ? pathData.maxInteractions
+      : Math.max(S.length + 1, 1);
+
+  let asphByIdx: ExactTraceLens["asphByIdx"];
+  try {
+    asphByIdx = buildAsphereIndex(data.asph, labelToIdx);
+  } catch {
+    return;
+  }
+
+  const lens: ExactTraceLens = {
+    S: S as unknown as ExactTraceLens["S"],
+    asphByIdx,
+    stopIdx: labelToIdx.STO,
+    opticalPath: {
+      mode: pathData.mode === "auto" ? "auto" : "sequential",
+      surfaceOrder,
+      surfaceLabels: surfaceLabels as string[] | null,
+      maxInteractions,
+    },
+    imagePlane: {
+      z: imagePlaneData.z,
+      y: typeof imagePlaneData.y === "number" && isFinite(imagePlaneData.y) ? imagePlaneData.y : 0,
+      normal,
+      label: typeof imagePlaneData.label === "string" ? imagePlaneData.label : "IMG",
+    },
+    isFoldedOptics: true,
+  };
+
+  const stopSd = typeof S[labelToIdx.STO]?.sd === "number" && isFinite(S[labelToIdx.STO].sd) ? S[labelToIdx.STO].sd : 1;
+  const probeHeights = [...new Set([0, 0.2 * stopSd, -0.2 * stopSd, 0.4 * stopSd, -0.4 * stopSd])];
+  const reachesImagePlane = probeHeights.some((y0) => {
+    const result = traceExactSurfaceStack(lens, { y0, uy0: 0 }, { leadDistance: 0, checkSemiDiameter: true });
+    return result.reachedImagePlane === true && result.failureReason === null && !result.clipped;
+  });
+
+  if (!reachesImagePlane) {
+    errors.push(`"opticalPath.imagePlane" is not reached by any conservative folded-path probe ray`);
   }
 }
 
@@ -615,6 +724,8 @@ export default function validateLensData(data: UntrustedLensData): string[] {
   }
 
   validateTiltedMirrorBackingNormals(S, explicitSpans, errors);
+  validatePairedInnerSdConsistency(S, explicitSpans, errors);
+  validateFoldedImagePlaneReachability(data, S, labelToIdx, errors);
 
   const stopIdx = typeof labelToIdx.STO === "number" ? labelToIdx.STO : -1;
   if (stopIdx >= 0) {

--- a/src/pages/ComparePage.tsx
+++ b/src/pages/ComparePage.tsx
@@ -9,7 +9,7 @@ import { useParams, Navigate, Link } from "react-router";
 import LensVisualization from "../components/layout/LensViewer.js";
 import SEOHead from "../components/SEOHead.js";
 import ClientOnly from "../components/ClientOnly.js";
-import { LENS_CATALOG, CATALOG_KEYS } from "../utils/catalog/lensCatalog.js";
+import { LENS_CATALOG } from "../utils/catalog/lensCatalog.js";
 import { deriveMaker } from "../utils/catalog/lensMetadata.js";
 import { comparePageTitle, comparePageDescription, compareCanonicalURL } from "../comparison/comparisonURLSync.js";
 
@@ -47,7 +47,7 @@ function LensSummary({ lensKey }: { lensKey: string }) {
 export default function ComparePage() {
   const { slugA, slugB } = useParams<{ slugA: string; slugB: string }>();
 
-  if (!slugA || !slugB || !CATALOG_KEYS.includes(slugA) || !CATALOG_KEYS.includes(slugB)) {
+  if (!slugA || !slugB || !LENS_CATALOG[slugA] || !LENS_CATALOG[slugB]) {
     return <Navigate to="/lenses" replace />;
   }
 
@@ -60,7 +60,7 @@ export default function ComparePage() {
         title={comparePageTitle(lensA, lensB)}
         description={comparePageDescription(lensA, lensB)}
         canonicalURL={compareCanonicalURL(slugA, slugB)}
-        robots="noindex,follow"
+        robots={lensA.visible === false || lensB.visible === false ? "noindex,nofollow" : "noindex,follow"}
         ogType="article"
       />
 

--- a/src/pages/LensIndexPage.tsx
+++ b/src/pages/LensIndexPage.tsx
@@ -16,11 +16,12 @@ import { usePageThemeToggle } from "../utils/theme/usePageThemeToggle.js";
 import LensIndexFilterPanel from "./lensIndex/LensIndexFilterPanel.js";
 import LensIndexResults from "./lensIndex/LensIndexResults.js";
 import {
-  CATALOG_ENTRIES,
   FILTER_BOUNDS,
-  IMAGE_FORMAT_OPTIONS,
-  MAKER_OPTIONS,
-  MOUNT_OPTIONS,
+  buildFilterBounds,
+  buildImageFormatOptions,
+  buildMakerOptions,
+  buildMountOptions,
+  catalogEntriesForView,
   groupByFocalLength,
   groupByImageFormat,
   groupByMaker,
@@ -32,17 +33,35 @@ import type { GroupMode } from "./lensIndex/types.js";
 import useLensIndexFilters from "./lensIndex/useLensIndexFilters.js";
 import { lensLinkFromLibrary } from "./lensIndex/clusterLinks.js";
 import type { LensLibraryBreadcrumbContext } from "./lensIndex/clusterLinks.js";
-import { parseLensIndexUrlState, serializeLensIndexUrlState } from "./lensIndex/urlState.js";
+import { parseLensIndexUrlState, parseLensIndexViewMode, serializeLensIndexUrlState } from "./lensIndex/urlState.js";
 
 export default function LensIndexPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const parsedUrlState = useMemo(() => parseLensIndexUrlState(searchParams.toString(), FILTER_BOUNDS), [searchParams]);
+  const requestedViewMode = useMemo(() => parseLensIndexViewMode(searchParams.toString()), [searchParams]);
+  const catalogEntries = useMemo(() => catalogEntriesForView(requestedViewMode), [requestedViewMode]);
+  const filterBounds = useMemo(
+    () => (requestedViewMode === "visible" ? FILTER_BOUNDS : buildFilterBounds(catalogEntries)),
+    [catalogEntries, requestedViewMode],
+  );
+  const makerOptions = useMemo(() => buildMakerOptions(catalogEntries), [catalogEntries]);
+  const mountOptions = useMemo(() => buildMountOptions(catalogEntries), [catalogEntries]);
+  const imageFormatOptions = useMemo(() => buildImageFormatOptions(catalogEntries), [catalogEntries]);
+  const parsedUrlState = useMemo(
+    () =>
+      parseLensIndexUrlState(
+        searchParams.toString(),
+        filterBounds,
+        makerOptions.map((option) => option.slug),
+      ),
+    [filterBounds, makerOptions, searchParams],
+  );
   const [groupMode, setGroupMode] = useState<GroupMode>(parsedUrlState.groupMode);
   const [filterOpen, setFilterOpen] = useState(parsedUrlState.filterOpen);
   const yearDir: "asc" | "desc" = groupMode === "year-desc" ? "desc" : "asc";
-  const totalLenses = CATALOG_KEYS.length;
+  const totalLenses = catalogEntries.length;
+  const publicLensCount = CATALOG_KEYS.length;
   const { theme: t, themeMode, highContrast, toggleTheme, toggleHC } = usePageThemeToggle();
-  const seoDescription = `Browse ${totalLenses} patent-derived lens cross-section diagrams from Nikon, Carl Zeiss, Ricoh, Voigtländer, and more, with ray tracing and optical analysis.`;
+  const seoDescription = `Browse ${publicLensCount} patent-derived lens cross-section diagrams from Nikon, Carl Zeiss, Ricoh, Voigtländer, and more, with ray tracing and optical analysis.`;
   const {
     customFilter,
     filterInputValues,
@@ -60,8 +79,8 @@ export default function LensIndexPage() {
     commitNumericInput,
     handleNumericInputKeyDown,
   } = useLensIndexFilters({
-    entries: CATALOG_ENTRIES,
-    bounds: FILTER_BOUNDS,
+    entries: catalogEntries,
+    bounds: filterBounds,
     initialFilter: parsedUrlState.customFilter,
   });
   const makerGroups = useMemo(() => groupByMaker(filteredEntries), [filteredEntries]);
@@ -70,10 +89,11 @@ export default function LensIndexPage() {
   const mountGroups = useMemo(() => groupByMount(filteredEntries), [filteredEntries]);
   const imageFormatGroups = useMemo(() => groupByImageFormat(filteredEntries), [filteredEntries]);
   const currentLensIndexSearch = serializeLensIndexUrlState({
+    viewMode: parsedUrlState.viewMode,
     groupMode,
     filterOpen,
     customFilter,
-    bounds: FILTER_BOUNDS,
+    bounds: filterBounds,
   });
   const returnTo = currentLensIndexSearch ? `/lenses?${currentLensIndexSearch}` : "/lenses";
   const hrefForLens = useCallback(
@@ -108,7 +128,7 @@ export default function LensIndexPage() {
   return (
     <div style={{ backgroundColor: t.bg, color: t.body, minHeight: "100vh" }}>
       <SEOHead
-        title={`Lens Patent Cross-Section Library — ${totalLenses} Diagrams | ${SITE_NAME}`}
+        title={`Lens Patent Cross-Section Library — ${publicLensCount} Diagrams | ${SITE_NAME}`}
         description={seoDescription}
         canonicalURL={`${SITE_URL}/lenses`}
         jsonLd={[
@@ -269,10 +289,10 @@ export default function LensIndexPage() {
           <LensIndexFilterPanel
             theme={t}
             customFilter={customFilter}
-            bounds={FILTER_BOUNDS}
-            makerOptions={MAKER_OPTIONS}
-            mountOptions={MOUNT_OPTIONS}
-            imageFormatOptions={IMAGE_FORMAT_OPTIONS}
+            bounds={filterBounds}
+            makerOptions={makerOptions}
+            mountOptions={mountOptions}
+            imageFormatOptions={imageFormatOptions}
             filterInputValues={filterInputValues}
             activeFilters={activeFilters}
             onClearFilters={clearFilters}

--- a/src/pages/LensPage.tsx
+++ b/src/pages/LensPage.tsx
@@ -9,7 +9,7 @@ import { useParams, Navigate, Link } from "react-router";
 import LensVisualization from "../components/layout/LensViewer.js";
 import SEOHead from "../components/SEOHead.js";
 import ClientOnly from "../components/ClientOnly.js";
-import { LENS_CATALOG, CATALOG_KEYS, mdForKey } from "../utils/catalog/lensCatalog.js";
+import { LENS_CATALOG, mdForKey } from "../utils/catalog/lensCatalog.js";
 import {
   lensPageTitle,
   lensPageDescription,
@@ -46,7 +46,7 @@ const TD_STYLE: React.CSSProperties = {
 export default function LensPage() {
   const { slug } = useParams<{ slug: string }>();
 
-  if (!slug || !CATALOG_KEYS.includes(slug)) {
+  if (!slug || !LENS_CATALOG[slug]) {
     return <Navigate to="/lenses" replace />;
   }
 
@@ -60,6 +60,7 @@ export default function LensPage() {
         title={lensPageTitle(lens)}
         description={lensPageDescription(lens)}
         canonicalURL={lensCanonicalURL(slug)}
+        robots={lens.visible === false ? "noindex,nofollow" : undefined}
         ogType="article"
         jsonLd={[
           lensJsonLd(lens, slug),

--- a/src/pages/lensIndex/catalog.ts
+++ b/src/pages/lensIndex/catalog.ts
@@ -7,7 +7,7 @@
  * instead of a 1000-line mix of SEO, state, and grouping math.
  */
 
-import { CATALOG_KEYS, LENS_CATALOG } from "../../utils/catalog/lensCatalog.js";
+import { ALL_CATALOG_KEYS, CATALOG_KEYS, DEBUG_CATALOG_KEYS, LENS_CATALOG } from "../../utils/catalog/lensCatalog.js";
 import { deriveMaker } from "../../utils/catalog/lensMetadata.js";
 import { IMAGE_FORMAT_BY_ID, LENS_MOUNT_BY_ID } from "../../utils/catalog/lensTaxonomy.js";
 import type {
@@ -17,6 +17,7 @@ import type {
   FocalSubGroup,
   ImageFormatGroup,
   ImageFormatOption,
+  LensIndexViewMode,
   MakerGroup,
   MakerOption,
   MountGroup,
@@ -67,8 +68,8 @@ function lensAperture(data: LensData): number | null {
   return data.nominalFno ?? null;
 }
 
-function buildCatalogEntries(): CatalogLensEntry[] {
-  return CATALOG_KEYS.map((key) => {
+function buildCatalogEntries(keys: readonly string[]): CatalogLensEntry[] {
+  return keys.map((key) => {
     const data = LENS_CATALOG[key];
     const lensMounts = (data.lensMounts ?? []).map((mountId) => LENS_MOUNT_BY_ID[mountId]);
     const imageFormat = data.imageFormat ? IMAGE_FORMAT_BY_ID[data.imageFormat] : null;
@@ -128,7 +129,7 @@ export function defaultCustomFilter(bounds: FilterBounds): CustomFilterState {
   };
 }
 
-function buildMakerOptions(entries: CatalogLensEntry[]): MakerOption[] {
+export function buildMakerOptions(entries: CatalogLensEntry[]): MakerOption[] {
   const counts = new Map<string, MakerOption>();
   for (const entry of entries) {
     const existing = counts.get(entry.maker.slug);
@@ -141,7 +142,7 @@ function buildMakerOptions(entries: CatalogLensEntry[]): MakerOption[] {
   return Array.from(counts.values()).sort((a, b) => a.display.localeCompare(b.display));
 }
 
-function buildMountOptions(entries: CatalogLensEntry[]): MountOption[] {
+export function buildMountOptions(entries: CatalogLensEntry[]): MountOption[] {
   const counts = new Map<LensMountId, MountOption>();
   for (const entry of entries) {
     for (const mount of entry.lensMounts) {
@@ -158,7 +159,7 @@ function buildMountOptions(entries: CatalogLensEntry[]): MountOption[] {
   );
 }
 
-function buildImageFormatOptions(entries: CatalogLensEntry[]): ImageFormatOption[] {
+export function buildImageFormatOptions(entries: CatalogLensEntry[]): ImageFormatOption[] {
   const counts = new Map<ImageFormatId, ImageFormatOption>();
   for (const entry of entries) {
     if (!entry.imageFormat) continue;
@@ -404,6 +405,17 @@ export function numericFilterInputValues(filter: CustomFilterState): Record<Nume
   };
 }
 
+export function catalogEntriesForView(viewMode: LensIndexViewMode): CatalogLensEntry[] {
+  switch (viewMode) {
+    case "all":
+      return ALL_CATALOG_ENTRIES;
+    case "debug":
+      return DEBUG_CATALOG_ENTRIES;
+    case "visible":
+      return CATALOG_ENTRIES;
+  }
+}
+
 function countStepDecimals(step: number): number {
   const [, decimals = ""] = step.toString().split(".");
   return decimals.length;
@@ -429,7 +441,9 @@ export function clampNumericFilterValue(value: number, min: number, max: number,
   return Number(snapped.toFixed(precision));
 }
 
-export const CATALOG_ENTRIES = buildCatalogEntries();
+export const CATALOG_ENTRIES = buildCatalogEntries(CATALOG_KEYS);
+export const ALL_CATALOG_ENTRIES = buildCatalogEntries(ALL_CATALOG_KEYS);
+export const DEBUG_CATALOG_ENTRIES = buildCatalogEntries(DEBUG_CATALOG_KEYS);
 export const FILTER_BOUNDS = buildFilterBounds(CATALOG_ENTRIES);
 export const MAKER_OPTIONS = buildMakerOptions(CATALOG_ENTRIES);
 export const MOUNT_OPTIONS = buildMountOptions(CATALOG_ENTRIES);

--- a/src/pages/lensIndex/types.ts
+++ b/src/pages/lensIndex/types.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../utils/catalog/lensTaxonomy.js";
 
 export type GroupMode = "maker" | "focal" | "year-asc" | "year-desc" | "mount" | "format";
+export type LensIndexViewMode = "visible" | "all" | "debug";
 
 export interface CatalogLensEntry {
   key: string;

--- a/src/pages/lensIndex/urlState.ts
+++ b/src/pages/lensIndex/urlState.ts
@@ -13,15 +13,17 @@ import {
 } from "../../utils/catalog/lensTaxonomy.js";
 import { allMakerSlugs } from "../../utils/catalog/lensMetadata.js";
 import { clampNumericFilterValue, defaultCustomFilter, hasActiveCustomFilters } from "./catalog.js";
-import type { CustomFilterState, FilterBounds, GroupMode, NumericFilterField } from "./types.js";
+import type { CustomFilterState, FilterBounds, GroupMode, LensIndexViewMode, NumericFilterField } from "./types.js";
 
 export interface LensIndexUrlState {
+  viewMode: LensIndexViewMode;
   groupMode: GroupMode;
   filterOpen: boolean;
   customFilter: CustomFilterState;
 }
 
 const GROUP_MODES = new Set<GroupMode>(["maker", "focal", "year-asc", "year-desc", "mount", "format"]);
+const VIEW_MODES = new Set<LensIndexViewMode>(["visible", "all", "debug"]);
 const NUMERIC_PARAMS: ReadonlyArray<{ param: string; field: NumericFilterField; step: number }> = [
   { param: "focalMin", field: "focalMin", step: 0.1 },
   { param: "focalMax", field: "focalMax", step: 0.1 },
@@ -39,8 +41,15 @@ function parseListParam(value: string | null): string[] {
     .filter(Boolean);
 }
 
-function sortedKnownMakers(values: string[]): string[] {
-  const makerSlugs = new Set(allMakerSlugs());
+export function parseLensIndexViewMode(search: string): LensIndexViewMode {
+  const requestedView = new URLSearchParams(search).get("view");
+  return requestedView && VIEW_MODES.has(requestedView as LensIndexViewMode)
+    ? (requestedView as LensIndexViewMode)
+    : "visible";
+}
+
+function sortedKnownMakers(values: string[], knownMakerSlugs = allMakerSlugs()): string[] {
+  const makerSlugs = new Set(knownMakerSlugs);
   return [...new Set(values.filter((slug) => makerSlugs.has(slug)))].sort((a, b) => a.localeCompare(b));
 }
 
@@ -73,8 +82,13 @@ function parseNumericParam(
   return clampNumericFilterValue(parsed, min, max, step);
 }
 
-export function parseLensIndexUrlState(search: string, bounds: FilterBounds): LensIndexUrlState {
+export function parseLensIndexUrlState(
+  search: string,
+  bounds: FilterBounds,
+  knownMakerSlugs = allMakerSlugs(),
+): LensIndexUrlState {
   const params = new URLSearchParams(search);
+  const viewMode = parseLensIndexViewMode(search);
   const defaultFilter = defaultCustomFilter(bounds);
   const requestedGroup = params.get("group");
   const groupMode =
@@ -82,7 +96,7 @@ export function parseLensIndexUrlState(search: string, bounds: FilterBounds): Le
 
   const customFilter: CustomFilterState = {
     ...defaultFilter,
-    makerSlugs: sortedKnownMakers(parseListParam(params.get("makers"))),
+    makerSlugs: sortedKnownMakers(parseListParam(params.get("makers")), knownMakerSlugs),
     lensMountIds: sortedKnownMounts(parseListParam(params.get("mounts"))),
     imageFormatIds: sortedKnownFormats(parseListParam(params.get("formats"))),
   };
@@ -105,10 +119,11 @@ export function parseLensIndexUrlState(search: string, bounds: FilterBounds): Le
   customFilter.patentYearMax = Math.max(patentYearMin, patentYearMax);
 
   const filterOpen = params.get("filters") === "open" || hasActiveCustomFilters(customFilter, bounds);
-  return { groupMode, filterOpen, customFilter };
+  return { viewMode, groupMode, filterOpen, customFilter };
 }
 
 export function serializeLensIndexUrlState({
+  viewMode,
   groupMode,
   filterOpen,
   customFilter,
@@ -117,6 +132,7 @@ export function serializeLensIndexUrlState({
   const params = new URLSearchParams();
 
   if (groupMode !== "maker") params.set("group", groupMode);
+  if (viewMode !== "visible") params.set("view", viewMode);
   if (customFilter.makerSlugs.length > 0) params.set("makers", customFilter.makerSlugs.join(","));
   if (customFilter.lensMountIds.length > 0) params.set("mounts", customFilter.lensMountIds.join(","));
   if (customFilter.imageFormatIds.length > 0) params.set("formats", customFilter.imageFormatIds.join(","));

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -13,8 +13,55 @@ export interface SurfaceData {
   d: number;
   nd: number;
   sd: number;
+  innerSd?: number;
   elemId: number;
   stopPlacement?: "inside-element";
+  interaction?: SurfaceInteraction;
+}
+
+export type SurfaceIncidentSide = "front" | "rear" | "both";
+export type SurfaceInactiveSideBehavior = "ignore" | "block";
+export type SurfaceInteractionType = "refract" | "reflect" | "block";
+export type MirrorKind = "first-surface" | "second-surface";
+
+export interface SurfaceInteraction {
+  type: SurfaceInteractionType;
+  incidentSide?: SurfaceIncidentSide;
+  inactiveSide?: SurfaceInactiveSideBehavior;
+  mirrorKind?: MirrorKind;
+}
+
+export interface ImagePlaneNormal {
+  z: number;
+  y: number;
+}
+
+export interface ImagePlaneData {
+  z: number;
+  y?: number;
+  normal?: ImagePlaneNormal;
+  label?: string;
+}
+
+export interface ResolvedImagePlane {
+  z: number;
+  y: number;
+  normal: ImagePlaneNormal;
+  label: string;
+}
+
+export interface OpticalPathData {
+  mode?: "sequential" | "auto";
+  surfaceOrder?: string[];
+  imagePlane?: ImagePlaneData;
+  maxInteractions?: number;
+}
+
+export interface ResolvedOpticalPath {
+  mode: "sequential" | "auto";
+  surfaceOrder: number[] | null;
+  surfaceLabels: string[] | null;
+  maxInteractions: number;
 }
 
 export interface AsphericCoefficients {
@@ -147,6 +194,7 @@ export interface LensData {
   visible?: boolean;
   perspectiveControl?: PerspectiveControlConfig;
   projection?: LensProjectionConfig;
+  opticalPath?: OpticalPathData;
   aberrationControl?: AberrationControlConfig;
   nominalFno?: number | number[];
   closeFocusM: number;
@@ -243,6 +291,9 @@ export interface RuntimeLens {
   readonly perspectiveControl: PerspectiveControlConfig | null;
   readonly aberrationControl: ResolvedAberrationControlConfig | null;
   readonly projection: LensProjectionConfig;
+  readonly opticalPath: ResolvedOpticalPath;
+  readonly imagePlane: ResolvedImagePlane;
+  readonly isFoldedOptics: boolean;
   readonly stopIdx: number;
   readonly stopPhysSD: number;
   readonly EFL: number;
@@ -324,6 +375,7 @@ export interface RayTraceResult {
   y: number;
   u: number;
   clipped: boolean;
+  reachedImagePlane?: boolean;
 }
 
 export interface ParaxialTraceResult {

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -430,6 +430,7 @@ export interface ElementShape {
   d: string;
   z1: number;
   z2: number;
+  fillRule?: "evenodd";
   asphPaths: AsphPathData[];
 }
 

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -29,6 +29,7 @@ export interface SurfaceInteraction {
   incidentSide?: SurfaceIncidentSide;
   inactiveSide?: SurfaceInactiveSideBehavior;
   mirrorKind?: MirrorKind;
+  normal?: ImagePlaneNormal;
 }
 
 export interface ImagePlaneNormal {

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -65,6 +65,68 @@ export interface ResolvedOpticalPath {
   maxInteractions: number;
 }
 
+export type FoldedPathTraceTermination =
+  | "image-plane"
+  | "explicit-path-complete"
+  | "no-next-surface"
+  | "trace-failure"
+  | "clipped"
+  | "loop-detected"
+  | "max-interactions"
+  | "sequential-return";
+
+export type FoldedPathClipReason =
+  | "semi-diameter"
+  | "inner-hole"
+  | "block-surface"
+  | "inactive-side-block"
+  | "intersection-failure"
+  | "total-internal-reflection"
+  | "loop-detected"
+  | "max-interactions";
+
+export type FoldedPathAutoSkipReason = "intersection-failed" | "passive-same-index" | "self-hit" | "non-forward-hit";
+
+export interface FoldedPathAutoCandidateSkip {
+  surfaceIdx: number;
+  surfaceLabel: string;
+  reason: FoldedPathAutoSkipReason;
+  failureReason?: string | null;
+  t?: number;
+}
+
+export interface FoldedPathAutoStepDiagnostics {
+  step: number;
+  skippedCandidates: FoldedPathAutoCandidateSkip[];
+}
+
+export interface FoldedPathClipEvent {
+  surfaceIdx: number | null;
+  surfaceLabel: string | null;
+  reason: FoldedPathClipReason;
+  failureReason?: string | null;
+}
+
+export interface FoldedPathTraceDiagnostics {
+  expectedPathMode: ResolvedOpticalPath["mode"];
+  expectedSurfaceLabels: string[] | null;
+  maxInteractions: number;
+  hitSurfaceIndexes: number[];
+  hitSurfaceLabels: string[];
+  finalMedium: number;
+  reachedImagePlane: boolean;
+  imagePlaneLabel: string | null;
+  terminalSurfaceIndex: number;
+  terminalSurfaceLabel: string | null;
+  clipped: boolean;
+  failureReason: string | null;
+  terminationReason: FoldedPathTraceTermination;
+  clipEvents: FoldedPathClipEvent[];
+  autoSteps: FoldedPathAutoStepDiagnostics[];
+  loopDetected: boolean;
+  loopKey: string | null;
+}
+
 export interface AsphericCoefficients {
   K: number;
   A4: number;
@@ -377,6 +439,7 @@ export interface RayTraceResult {
   u: number;
   clipped: boolean;
   reachedImagePlane?: boolean;
+  diagnostics?: FoldedPathTraceDiagnostics;
 }
 
 export interface ParaxialTraceResult {

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -489,6 +489,12 @@ export interface AsphPathData {
   labelY: number;
 }
 
+export interface SurfaceAccentPathData {
+  surfIdx: number;
+  pathD: string;
+  kind: "second-surface-coating";
+}
+
 export interface ElementShape {
   eid: number;
   d: string;
@@ -496,6 +502,7 @@ export interface ElementShape {
   z2: number;
   fillRule?: "evenodd";
   asphPaths: AsphPathData[];
+  surfaceAccentPaths: SurfaceAccentPathData[];
 }
 
 export type ElementRenderTrimCause = "none" | "slope" | "gap" | "conic-limit";

--- a/src/utils/catalog/lensCatalog.ts
+++ b/src/utils/catalog/lensCatalog.ts
@@ -21,10 +21,30 @@ for (const [path, mod] of Object.entries(_modules)) {
     console.warn(`[LensVisualizer] Skipped ${path}: no "key" field in default export`);
   }
 }
+function sortLensKeysByName(keys: string[]): string[] {
+  return keys.sort((a, b) => LENS_CATALOG[a].name.localeCompare(LENS_CATALOG[b].name));
+}
+
+function isDebugLensKey(key: string): boolean {
+  const data = LENS_CATALOG[key];
+  return (
+    data.visible === false ||
+    key.startsWith("reference-") ||
+    data.maker === "Reference" ||
+    data.name.startsWith("REFERENCE ")
+  );
+}
+
+/* All lenses sorted alphabetically by display name, including hidden fixtures. */
+const ALL_CATALOG_KEYS: string[] = sortLensKeysByName(Object.keys(LENS_CATALOG));
+
 /* Visible lenses sorted alphabetically by display name */
-const CATALOG_KEYS: string[] = Object.keys(LENS_CATALOG)
-  .filter((k) => LENS_CATALOG[k].visible !== false)
-  .sort((a, b) => LENS_CATALOG[a].name.localeCompare(LENS_CATALOG[b].name));
+const CATALOG_KEYS: string[] = ALL_CATALOG_KEYS.filter((k) => LENS_CATALOG[k].visible !== false).sort((a, b) =>
+  LENS_CATALOG[a].name.localeCompare(LENS_CATALOG[b].name),
+);
+
+/* Debug/reference lenses sorted alphabetically by display name. */
+const DEBUG_CATALOG_KEYS: string[] = ALL_CATALOG_KEYS.filter(isDebugLensKey);
 
 const _mdModules = import.meta.glob<string>("../../lens-data/**/*.analysis.md", {
   eager: true,
@@ -72,5 +92,14 @@ const ALL_LENSES_BY_DATE: RecentLensEntry[] = Object.entries(
 /** Up to 7 most recently added lenses, newest-first. */
 const RECENT_LENS_KEYS: RecentLensEntry[] = ALL_LENSES_BY_DATE.slice(0, 7);
 
-export { LENS_CATALOG, CATALOG_KEYS, mdForKey, RECENT_LENS_KEYS, ALL_LENSES_BY_DATE };
+export {
+  LENS_CATALOG,
+  ALL_CATALOG_KEYS,
+  CATALOG_KEYS,
+  DEBUG_CATALOG_KEYS,
+  isDebugLensKey,
+  mdForKey,
+  RECENT_LENS_KEYS,
+  ALL_LENSES_BY_DATE,
+};
 export type { RecentLensEntry };


### PR DESCRIPTION
## Summary

- Adds generalized mirror/folded optics support for explicit and automatic optical paths, repeated surface hits, side-aware reflect/block behavior, annular apertures/obstructions, tilted fold planes, and arbitrary image planes.
- Fixes folded off-axis accuracy by routing folded stop/chief-ray solves through generalized tracing, deriving folded entrance/exit pupil geometry from real rays, and using shared path-aware image-plane intercept math.
- Fixes mirror back-side tracing so side-limited reflective surfaces block inactive-side hits by default.
- Annotates all hidden/reference mirror fixtures with `inactiveSide: "block"` so back-side opacity is explicit in the data, including the Newtonian diagonal and primary/secondary mirror fixtures.
- Adds hidden reference fixtures and regression anchors for first-surface mirrors, Mangin second-surface mirrors, Newtonian side focus, Cassegrain/Gregorian/Maksutov-style folded paths, annular blockers, off-axis image-height behavior, symmetry, repeated stops, and validation hardening.
- Improves folded-system UI and authoring: folded diagnostics, element inspector metadata, lens library `?view=all` / `?view=debug`, second-surface coating accents, stricter validation, and a generated hidden mirror fixture authoring report.
- Updates agent and user documentation for mirror/folded accuracy work, inactive-side mirror blocking defaults, guarded analysis tabs, authoring rules, testing expectations, branch records, changelog coverage, and future follow-ups.
- Merges current `main` after PR #517 and regenerates affected reports/metadata so the branch is conflict-free against the latest catalog.

## Validation

Implementation pass:

- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run generate:mirror-reports`

Latest mirror back-side blocking update:

- `npm test -- mirrorOptics`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test`

Latest reference annotation update:

- `npm run generate:mirror-reports`
- `npm test -- mirrorOptics`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`

Final docs / main-merge pass:

- `npm run generate:glass-reports`
- `npm run generate:mirror-reports`
- `npm run generate:metadata`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test` (passed after refreshing generated build metadata)
- `npm run build`
- `npm run seo:audit`

Build completed successfully with the existing Vite warnings for `%VITE_GOATCOUNTER_URL%` and large bundle size. SEO audit completed with 0 errors and 0 warnings.
