### PR TITLE
[codex] Add Minolta AF lens batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart TD
 
 ## Current Scope
 
-- `258` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
+- `261` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Canon, Carl Zeiss Jena, Carl Zeiss Oberkochen, Fujifilm,
   Hasselblad, Laowa, Leica, Minolta, Nikon, Olympus, Panasonic, Pentax, Ricoh, Schneider-Kreuznach, Sigma, Sony,
   Vivitar, and Voigtländer

--- a/agent_docs/generated/catalog-mismatches.generated.md
+++ b/agent_docs/generated/catalog-mismatches.generated.md
@@ -13,10 +13,10 @@ with words like "probable" or "approx").
 
 ## Summary
 
-- **258** lenses scanned
-- **2973** glass surfaces examined
-- **2967** surfaces with non-empty `glass` strings
-- **2315** of those resolved to a catalog entry
+- **261** lenses scanned
+- **2998** glass surfaces examined
+- **2992** surfaces with non-empty `glass` strings
+- **2326** of those resolved to a catalog entry
 - **49** mismatches found (2.1% of resolved surfaces)
 - **22** distinct lens files affected
 

--- a/agent_docs/generated/sellmeier-coverage.generated.md
+++ b/agent_docs/generated/sellmeier-coverage.generated.md
@@ -9,12 +9,12 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **258** lenses scanned
-- **258** visible lenses scanned
+- **261** lenses scanned
+- **261** visible lenses scanned
 - **51** lenses fully covered
 - **51** visible lenses fully covered
-- **2266 / 2973** non-air surfaces use trusted Sellmeier data
-- **76.2%** surface coverage overall
+- **2277 / 2998** non-air surfaces use trusted Sellmeier data
+- **76.0%** surface coverage overall
 
 ## Fully Covered Lenses
 
@@ -245,64 +245,67 @@ Fully covered lenses are listed above; this table focuses on the remaining catal
 | 155 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
 | 156 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
 | 157 | [VIVITAR SERIES 1 200mm f/3.0 VMC](../../src/lens-data/vivitar/VivitarSeries1200mmf3.data.ts) | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
-| 158 | [SONY PLANAR T* 50mm F1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
-| 159 | [NIKON NIKKOR Z DX 16-50mm f/3.5-6.3 VR](../../src/lens-data/nikon/NikonZDX1650mmf3563VR.data.ts) | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
-| 160 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 161 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 162 | [Nikon AF-P DX NIKKOR 10-20mm f/4.5-5.6G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
-| 163 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
-| 164 | [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
+| 158 | [Minolta AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
+| 159 | [SONY PLANAR T* 50mm F1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
+| 160 | [NIKON NIKKOR Z DX 16-50mm f/3.5-6.3 VR](../../src/lens-data/nikon/NikonZDX1650mmf3563VR.data.ts) | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
+| 161 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 162 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 163 | [Nikon AF-P DX NIKKOR 10-20mm f/4.5-5.6G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
+| 164 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
+| 165 | [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
 |  | **40-44.9% coverage** |  |  |  |  |  |
-| 165 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 166 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 44.4% | 8/18 | 8/17 | 10 | abbe: 9, constant: 1 |
-| 167 | [SONY SONNAR T* FE 35mm F2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 168 | [Laowa 58 mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
-| 169 | [HASSELBLAD XCD 2,5/90V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 41.7% | 5/12 | 5/9 | 7 | abbe: 4, constant: 3 |
-| 170 | [PENTAX-F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 171 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 172 | [VOIGTLÄNDER ULTRON Vintage Line 28mm F2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) | 40.0% | 4/10 | 4/10 | 6 | abbe: 6 |
+| 166 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 167 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 44.4% | 8/18 | 8/17 | 10 | abbe: 9, constant: 1 |
+| 168 | [Minolta AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 169 | [SONY SONNAR T* FE 35mm F2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 170 | [Laowa 58 mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
+| 171 | [HASSELBLAD XCD 2,5/90V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 41.7% | 5/12 | 5/9 | 7 | abbe: 4, constant: 3 |
+| 172 | [PENTAX-F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 173 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 174 | [Minolta AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) | 40.0% | 4/10 | 4/10 | 6 | abbe: 6 |
+| 175 | [VOIGTLÄNDER ULTRON Vintage Line 28mm F2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) | 40.0% | 4/10 | 4/10 | 6 | abbe: 6 |
 |  | **35-39.9% coverage** |  |  |  |  |  |
-| 173 | [Nikon AF-P NIKKOR 70-300mm f/4.5-5.6E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
-| 174 | [Minolta AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
-| 175 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
-| 176 | [Nikon NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
-| 177 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
-| 178 | [SONY FE 70-200mm F2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
+| 176 | [Nikon AF-P NIKKOR 70-300mm f/4.5-5.6E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
+| 177 | [Minolta AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
+| 178 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
+| 179 | [Nikon NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
+| 180 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
+| 181 | [SONY FE 70-200mm F2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
 |  | **30-34.9% coverage** |  |  |  |  |  |
-| 179 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 180 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 181 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 182 | [NIKON NIKKOR 35mm f/2.8 (35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 183 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 184 | [CARL ZEISS Distagon T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 33.3% | 3/9 | 3/9 | 6 | abbe: 6 |
-| 185 | [NIKON AF-S NIKKOR 58mm f/1.4G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 33.3% | 3/9 | 3/9 | 6 | abbe: 6 |
-| 186 | [SIGMA 85mm F/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
-| 187 | [Nikon AF-S DX NIKKOR 55-200mm f/4-5.6G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
-| 188 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
-| 189 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
+| 182 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 183 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 184 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 185 | [NIKON NIKKOR 35mm f/2.8 (35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 186 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 187 | [CARL ZEISS Distagon T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 33.3% | 3/9 | 3/9 | 6 | abbe: 6 |
+| 188 | [NIKON AF-S NIKKOR 58mm f/1.4G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 33.3% | 3/9 | 3/9 | 6 | abbe: 6 |
+| 189 | [SIGMA 85mm F/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
+| 190 | [Nikon AF-S DX NIKKOR 55-200mm f/4-5.6G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
+| 191 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
+| 192 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
 |  | **25-29.9% coverage** |  |  |  |  |  |
-| 190 | [CARL ZEISS Jena Biogon 3.5 cm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 28.6% | 2/7 | 2/7 | 5 | abbe: 4, lineIndices: 1 |
+| 193 | [CARL ZEISS Jena Biogon 3.5 cm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 28.6% | 2/7 | 2/7 | 5 | abbe: 4, lineIndices: 1 |
 |  | **20-24.9% coverage** |  |  |  |  |  |
-| 191 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
-| 192 | [Nikon AI Nikkor 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
+| 194 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
+| 195 | [Nikon AI Nikkor 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
 |  | **15-19.9% coverage** |  |  |  |  |  |
-| 193 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
-| 194 | [SONY FE 28-70mm F2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
+| 196 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
+| 197 | [SONY FE 28-70mm F2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
 |  | **10-14.9% coverage** |  |  |  |  |  |
-| 195 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 12.5% | 1/8 | 1/8 | 7 | abbe: 7 |
-| 196 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
-| 197 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 198 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 12.5% | 1/8 | 1/8 | 7 | abbe: 7 |
+| 199 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 200 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
 |  | **0-4.9% coverage** |  |  |  |  |  |
-| 198 | [Nikon Fuwatto Soft 90mm f/4.8](../../src/lens-data/nikon/NikonFuwattoSoft90mmf48.data.ts) | 0.0% | 0/2 | 0/2 | 2 | abbe: 2 |
-| 199 | [CARL ZEISS TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 200 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 201 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 202 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 203 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 204 | [Nikon AI Nikkor 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 205 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 206 | [CARL ZEISS SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 207 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
+| 201 | [Nikon Fuwatto Soft 90mm f/4.8](../../src/lens-data/nikon/NikonFuwattoSoft90mmf48.data.ts) | 0.0% | 0/2 | 0/2 | 2 | abbe: 2 |
+| 202 | [CARL ZEISS TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 203 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 204 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 205 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 206 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 207 | [Nikon AI Nikkor 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 208 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 209 | [CARL ZEISS SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 210 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
 
 ## Missing Surface Details
 
@@ -1473,6 +1476,15 @@ Incomplete visible lenses, still ordered by descending completeness.
 | 10 | Element 5 | abbe | `713-433 region (LaF/BaSF boundary; likely discontinued Japanese type)` | No catalog match |
 | 12 | Element 6 | abbe | `BaLF4 (Schott)` | No catalog match |
 
+### [Minolta AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) - 50.0% (4/8) - US 4,786,152
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 1 | Element 1 | abbe | `Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)` | Explicit unmatched/proprietary annotation |
+| 3 | Element 2 | abbe | `Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)` | Explicit unmatched/proprietary annotation |
+| 5 | Element 3 | abbe | `Unmatched high-index lanthanum crown (720/521)` | Explicit unmatched/proprietary annotation |
+| 7 | Element 4 | abbe | `Unmatched dense lanthanum flint (721/334)` | Explicit unmatched/proprietary annotation |
+
 ### [SONY PLANAR T* 50mm F1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) - 50.0% (4/8) - US 2014/0071331 A1
 
 | Surface | Element | Runtime quality | Glass annotation | Reason |
@@ -1577,6 +1589,15 @@ Incomplete visible lenses, still ordered by descending completeness.
 | 24 | Element 15 | abbe | `Dense flint (near S-NBH52V)` | S-NBH52V rejected by nd safety net (Δnd=-0.0260) |
 | ... | ... | ... | ... | 2 more missing surfaces |
 
+### [Minolta AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) - 42.9% (3/7) - US 4,560,253
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 4 | Component I-2 resin layer | abbe | `UV-curing acrylic resin (patent thin transparent layer)` | No catalog match |
+| 5 | Component II-1 | abbe | `Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)` | Explicit unmatched/proprietary annotation |
+| 7 | Component II-2 | abbe | `Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)` | Explicit unmatched/proprietary annotation |
+| 9 | Component II-3 | abbe | `Unmatched dense/fluor flint code 750/251 (closest current HOYA FF8 class is 752/251)` | Explicit unmatched/proprietary annotation |
+
 ### [SONY SONNAR T* FE 35mm F2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) - 42.9% (3/7) - JP 2015-41012 A
 
 | Surface | Element | Runtime quality | Glass annotation | Reason |
@@ -1626,6 +1647,17 @@ Incomplete visible lenses, still ordered by descending completeness.
 | 1 | Element a (front) | abbe | `Light Flint (LF, probable discontinued Schott type)` | No catalog match |
 | 4 | Element c (central) | abbe | `Light Flint (LF, same glass as elements a/a′)` | No catalog match |
 | 7 | Element a′ (rear) | abbe | `Light Flint (LF, same glass as elements a/c)` | No catalog match |
+
+### [Minolta AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) - 40.0% (4/10) - US 4,518,229
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 1 | Element 1 | abbe | `Unmatched fluorophosphate ED-class (495/797; not S-FPL51)` | Explicit unmatched/proprietary annotation |
+| 3 | Element 2 | abbe | `Unmatched fluorophosphate ED-class (495/797; not S-FPL51)` | Explicit unmatched/proprietary annotation |
+| 5 | Element 3 | abbe | `Unmatched dense flint class (682/366)` | Explicit unmatched/proprietary annotation |
+| 7 | Element 4 | abbe | `Unmatched dense flint class (654/339)` | Explicit unmatched/proprietary annotation |
+| 14 | Element 8 | abbe | `Unmatched high-index crown / lanthanum-crown class (670/571)` | Explicit unmatched/proprietary annotation |
+| 17 | Element 10 | abbe | `Unmatched dense flint class (654/339)` | Explicit unmatched/proprietary annotation |
 
 ### [VOIGTLÄNDER ULTRON Vintage Line 28mm F2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) - 40.0% (4/10) - JP2022-100641A
 

--- a/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
@@ -9,30 +9,32 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **258** lenses scanned
-- **254** total code-only elements found
-- **183** elements in this report
-- **75** distinct lens files affected
+- **261** lenses scanned
+- **264** total code-only elements found
+- **193** elements in this report
+- **78** distinct lens files affected
 
 ## Codes by Frequency
 
 | Code | Elements | Lens files |
 |---|---:|---:|
+| 670571 | 7 | 4 |
 | 770297 | 6 | 5 |
 | 855252 | 5 | 4 |
 | 662561 | 4 | 1 |
-| 670571 | 4 | 2 |
 | 516565 | 3 | 1 |
 | 585587 | 3 | 1 |
 | 672472 | 3 | 1 |
 | 744495 | 3 | 3 |
 | 777297 | 3 | 3 |
 | 863248 | 3 | 1 |
+| 493836 | 2 | 1 |
 | 514428 | 2 | 1 |
 | 531559 | 2 | 2 |
 | 561453 | 2 | 2 |
 | 585594 | 2 | 1 |
 | 586609 | 2 | 1 |
+| 654339 | 2 | 1 |
 | 666356 | 2 | 1 |
 | 694508 | 2 | 1 |
 | 755516 | 2 | 1 |
@@ -90,6 +92,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 672323 | 1 | 1 |
 | 675348 | 1 | 1 |
 | 680312 | 1 | 1 |
+| 682366 | 1 | 1 |
 | 683447 | 1 | 1 |
 | 683548 | 1 | 1 |
 | 694532 | 1 | 1 |
@@ -98,6 +101,8 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 713433 | 1 | 1 |
 | 717295 | 1 | 1 |
 | 720347 | 1 | 1 |
+| 720521 | 1 | 1 |
+| 721334 | 1 | 1 |
 | 728403 | 1 | 1 |
 | 731405 | 1 | 1 |
 | 738493 | 1 | 1 |
@@ -339,6 +344,31 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | L8 (Element 8) | 13 | `670571 - moderate-index crown (unresolved)` | 1.67000 / 57.07 | No catalog entry | abbe |
 | L10 (Element 10) | 17 | `755516 - high-index crown (unresolved)` | 1.75450 / 51.57 | No catalog entry | abbe |
 | L14 (Element 14) | 25 | `781446 - high-index mid-dispersion glass (unresolved)` | 1.78100 / 44.55 | No catalog entry | abbe |
+
+### [Minolta AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) - US 4,786,152
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality |
+|---|---|---|---|---|---|
+| L1 (Element 1) | 1 | `Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)` | 1.49310 / 83.55 | No catalog entry | abbe |
+| L2 (Element 2) | 3 | `Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)` | 1.49310 / 83.55 | No catalog entry | abbe |
+| L3 (Element 3) | 5 | `Unmatched high-index lanthanum crown (720/521)` | 1.72000 / 52.14 | No catalog entry | abbe |
+| L4 (Element 4) | 7 | `Unmatched dense lanthanum flint (721/334)` | 1.72100 / 33.40 | No catalog entry | abbe |
+
+### [Minolta AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) - US 4,518,229
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality |
+|---|---|---|---|---|---|
+| L3 (Element 3) | 5 | `Unmatched dense flint class (682/366)` | 1.68150 / 36.64 | No catalog entry | abbe |
+| L4 (Element 4) | 7 | `Unmatched dense flint class (654/339)` | 1.65446 / 33.86 | No catalog entry | abbe |
+| L8 (Element 8) | 14 | `Unmatched high-index crown / lanthanum-crown class (670/571)` | 1.67000 / 57.07 | No catalog entry | abbe |
+| L10 (Element 10) | 17 | `Unmatched dense flint class (654/339)` | 1.65446 / 33.86 | No catalog entry | abbe |
+
+### [Minolta AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) - US 4,560,253
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality |
+|---|---|---|---|---|---|
+| L3 (Component II-1) | 5 | `Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)` | 1.67000 / 57.07 | No catalog entry | abbe |
+| L4 (Component II-2) | 7 | `Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)` | 1.67000 / 57.07 | No catalog entry | abbe |
 
 ### [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) - US 4,124,276
 

--- a/agent_docs/generated/six-digit-glass-codes.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes.generated.md
@@ -9,21 +9,21 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **258** lenses scanned
-- **254** total code-only elements found
-- **254** elements in this report
-- **92** distinct lens files affected
+- **261** lenses scanned
+- **264** total code-only elements found
+- **264** elements in this report
+- **95** distinct lens files affected
 
 ## Codes by Frequency
 
 | Code | Elements | Lens files |
 |---|---:|---:|
 | 593670 | 7 | 4 |
+| 670571 | 7 | 4 |
 | 593679 | 6 | 4 |
 | 770297 | 6 | 5 |
 | 855252 | 5 | 4 |
 | 662561 | 4 | 1 |
-| 670571 | 4 | 2 |
 | 694533 | 4 | 3 |
 | 738323 | 4 | 4 |
 | 764485 | 4 | 4 |
@@ -41,6 +41,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 903357 | 3 | 3 |
 | 911353 | 3 | 3 |
 | 051269 | 2 | 1 |
+| 493836 | 2 | 1 |
 | 514428 | 2 | 1 |
 | 519699 | 2 | 1 |
 | 531559 | 2 | 2 |
@@ -48,6 +49,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 585594 | 2 | 1 |
 | 586609 | 2 | 1 |
 | 603380 | 2 | 1 |
+| 654339 | 2 | 1 |
 | 666356 | 2 | 1 |
 | 694508 | 2 | 1 |
 | 720347 | 2 | 2 |
@@ -115,6 +117,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 673322 | 1 | 1 |
 | 675348 | 1 | 1 |
 | 680312 | 1 | 1 |
+| 682366 | 1 | 1 |
 | 683447 | 1 | 1 |
 | 683548 | 1 | 1 |
 | 694532 | 1 | 1 |
@@ -124,6 +127,8 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 713433 | 1 | 1 |
 | 717295 | 1 | 1 |
 | 720502 | 1 | 1 |
+| 720521 | 1 | 1 |
+| 721334 | 1 | 1 |
 | 728284 | 1 | 1 |
 | 728285 | 1 | 1 |
 | 728403 | 1 | 1 |
@@ -436,6 +441,31 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | L8 (Element 8) | 13 | `670571 - moderate-index crown (unresolved)` | 1.67000 / 57.07 | No catalog entry | abbe |
 | L10 (Element 10) | 17 | `755516 - high-index crown (unresolved)` | 1.75450 / 51.57 | No catalog entry | abbe |
 | L14 (Element 14) | 25 | `781446 - high-index mid-dispersion glass (unresolved)` | 1.78100 / 44.55 | No catalog entry | abbe |
+
+### [Minolta AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) - US 4,786,152
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality |
+|---|---|---|---|---|---|
+| L1 (Element 1) | 1 | `Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)` | 1.49310 / 83.55 | No catalog entry | abbe |
+| L2 (Element 2) | 3 | `Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)` | 1.49310 / 83.55 | No catalog entry | abbe |
+| L3 (Element 3) | 5 | `Unmatched high-index lanthanum crown (720/521)` | 1.72000 / 52.14 | No catalog entry | abbe |
+| L4 (Element 4) | 7 | `Unmatched dense lanthanum flint (721/334)` | 1.72100 / 33.40 | No catalog entry | abbe |
+
+### [Minolta AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) - US 4,518,229
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality |
+|---|---|---|---|---|---|
+| L3 (Element 3) | 5 | `Unmatched dense flint class (682/366)` | 1.68150 / 36.64 | No catalog entry | abbe |
+| L4 (Element 4) | 7 | `Unmatched dense flint class (654/339)` | 1.65446 / 33.86 | No catalog entry | abbe |
+| L8 (Element 8) | 14 | `Unmatched high-index crown / lanthanum-crown class (670/571)` | 1.67000 / 57.07 | No catalog entry | abbe |
+| L10 (Element 10) | 17 | `Unmatched dense flint class (654/339)` | 1.65446 / 33.86 | No catalog entry | abbe |
+
+### [Minolta AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) - US 4,560,253
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality |
+|---|---|---|---|---|---|
+| L3 (Component II-1) | 5 | `Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)` | 1.67000 / 57.07 | No catalog entry | abbe |
+| L4 (Component II-2) | 7 | `Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)` | 1.67000 / 57.07 | No catalog entry | abbe |
 
 ### [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) - US 4,124,276
 

--- a/agent_docs/generated/unresolved-glass.generated.md
+++ b/agent_docs/generated/unresolved-glass.generated.md
@@ -8,10 +8,10 @@ or per-lens patent backfills.
 
 ## Summary
 
-- **258** lenses scanned
-- **2973** non-air surfaces examined
-- **2966** element glass declarations examined
-- **584** non-explicit-unmatched annotations did not resolve
+- **261** lenses scanned
+- **2998** non-air surfaces examined
+- **2991** element glass declarations examined
+- **585** non-explicit-unmatched annotations did not resolve
 - **218** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency

--- a/src/lens-data/minolta/MinoltaAF200mmf28.analysis.md
+++ b/src/lens-data/minolta/MinoltaAF200mmf28.analysis.md
@@ -1,0 +1,173 @@
+# Minolta AF APO Tele 200mm f/2.8 — Optical Design Analysis
+
+## Patent Reference and Design Identification
+
+**Patent:** US 4,786,152  
+**Application Number:** 35,068  
+**Filed:** April 6, 1987  
+**Granted:** November 22, 1988  
+**Priority:** April 7, 1986 (JP 61-79484)  
+**Inventor:** Tetsuya Arimoto  
+**Assignee:** Minolta Camera Kabushiki Kaisha, Osaka, Japan  
+**Title:** Telephoto Lens System  
+**Embodiment analyzed:** Embodiment 3 (Table 3, Figure 7)
+
+The patent discloses a compact large-aperture telephoto lens made from three lens units in positive-negative-positive order. Only the negative second unit moves for focusing. Embodiment 3 is the closest disclosed numerical form for the Minolta AF APO Tele 200mm f/2.8 because the worked example has the same 8-element, 7-group count, the same all-spherical three-unit layout, two patent-listed anomalous-dispersion positive front elements, an f/2.8 aperture, and a full field close to the production lens. The manufacturer manual for the high-speed version lists the AF 200mm f/2.8 APO TELE (N), inner autofocusing, anomalous-dispersion glass, a 1.5 m minimum focus distance, f/32 minimum aperture, 72 mm filter, 86 × 134 mm size, and 790 g weight.
+
+The patent table states a normalized focal length of `f = 100.0`, `F No. = 2.8`, and `2ω = 12°`. Direct paraxial tracing of the tabulated radii, thicknesses, and refractive indices gives an effective focal length of 107.407402 patent units rather than exactly 100.0. The data file therefore scales the patent prescription by ×1.862069062, making the computed data-file effective focal length 200 mm and preserving the manufacturer's focal-length marking. This is a deliberate production-normalized transcription rather than a blind ×2 expansion of the printed patent normalization.
+
+## Optical Architecture
+
+The lens is a classical telephoto in three functional units. Unit I is a strong positive front unit made from three positive elements followed by a negative meniscus. Unit II is a negative internal-focus unit consisting of a cemented doublet plus a separate negative meniscus. Unit III is a single positive rear relay element. Figure 7 of the patent places the aperture stop in the air gap immediately ahead of Unit II, which is consistent with the patent text explaining that a fixed diaphragm just in front of the movable negative unit minimizes focus-induced off-axis aberration change.
+
+An independent paraxial trace of the unscaled Embodiment 3 prescription gives:
+
+| Quantity | Patent-normalized value | Production-scaled value |
+|---|---:|---:|
+| Effective focal length | 107.407402 | 200.000 mm |
+| Back focal distance from r15 | 30.566839 | 56.918 mm |
+| Total axial track to paraxial image | 92.270839 | 171.815 mm |
+| Telephoto ratio, track/EFL | 0.859 | 0.859 |
+| Surface-by-surface Petzval sum | -0.001598424 | -0.000858413 mm^-1 |
+
+The telephoto ratio of 0.859 confirms true telephoto contraction: the axial track is shorter than the effective focal length. This is not a retrofocus construction; it is the opposite configuration, with a shorter physical length obtained by placing negative power behind the strong positive front unit.
+
+**Unit I (L1-L4, positive):** Unit I has a computed focal length of 63.894 patent units (118.97 mm scaled). Component I-1, consisting of L1-L3, has a compound focal length of 27.169 patent units; component I-2, L4 alone, is -30.990 patent units. Their independent ratio is 0.877, while the patent table reports 0.900 for the same condition. Both satisfy the claimed interval.
+
+**Unit II (L5-L7, negative):** Unit II has a computed focal length of -31.028 patent units (-57.78 mm scaled). It is the only moving optical unit during focusing. The cemented L5-L6 doublet alone is -52.048 patent units, and the trailing negative L7 strengthens the unit to roughly -31 patent units.
+
+**Unit III (L8, positive):** Unit III is a single biconvex low-dispersion positive element with a computed focal length of 52.336 patent units (97.45 mm scaled). It recollimates the diverging bundle from Unit II and supplies the rear relay/field-flattening action.
+
+## Element-by-Element Analysis
+
+### L1 — Biconvex Positive, AD Crown
+
+`nd = 1.49310`, `νd = 83.55`. Glass: unmatched AD fluorophosphate crown, patent code 493/836, `θgF = 0.539`. `f = +179.4 mm` production-scaled (`+96.3` patent units).
+
+L1 is nearly plano-convex, with a strong front surface and a very weak rear surface. It starts the high-aperture converging bundle while keeping dispersion very low. The patent's condition (4) requires at least one positive front-unit element with partial dispersion ratio above 0.53 and Abbe number above 75; L1 satisfies this directly.
+
+Current public HOYA and OHARA catalog data do not provide a confident exact name for the `1.49310 / 83.55 / θgF = 0.539` glass. No exact public HOYA or OHARA catalog name is assigned here. The data file records the element as an unmatched patent-listed anomalous-dispersion fluorophosphate crown.
+
+### L2 — Positive Meniscus, Convex to Object, AD Crown
+
+`nd = 1.49310`, `νd = 83.55`. Glass: unmatched AD fluorophosphate crown, patent code 493/836, `θgF = 0.539`. `f = +155.0 mm` production-scaled (`+83.2` patent units).
+
+L2 is the second anomalous-dispersion positive element. It shares the chromatic correction load with L1 and carries substantial positive front-group power without relying on high refractive index. The close L1-L2 spacing makes this pair behave as a strong low-dispersion collector, while the different bending of L2 provides an additional spherical and coma balancing degree of freedom.
+
+### L3 — Positive Meniscus, Convex to Object
+
+`nd = 1.72000`, `νd = 52.14`. Glass: unmatched high-index lanthanum-crown class, code 720/521. `f = +116.1 mm` production-scaled (`+62.4` patent units).
+
+L3 is the third element of component I-1 and provides high-index positive power after the two low-index AD crowns. Its rear surface, r6, is one of the patent's explicitly controlled surfaces. The r6/r7 radius ratio and the d6 air gap between L3 and L4 are the main distinction from the prior art designs cited by the patent, where the third positive and fourth negative front elements were cemented.
+
+The stored `1.72000 / 52.14` glass does not match the current public HOYA LAC10 or OHARA S-LAL10 values closely enough for a firm catalog identification. It is best treated as an unmatched high-index lanthanum crown or a discontinued/proprietary melt rather than forced into a near match.
+
+### L4 — Negative Meniscus, Convex to Object
+
+`nd = 1.72100`, `νd = 33.40`. Glass: unmatched dense lanthanum flint, code 721/334. `f = -57.7 mm` production-scaled (`-31.0` patent units).
+
+L4 is component I-2: the negative meniscus immediately behind the positive three-element front component. Its strongly curved rear surface adds the front unit's main negative compensating power. The positive/negative component spacing lets the compound front unit have a comparatively long focal length even though its subcomponents are individually much stronger.
+
+No current public HOYA or OHARA catalog match is assigned to this glass. It is recorded as an unmatched dense lanthanum flint rather than forced into a named catalog type.
+
+### L5 — Biconvex Positive, Cemented to L6
+
+`nd = 1.75520`, `νd = 27.51`. Glass: HOYA E-FD4 / OHARA S-TIH4 dense flint. `f = +90.6 mm` production-scaled (`+48.6` patent units).
+
+L5 is the front element of the Unit II cemented doublet. Its standalone in-air focal length is +48.641 patent units. Its high index and high dispersion let the cemented interface with L6 provide a controlled chromatic correction term inside the moving focus unit.
+
+The patent's condition (6) constrains the cemented-surface power. Using L5 as the front element and L6 as the rear element gives `r_ab / (n_b - n_a) = -43.717 / (1.72000 - 1.75520) = 1242.0`, matching the tabulated value 1242.
+
+### L6 — Biconcave Negative, Cemented to L5
+
+`nd = 1.72000`, `νd = 50.31`. Glass: HOYA LAC10 / OHARA S-LAL10 lanthanum crown. `f = -46.1 mm` production-scaled (`-24.8` patent units).
+
+L6 is the negative lower-dispersion partner of the Unit II cemented doublet. Its standalone focal length is -24.773 patent units. In combination with L5, the pair is a net negative achromat with a compound focal length of -52.048 patent units.
+
+The patent prose and claim language around condition (5) are internally awkward because the text writes `νa - νb > 20`, while the numerical table reports `νb - νa = 22.8`. The numerical value can only be obtained as `50.31 - 27.51`, i.e., L6's Abbe number minus L5's Abbe number. The analysis follows the numerical table because it is the value tied directly to the embodiment prescription.
+
+### L7 — Negative Meniscus, Convex to Object
+
+`nd = 1.58144`, `νd = 40.89`. Glass: HOYA E-FL5 light flint. `f = -156.7 mm` production-scaled (`-84.1` patent units).
+
+L7 is the air-spaced trailing singlet of Unit II. It adds negative power behind the cemented doublet, taking the moving unit from the doublet's -52.048 patent-unit focal length to -31.028 patent units for the whole focusing group. Current public HOYA catalog matching supports E-FL5 for this glass.
+
+### L8 — Biconvex Positive
+
+`nd = 1.48749`, `νd = 70.44`. Glass: HOYA FC5 / OHARA S-FSL5 fluor crown. `f = +97.5 mm` production-scaled (`+52.3` patent units).
+
+L8 is the single positive rear relay element. Its low dispersion avoids introducing a large residual chromatic term at the rear of the lens, while its position after the largest air gap gives it leverage over field curvature and astigmatism.
+
+## Glass Identification and Selection
+
+| Element | nd | νd | Catalog treatment | Role |
+|---|---:|---:|---|---|
+| L1 | 1.49310 | 83.55 | Unmatched AD fluorophosphate crown, θgF = 0.539 | Primary anomalous-dispersion positive collector |
+| L2 | 1.49310 | 83.55 | Unmatched AD fluorophosphate crown, θgF = 0.539 | Secondary anomalous-dispersion positive collector |
+| L3 | 1.72000 | 52.14 | Unmatched high-index lanthanum crown, 720/521 | High-index positive power in I-1 |
+| L4 | 1.72100 | 33.40 | Unmatched dense lanthanum flint, 721/334 | Negative front-unit compensator |
+| L5 | 1.75520 | 27.51 | HOYA E-FD4 / OHARA S-TIH4 | Dense-flint member of Unit II doublet |
+| L6 | 1.72000 | 50.31 | HOYA LAC10 / OHARA S-LAL10 | Lower-dispersion crown member of Unit II doublet |
+| L7 | 1.58144 | 40.89 | HOYA E-FL5 | Negative auxiliary element in Unit II |
+| L8 | 1.48749 | 70.44 | HOYA FC5 / OHARA S-FSL5 | Low-dispersion rear relay |
+
+The front unit's chromatic strategy is not a conventional crown/flint achromat alone. The two low-index, very-high-Abbe positive front elements are also anomalous-dispersion glasses, and the patent explicitly uses `θgF > 0.53` and `νd > 75` to describe the required glass behavior. Because the patent provides the partial-dispersion ratio directly, the AD function is patent-grounded even though the exact public catalog name is unresolved.
+
+The moving Unit II is separately achromatized. L5 and L6 have a large Abbe-number separation and a strongly controlled cemented interface, reducing chromatic-aberration change as the negative unit translates during focusing.
+
+## Focus Mechanism
+
+The lens uses internal focusing by moving Unit II, consisting of L5-L7, toward the image side when focusing from infinity to close range. Unit I, Unit III, and the image plane remain fixed. The patent states that Embodiment 3 moves Unit II by 5.389 patent units at magnification `β = -0.1`; direct first-order tracing of the published prescription does not reproduce that exact conjugate. Using the computed paraxial model, a 5.389-unit movement gives approximately `β = -0.128` at the fixed image plane, while `β = -0.1` would require approximately 4.153 patent units. This is consistent with the broader focal-length normalization discrepancy noted above.
+
+For the production-scaled data file, focus travel is instead solved against the manufacturer 1.5 m minimum focus distance. The resulting Unit II travel is 12.731 mm, giving a paraxial magnification of -0.161× at the fixed image plane. This aligns with the usual published maximum-magnification range for this lens class and is more useful for the viewer than stopping at the patent's internally inconsistent `β = -0.1` note.
+
+| Gap | Infinity, production-scaled | Close-focus model, production-scaled | Function |
+|---|---:|---:|---|
+| r8 → STO | 25.427 mm | 25.427 mm | fixed stop placement in d8 |
+| STO → r9 | 0.931 mm | 13.662 mm | Unit II moves imageward |
+| r11 → r12 | 6.603 mm | 6.603 mm | fixed spacing inside Unit II |
+| r13 → r14 | 33.813 mm | 21.082 mm | compensating rear gap shrinkage |
+
+The stop is modeled 0.5 patent units ahead of surface r9, i.e., just in front of Unit II as shown in the patent figures. This position gives a computed stop semi-diameter of 16.014 mm for f/2.8 after production scaling.
+
+## Aspherical Surfaces
+
+The design is entirely spherical. No aspherical coefficients are listed for any of the three patent embodiments, and the figures show conventional spherical lens elements. Aberration correction is accomplished by the positive-negative-positive telephoto power distribution, the r6/r7 and d6 front-unit spacing controls, two AD positive front elements, and the achromatized Unit II cemented doublet.
+
+## Conditional Expressions
+
+| Condition | Expression | Value used for Embodiment 3 | Status |
+|---|---|---:|---|
+| (1) | r6 / r7 | 0.646 | Satisfied |
+| (2) | d6 / f, patent basis | 0.00979 | Satisfied |
+| (3) | fI-1 / |fI-2| | 0.877 independent; 0.900 patent table | Satisfied |
+| (4) | θgF > 0.53, νd > 75 | θgF = 0.539, νd = 83.55 for L1/L2 | Satisfied |
+| (5) | Abbe-number separation in cemented pair | 50.31 - 27.51 = 22.80 | Satisfied |
+| (6) | r_ab / (n_b - n_a) | 1242.0 | Satisfied |
+| (7) | fI / f | 0.639 on patent f=100 basis; 0.595 on traced-EFL basis | Satisfied |
+| (8) | tI,II < tII,III | 14.155 < 18.159 | Satisfied |
+
+The `500f` and `1600f` notation in condition (6) is treated as a typographical artifact for the numerical examples: the table reports 1242, which is obtained from the raw radius and index difference, not from a value multiplied by the system focal length.
+
+## Petzval Sum and Field Curvature
+
+Using the surface-by-surface Petzval formula `Σ φ/(n n')`, with `φ = (n' - n)/R`, the normalized Petzval sum is -0.001598424. The corresponding Petzval radius is +625.6 patent units, or about +1165 mm in the production-scaled data file.
+
+The sign and magnitude are produced by competing contributions. L1-L3 initially drive the sum positive, but the strongly curved rear surface of L4 contributes -0.023944 by itself, pulling Unit I much closer to zero. The negative elements in Unit II then push the final sum slightly negative. The net field curvature is therefore much flatter than a simple positive front telephoto group would suggest.
+
+## Verification Summary
+
+The prescription is based on a fresh transcription of Table 3 and Figure 7, with paraxial verification of effective focal length, back focal distance, total track, group focal lengths, standalone in-air element focal lengths, conditional-expression values, stop semi-diameter, close-focus travel, and Petzval sum. The data file uses the production-normalized scale factor described above, retains the patent's all-spherical prescription, and models focus by the two variable air gaps surrounding Unit II.
+
+## Design Heritage and Context
+
+The patent contrasts the invention with earlier positive-negative-positive telephoto systems in which the third positive and fourth negative elements of the first unit were cemented. The present design deliberately introduces an air gap between L3 and L4. That gap, controlled by conditions (1) and (2), is the chief structural distinction in the front unit and gives the designer an additional coma-correction degree of freedom.
+
+The production lens belongs to Minolta's autofocus APO telephoto line. The manufacturer manual identifies inner autofocusing and anomalous-dispersion glass as core features of the AF APO telephoto lenses, matching the central optical strategy disclosed in this patent.
+
+## Sources
+
+1. Tetsuya Arimoto / Minolta Camera Kabushiki Kaisha, US 4,786,152, "Telephoto Lens System," filed April 6, 1987 and granted November 22, 1988. Embodiment 3, Table 3 and Figure 7.
+2. Minolta, *Maxxum AF High-Speed Lenses* instruction manual for AF 200mm f/2.8 APO TELE (N), AF 300mm f/2.8 APO TELE (N), and AF 600mm f/4 APO TELE (N).
+3. HOYA GROUP Optics Division, optical-glass data download and designation documentation, accessed for current catalog matching and glass-family terminology.
+4. OHARA Corporation, optical-glass catalog download and catalog-data notes, accessed for current catalog matching and cross-vendor verification.

--- a/src/lens-data/minolta/MinoltaAF200mmf28.data.ts
+++ b/src/lens-data/minolta/MinoltaAF200mmf28.data.ts
@@ -1,0 +1,189 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * LENS DATA — Minolta AF APO Tele 200mm f/2.8
+ *
+ * Data source: US 4,786,152, Embodiment 3 (Arimoto / Minolta).
+ * Three-unit telephoto: positive front unit, negative internal-focus unit, positive rear relay.
+ * 8 elements / 7 air-spaced groups; all spherical.
+ *
+ * Focus: Unit II (L5-L7) moves imageward. Front Unit I, rear Unit III, and image plane remain fixed.
+ *
+ * Scaling note: Patent Table 3 is nominally normalized to f = 100, but an independent
+ * paraxial trace gives EFL = 107.407402. R, d, and sd values are uniformly scaled by
+ * ×1.862069062 so the data-file EFL is 200 mm, matching the production lens marking
+ * rather than the internally inconsistent patent normalization.
+ *
+ * Semi-diameter note: The patent omits clear apertures. Semi-diameters here are conservative
+ * estimates from the f/2.8 marginal ray envelope, stop imaging, element edge thickness,
+ * and cross-gap sag limits.
+ */
+
+const LENS_DATA = {
+  key: "minolta-af-200mm-f28",
+  maker: "Minolta",
+  name: "Minolta AF APO Tele 200mm f/2.8",
+  subtitle: "US 4,786,152 Embodiment 3 — Minolta / Arimoto",
+  specs: [
+    "200mm f/2.8",
+    "8 elements / 7 groups",
+    "2ω = 12° in patent; 12°30′ manufacturer angle of view",
+    "Two patent-listed anomalous-dispersion crowns",
+    "Internal focusing, Unit II",
+  ],
+
+  focalLengthMarketing: 200,
+  focalLengthDesign: 200,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.8,
+  lensMounts: ["sony-a"],
+  imageFormat: "135-full-frame",
+  patentYear: 1988,
+  elementCount: 8,
+  groupCount: 7,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.4931,
+      vd: 83.55,
+      fl: 179.37,
+      glass: "Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)",
+      apd: "patent",
+      apdNote: "θgF = 0.539; public catalog glass unresolved against current HOYA/OHARA data",
+      role: "Front positive collector and primary anomalous-dispersion chromatic corrector.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.4931,
+      vd: 83.55,
+      fl: 154.97,
+      glass: "Unmatched AD fluorophosphate crown (493/836; θgF = 0.539 patent-listed)",
+      apd: "patent",
+      apdNote: "θgF = 0.539; public catalog glass unresolved against current HOYA/OHARA data",
+      role: "Second anomalous-dispersion positive element; shares the front-group chromatic correction load.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.72,
+      vd: 52.14,
+      fl: 116.11,
+      glass: "Unmatched high-index lanthanum crown (720/521)",
+      role: "High-index positive meniscus completing component I-1; its rear radius and following air gap govern coma control.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.721,
+      vd: 33.4,
+      fl: -57.71,
+      glass: "Unmatched dense lanthanum flint (721/334)",
+      role: "Negative component I-2; balances front-group power and contributes telephoto contraction.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Biconvex Positive",
+      nd: 1.7552,
+      vd: 27.51,
+      fl: 90.57,
+      glass: "E-FD4 (HOYA) / S-TIH4 (OHARA)",
+      role: "Positive dense-flint front component of the Unit II cemented doublet.",
+      cemented: "D1",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.72,
+      vd: 50.31,
+      fl: -46.13,
+      glass: "LAC10 (HOYA) / S-LAL10 (OHARA)",
+      role: "Negative lower-dispersion partner in the Unit II cemented doublet; dominant negative power in the pair.",
+      cemented: "D1",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.58144,
+      vd: 40.89,
+      fl: -156.68,
+      glass: "E-FL5 (HOYA)",
+      role: "Trailing negative meniscus in Unit II, adding negative power to the internal-focus group.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.48749,
+      vd: 70.44,
+      fl: 97.45,
+      glass: "FC5 (HOYA) / S-FSL5 (OHARA)",
+      role: "Rear positive relay and field-flattening singlet with low dispersion.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 90.4109, d: 8.78152, nd: 1.4931, elemId: 1, sd: 36.21724 },
+    { label: "2", R: -3943.72262, d: 0.27745, nd: 1.0, elemId: 0, sd: 35.75173 },
+    { label: "3", R: 57.72042, d: 9.59897, nd: 1.4931, elemId: 2, sd: 35.56552 },
+    { label: "4", R: 222.98277, d: 0.31655, nd: 1.0, elemId: 0, sd: 32.02759 },
+    { label: "5", R: 47.61124, d: 7.3049, nd: 1.72, elemId: 3, sd: 31.84138 },
+    { label: "6", R: 103.49566, d: 1.82297, nd: 1.0, elemId: 0, sd: 28.30345 },
+    { label: "7", R: 160.13794, d: 5.1449, nd: 1.721, elemId: 4, sd: 27.18621 },
+    { label: "8", R: 32.58062, d: 25.42655, nd: 1.0, elemId: 0, sd: 24.76552 },
+    { label: "STO", R: 1e15, d: 0.93103, nd: 1.0, elemId: 0, sd: 16.01449 },
+    { label: "9", R: 419.51113, d: 3.83959, nd: 1.7552, elemId: 5, sd: 16.94483 },
+    { label: "10", R: -81.40407, d: 2.87876, nd: 1.72, elemId: 6, sd: 16.57241 },
+    { label: "11", R: 56.93462, d: 6.6029, nd: 1.0, elemId: 0, sd: 16.01379 },
+    { label: "12", R: 109.55297, d: 2.87876, nd: 1.58144, elemId: 7, sd: 15.08276 },
+    { label: "13", R: 49.25917, d: 33.81331, nd: 1.0, elemId: 0, sd: 15.08276 },
+    { label: "14", R: 66.35856, d: 5.27897, nd: 1.48749, elemId: 8, sd: 18.62069 },
+    { label: "15", R: -162.87146, d: 56.91756, nd: 1.0, elemId: 0, sd: 18.62069 },
+  ],
+
+  asph: {},
+
+  var: {
+    STO: [0.93103, 13.66231],
+    "13": [33.81331, 21.08203],
+  },
+  varLabels: [
+    ["STO", "D8b"],
+    ["13", "D13"],
+  ],
+
+  groups: [
+    { text: "I", fromSurface: "1", toSurface: "8" },
+    { text: "II", fromSurface: "9", toSurface: "13" },
+    { text: "III", fromSurface: "14", toSurface: "15" },
+  ],
+  doublets: [{ text: "D1", fromSurface: "9", toSurface: "11" }],
+
+  focusDescription: "Internal focusing: Unit II (L5-L7) moves imageward; front Unit I and rear Unit III remain fixed.",
+  closeFocusM: 1.5,
+  nominalFno: 2.8,
+  maxFstop: 32,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16, 22, 32],
+  scFill: 0.62,
+  yScFill: 0.42,
+  maxAspectRatio: 2.0,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/minolta/MinoltaAF300mmf28.analysis.md
+++ b/src/lens-data/minolta/MinoltaAF300mmf28.analysis.md
@@ -1,0 +1,196 @@
+# Minolta AF APO TELE 300mm f/2.8
+
+## Patent Reference and Design Identification
+
+**Patent:** US 4,518,229  
+**Filed:** April 5, 1982  
+**Granted:** May 21, 1985  
+**Priority:** April 6, 1981 (JP 56-52120)  
+**Inventor:** Mitsuo Yasukuni  
+**Assignee:** Minolta Camera Kabushiki Kaisha, Osaka, Japan  
+**Title:** Telephoto Lens System  
+**Embodiment analyzed:** Example 8 (Table 8, FIG. 22)
+
+US 4,518,229 discloses a telephoto lens system with a fixed positive front group and a negative rear group divided into three subunits: a fixed positive first subunit, a movable negative second subunit, and a fixed positive third subunit. The movable negative subunit shifts toward the image side for close focusing. Example 8 is the embodiment transcribed here.
+
+The patent does not name the commercial lens. Example 8 is nevertheless a close fit to the original Minolta AF APO TELE 300mm f/2.8 because it has the same class of focal length and aperture, the same rear-inner-focus architecture, and the same two large low-dispersion front positive elements implied by Minolta's APO/AD-glass description. The production lens is normally catalogued as 11 elements in 9 groups, while Example 8 contains 10 prescription elements in 8 air-separated groups. That difference is consistent with the production lens's rear drop-in / protective filter being counted in the commercial optical construction but absent from the patent prescription.
+
+The patent itself gives $f = 295.0$ mm and FN = 2.9 for Example 8. The aberration figures for Example 8 are labelled F/2.8 and $y' = 21.6$ mm, matching 135-format coverage. The data file therefore records the marketed lens as 300mm f/2.8 but retains the patent design values as $f = 294.999$ mm and apertureDesign = 2.9.
+
+## Optical Architecture
+
+The design is a short telephoto system in the classical positive/negative sense. The fixed front group I has positive power and supplies the dominant convergence. The rear group II has net negative power and is divided into the fixed positive II-1, movable negative II-2, and fixed positive II-3 subunits described in the patent.
+
+The verified effective focal length is 294.999 mm. The distance from the first optical surface to the infinity image plane is 273.499 mm, giving a telephoto ratio of 0.927. This is a genuine telephoto construction by the usual track-length criterion because the optical track is shorter than the effective focal length.
+
+Group I contains three air-separated elements: two large biconvex positive low-dispersion crowns followed by a negative flint. Its verified focal length is +210.668 mm. This group carries most of the positive power and establishes the chromatic correction problem that the rear group must complete.
+
+Rear group II has a verified standalone focal length of −802.037 mm. Subunit II-1 is weakly positive at +423.178 mm; its first surface is concave to the object side and is the surface governed by the patent's first conditional expression. Subunit II-2 is the moving negative focus group at −74.055 mm. Subunit II-3 is a final positive cemented doublet at +133.218 mm.
+
+The patent does not publish a stop coordinate or clear semi-diameters. For the data file, the stop is inserted in the long $d_6 = 78.00$ mm air gap, 7.00 mm after surface 6 and 71.00 mm before surface 7. That preserves the patent axial spacing while keeping the inferred front clear aperture inside the production lens's 114 mm front-filter envelope. Semi-diameters are therefore inferred rather than patent-listed.
+
+## Element-by-Element Analysis
+
+### L1 — Biconvex Positive Front Crown
+
+nd = 1.49520, νd = 79.74. Glass: unmatched fluorophosphate ED-class glass, code 495/797. f = +218.33 mm.
+
+L1 is the first of the two large positive low-dispersion elements that form the front collector. The front surface has substantially stronger curvature than the rear surface, so most of the element's power is carried at the first surface. Its high Abbe number reduces the axial chromatic burden for a front element with large positive power.
+
+The glass is not S-FPL51. Current OHARA S-FPL51 is code 497816 with nd = 1.49700 and νd = 81.54, whereas the patent gives nd = 1.49520 and νd = 79.74. The patent glass is therefore recorded as an unmatched fluorophosphate ED-class glass rather than assigned to a current catalog name.
+
+### L2 — Biconvex Positive Second Crown
+
+nd = 1.49520, νd = 79.74. Glass: unmatched fluorophosphate ED-class glass, code 495/797. f = +202.12 mm.
+
+L2 repeats the same low-dispersion glass as L1 and supplies slightly stronger standalone positive power. Splitting the front positive power across L1 and L2 reduces the burden on any single refracting surface, which is important in a 300mm f/2.8-class lens where marginal-ray heights in the front group are large.
+
+The thin 0.42 mm air gap between L1 and L2 functions mainly as a manufacturing and aberration-tuning separation. In the data file, the front-group semi-diameters were constrained by the 114 mm front filter and by ray clearance at the marketed f/2.8 aperture.
+
+### L3 — Biconcave Negative Front Flint
+
+nd = 1.68150, νd = 36.64. Glass: unmatched dense flint class, code 682/366. f = −183.98 mm.
+
+L3 is the front group's negative chromatic partner. It offsets part of the positive power of L1 and L2 while providing the lower Abbe number needed to balance primary axial color. Its rear surface faces the long air space before the rear group and contributes significantly to the surface-by-surface Petzval balance.
+
+The glass was left as unmatched. Its refractive index and Abbe number place it in a dense flint or lanthanum-flint region, but no current OHARA, HOYA, Schott, HIKARI, CDGM, or Sumita catalog match should be asserted without a direct catalog match.
+
+### L4 — Negative Meniscus, Concave to Object
+
+nd = 1.65446, νd = 33.86. Glass: unmatched dense flint class, code 654/339. f = −520.27 mm.
+
+L4 opens rear subunit II-1. The object-side surface is concave and is the surface singled out in the patent's claims and conditional expressions. In paraxial power it is not strong as an element, but as a surface it supplies the specified concave leading correction used to control the residual negative spherical aberration and off-axis flare described in the patent.
+
+The computed ratio $|\phi'_{II-1}| / \phi_I$ is 1.04683. This satisfies both the broad patent range and the preferred lower bound above 1.0.
+
+### L5 — Positive Meniscus
+
+nd = 1.60311, νd = 60.74. Glass: S-BSM14 class (OHARA), close vintage 603/607 match. f = +235.41 mm.
+
+L5 supplies the positive component of subunit II-1 and brings the subunit's verified focal length to +423.178 mm. The glass is a close match to current OHARA S-BSM14 in refractive index and code, but the patent Abbe number differs by about 0.10 from the current catalog value. It is therefore identified as S-BSM14 class rather than an exact modern catalog identity.
+
+### L6 — Positive Meniscus, First Component of Moving Doublet
+
+nd = 1.71736, νd = 29.42. Glass: S-TIH1 class (OHARA), close vintage 717/295 match. f = +96.15 mm standalone; L6+L7 cemented doublet f = −2117.01 mm.
+
+L6 is the dense-flint member of the cemented doublet at the front of the moving focus subunit. It has a weakly curved front surface and a much stronger cemented interface at surface 12. The current OHARA S-TIH1 catalog gives the same d-line index but a slightly different Abbe number, so this is again a close class match rather than an exact modern-catalog assertion.
+
+The cemented L6+L7 pair is nearly afocal in paraxial power. Its importance is therefore not its net power but its chromatic and aberrational correction inside the moving negative subunit.
+
+### L7 — Biconcave Negative, Second Component of Moving Doublet
+
+nd = 1.60311, νd = 60.74. Glass: S-BSM14 class (OHARA), close vintage 603/607 match. f = −92.00 mm standalone.
+
+L7 is cemented to L6 and supplies the opposing crown component of the L6+L7 pair. Its standalone negative power is largely cancelled by L6's positive power, leaving a very weak negative cemented doublet. This pairing is a local chromatic correction stage ahead of the stronger negative L8 element.
+
+### L8 — Biconcave Negative Moving Singlet
+
+nd = 1.67000, νd = 57.07. Glass: unmatched high-index crown / lanthanum-crown class, code 670/571. f = −76.94 mm.
+
+L8 is the principal negative-power element of the moving II-2 subunit. It dominates the subunit's net focal length of −74.055 mm. Its rear surface is the strongest negative Petzval contributor in the system, with a surface-by-surface Petzval term of −0.00601 mm⁻¹.
+
+The glass has a high refractive index and moderate Abbe number, consistent with a high-index crown or lanthanum-crown class. It remains unmatched because no authoritative catalog identity has been verified.
+
+### L9 — Biconvex Positive, First Component of Final Doublet
+
+nd = 1.60311, νd = 60.74. Glass: S-BSM14 class (OHARA), close vintage 603/607 match. f = +67.23 mm standalone; L9+L10 cemented doublet f = +133.22 mm.
+
+L9 supplies the strong positive power of the final subunit II-3. Its cemented rear interface is the strongest curvature in the design and drives much of the final reconvergence of the beam after the negative moving group.
+
+### L10 — Negative Meniscus, Final Flint Component
+
+nd = 1.65446, νd = 33.86. Glass: unmatched dense flint class, code 654/339. f = −137.58 mm.
+
+L10 is the negative flint component cemented to L9. It tempers L9's positive power and supplies chromatic correction for the final positive doublet. The exit surface at R18 = −79.965 has a verified refractive power of +0.008184 mm⁻¹ and is used in condition (3) against the power of moving subunit II-2.
+
+## Glass Identification and Selection
+
+The patent gives refractive index and Abbe number but no manufacturer glass names. The data file therefore distinguishes close catalog-class matches from unmatched glasses.
+
+|    Code | Patent nd | Patent νd | Identification used                                           | Elements   |
+| ------: | --------: | --------: | ------------------------------------------------------------- | ---------- |
+| 495/797 |   1.49520 |     79.74 | Unmatched fluorophosphate ED-class glass; not current S-FPL51 | L1, L2     |
+| 682/366 |   1.68150 |     36.64 | Unmatched dense flint class                                   | L3         |
+| 654/339 |   1.65446 |     33.86 | Unmatched dense flint class                                   | L4, L10    |
+| 603/607 |   1.60311 |     60.74 | S-BSM14 class, close OHARA vintage match                      | L5, L7, L9 |
+| 717/294 |   1.71736 |     29.42 | S-TIH1 class, close OHARA vintage match                       | L6         |
+| 670/571 |   1.67000 |     57.07 | Unmatched high-index crown / lanthanum-crown class            | L8         |
+
+The two front positive glasses are the key chromatic correction elements. Minolta/Konica Minolta literature describes AD, or anomalous-dispersion, glass in this lens, but the patent does not publish partial-dispersion ratios, C/F/g-line indices, or ΔPgF values. The analysis therefore treats anomalous partial dispersion as a production-literature inference rather than a patent-quantified value.
+
+The current OHARA S-FPL51 entry is not a match to the patent's 495/797 glass. S-FPL51 is code 497816, nd = 1.49700, νd = 81.54. Assigning the front elements to S-FPL51 would therefore be a catalog mismatch.
+
+## Focus Mechanism
+
+The lens uses inner focusing by translating subunit II-2, made up of L6, L7, and L8. The front group I, subunit II-1, and subunit II-3 remain fixed. Patent Table 9 gives an 11.760 mm image-side movement of II-2 for the Example 8 close-focus condition at 3 m.
+
+| Gap              |  Infinity | Patent 3 m state |     Change |
+| ---------------- | --------: | ---------------: | ---------: |
+| d10, before II-2 |  3.000 mm |        14.760 mm | +11.760 mm |
+| d15, after II-2  | 22.000 mm |        10.240 mm | −11.760 mm |
+| d10 + d15        | 25.000 mm |        25.000 mm |   0.000 mm |
+
+The image plane remains fixed in an actual camera. A finite-conjugate paraxial check confirms that the 11.760 mm group motion focuses an object approximately 3 m from the image plane onto the original infinity image plane. A separate collimated-input diagnostic after moving II-2 gives an equivalent EFL of 266.346 mm and a collimated BFL of 73.985 mm, but that is not the physical close-focus image-plane spacing.
+
+The production lens is catalogued with a 2.5 m minimum focus distance and 1:7.14 maximum magnification. That production endpoint is not tabulated in the patent; the data file's focus slider endpoint uses the patent's documented 3 m state rather than extrapolating the additional travel.
+
+## Aspherical Surfaces
+
+The design is entirely spherical. US 4,518,229 publishes no aspherical coefficients for Example 8, and every surface in the transcribed prescription is spherical. The data file therefore has `asph: {}`.
+
+## Conditional Expressions
+
+The patent states conditions governing the concave leading surface of II-1, the power of II-3, the relationship between the exit surface of II-3 and moving subunit II-2, the weak net power through II-2, and the spacing between front and rear groups. Example 8 satisfies all of the checked conditions.
+
+| Condition |                              Expression | Patent range | Verified value | Result |
+| --------- | --------------------------------------: | -----------: | -------------: | ------ |
+| (1)       |     $\lvert\phi'_{II-1}\rvert / \phi_I$ |      0.6–2.5 |        1.04683 | Pass   |
+| (1′)      |     $\lvert\phi'_{II-1}\rvert / \phi_I$ |      1.0–2.5 |        1.04683 | Pass   |
+| (2)       |                              $F_{II-3}$ |    0.2f–0.7f |     133.218 mm | Pass   |
+| (2′)      |                              $F_{II-3}$ |  0.25f–0.65f |     133.218 mm | Pass   |
+| (3)       | $\phi''_{II-3}/\lvert\phi_{II-2}\rvert$ |      0.3–0.7 |        0.60609 | Pass   |
+| (3′)      | $\phi''_{II-3}/\lvert\phi_{II-2}\rvert$ |    0.31–0.68 |        0.60609 | Pass   |
+| (4)       |          $\lvert F_{I+II-1+II-2}\rvert$ |       > 2.5f |    1342.604 mm | Pass   |
+| (5)       |                                 $D/F_I$ |      0.4–0.7 |        0.54655 | Pass   |
+
+Condition (1) is the patent's central architectural condition. It constrains the object-side concave surface of II-1 relative to the front group power so that the rear group can correct the front group's residual spherical aberration without imposing excessive coma and off-axis flare correction on the remaining rear elements.
+
+## Verification Summary
+
+All numerical values below were recomputed from the patent prescription by paraxial y–n ray tracing and ABCD matrices. The Petzval value uses the surface-by-surface expression $\sum \phi/(n n')$, not a thin-element approximation.
+
+| Quantity                                      |   Verified value |
+| --------------------------------------------- | ---------------: |
+| Effective focal length, infinity              |    294.998985 mm |
+| Back focal length, infinity                   |    103.708841 mm |
+| First surface to infinity image plane         |    273.498841 mm |
+| Telephoto ratio                               |          0.92712 |
+| Group I focal length                          |   +210.667807 mm |
+| Rear group II focal length                    |   −802.036999 mm |
+| Subunit II-1 focal length                     |   +423.178151 mm |
+| Subunit II-2 focal length                     |    −74.055110 mm |
+| Subunit II-3 focal length                     |   +133.217558 mm |
+| L6+L7 cemented doublet focal length           |  −2117.013293 mm |
+| L9+L10 cemented doublet focal length          |   +133.217558 mm |
+| Petzval sum                                   | +0.00100054 mm⁻¹ |
+| Petzval radius                                |       999.456 mm |
+| Half field from y′ = 21.6 mm and computed EFL |          4.1878° |
+| Full diagonal field from same                 |          8.3755° |
+
+Semi-diameters in the data file are inferred, not patent-listed. The selected values clear the f/2.8 marginal ray envelope, respect the front-filter envelope, keep common-aperture edge thickness above 1.8 mm for every element, and satisfy the signed 90% cross-gap sag-intrusion criterion.
+
+## Design Heritage and Context
+
+The Minolta AF APO TELE 300mm f/2.8 was an A-mount autofocus super-telephoto lens introduced in 1985. Its production specification is 11 elements in 9 groups, 2.5 m minimum focus distance, 1:7.14 maximum magnification, 9 aperture blades, internal focusing, 238.5 mm length, 128 mm maximum diameter, and 2480 g weight. The 1988 HS-APO G version is described as using the same optical design with faster gearing.
+
+Later Minolta/Konica Minolta and Sony 300mm f/2.8 SSM lenses used a substantially different optical formula and should not be conflated with this prescription.
+
+## Sources
+
+- US Patent 4,518,229, Mitsuo Yasukuni / Minolta Camera Kabushiki Kaisha, “Telephoto Lens System,” granted May 21, 1985.
+- Michael Hohner, “Lens tech data for Minolta AF 300/2.8 APO,” https://www.mhohner.de/sony-minolta/onelens/af300f28.
+- Michael Hohner, “Lens tech data for Minolta AF 300/2.8 HS-APO G,” https://www.mhohner.de/sony-minolta/onelens/af300f28g.
+- Imaging Resource lens listing quoting Konica Minolta lens literature for AD glass and inner autofocus element, https://www.imaging-resource.com/lenses/konica-minolta-300mm-f-2-8-apo-g-af/.
+- OHARA Corporation, S-FPL51 catalog page, https://oharacorp.com/glass/s-fpl51/.
+- OHARA Corporation, S-BSM14 catalog page, https://oharacorp.com/glass/s-bsm14/.
+- OHARA Corporation, S-TIH1 catalog page, https://oharacorp.com/glass/s-tih1/.

--- a/src/lens-data/minolta/MinoltaAF300mmf28.data.ts
+++ b/src/lens-data/minolta/MinoltaAF300mmf28.data.ts
@@ -1,0 +1,235 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — Minolta AF APO TELE 300mm f/2.8              ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,518,229, Example 8 (Yasukuni / Minolta).        ║
+ * ║  Telephoto lens with fixed positive front group and inner-focusing ║
+ * ║  rear negative subunit II-2.                                       ║
+ * ║  10 prescription elements / 8 prescription groups, all spherical.  ║
+ * ║  Production catalog count is 11/9 because the rear filter is not   ║
+ * ║  part of the patent optical prescription.                          ║
+ * ║                                                                    ║
+ * ║  Focus endpoint: patent Table 9 gives an 11.760 mm image-side      ║
+ * ║  movement of subunit II-2 for a 3 m object distance. The production║
+ * ║  lens focuses to 2.5 m, but that endpoint is not tabulated in the  ║
+ * ║  patent.                                                          ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP / SEMI-DIAMETERS:                                    ║
+ * ║    The patent does not publish clear apertures or a stop coordinate.║
+ * ║    The stop is inserted in the 78.00 mm air gap after surface 6,   ║
+ * ║    7.00 mm behind surface 6, preserving the patent axial spacing.  ║
+ * ║    Semi-diameters were estimated from paraxial marginal and chief  ║
+ * ║    ray envelopes, then constrained by the 114 mm front-filter      ║
+ * ║    diameter, minimum edge thickness, and signed cross-gap sag.     ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "minolta-af-300mm-f28",
+  maker: "Minolta",
+  name: "Minolta AF APO TELE 300mm f/2.8",
+  subtitle: "US 4,518,229 Example 8 — Minolta / Yasukuni",
+  specs: [
+    "Patent Example 8: f = 295.0 mm, FN = 2.9",
+    "Marketed as 300mm f/2.8",
+    "10 prescription elements / 8 groups",
+    "11 / 9 production count includes rear filter",
+    "Inner focus to patent 3 m endpoint",
+    "All spherical surfaces",
+  ],
+
+  focalLengthMarketing: 300,
+  focalLengthDesign: 294.999,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.9,
+  lensMounts: ["sony-a"],
+  imageFormat: "135-full-frame",
+  patentYear: 1985,
+  elementCount: 10,
+  groupCount: 8,
+  apertureBlades: 9,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.4952,
+      vd: 79.74,
+      fl: 218.33,
+      glass: "Unmatched fluorophosphate ED-class (495/797; not S-FPL51)",
+      apd: "inferred",
+      apdNote:
+        "Anomalous partial dispersion is inferred from Minolta production literature; the patent gives only nd/vd.",
+      role: "First large positive ED-class crown in the front collector group.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconvex Positive",
+      nd: 1.4952,
+      vd: 79.74,
+      fl: 202.12,
+      glass: "Unmatched fluorophosphate ED-class (495/797; not S-FPL51)",
+      apd: "inferred",
+      apdNote:
+        "Anomalous partial dispersion is inferred from Minolta production literature; the patent gives only nd/vd.",
+      role: "Second positive ED-class crown, splitting the front-group positive power.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconcave Negative",
+      nd: 1.6815,
+      vd: 36.64,
+      fl: -183.98,
+      glass: "Unmatched dense flint class (682/366)",
+      role: "Front-group negative flint used to balance the two low-dispersion positive crowns.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.65446,
+      vd: 33.86,
+      fl: -520.27,
+      glass: "Unmatched dense flint class (654/339)",
+      role: "Concave leading element of rear subunit II-1; central surface-level aberration corrector in the patent claims.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Positive Meniscus",
+      nd: 1.60311,
+      vd: 60.74,
+      fl: 235.41,
+      glass: "S-BSM14 class (OHARA; close vintage 603/607 match)",
+      role: "Positive trailing element of subunit II-1.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Positive Meniscus",
+      nd: 1.71736,
+      vd: 29.42,
+      fl: 96.15,
+      glass: "S-TIH1 class (OHARA; close vintage 717/295 match)",
+      role: "Dense-flint component of the weakly negative cemented corrector in the moving focus subunit.",
+      cemented: "D1",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconcave Negative",
+      nd: 1.60311,
+      vd: 60.74,
+      fl: -92.0,
+      glass: "S-BSM14 class (OHARA; close vintage 603/607 match)",
+      role: "Crown component paired with L6 in the first cemented doublet of the moving focus subunit.",
+      cemented: "D1",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconcave Negative",
+      nd: 1.67,
+      vd: 57.07,
+      fl: -76.94,
+      glass: "Unmatched high-index crown / lanthanum-crown class (670/571)",
+      role: "Primary negative-power element of the moving focus subunit II-2.",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Biconvex Positive",
+      nd: 1.60311,
+      vd: 60.74,
+      fl: 67.23,
+      glass: "S-BSM14 class (OHARA; close vintage 603/607 match)",
+      role: "Positive crown component of the final re-converging cemented doublet.",
+      cemented: "D2",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Negative Meniscus",
+      nd: 1.65446,
+      vd: 33.86,
+      fl: -137.58,
+      glass: "Unmatched dense flint class (654/339)",
+      role: "Negative flint component of the final cemented doublet, correcting L9 chromatic power.",
+      cemented: "D2",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 140.872, d: 16.0, nd: 1.4952, elemId: 1, sd: 56.0 },
+    { label: "2", R: -447.513, d: 0.42, nd: 1.0, elemId: 0, sd: 53.85 },
+    { label: "3", R: 115.956, d: 14.5, nd: 1.4952, elemId: 2, sd: 53.75 },
+    { label: "4", R: -701.292, d: 2.52, nd: 1.0, elemId: 0, sd: 49.05 },
+    { label: "5", R: -474.476, d: 3.7, nd: 1.6815, elemId: 3, sd: 46.25 },
+    // Patent d6 = 78.00 mm. Split here to insert an inferred aperture stop: 7.00 + 71.00 = 78.00.
+    { label: "6", R: 170.954, d: 7.0, nd: 1.0, elemId: 0, sd: 46.75 },
+    { label: "STO", R: 1e15, d: 71.0, nd: 1.0, elemId: 0, sd: 42.3 },
+    { label: "7", R: -131.706, d: 2.5, nd: 1.65446, elemId: 4, sd: 26.05 },
+    { label: "8", R: -216.4, d: 1.35, nd: 1.0, elemId: 0, sd: 25.8 },
+    { label: "9", R: 111.332, d: 4.0, nd: 1.60311, elemId: 5, sd: 25.55 },
+    { label: "10", R: 508.815, d: 3.0, nd: 1.0, elemId: 0, sd: 24.65 },
+    { label: "11", R: -1256.8, d: 6.5, nd: 1.71736, elemId: 6, sd: 23.7 },
+    { label: "12", R: -65.525, d: 1.85, nd: 1.60311, elemId: 7, sd: 22.5 },
+    { label: "13", R: 366.046, d: 3.15, nd: 1.0, elemId: 0, sd: 22.1 },
+    { label: "14", R: -228.633, d: 1.7, nd: 1.67, elemId: 8, sd: 21.1 },
+    { label: "15", R: 66.759, d: 22.0, nd: 1.0, elemId: 0, sd: 20.85 },
+    { label: "16", R: 1084.8, d: 7.0, nd: 1.60311, elemId: 9, sd: 19.95 },
+    { label: "17", R: -42.017, d: 1.6, nd: 1.65446, elemId: 10, sd: 19.7 },
+    { label: "18", R: -79.965, d: 103.708841, nd: 1.0, elemId: 0, sd: 19.7 },
+  ],
+
+  asph: {},
+
+  var: {
+    "10": [3.0, 14.76],
+    "15": [22.0, 10.24],
+  },
+  varLabels: [
+    ["10", "D10"],
+    ["15", "D15"],
+  ],
+
+  groups: [
+    { text: "I", fromSurface: "1", toSurface: "6" },
+    { text: "II-1", fromSurface: "7", toSurface: "10" },
+    { text: "II-2 IF", fromSurface: "11", toSurface: "15" },
+    { text: "II-3", fromSurface: "16", toSurface: "18" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "11", toSurface: "13" },
+    { text: "D2", fromSurface: "16", toSurface: "18" },
+  ],
+
+  focusDescription:
+    "Inner focus by image-side translation of subunit II-2 (L6-L8). Patent Table 9 gives 11.760 mm travel for a 3 m object distance; production MFD is 2.5 m but is not tabulated in the patent.",
+
+  closeFocusM: 3.0,
+  nominalFno: 2.8,
+  maxFstop: 32,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16, 22, 32],
+
+  scFill: 0.74,
+  yScFill: 0.72,
+  maxAspectRatio: 3.0,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/minolta/MinoltaAF3570mmf4.analysis.md
+++ b/src/lens-data/minolta/MinoltaAF3570mmf4.analysis.md
@@ -1,0 +1,198 @@
+# Minolta AF Zoom 35-70mm f/4 — Optical Design Analysis
+
+## Patent Reference and Design Identification
+
+**Patent:** US 4,560,253, “Zoom Lens System”  
+**Application number:** US 538,987  
+**Filed:** October 4, 1983  
+**Priority:** JP 57-175692, October 5, 1982  
+**Granted:** December 24, 1985  
+**Inventor:** Shuji Ogino  
+**Assignee:** Minolta Camera Kabushiki Kaisha, Osaka, Japan  
+**Embodiment analyzed:** Embodiment 2, Table 2
+
+US 4,560,253 discloses a compact two-group inverted-telephoto zoom lens for 35 mm SLR use. The selected prescription is Embodiment 2, whose tabulated focal lengths are 68.2 mm, 50.0 mm, and 36.0 mm with design aperture $F_{NO}=4.1$. The embodiment uses six patent components in two moving groups: a negative two-component front group and a positive four-component rear group. The second front-group component is a composite element, consisting of a high-dispersion glass body with a thin lower-dispersion transparent layer on its rear surface. The air-facing surface of that thin layer is the sole aspherical surface.
+
+The identification with the Minolta AF Zoom 35-70mm f/4 is strongly consistent rather than explicitly named in the patent. The matching evidence is the 36.0-68.2 mm design range, the constant f/4-class aperture, the six-component negative-positive zoom architecture, the single hybrid asphere on the rear surface of the front positive meniscus, the 35 mm SLR image format, and the patent timing immediately before the first Minolta A-mount autofocus system. The supplied patent itself does not state the production product name, so production-link claims should remain qualified.
+
+The data file transcribes Embodiment 2 directly. It does not apply a focal-length scale factor. The patent table is ordered long-to-short, but the data file stores zoom positions in the monotonic LensVisualizer order $36.0 \rightarrow 50.0 \rightarrow 68.2$ mm.
+
+## Optical Architecture
+
+The lens is a two-group negative-positive inverted-telephoto zoom. Group I is a negative front group consisting of a negative meniscus followed by a positive meniscus composite element. Group II is a positive rear group consisting of two positive components, a negative high-dispersion component, and a final positive rear component. The patent states that both groups shift during zooming while the air space between them varies; it separately states that the first group alone shifts during focusing.
+
+The principal zoom variable is the inter-group air gap after the aspherical resin surface. In the patent’s long-to-short order, this gap changes from 0.800 mm at 68.2 mm to 17.200 mm at 50.0 mm and 41.100 mm at 36.0 mm. Independent paraxial tracing gives effective focal lengths of 68.187 mm, 49.996 mm, and 35.999 mm for those three spacings. Relative to the front vertex, the corresponding back focal distances are 59.463 mm, 49.429 mm, and 41.709 mm.
+
+At the wide-angle end, the system is retrofocus in the ordinary SLR sense: $BFD/EFL = 41.709/35.999 = 1.159$. At the long end, $BFD/EFL = 0.872$, but the total track remains longer than the focal length, so the design is not a true telephoto lens in the strict optical sense. Its architecture remains a negative-positive wide-angle zoom carried into a short normal/short telephoto range.
+
+The patent does not designate an aperture-stop surface in the numerical table. The data file therefore places a diagrammatic stop at the midpoint of the $d_8$ air space between the fourth positive component and the fifth negative component. This placement is consistent with the schematic rear-group layout, but it is an inferred rendering choice, not a patent-listed prescription value.
+
+The computed surface-by-surface Petzval sum is $+0.002548\ \mathrm{mm}^{-1}$, corresponding to a Petzval radius of approximately $+392.45$ mm. Group I contributes $-0.008788\ \mathrm{mm}^{-1}$ and Group II contributes $+0.011336\ \mathrm{mm}^{-1}$. The partial cancellation between the negative front group and positive rear group is central to the field-control strategy of this compact retrofocus zoom.
+
+## Element-by-Element Analysis
+
+### L1 — Component I-1: Negative Meniscus, Convex to Object
+
+$n_d = 1.74400$, $\nu_d = 44.93$. Glass: LAF2 / N-LAF2 / S-LAM2 class, code 744/449. Standalone $f = -36.47$ mm.
+
+The first component is a negative meniscus with $R_1=+197.705$ mm and $R_2=+23.754$ mm. The patent requires the image-side radius of the first component to have a smaller absolute value than the object-side radius, and this component follows that rule closely. Most of the negative power is therefore concentrated at the steep rear surface, while the weak front surface admits the wide-angle bundle with less abrupt first-surface refraction.
+
+The glass is a high-index, moderate-dispersion lanthanum flint region. The closest cross-reference family is LAF2 / N-LAF2 / S-LAM2. The patent value $n_d=1.74400$ is exact for OHARA S-LAM2, while the patent Abbe number is closer to the 744/449 cross-reference code than to OHARA’s current S-LAM2 listing at 744/448. The safe identification is therefore class-level rather than a single-vendor assertion.
+
+### L2g — Component I-2 Glass Body: Positive Meniscus Substrate
+
+$n_d = 1.71736$, $\nu_d = 29.42$. Glass: E-FD1L / N-SF1 / S-TIH1 class, code 717/295. Standalone $f = +71.06$ mm.
+
+The glass body of the second component is a positive meniscus with $R_3=+32.800$ mm and rear spherical substrate radius $R_{4'}=+86.956$ mm. In the prior draft this glass was described as a LaSF3 / S-LAH53 class lanthanum flint. That attribution is not supported by current catalog cross-references. The six-digit optical code is instead in the 717/294-295 dense flint region, with catalog equivalents such as E-FD1L, N-SF1, and S-TIH1.
+
+The high dispersion of this glass body is not incidental. The patent specifically explains that the glass forming the spherical surface has high dispersion and that a lower-dispersion transparent layer can be applied to reduce wavelength-dependent coma differences at the wide-angle end. The glass body supplies the positive meniscus power, while the resin layer supplies both a weak chromatic interface and the aspherical correction surface.
+
+### L2r — Component I-2 Thin Resin Layer: Aspherical Hybrid Surface
+
+$n_d = 1.52000$, $\nu_d = 51.06$. Material: patent-listed thin transparent layer. Standalone $f \approx -718.76$ mm.
+
+The resin layer is only 0.150 mm thick on axis and is bonded to the rear spherical surface of L2g. Its rear air-facing surface has base radius $R_{4''}=+70.502$ mm and carries the aspherical polynomial. Treated by itself in air, the layer has very weak negative power; in the assembled component, its main value is not paraxial power but the controlled aspherical departure and the dispersion mismatch against the high-dispersion glass body.
+
+Because the center thickness is only 0.150 mm, the data file models the resin layer as a separate optical element but treats its semi-diameter conservatively. This is a special hybrid-asphere case rather than an ordinary glass element with normal edge-thickness expectations.
+
+### L3 — Component II-1: Biconvex Positive
+
+$n_d = 1.67000$, $\nu_d = 57.07$. Glass: unmatched lanthanum crown code 670/571. Standalone $f = +46.02$ mm.
+
+The first component of Group II is a biconvex positive element with $R_5=+35.910$ mm and $R_6=-210.680$ mm. The front surface carries most of the power, while the rear surface is weakly curved. This element begins the rear group’s convergence after the variable inter-group air space.
+
+The previous draft identified the glass as HOYA LaC3. That specific catalog match was not verified from the available current manufacturer cross-reference data. The safe description is an unmatched high-Abbe lanthanum crown-like glass with optical code 670/571. L3 and L4 use the same glass, which simplifies the rear positive section and keeps the principal positive power in relatively low-dispersion material.
+
+### L4 — Component II-2: Positive Meniscus, Convex to Object
+
+$n_d = 1.67000$, $\nu_d = 57.07$. Glass: unmatched lanthanum crown code 670/571. Standalone $f = +46.76$ mm.
+
+The fourth component is a positive meniscus with $R_7=+23.426$ mm and $R_8=+88.401$ mm. It shares the same glass as L3 and has nearly the same standalone focal length. The strongly curved front surface is the most powerful converging surface in the rear positive section.
+
+Together, L3 and L4 divide the positive rear-group power over two air-spaced components. This reduces the burden on any single converging surface and gives the designer degrees of freedom for balancing spherical aberration, coma, astigmatism, and distortion over the zoom range.
+
+### L5 — Component II-3: Biconcave Negative Chromatic Corrector
+
+$n_d = 1.75000$, $\nu_d = 25.14$. Glass: unmatched dense/fluor flint code 750/251. Standalone $f = -21.02$ mm.
+
+L5 is the strongest component in the prescription by focal-length magnitude. It is a biconcave negative element with $R_9=-109.921$ mm and $R_{10}=+18.693$ mm. The patent’s condition that the image-side radius of the fifth component be smaller in absolute value than the object-side radius is strongly satisfied.
+
+The prior analysis described this glass as SFS1 / FDS1 class. That is too specific and is not supported by the current catalog check. The patent values correspond to code 750/251. Current HOYA cross-reference data lists FF8 at 752/251, which is close in dispersion but not an exact $n_d$ match. The data file therefore uses an explicit unmatched dense/fluor flint annotation rather than a false catalog identification.
+
+Optically, L5 is the principal negative chromatic-correction element. Its low Abbe number supplies dispersion of opposite sign to the positive low-dispersion components in Group II. It also makes a large negative contribution to the Petzval sum and therefore helps restrain field curvature generated by the positive rear group.
+
+### L6 — Component II-4: Rear Positive Element, Nearly Plano-Convex
+
+$n_d = 1.67270$, $\nu_d = 32.22$. Glass: E-FD5 / N-SF5 / S-TIM25 class, code 673/322. Standalone $f = +47.89$ mm.
+
+The final component has a very weak front radius, $R_{11}=+892.777$ mm, and a substantially stronger rear radius, $R_{12}=-33.382$ mm. It is therefore best interpreted as a nearly plano-convex positive rear element, despite being formally biconvex by sign convention.
+
+The glass matches the FD5 / SF5 / TIM25 region closely. Its relatively high index permits useful rear-surface power without an extreme curvature, while its flint-like dispersion gives the rear group an additional chromatic degree of freedom. Its rear position gives it leverage over exit-pupil behavior, field curvature, lateral color, and distortion.
+
+## Glass Identification and Selection
+
+The glass table below reflects current catalog cross-checking rather than a one-to-one assertion of Minolta procurement. The patent gives only $n_d$ and $\nu_d$, not vendor glass names.
+
+| Modeled element | Patent $n_d$ | Patent $\nu_d$ | Code | Corrected identification | Note |
+|---|---:|---:|---:|---|---|
+| L1 | 1.74400 | 44.93 | 744/449 | LAF2 / N-LAF2 / S-LAM2 class | Strong class match; exact vendor uncertain. |
+| L2g | 1.71736 | 29.42 | 717/294-295 | E-FD1L / N-SF1 / S-TIH1 class | Corrects the prior LaSF3 / S-LAH53 misidentification. |
+| L2r | 1.52000 | 51.06 | — | Thin transparent resin layer | Patent-listed material class only. |
+| L3 | 1.67000 | 57.07 | 670/571 | Unmatched lanthanum crown-like glass | Prior LaC3 label not verified. |
+| L4 | 1.67000 | 57.07 | 670/571 | Unmatched lanthanum crown-like glass | Same glass as L3. |
+| L5 | 1.75000 | 25.14 | 750/251 | Unmatched dense/fluor flint | Closest current HOYA table entry is FF8 at 752/251, not exact. |
+| L6 | 1.67270 | 32.22 | 673/322 | E-FD5 / N-SF5 / S-TIM25 class | Strong cross-reference match. |
+
+The design’s chromatic strategy is conventional but compact. The main positive rear-group power is carried by high-Abbe L3 and L4. The strong negative L5 supplies high-dispersion correction. The final positive L6 is a flint-region positive element, which is less common than a crown rear field flattener but useful here because it adds chromatic leverage near the image side. The front hybrid element adds a further chromatic interface: high-dispersion glass against lower-dispersion resin.
+
+## Focus Mechanism
+
+The patent describes the class of lens as one in which both groups shift during zooming and the first group alone shifts during focusing. It does not publish close-focus distances, close-focus magnifications, or a finite-distance spacing table.
+
+The data file therefore treats focus as a simplified first-group shift. For the normal close-focus state it solves the inter-group spacing needed for approximately 1.0 m object distance measured from the image plane, while keeping the rear-group-to-image back focus fixed. This gives close-state inter-group spacings of 46.965 mm at the wide position, 22.966 mm at the middle position, and 6.528 mm at the long position. These values are paraxial modeling values, not patent-tabulated mechanical data.
+
+Published production discussions often distinguish the ordinary focus range from a closer macro range, but the macro mechanism is not described in the supplied patent. It is therefore not modeled as an independent macro state in the data file.
+
+## Aspherical Surface
+
+Embodiment 2 places the sole aspherical surface on the air-facing side of the thin resin layer on Component I-2. In the data file this is surface `4A`. The base radius is $R=+70.502$ mm.
+
+The patent’s sag equation is a spherical base plus even-order polynomial terms:
+
+$$
+X = \frac{Y^2}{\gamma_i + \gamma_i\sqrt{1-(Y/\gamma_i)^2}} + B Y^4 + C Y^6 + D Y^8.
+$$
+
+This is equivalent to the standard conic form with $K=0$ and coefficients $A_4=B$, $A_6=C$, and $A_8=D$.
+
+| Coefficient | Value |
+|---|---:|
+| $K$ | 0 |
+| $A_4$ | $-3.2454086 \times 10^{-6}$ |
+| $A_6$ | $-1.6458645 \times 10^{-9}$ |
+| $A_8$ | $-1.2334671 \times 10^{-11}$ |
+
+The polynomial departure relative to the base sphere is negative. At $h=8$ mm the departure is $-0.01393$ mm; at $h=12$ mm it is $-0.07752$ mm; at $h=14$ mm it is $-0.15527$ mm; and at $h=16$ mm it is $-0.29328$ mm. For a positive-radius surface, this means the peripheral sag is less positive than the corresponding sphere: the surface is flattened relative to the base sphere in the outer zone. The patent places this asphere in the front group because peripheral wide-angle rays pass through outer zones of the front group, where distortion and astigmatism can be corrected with comparatively small refraction-angle penalty.
+
+## Conditional Expressions
+
+The patent defines two main conditions using the shortest focal length $f_s$, the total axial distance $l$ from the first surface to the image plane in the longest-focal-length condition, and the radius $\gamma_3$ of the object-side surface of Component I-2.
+
+For Embodiment 2, $f_s=36.0$ mm, $l=94.0$ mm, and $\gamma_3=32.800$ mm. The broad conditions are satisfied:
+
+$$
+2.3 f_s < l < 2.75 f_s \Rightarrow 82.8 < 94.0 < 99.0,
+$$
+
+$$
+0.55 f_s < \gamma_3 < 1.8 f_s \Rightarrow 19.8 < 32.8 < 64.8.
+$$
+
+The tighter dependent-claim conditions are also satisfied:
+
+$$
+2.55 f_s < l < 2.75 f_s \Rightarrow 91.8 < 94.0 < 99.0,
+$$
+
+$$
+0.75 f_s < \gamma_3 < 1.8 f_s \Rightarrow 27.0 < 32.8 < 64.8.
+$$
+
+The design sits near the compact end of the tightened total-length condition, which is consistent with the patent’s stated goal of a relatively economical and compact six-component zoom.
+
+## Aberration Performance from the Patent Figures
+
+The patent provides aberration plots for Embodiment 2 at the long, middle, and short focal-length positions. The plots are computed at approximately f/4 and extend to an image height of $y'=21.6$ mm, corresponding to the half-diagonal of the 24 x 36 mm frame.
+
+The long-end plots show small residual spherical aberration, modest astigmatic separation, and weak positive distortion. The middle position shows increased field curvature and the transition toward near-zero distortion. The wide position shows the largest wide-angle residuals, especially barrel distortion and astigmatic separation. These are the residuals the front-group asphere is intended to reduce relative to the all-spherical predecessor architecture discussed in the patent.
+
+The figures are qualitative plots rather than numeric distortion or MTF tables. The analysis therefore does not assign exact percentage values beyond the approximate scale visible in the patent drawings.
+
+## Verification Summary
+
+All focal-length, back-focus, group-power, element-power, Petzval, aspheric-departure, and conditional-expression values in this document were recomputed from the patent prescription by an independent paraxial ray trace using the patent radii, thicknesses, indices, and variable spacing table.
+
+| Quantity | Patent / source value | Computed value | Comment |
+|---|---:|---:|---|
+| EFL, wide | 36.0 mm | 35.999 mm | Matches Embodiment 2. |
+| EFL, middle | 50.0 mm | 49.996 mm | Matches Embodiment 2. |
+| EFL, long | 68.2 mm | 68.187 mm | Matches Embodiment 2. |
+| BFD, wide | not separately tabulated | 41.709 mm | Computed from the prescription. |
+| BFD, middle | not separately tabulated | 49.429 mm | Computed from the prescription. |
+| BFD, long | not separately tabulated | 59.463 mm | Computed from the prescription. |
+| Total track at long end | 94.0 mm | 94.021 mm | Matches patent $l$ within rounding. |
+| Group I focal length | not tabulated | -74.647 mm | Computed as isolated front group. |
+| Group II focal length | not tabulated | +41.172 mm | Computed as isolated rear group. |
+| Full-system Petzval sum | not tabulated | +0.002548 mm$^{-1}$ | Surface-by-surface $\phi/(nn')$. |
+| Wide-end $BFD/EFL$ | not tabulated | 1.159 | Retrofocus geometry. |
+| Long-end total track / EFL | not tabulated | 1.379 | Not a true telephoto ratio. |
+
+## Sources
+
+US 4,560,253, Shuji Ogino, “Zoom Lens System,” assigned to Minolta Camera Kabushiki Kaisha, granted December 24, 1985. Primary source for prescription data, group architecture, conditional expressions, aspherical construction, and aberration figures.
+
+HOYA Group Optics Division, “Glass Cross Reference Index.” Used for six-digit glass-code interpretation and cross-vendor glass-family checks.
+
+OHARA Corporation, S-LAM2 glass data. Used to verify the L1 class match at $n_d=1.74400$ and code 744/448.
+
+SCHOTT, N-SF5 data sheet. Used to verify the final-element FD5 / SF5 family match near $n_d=1.6727$, $\nu_d \approx 32.2$.

--- a/src/lens-data/minolta/MinoltaAF3570mmf4.data.ts
+++ b/src/lens-data/minolta/MinoltaAF3570mmf4.data.ts
@@ -1,0 +1,206 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║        LENS DATA — Minolta AF Zoom 35-70mm f/4                    ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,560,253, Ogino / Minolta, Embodiment 2.        ║
+ * ║  Two-group negative-positive inverted-telephoto zoom.             ║
+ * ║  Six patent components / six air-spaced groups; the hybrid        ║
+ * ║  resin layer on component I-2 is modeled as a separate element     ║
+ * ║  so the glass/resin junction and resin asphere are explicit.      ║
+ * ║  Focus: patent states first group shifts for focusing; the close  ║
+ * ║  state below is a paraxial normal-range approximation to 1.0 m,   ║
+ * ║  not a patent-published macro prescription.                       ║
+ * ║                                                                    ║
+ * ║  Zoom variable gaps: surface 4A (inter-group spacing) and BF.     ║
+ * ║  Zoom positions are sorted wide-to-tele for LensVisualizer.       ║
+ * ║  Patent table order is tele-mid-wide: f = 68.2-50.0-36.0 mm.      ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    The patent gives no clear-aperture or semi-diameter table.     ║
+ * ║    SDs are conservative diagrammatic estimates constrained by     ║
+ * ║    surface sag, thin air gaps, the hybrid-resin layer, and a       ║
+ * ║    conservative front-group envelope. The stop                    ║
+ * ║    position is inferred and placed at the midpoint of d8.         ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "minolta-af-35-70-f4",
+  maker: "Minolta",
+  name: "Minolta AF Zoom 35-70mm f/4",
+  subtitle: "US 4,560,253 Embodiment 2 — Minolta / Ogino",
+  specs: [
+    "6 components / 6 air-spaced groups",
+    "7 modeled optical media including hybrid resin layer",
+    "36.0-68.2 mm patent design range",
+    "FNO 4.1 patent design aperture",
+    "1 hybrid aspherical surface",
+  ],
+
+  focalLengthMarketing: [35, 70],
+  focalLengthDesign: [35.999, 68.187],
+  apertureMarketing: 4,
+  apertureDesign: 4.1,
+  lensMounts: ["sony-a"],
+  imageFormat: "135-full-frame",
+  patentYear: 1985,
+  elementCount: 6,
+  groupCount: 6,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Component I-1",
+      type: "Negative Meniscus",
+      nd: 1.744,
+      vd: 44.93,
+      fl: -36.47,
+      glass: "LAF2 / N-LAF2 / S-LAM2 class (744/449)",
+      apd: false,
+      role: "Strong negative front meniscus that supplies the divergent front-group power for the inverted-telephoto geometry.",
+    },
+    {
+      id: 2,
+      name: "L2g",
+      label: "Component I-2 glass body",
+      type: "Positive Meniscus",
+      nd: 1.71736,
+      vd: 29.42,
+      fl: 71.06,
+      glass: "E-FD1L / N-SF1 / S-TIH1 class (717/295; patent νd = 29.42)",
+      apd: false,
+      cemented: "H1",
+      role: "High-dispersion positive meniscus substrate for the rear hybrid asphere.",
+    },
+    {
+      id: 3,
+      name: "L2r",
+      label: "Component I-2 resin layer",
+      type: "Aspherical Resin Layer",
+      nd: 1.52,
+      vd: 51.06,
+      fl: -718.76,
+      glass: "UV-curing acrylic resin (patent thin transparent layer)",
+      apd: false,
+      cemented: "H1",
+      role: "Thin low-dispersion resin layer carrying the sole aspherical air-facing surface.",
+    },
+    {
+      id: 4,
+      name: "L3",
+      label: "Component II-1",
+      type: "Biconvex Positive",
+      nd: 1.67,
+      vd: 57.07,
+      fl: 46.02,
+      glass: "Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)",
+      apd: false,
+      role: "First positive component of the rear group; starts the main converging section.",
+    },
+    {
+      id: 5,
+      name: "L4",
+      label: "Component II-2",
+      type: "Positive Meniscus",
+      nd: 1.67,
+      vd: 57.07,
+      fl: 46.76,
+      glass: "Unmatched lanthanum crown code 670/571 (historic/proprietary catalog match not verified)",
+      apd: false,
+      role: "Second positive component of the rear group; works with L3 as the split positive front section of Group II.",
+    },
+    {
+      id: 6,
+      name: "L5",
+      label: "Component II-3",
+      type: "Biconcave Negative",
+      nd: 1.75,
+      vd: 25.14,
+      fl: -21.02,
+      glass: "Unmatched dense/fluor flint code 750/251 (closest current HOYA FF8 class is 752/251)",
+      apd: false,
+      role: "Strong negative chromatic-correction component in the rear group.",
+    },
+    {
+      id: 7,
+      name: "L6",
+      label: "Component II-4",
+      type: "Biconvex Positive",
+      nd: 1.6727,
+      vd: 32.22,
+      fl: 47.89,
+      glass: "E-FD5 / N-SF5 / S-TIM25 class (673/322)",
+      apd: false,
+      role: "Rear positive field-flattening and exit-pupil-shaping component.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 197.705, d: 2, nd: 1.744, elemId: 1, sd: 21 },
+    { label: "2", R: 23.754, d: 5.7, nd: 1, elemId: 0, sd: 20.5 },
+    { label: "3", R: 32.8, d: 4.3, nd: 1.71736, elemId: 2, sd: 14 },
+    { label: "4", R: 86.956, d: 0.15, nd: 1.52, elemId: 3, sd: 14 },
+    { label: "4A", R: 70.502, d: 41.1, nd: 1, elemId: 0, sd: 14 },
+    { label: "5", R: 35.91, d: 3, nd: 1.67, elemId: 4, sd: 10.8 },
+    { label: "6", R: -210.68, d: 0.15, nd: 1, elemId: 0, sd: 10.3 },
+    { label: "7", R: 23.426, d: 2.8, nd: 1.67, elemId: 5, sd: 9.8 },
+    { label: "8", R: 88.401, d: 2.096, nd: 1, elemId: 0, sd: 8.8 },
+    { label: "STO", R: 1e15, d: 2.095, nd: 1, elemId: 0, sd: 7.3 },
+    { label: "9", R: -109.921, d: 4.067, nd: 1.75, elemId: 6, sd: 8.6 },
+    { label: "10", R: 18.693, d: 4.6, nd: 1, elemId: 0, sd: 8.8 },
+    { label: "11", R: 892.777, d: 2.8, nd: 1.6727, elemId: 7, sd: 10.5 },
+    { label: "12", R: -33.382, d: 41.7093032197, nd: 1, elemId: 0, sd: 11 },
+  ],
+
+  asph: {
+    "4A": {
+      K: 0,
+      A4: -3.2454086e-6,
+      A6: -1.6458645e-9,
+      A8: -1.2334671e-11,
+      A10: 0,
+      A12: 0,
+      A14: 0,
+    },
+  },
+
+  zoomPositions: [36, 50, 68.2],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+
+  var: {
+    "4A": [
+      [41.1, 46.9647876298],
+      [17.2, 22.9659926164],
+      [0.8, 6.52803161881],
+    ],
+    "12": [
+      [41.7093032197, 41.7093032197],
+      [49.4290164921, 49.4290164921],
+      [59.4625637623, 59.4625637623],
+    ],
+  },
+  varLabels: [
+    ["4A", "D4"],
+    ["12", "BF"],
+  ],
+
+  groups: [
+    { text: "I", fromSurface: "1", toSurface: "4A" },
+    { text: "II", fromSurface: "5", toSurface: "12" },
+  ],
+  doublets: [{ text: "H1", fromSurface: "3", toSurface: "4A" }],
+
+  focusDescription:
+    "Front-group focus. The patent states that Group I alone shifts during focusing; close-focus spacings are paraxial estimates because the patent publishes no close-focus table.",
+  closeFocusM: 1,
+  nominalFno: 4,
+  fstopSeries: [4, 5.6, 8, 11, 16],
+  scFill: 0.64,
+  yScFill: 0.5,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -19,6 +19,12 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-05-26 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-05-26",
+    type: "lens",
+    summary: "Added three Minolta AF lenses, from 35-70mm f/4 zoom to APO telephotos",
+  },
   // ── 2026-05-25 ──────────────────────────────────────────────────────────
   {
     date: "2026-05-25",

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -23,7 +23,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-05-26",
     type: "lens",
-    summary: "Added three Minolta AF lenses, from 35-70mm f/4 zoom to APO telephotos",
+    summary: "Added three Minolta AF lenses, a 35-70mm f/4 zoom and APO telephotos",
   },
   // ── 2026-05-25 ──────────────────────────────────────────────────────────
   {


### PR DESCRIPTION
## Summary

Adds three Minolta AF lens entries to the catalog:

- Minolta AF APO Tele 200mm f/2.8
- Minolta AF APO TELE 300mm f/2.8
- Minolta AF Zoom 35-70mm f/4

Each lens includes a patent-derived prescription and companion analysis note. The update also refreshes the visible lens count, generated glass reports, and the public changelog entry for May 26, 2026.

## User Impact

Visitors can now inspect these Minolta AF designs in the lens viewer, including their focus/zoom behavior, glass notes, diagrams, and analysis documentation.

## Validation

- `npm run typecheck`
- `npm run format:check`