### PR TITLE
[codex] Add chromatic analysis charts and overlay refinements

### DIFF
--- a/__tests__/src/components/display/DiagramLegendCoverage.test.tsx
+++ b/__tests__/src/components/display/DiagramLegendCoverage.test.tsx
@@ -15,6 +15,9 @@ function lens(hasAbbeData = true): RuntimeLens {
   } as unknown as RuntimeLens;
 }
 
+const defaultAxialSpread = { lcaMm: 0.0012, tcaMm: 0, intercepts: {}, imgHeights: {} };
+const defaultOffAxisSpread = { lcaMm: 0.0002, tcaMm: 0.0004, intercepts: {}, imgHeights: {} };
+
 function renderLegend({
   isWide = true,
   legendExpanded = true,
@@ -26,7 +29,13 @@ function renderLegend({
   chromB = true,
   chromV = false,
   rayTracksF = true,
-  chromSpread = { lcaMm: 0.0012, tcaMm: 0.0004, intercepts: {}, imgHeights: {} },
+  chromSpread = defaultAxialSpread,
+  chromaticSpreads = chromSpread
+    ? {
+        onAxis: chromSpread,
+        offAxis: defaultOffAxisSpread,
+      }
+    : { onAxis: null, offAxis: null },
   onLegendExpandedChange = vi.fn(),
   onOpenAbbeDiagram = vi.fn(),
   L = lens(),
@@ -46,6 +55,7 @@ function renderLegend({
         chromB={chromB}
         chromV={chromV}
         chromSpread={chromSpread}
+        chromaticSpreads={chromaticSpreads}
         rayTracksF={rayTracksF}
         legendExpanded={legendExpanded}
         onLegendExpandedChange={onLegendExpandedChange}
@@ -78,8 +88,27 @@ describe("DiagramLegend", () => {
     expect(screen.getByText(/Off-axis rays \(15\.4°/)).toBeTruthy();
     expect(screen.getByText("Vignetted (ghost)")).toBeTruthy();
     expect(screen.getByText(/Chromatic \(R\/B\)/)).toBeTruthy();
+    expect(screen.getByText("AXIAL LCA")).toBeTruthy();
+    expect(screen.getByText("OFF-AXIS TCA")).toBeTruthy();
     expect(screen.getAllByText("1 µm").length).toBeGreaterThan(0);
     expect(screen.getByText("0.4 µm")).toBeTruthy();
+  });
+
+  it("keeps axial LCA and off-axis TCA readouts on their own axis spreads", () => {
+    renderLegend({
+      chromSpread: { lcaMm: 0.099, tcaMm: 0.088, intercepts: {}, imgHeights: {} },
+      chromaticSpreads: {
+        onAxis: { lcaMm: 0.0012, tcaMm: 0.077, intercepts: {}, imgHeights: {} },
+        offAxis: { lcaMm: 0.066, tcaMm: 0.0004, intercepts: {}, imgHeights: {} },
+      },
+    });
+
+    expect(screen.getByText("AXIAL LCA")).toBeTruthy();
+    expect(screen.getByText("OFF-AXIS TCA")).toBeTruthy();
+    expect(screen.getAllByText("1 µm").length).toBeGreaterThan(0);
+    expect(screen.getByText("0.4 µm")).toBeTruthy();
+    expect(screen.queryByText("99 µm")).toBeNull();
+    expect(screen.queryByText("88 µm")).toBeNull();
   });
 
   it("renders the Abbe button only when data and a callback are available", () => {

--- a/__tests__/src/components/display/ElementInspector.test.tsx
+++ b/__tests__/src/components/display/ElementInspector.test.tsx
@@ -7,7 +7,7 @@ import buildLens from "../../../../src/optics/buildLens.js";
 import { LENS_CATALOG } from "../../../../src/utils/catalog/lensCatalog.js";
 
 afterEach(() => cleanup());
-import type { RuntimeLens, ElementData } from "../../../../src/types/optics.js";
+import type { ChromaticChannel, RuntimeLens, ElementData } from "../../../../src/types/optics.js";
 import type { Theme } from "../../../../src/types/theme.js";
 
 const mockTheme = {
@@ -26,6 +26,13 @@ const mockTheme = {
   role: "#8af",
   elemType: "#ccc",
   panelBorder: "#333",
+  rayChromR: "#f00",
+  rayChromG: "#0f0",
+  rayChromB: "#00f",
+  rayChromV: "#80f",
+  chromDispHigh: "#f30",
+  chromDispMid: "#cc0",
+  chromDispLow: "#0c0",
 } as unknown as Theme;
 
 const basicElement: ElementData = {
@@ -108,6 +115,37 @@ describe("ElementInspector", () => {
     expect(screen.getByText(/refract, active both, normal z=1 y=1/)).toBeTruthy();
     expect(screen.getByText("Image plane IMG:")).toBeTruthy();
     expect(screen.getByText(/z=35 mm y=25 mm normal z=0 y=1/)).toBeTruthy();
+  });
+
+  it("shows resolved chromatic indices and quality instead of recomputing an Abbe-only fallback", () => {
+    const chromaticLens = {
+      ...mockLens,
+      S: [{ label: "1", R: 100, d: 5, nd: 1.5, sd: 10, elemId: basicElement.id }],
+      ES: [[basicElement.id, 0, 0] as [number, number, number]],
+      indexByIdx: {
+        0: {
+          quality: "sellmeier",
+          glassEntry: { name: "N-BK7" },
+          fn: (channel: ChromaticChannel) => ({ R: 1.49, G: 1.5, B: 1.51, V: 1.515 })[channel],
+        },
+      },
+    } as unknown as RuntimeLens;
+
+    render(
+      <ElementInspector
+        info={{ ...basicElement, nd: 1.5, glass: "N-BK7" }}
+        L={chromaticLens}
+        t={mockTheme}
+        showChromatic={true}
+      />,
+    );
+
+    expect(screen.getByText("Sellmeier (N-BK7)")).toBeTruthy();
+    expect(screen.getByText("0.02000")).toBeTruthy();
+    expect(screen.getByText("1.49000").getAttribute("title")).toBe("C-line 656.3 nm");
+    expect(screen.getByText("1.50000").getAttribute("title")).toBe("d-line 587.6 nm");
+    expect(screen.getByText("1.51000").getAttribute("title")).toBe("F-line 486.1 nm");
+    expect(screen.getByText("1.51500").getAttribute("title")).toBe("g-line 435.8 nm");
   });
 });
 

--- a/__tests__/src/components/display/analysis/AberrationsPanel.test.tsx
+++ b/__tests__/src/components/display/analysis/AberrationsPanel.test.tsx
@@ -62,7 +62,7 @@ const theme = {
 } as unknown as Theme;
 
 const baseProps = {
-  L: { N: 2 } as RuntimeLens,
+  L: { N: 2, offAxisFieldFrac: 0.6 } as RuntimeLens,
   t: theme,
   zPos: [0, 5],
   focusT: 0,
@@ -148,6 +148,12 @@ describe("AberrationsPanel", () => {
           centroidSagittalImageHeight: 0,
           rmsRadiusMm: 0.005,
           rmsRadiusUm: 5,
+          tangentialSpanMm: 0.02,
+          tangentialSpanUm: 20,
+          sagittalSpanMm: 0.02,
+          sagittalSpanUm: 20,
+          centroidOffsetMm: 0,
+          centroidOffsetUm: 0,
           tailDirection: "balanced",
           tailSkewRatio: 1,
           sagittalToTangentialRatio: 1,
@@ -174,6 +180,12 @@ describe("AberrationsPanel", () => {
           centroidSagittalImageHeight: 0.002,
           rmsRadiusMm: 0.012,
           rmsRadiusUm: 12,
+          tangentialSpanMm: 0.07,
+          tangentialSpanUm: 70,
+          sagittalSpanMm: 0.03,
+          sagittalSpanUm: 30,
+          centroidOffsetMm: 0.0102,
+          centroidOffsetUm: 10.2,
           tailDirection: "toward-center",
           tailSkewRatio: 1.35,
           sagittalToTangentialRatio: 0.43,
@@ -198,6 +210,12 @@ describe("AberrationsPanel", () => {
           centroidSagittalImageHeight: 0.003,
           rmsRadiusMm: 0.018,
           rmsRadiusUm: 18,
+          tangentialSpanMm: 0.11,
+          tangentialSpanUm: 110,
+          sagittalSpanMm: 0.04,
+          sagittalSpanUm: 40,
+          centroidOffsetMm: 0.0182,
+          centroidOffsetUm: 18.2,
           tailDirection: "toward-center",
           tailSkewRatio: 1.42,
           sagittalToTangentialRatio: 0.36,
@@ -222,6 +240,12 @@ describe("AberrationsPanel", () => {
           centroidSagittalImageHeight: 0.004,
           rmsRadiusMm: 0.02,
           rmsRadiusUm: 20,
+          tangentialSpanMm: 0.11,
+          tangentialSpanUm: 110,
+          sagittalSpanMm: 0.06,
+          sagittalSpanUm: 60,
+          centroidOffsetMm: 0.0126,
+          centroidOffsetUm: 12.6,
           tailDirection: "toward-edge",
           tailSkewRatio: 1.28,
           sagittalToTangentialRatio: 0.55,
@@ -233,6 +257,7 @@ describe("AberrationsPanel", () => {
       ],
     };
     const meridionalComaResult = {
+      fieldFraction: 0.6,
       fieldAngleDeg: 12.5,
       sampleCount: 51,
       validSampleCount: 47,
@@ -240,17 +265,24 @@ describe("AberrationsPanel", () => {
       centerIntercept: -0.02,
       minIntercept: -0.12,
       maxIntercept: 0.18,
+      minRelativeIntercept: -0.1,
+      maxRelativeIntercept: 0.2,
       spanMm: 0.3,
       spanUm: 300,
+      signedOuterDeltaMm: 0.3,
+      signedOuterDeltaUm: 300,
       lowerIntercept: -0.12,
       upperIntercept: 0.18,
+      lowerRelativeIntercept: -0.1,
+      upperRelativeIntercept: 0.2,
       samples: [
-        { index: 0, pupilFraction: -1, launchHeight: -10, imageHeight: null, clipped: true },
-        { index: 25, pupilFraction: 0, launchHeight: 0, imageHeight: -0.02, clipped: false },
-        { index: 50, pupilFraction: 1, launchHeight: 10, imageHeight: null, clipped: true },
+        { index: 0, pupilFraction: -1, launchHeight: -10, imageHeight: null, relativeImageHeight: null, clipped: true },
+        { index: 25, pupilFraction: 0, launchHeight: 0, imageHeight: -0.02, relativeImageHeight: 0, clipped: false },
+        { index: 50, pupilFraction: 1, launchHeight: 10, imageHeight: null, relativeImageHeight: null, clipped: true },
       ],
     };
     const sagittalComaResult = {
+      fieldFraction: 0.6,
       fieldAngleDeg: 12.5,
       sampleCount: 51,
       validSampleCount: 43,
@@ -258,14 +290,20 @@ describe("AberrationsPanel", () => {
       centerIntercept: 0.002,
       minIntercept: -0.06,
       maxIntercept: 0.07,
+      minRelativeIntercept: -0.062,
+      maxRelativeIntercept: 0.068,
       spanMm: 0.13,
       spanUm: 130,
+      signedOuterDeltaMm: 0.13,
+      signedOuterDeltaUm: 130,
       lowerIntercept: -0.06,
       upperIntercept: 0.07,
+      lowerRelativeIntercept: -0.062,
+      upperRelativeIntercept: 0.068,
       samples: [
-        { index: 0, pupilFraction: -1, launchX: -10, imageX: null, clipped: true },
-        { index: 25, pupilFraction: 0, launchX: 0, imageX: 0.002, clipped: false },
-        { index: 50, pupilFraction: 1, launchX: 10, imageX: null, clipped: true },
+        { index: 0, pupilFraction: -1, launchX: -10, imageX: null, relativeImageX: null, clipped: true },
+        { index: 25, pupilFraction: 0, launchX: 0, imageX: 0.002, relativeImageX: 0, clipped: false },
+        { index: 50, pupilFraction: 1, launchX: 10, imageX: null, relativeImageX: null, clipped: true },
       ],
     };
     mockComputeMeridionalComa.mockReturnValue(meridionalComaResult);
@@ -667,6 +705,35 @@ describe("AberrationsPanel", () => {
       baseProps.currentPhysStopSD,
       0,
       fieldGeometry,
+    );
+  });
+
+  it("passes the selected detailed coma field fraction into calculations", () => {
+    render(
+      <ComaTab
+        L={baseProps.L}
+        t={baseProps.t}
+        zPos={baseProps.zPos}
+        focusT={baseProps.focusT}
+        zoomT={baseProps.zoomT}
+        currentEPSD={baseProps.currentEPSD}
+        currentPhysStopSD={baseProps.currentPhysStopSD}
+      />,
+    );
+
+    mockComputeComaAnalysis.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "100%" }));
+
+    expect(mockComputeComaAnalysis).toHaveBeenLastCalledWith(
+      baseProps.L,
+      baseProps.zPos,
+      baseProps.focusT,
+      baseProps.zoomT,
+      baseProps.currentEPSD,
+      baseProps.currentPhysStopSD,
+      0,
+      undefined,
+      { comaDetailFieldFraction: 1 },
     );
   });
 

--- a/__tests__/src/components/display/analysis/AberrationsPanel.test.tsx
+++ b/__tests__/src/components/display/analysis/AberrationsPanel.test.tsx
@@ -566,6 +566,7 @@ describe("AberrationsPanel", () => {
       baseProps.currentPhysStopSD,
       preparedState.aberrationT,
       undefined,
+      undefined,
     );
   });
 
@@ -621,6 +622,7 @@ describe("AberrationsPanel", () => {
       baseProps.currentEPSD,
       baseProps.currentPhysStopSD,
       preparedState.aberrationT,
+      undefined,
       undefined,
     );
   });

--- a/__tests__/src/components/display/analysis/ComaPreviewGrid.test.tsx
+++ b/__tests__/src/components/display/analysis/ComaPreviewGrid.test.tsx
@@ -170,6 +170,12 @@ function pointCloudResult(): ComaPointCloudPreviewResult {
         centroidSagittalImageHeight: 0,
         rmsRadiusMm: 0.03,
         rmsRadiusUm: 30,
+        tangentialSpanMm: 0.2,
+        tangentialSpanUm: 200,
+        sagittalSpanMm: 0.08,
+        sagittalSpanUm: 80,
+        centroidOffsetMm: 0,
+        centroidOffsetUm: 0,
         tailDirection: "balanced",
         tailSkewRatio: 1,
         sagittalToTangentialRatio: 0.4,
@@ -192,6 +198,12 @@ function pointCloudResult(): ComaPointCloudPreviewResult {
         centroidSagittalImageHeight: 0.01,
         rmsRadiusMm: 0.05,
         rmsRadiusUm: 50,
+        tangentialSpanMm: 0.4,
+        tangentialSpanUm: 400,
+        sagittalSpanMm: 0.1,
+        sagittalSpanUm: 100,
+        centroidOffsetMm: 0.0608276253029822,
+        centroidOffsetUm: 60.8276253029822,
         tailDirection: "toward-center",
         tailSkewRatio: 1.6,
         sagittalToTangentialRatio: 0.25,
@@ -214,6 +226,12 @@ function pointCloudResult(): ComaPointCloudPreviewResult {
         centroidSagittalImageHeight: 0,
         rmsRadiusMm: 0,
         rmsRadiusUm: 0,
+        tangentialSpanMm: 0,
+        tangentialSpanUm: 0,
+        sagittalSpanMm: 0,
+        sagittalSpanUm: 0,
+        centroidOffsetMm: 0,
+        centroidOffsetUm: 0,
         tailDirection: "balanced",
         tailSkewRatio: 1,
         sagittalToTangentialRatio: 0,
@@ -236,6 +254,12 @@ function pointCloudResult(): ComaPointCloudPreviewResult {
         centroidSagittalImageHeight: 0.01,
         rmsRadiusMm: 0.04,
         rmsRadiusUm: 40,
+        tangentialSpanMm: 0.1,
+        tangentialSpanUm: 100,
+        sagittalSpanMm: 0.2,
+        sagittalSpanUm: 200,
+        centroidOffsetMm: 0.022360679774997897,
+        centroidOffsetUm: 22.360679774997898,
         tailDirection: "toward-edge",
         tailSkewRatio: 1.4,
         sagittalToTangentialRatio: 2,
@@ -272,7 +296,7 @@ describe("ComaPreviewGrid", () => {
     render(<ComaPreviewGrid result={pointCloudResult()} t={theme} mode="pointCloud" />);
 
     expect(screen.getAllByText("Traced real-ray").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("spot plot").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("spot footprint").length).toBeGreaterThan(0);
     expect(screen.getByText("Sagittal (horiz.) / tangential (vert.)")).toBeTruthy();
     expect(screen.getByText("scale relative to chief ray (mm)")).toBeTruthy();
     expect(screen.getByText("Crosshair")).toBeTruthy();
@@ -288,10 +312,10 @@ describe("ComaPreviewGrid", () => {
   it("renders an idealized comparison view for point-cloud previews", () => {
     render(<ComaPreviewGrid result={pointCloudResult()} t={theme} mode="pointCloud" pointCloudStyle="idealized" />);
 
-    expect(screen.getAllByText("Idealized").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Schematic").length).toBeGreaterThan(0);
     expect(screen.getAllByText("coma sketch").length).toBeGreaterThan(0);
     expect(screen.getByText("Outline")).toBeTruthy();
-    expect(screen.getByText("idealized footprint")).toBeTruthy();
+    expect(screen.getByText("schematic footprint")).toBeTruthy();
     expect(screen.getByText("Diamond")).toBeTruthy();
     expect(screen.getByText("centroid")).toBeTruthy();
   });

--- a/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
+++ b/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
@@ -152,7 +152,7 @@ describe("analysis chart coverage", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it("renders on-axis and off-axis LCA overlay panels side by side when both spreads are available", () => {
+  it("renders axial LCA with a separate off-axis TCA summary when both spreads are available", () => {
     render(
       <LCAOverlayContent
         chromSpread={{ lcaMm: 0.0004, tcaMm: 0, intercepts: { R: -0.02, G: 0, B: 0.03 }, imgHeights: {} }}
@@ -166,10 +166,11 @@ describe("analysis chart coverage", () => {
       />,
     );
 
-    expect(screen.getByText("ON-AXIS")).toBeTruthy();
-    expect(screen.getByText("OFF-AXIS")).toBeTruthy();
+    expect(screen.getByText("LCA")).toBeTruthy();
+    expect(screen.getByText("OFF-AXIS TCA")).toBeTruthy();
     expect(screen.getByText("0.4 µm")).toBeTruthy();
-    expect(screen.getByText("0.8 µm")).toBeTruthy();
+    expect(screen.getAllByText("0.5 µm").length).toBeGreaterThan(0);
+    expect(screen.queryByText("0.8 µm")).toBeNull();
   });
 
   it("shares chart math helpers for scales, domains, ticks, and SVG paths", () => {

--- a/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
+++ b/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
@@ -2,6 +2,7 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import ChromaticFieldCurvaturePlot from "../../../../../src/components/display/analysis/ChromaticFieldCurvaturePlot.js";
 import FieldCurvatureMeanPlot from "../../../../../src/components/display/analysis/FieldCurvatureMeanPlot.js";
 import VignettingChart from "../../../../../src/components/display/analysis/VignettingChart.js";
 import LCAInsetWidget from "../../../../../src/components/diagram/LCAInsetWidget.js";
@@ -25,6 +26,7 @@ function field(
   petzvalShiftMm: number,
   chiefImageHeight: number,
   usable = true,
+  chromaticFieldShifts: FieldCurvatureFieldResult["chromaticFieldShifts"] = null,
 ): FieldCurvatureFieldResult {
   return {
     fieldFraction,
@@ -42,7 +44,7 @@ function field(
     petzvalShiftMm,
     astigmaticDifferenceMm: 0,
     astigmaticDifferenceUm: 0,
-    chromaticFieldShifts: null,
+    chromaticFieldShifts,
     usable,
   };
 }
@@ -98,6 +100,25 @@ describe("analysis chart coverage", () => {
     expect(screen.getByText("Current image plane")).toBeTruthy();
     expect(container.querySelector("polyline")).toBeNull();
     expect(container.querySelector("polygon")).toBeNull();
+  });
+
+  it("renders violet values in chromatic field-curvature traces", () => {
+    const shifts = (base: number): FieldCurvatureFieldResult["chromaticFieldShifts"] => [
+      { channel: "R", tangentialShiftMm: base - 0.03, sagittalShiftMm: base - 0.02 },
+      { channel: "G", tangentialShiftMm: base, sagittalShiftMm: base + 0.01 },
+      { channel: "B", tangentialShiftMm: base + 0.02, sagittalShiftMm: base + 0.03 },
+      { channel: "V", tangentialShiftMm: base + 0.04, sagittalShiftMm: base + 0.05 },
+    ];
+    const result = fieldCurvatureResult([
+      field(0, 0, 0, true, shifts(0)),
+      field(0.5, 0, 0, true, shifts(0.03)),
+      field(1, 0, 0, true, shifts(0.06)),
+    ]);
+
+    const { container } = render(<ChromaticFieldCurvaturePlot result={result} t={themes.dark} />);
+
+    expect(screen.getByText("V T/S")).toBeTruthy();
+    expect(container.querySelectorAll("polyline")).toHaveLength(8);
   });
 
   it("renders vignetting fallback for insufficient samples", () => {

--- a/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
+++ b/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
@@ -6,6 +6,7 @@ import FieldCurvatureMeanPlot from "../../../../../src/components/display/analys
 import VignettingChart from "../../../../../src/components/display/analysis/VignettingChart.js";
 import LCAInsetWidget from "../../../../../src/components/diagram/LCAInsetWidget.js";
 import LCAOverlayContent from "../../../../../src/components/diagram/LCAOverlayContent.js";
+import TCAInsetWidget from "../../../../../src/components/diagram/TCAInsetWidget.js";
 import {
   angleTicks,
   formatSignedCompactTick,
@@ -152,13 +153,42 @@ describe("analysis chart coverage", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it("renders axial LCA with a separate off-axis TCA summary when both spreads are available", () => {
+  it("renders TCA inset channels and image-plane formatting", () => {
+    render(
+      <svg>
+        <TCAInsetWidget
+          chromSpread={{ lcaMm: 0, tcaMm: 0.0005, intercepts: {}, imgHeights: { R: -0.00025, G: 0, B: 0.00025 } }}
+          effectiveSC={1}
+          t={themes.dark}
+          width={160}
+          height={140}
+          originX={12}
+          originY={18}
+          fontScale={1.4}
+        />
+      </svg>,
+    );
+
+    expect(screen.getByText("TCA")).toBeTruthy();
+    expect(screen.getByText("IMAGE HEIGHT")).toBeTruthy();
+    expect(screen.getByText("R")).toBeTruthy();
+    expect(screen.getByText("G")).toBeTruthy();
+    expect(screen.getByText("B")).toBeTruthy();
+    expect(screen.getByText("0.5 µm")).toBeTruthy();
+  });
+
+  it("renders axial LCA with a matching off-axis TCA chart when both spreads are available", () => {
     render(
       <LCAOverlayContent
         chromSpread={{ lcaMm: 0.0004, tcaMm: 0, intercepts: { R: -0.02, G: 0, B: 0.03 }, imgHeights: {} }}
         chromaticSpreads={{
           onAxis: { lcaMm: 0.0004, tcaMm: 0, intercepts: { R: -0.02, G: 0, B: 0.03 }, imgHeights: {} },
-          offAxis: { lcaMm: 0.0008, tcaMm: 0.0005, intercepts: { R: -0.04, G: 0, B: 0.04 }, imgHeights: {} },
+          offAxis: {
+            lcaMm: 0.0008,
+            tcaMm: 0.0005,
+            intercepts: { R: -0.04, G: 0, B: 0.04 },
+            imgHeights: { R: -0.00025, G: 0, B: 0.00025 },
+          },
         }}
         effectiveSC={1}
         IMG_MM={0}
@@ -167,7 +197,8 @@ describe("analysis chart coverage", () => {
     );
 
     expect(screen.getByText("LCA")).toBeTruthy();
-    expect(screen.getByText("OFF-AXIS TCA")).toBeTruthy();
+    expect(screen.getByText("TCA")).toBeTruthy();
+    expect(screen.getByText(/OFF-AXIS TCA/)).toBeTruthy();
     expect(screen.getByText("0.4 µm")).toBeTruthy();
     expect(screen.getAllByText("0.5 µm").length).toBeGreaterThan(0);
     expect(screen.queryByText("0.8 µm")).toBeNull();

--- a/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
+++ b/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
@@ -178,7 +178,7 @@ describe("analysis chart coverage", () => {
   });
 
   it("renders axial LCA with a matching off-axis TCA chart when both spreads are available", () => {
-    render(
+    const { container } = render(
       <LCAOverlayContent
         chromSpread={{ lcaMm: 0.0004, tcaMm: 0, intercepts: { R: -0.02, G: 0, B: 0.03 }, imgHeights: {} }}
         chromaticSpreads={{
@@ -202,6 +202,11 @@ describe("analysis chart coverage", () => {
     expect(screen.getByText("0.4 µm")).toBeTruthy();
     expect(screen.getAllByText("0.5 µm").length).toBeGreaterThan(0);
     expect(screen.queryByText("0.8 µm")).toBeNull();
+
+    const charts = Array.from(container.querySelectorAll("svg"));
+    expect(charts).toHaveLength(2);
+    expect(charts.map((chart) => chart.getAttribute("width"))).toEqual(["340", "340"]);
+    expect(charts.map((chart) => chart.getAttribute("height"))).toEqual(["280", "280"]);
   });
 
   it("shares chart math helpers for scales, domains, ticks, and SVG paths", () => {

--- a/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
+++ b/__tests__/src/components/display/analysis/analysisChartsAdditional.test.tsx
@@ -199,6 +199,9 @@ describe("analysis chart coverage", () => {
     expect(screen.getByText("LCA")).toBeTruthy();
     expect(screen.getByText("TCA")).toBeTruthy();
     expect(screen.getByText(/OFF-AXIS TCA/)).toBeTruthy();
+    expect(screen.getByText(/Longitudinal color is the wavelength focus spread/)).toBeTruthy();
+    expect(screen.getByText(/Transverse color is the surviving wavelength spread/)).toBeTruthy();
+    expect(screen.getByText("Transverse Chromatic Aberration (TCA)")).toBeTruthy();
     expect(screen.getByText("0.4 µm")).toBeTruthy();
     expect(screen.getAllByText("0.5 µm").length).toBeGreaterThan(0);
     expect(screen.queryByText("0.8 µm")).toBeNull();

--- a/__tests__/src/components/display/analysis/analysisDisplayTabs.test.ts
+++ b/__tests__/src/components/display/analysis/analysisDisplayTabs.test.ts
@@ -204,9 +204,9 @@ describe("analysis display tabs", () => {
       }),
     );
 
-    expect(html).toContain("Spot Diagram (Real-Ray)");
-    expect(html).toContain("higher-resolution chief-ray-referenced real-ray spot grid");
-    expect(html).toContain("Idealized coma comparison");
+    expect(html).toContain("Chief-Ray Spot Footprints");
+    expect(html).toContain("chief-ray-referenced real-ray spot footprints");
+    expect(html).toContain("Schematic coma comparison");
     expect(html).toContain("Crosshair");
     expect(html).toContain("chief-ray ref.");
     expect(html).toContain("Diamond");
@@ -220,7 +220,7 @@ describe("analysis display tabs", () => {
     expect(html).toContain("Tangential Ray Fan");
     expect(html).toContain("Tangential ray fan using a dense off-axis meridional pupil sweep");
     expect(html).toContain("Chief ray");
-    expect(html).toContain("COMA SPAN");
+    expect(html).toContain("FAN SPAN");
     expect(html).not.toContain("Spherical Aberration");
     expect(html).not.toContain("Field Curves &amp; Astigmatism");
   });

--- a/__tests__/src/components/display/analysis/analysisDisplayTabs.test.ts
+++ b/__tests__/src/components/display/analysis/analysisDisplayTabs.test.ts
@@ -11,6 +11,7 @@ import {
   fopenAtZoom,
 } from "../../../../../src/optics/optics.js";
 import AberrationsPanel from "../../../../../src/components/display/analysis/AberrationsPanel.js";
+import ChromaticTab from "../../../../../src/components/display/analysis/ChromaticTab.js";
 import ComaTab from "../../../../../src/components/display/analysis/ComaTab.js";
 import DistortionChart from "../../../../../src/components/display/analysis/DistortionChart.js";
 import DistortionTab from "../../../../../src/components/display/analysis/DistortionTab.js";
@@ -222,6 +223,43 @@ describe("analysis display tabs", () => {
     expect(html).toContain("COMA SPAN");
     expect(html).not.toContain("Spherical Aberration");
     expect(html).not.toContain("Field Curves &amp; Astigmatism");
+  });
+
+  it("ChromaticTab renders axial, lateral, and field-focus chromatic diagnostics", () => {
+    const L = build(Sonnar50f15Raw);
+    const focusT = 0;
+    const zoomT = 0;
+    const { currentPhysStopSD, currentEPSD } = apertureAt(L, zoomT, 0.25);
+    const fieldGeometry = computeAnalysisFieldGeometryAtState(focusT, zoomT, L);
+
+    const html = renderToStaticMarkup(
+      React.createElement(ChromaticTab, {
+        L,
+        t: themes.dark,
+        focusT,
+        zoomT,
+        currentEPSD,
+        currentPhysStopSD,
+        fieldGeometry,
+      }),
+    );
+
+    expect(html).toContain("Chromatic Analysis");
+    expect(html).toContain("Geometric traces at C, d, F, and g spectral lines");
+    expect(html).toContain("do not classify apochromatic correction");
+    expect(html).toContain("AXIAL LCA");
+    expect(html).toContain("MAX LATERAL COLOR");
+    expect(html).toContain("OFF-AXIS MARGINAL TCA");
+    expect(html).toContain("Longitudinal Color");
+    expect(html).toContain("Lateral Color");
+    expect(html).toContain("Field-Focus Color");
+    expect(html).toContain("Focus from G nd (um)");
+    expect(html).toContain("Height from G nd (um)");
+    expect(html).toContain("C-line 656.3 nm");
+    expect(html).toContain("d-line 587.6 nm");
+    expect(html).toContain("F-line 486.1 nm");
+    expect(html).toContain("g-line 435.8 nm");
+    expect(html).toContain("MAX FOCUS");
   });
 
   it("FocusBreathingTab renders the breathing chart and summary metrics", () => {

--- a/__tests__/src/components/display/analysis/preparedAnalysisJobs.test.ts
+++ b/__tests__/src/components/display/analysis/preparedAnalysisJobs.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import ChromaticTab from "../../../../../src/components/display/analysis/ChromaticTab.js";
 import DistortionTab from "../../../../../src/components/display/analysis/DistortionTab.js";
 import OpticalSummaryTab from "../../../../../src/components/display/analysis/OpticalSummaryTab.js";
 import PupilAberrationTab from "../../../../../src/components/display/analysis/PupilAberrationTab.js";
@@ -11,16 +12,22 @@ import type { RuntimeLens } from "../../../../../src/types/optics.js";
 
 const {
   mockComputeBothPupilAberrationProfiles,
+  mockComputeChromaticAnalysis,
+  mockComputeChromaticRayTraceAnalysis,
   mockComputeDistortionCurve,
   mockComputeDistortionFieldGrid,
+  mockComputeFieldCurvatureBundle,
   mockComputeOpticalSummary,
   mockComputeVignettingCurve,
   mockPreparedState,
   mockPrepareRuntimeState,
 } = vi.hoisted(() => ({
   mockComputeBothPupilAberrationProfiles: vi.fn(),
+  mockComputeChromaticAnalysis: vi.fn(),
+  mockComputeChromaticRayTraceAnalysis: vi.fn(),
   mockComputeDistortionCurve: vi.fn(),
   mockComputeDistortionFieldGrid: vi.fn(),
+  mockComputeFieldCurvatureBundle: vi.fn(),
   mockComputeOpticalSummary: vi.fn(),
   mockComputeVignettingCurve: vi.fn(),
   mockPreparedState: { cacheKey: "prepared-analysis-test" },
@@ -34,8 +41,11 @@ vi.mock("../../../../../src/optics/compat.js", async () => {
     analysisJobsForState2: {
       ...(actual as { analysisJobsForState2: Record<string, unknown> }).analysisJobsForState2,
       computeBothPupilAberrationProfiles: mockComputeBothPupilAberrationProfiles,
+      computeChromaticAnalysis: mockComputeChromaticAnalysis,
+      computeChromaticRayTraceAnalysis: mockComputeChromaticRayTraceAnalysis,
       computeDistortionCurve: mockComputeDistortionCurve,
       computeDistortionFieldGrid: mockComputeDistortionFieldGrid,
+      computeFieldCurvatureBundle: mockComputeFieldCurvatureBundle,
       computeOpticalSummary: mockComputeOpticalSummary,
       computeVignettingCurve: mockComputeVignettingCurve,
     },
@@ -109,6 +119,125 @@ const vignettingSamples = [
   { fieldAngleDeg: 12, geometricTransmission: 0.82, relativeIllumination: 0.75 },
 ];
 
+const chromaticAnalysis = {
+  longitudinalFocus: {
+    channels: ["R", "G", "B"],
+    referenceChannel: "G",
+    marginalFraction: 0.95,
+    imagePlaneZ: 60,
+    lastSurfaceZ: 20,
+    longitudinalSpreadMm: 0.03,
+    longitudinalSpreadUm: 30,
+    transverseSpreadMm: 0.005,
+    transverseSpreadUm: 5,
+    spread: {
+      lcaMm: 0.03,
+      tcaMm: 0.005,
+      intercepts: { R: 59.99, G: 60, B: 60.02 },
+      imgHeights: { R: -0.002, G: 0, B: 0.003 },
+      axis: "onAxis",
+      fraction: 0.95,
+      channels: ["R", "G", "B"],
+    },
+    samples: [
+      {
+        channel: "R",
+        focusZ: 59.99,
+        focusShiftMm: -0.01,
+        relativeFocusShiftMm: -0.01,
+        imageHeightMm: -0.002,
+        relativeImageHeightMm: -0.002,
+        usable: true,
+        clipped: false,
+      },
+      {
+        channel: "G",
+        focusZ: 60,
+        focusShiftMm: 0,
+        relativeFocusShiftMm: 0,
+        imageHeightMm: 0,
+        relativeImageHeightMm: 0,
+        usable: true,
+        clipped: false,
+      },
+      {
+        channel: "B",
+        focusZ: 60.02,
+        focusShiftMm: 0.02,
+        relativeFocusShiftMm: 0.02,
+        imageHeightMm: 0.003,
+        relativeImageHeightMm: 0.003,
+        usable: true,
+        clipped: false,
+      },
+    ],
+    validChannelCount: 3,
+  },
+  lateralColor: {
+    channels: ["R", "G", "B"],
+    referenceChannel: "G",
+    fieldFractions: [0, 1],
+    fields: [
+      {
+        fieldFraction: 0,
+        label: "0%",
+        fieldAngleDeg: 0,
+        referenceChannel: "G",
+        referenceImageHeightMm: 0,
+        lateralSpreadMm: 0,
+        lateralSpreadUm: 0,
+        samples: [
+          { channel: "R", imageHeightMm: 0, relativeHeightMm: 0, usable: true, clipped: false },
+          { channel: "G", imageHeightMm: 0, relativeHeightMm: 0, usable: true, clipped: false },
+          { channel: "B", imageHeightMm: 0, relativeHeightMm: 0, usable: true, clipped: false },
+        ],
+        validChannelCount: 3,
+        usable: true,
+      },
+      {
+        fieldFraction: 1,
+        label: "100%",
+        fieldAngleDeg: 12,
+        referenceChannel: "G",
+        referenceImageHeightMm: 10,
+        lateralSpreadMm: 0.012,
+        lateralSpreadUm: 12,
+        samples: [
+          { channel: "R", imageHeightMm: 9.995, relativeHeightMm: -0.005, usable: true, clipped: false },
+          { channel: "G", imageHeightMm: 10, relativeHeightMm: 0, usable: true, clipped: false },
+          { channel: "B", imageHeightMm: 10.007, relativeHeightMm: 0.007, usable: true, clipped: false },
+        ],
+        validChannelCount: 3,
+        usable: true,
+      },
+    ],
+    usableFieldCount: 2,
+    maxLateralSpreadMm: 0.012,
+    maxLateralSpreadUm: 12,
+    imagePlaneZ: 60,
+    halfFieldDeg: 12,
+  },
+};
+
+const chromaticRayTraceAnalysis = {
+  channels: ["R", "G", "B", "V"],
+  spreads: {
+    onAxis: chromaticAnalysis.longitudinalFocus.spread,
+    offAxis: {
+      lcaMm: 0.018,
+      tcaMm: 0.009,
+      intercepts: { R: 59.98, G: 60, B: 60.01, V: 60.015 },
+      imgHeights: { R: 9.99, G: 10, B: 10.006, V: 10.009 },
+      axis: "offAxis",
+      fraction: 0.75,
+      channels: ["R", "G", "B", "V"],
+    },
+  },
+  offAxisFieldAngleDeg: 12,
+  onAxisAttemptedRayCount: 4,
+  offAxisAttemptedRayCount: 4,
+};
+
 const pupilProfiles = {
   ep: {
     samples: [
@@ -160,10 +289,16 @@ describe("prepared-state analysis tabs", () => {
   beforeEach(() => {
     mockComputeBothPupilAberrationProfiles.mockReset();
     mockComputeBothPupilAberrationProfiles.mockReturnValue(pupilProfiles);
+    mockComputeChromaticAnalysis.mockReset();
+    mockComputeChromaticAnalysis.mockReturnValue(chromaticAnalysis);
+    mockComputeChromaticRayTraceAnalysis.mockReset();
+    mockComputeChromaticRayTraceAnalysis.mockReturnValue(chromaticRayTraceAnalysis);
     mockComputeDistortionCurve.mockReset();
     mockComputeDistortionCurve.mockReturnValue(distortionSamples);
     mockComputeDistortionFieldGrid.mockReset();
     mockComputeDistortionFieldGrid.mockReturnValue(distortionFieldGrid);
+    mockComputeFieldCurvatureBundle.mockReset();
+    mockComputeFieldCurvatureBundle.mockReturnValue({ fieldCurvature: null, chromaticFieldCurvature: null });
     mockComputeOpticalSummary.mockReset();
     mockComputeOpticalSummary.mockReturnValue(opticalSummary);
     mockComputeVignettingCurve.mockReset();
@@ -211,6 +346,30 @@ describe("prepared-state analysis tabs", () => {
     expect(html).toContain("Optical State");
     expect(mockPrepareRuntimeState).not.toHaveBeenCalled();
     expect(mockComputeOpticalSummary).toHaveBeenCalledWith(preparedState, 51, 10, 5, fieldGeometry);
+  });
+
+  it("routes chromatic work through the prepared-state job facade", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ChromaticTab, {
+        L: lens,
+        t: themes.dark,
+        focusT: 0.2,
+        zoomT: 0.3,
+        aberrationT: 0.4,
+        currentEPSD: 10,
+        currentPhysStopSD: 5,
+        fieldGeometry,
+        preparedState,
+      }),
+    );
+
+    expect(html).toContain("Longitudinal Color");
+    expect(mockPrepareRuntimeState).not.toHaveBeenCalled();
+    expect(mockComputeChromaticAnalysis).toHaveBeenCalledWith(preparedState, 10, 5, fieldGeometry);
+    expect(mockComputeChromaticRayTraceAnalysis).toHaveBeenCalledWith(preparedState, 10, 5, fieldGeometry, {
+      channels: ["R", "G", "B", "V"],
+    });
+    expect(mockComputeFieldCurvatureBundle).toHaveBeenCalledWith(preparedState, 10, 5, fieldGeometry);
   });
 
   it("routes vignetting work through the prepared-state job facade", () => {

--- a/__tests__/src/components/display/analysis/preparedAnalysisJobs.test.ts
+++ b/__tests__/src/components/display/analysis/preparedAnalysisJobs.test.ts
@@ -121,23 +121,23 @@ const vignettingSamples = [
 
 const chromaticAnalysis = {
   longitudinalFocus: {
-    channels: ["R", "G", "B"],
+    channels: ["R", "G", "B", "V"],
     referenceChannel: "G",
     marginalFraction: 0.95,
     imagePlaneZ: 60,
     lastSurfaceZ: 20,
-    longitudinalSpreadMm: 0.03,
-    longitudinalSpreadUm: 30,
-    transverseSpreadMm: 0.005,
-    transverseSpreadUm: 5,
+    longitudinalSpreadMm: 0.035,
+    longitudinalSpreadUm: 35,
+    transverseSpreadMm: 0.007,
+    transverseSpreadUm: 7,
     spread: {
-      lcaMm: 0.03,
-      tcaMm: 0.005,
-      intercepts: { R: 59.99, G: 60, B: 60.02 },
-      imgHeights: { R: -0.002, G: 0, B: 0.003 },
+      lcaMm: 0.035,
+      tcaMm: 0.007,
+      intercepts: { R: 59.99, G: 60, B: 60.02, V: 60.025 },
+      imgHeights: { R: -0.002, G: 0, B: 0.003, V: 0.005 },
       axis: "onAxis",
       fraction: 0.95,
-      channels: ["R", "G", "B"],
+      channels: ["R", "G", "B", "V"],
     },
     samples: [
       {
@@ -170,11 +170,21 @@ const chromaticAnalysis = {
         usable: true,
         clipped: false,
       },
+      {
+        channel: "V",
+        focusZ: 60.025,
+        focusShiftMm: 0.025,
+        relativeFocusShiftMm: 0.025,
+        imageHeightMm: 0.005,
+        relativeImageHeightMm: 0.005,
+        usable: true,
+        clipped: false,
+      },
     ],
-    validChannelCount: 3,
+    validChannelCount: 4,
   },
   lateralColor: {
-    channels: ["R", "G", "B"],
+    channels: ["R", "G", "B", "V"],
     referenceChannel: "G",
     fieldFractions: [0, 1],
     fields: [
@@ -190,8 +200,9 @@ const chromaticAnalysis = {
           { channel: "R", imageHeightMm: 0, relativeHeightMm: 0, usable: true, clipped: false },
           { channel: "G", imageHeightMm: 0, relativeHeightMm: 0, usable: true, clipped: false },
           { channel: "B", imageHeightMm: 0, relativeHeightMm: 0, usable: true, clipped: false },
+          { channel: "V", imageHeightMm: 0, relativeHeightMm: 0, usable: true, clipped: false },
         ],
-        validChannelCount: 3,
+        validChannelCount: 4,
         usable: true,
       },
       {
@@ -200,20 +211,21 @@ const chromaticAnalysis = {
         fieldAngleDeg: 12,
         referenceChannel: "G",
         referenceImageHeightMm: 10,
-        lateralSpreadMm: 0.012,
-        lateralSpreadUm: 12,
+        lateralSpreadMm: 0.017,
+        lateralSpreadUm: 17,
         samples: [
           { channel: "R", imageHeightMm: 9.995, relativeHeightMm: -0.005, usable: true, clipped: false },
           { channel: "G", imageHeightMm: 10, relativeHeightMm: 0, usable: true, clipped: false },
           { channel: "B", imageHeightMm: 10.007, relativeHeightMm: 0.007, usable: true, clipped: false },
+          { channel: "V", imageHeightMm: 10.012, relativeHeightMm: 0.012, usable: true, clipped: false },
         ],
-        validChannelCount: 3,
+        validChannelCount: 4,
         usable: true,
       },
     ],
     usableFieldCount: 2,
-    maxLateralSpreadMm: 0.012,
-    maxLateralSpreadUm: 12,
+    maxLateralSpreadMm: 0.017,
+    maxLateralSpreadUm: 17,
     imagePlaneZ: 60,
     halfFieldDeg: 12,
   },
@@ -364,6 +376,7 @@ describe("prepared-state analysis tabs", () => {
     );
 
     expect(html).toContain("Longitudinal Color");
+    expect(html).toContain("V ng");
     expect(mockPrepareRuntimeState).not.toHaveBeenCalled();
     expect(mockComputeChromaticAnalysis).toHaveBeenCalledWith(preparedState, 10, 5, fieldGeometry);
     expect(mockComputeChromaticRayTraceAnalysis).toHaveBeenCalledWith(preparedState, 10, 5, fieldGeometry, {

--- a/__tests__/src/components/hooks/useChromaticRays.test.ts
+++ b/__tests__/src/components/hooks/useChromaticRays.test.ts
@@ -268,6 +268,8 @@ describe("useChromaticRays", () => {
     expect(result.current.chromaticRays.every((r) => r.axis === "offAxis")).toBe(true);
     expect(result.current.chromaticSpreads.onAxis).toBeNull();
     expect(result.current.chromaticSpreads.offAxis).not.toBeNull();
+    expect(result.current.chromaticSpreads.offAxis?.axis).toBe("offAxis");
+    expect(result.current.chromaticSpreads.offAxis?.channels).toEqual(["R", "G"]);
     expect(result.current.chromSpread).toBe(result.current.chromaticSpreads.offAxis);
   });
 
@@ -303,6 +305,9 @@ describe("useChromaticRays", () => {
     expect(result.current.chromaticSpreads.offAxis).toBeNull();
     expect(typeof result.current.chromSpread!.lcaMm).toBe("number");
     expect(typeof result.current.chromSpread!.tcaMm).toBe("number");
+    expect(result.current.chromSpread!.axis).toBe("onAxis");
+    expect(result.current.chromSpread!.channels).toEqual(["R", "G", "B"]);
+    expect(typeof result.current.chromSpread!.fraction).toBe("number");
   });
 
   it("does not report a larger LCA when a selected RGB channel is hidden", () => {

--- a/__tests__/src/components/hooks/useChromaticRays.test.ts
+++ b/__tests__/src/components/hooks/useChromaticRays.test.ts
@@ -4,7 +4,12 @@ import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import useChromaticRays from "../../../../src/components/hooks/useChromaticRays.js";
 import buildLens from "../../../../src/optics/buildLens.js";
-import { doLayout, entrancePupilAtState, fopenAtZoom } from "../../../../src/optics/optics.js";
+import {
+  computeLongitudinalChromaticFocus,
+  doLayout,
+  entrancePupilAtState,
+  fopenAtZoom,
+} from "../../../../src/optics/optics.js";
 import { createCoordinateTransforms } from "../../../../src/optics/diagramGeometry.js";
 import { raySampleCountForDensity } from "../../../../src/optics/raySampling.js";
 import LENS_DEFAULTS from "../../../../src/lens-data/defaults.js";
@@ -14,6 +19,7 @@ import ApoLantharRaw from "../../../../src/lens-data/voigtlander/VoigtlanderApoL
 
 const Sonnar = { ...LENS_DEFAULTS, ...SonnarRaw } as LensData;
 const ApoLanthar = { ...LENS_DEFAULTS, ...ApoLantharRaw } as LensData;
+const displayLcaFallbackFractions = [0.97, 0.95, 0.9, 0.85, 0.8] as const;
 
 function buildTestFixture(focusT = 0, zoomT = 0, data: LensData = Sonnar) {
   const L = buildLens(data);
@@ -37,6 +43,17 @@ function buildTestFixture(focusT = 0, zoomT = 0, data: LensData = Sonnar) {
   const baseEPSD = entrancePupilAtState(L.stopPhysSD, focusT, zoomT, L).epSD;
   const currentEPSD = (baseEPSD * L.FOPEN) / fNumber;
   return { L, zPos, IMG_MM, sx, sy, clampedRayEnd, currentPhysStopSD, currentEPSD };
+}
+
+function expectedDisplayLcaFractions(L: RuntimeLens): number[] {
+  const fractions: number[] = [...displayLcaFallbackFractions];
+  for (const fraction of L.rayFractions) {
+    const absolute = Math.abs(fraction);
+    if (absolute > 1e-12 && !fractions.some((value) => Math.abs(value - absolute) < 1e-12)) {
+      fractions.push(absolute);
+    }
+  }
+  return fractions.sort((a, b) => b - a);
 }
 
 describe("useChromaticRays", () => {
@@ -308,6 +325,13 @@ describe("useChromaticRays", () => {
     expect(result.current.chromSpread!.axis).toBe("onAxis");
     expect(result.current.chromSpread!.channels).toEqual(["R", "G", "B"]);
     expect(typeof result.current.chromSpread!.fraction).toBe("number");
+
+    const expected = computeLongitudinalChromaticFocus(L, zPos, 0, 0, currentEPSD, currentPhysStopSD, 0, {
+      channels: ["R", "G", "B"],
+      longitudinalFractions: expectedDisplayLcaFractions(L),
+    })!.spread;
+    expect(result.current.chromSpread!.lcaMm).toBeCloseTo(expected.lcaMm, 12);
+    expect(result.current.chromSpread!.fraction).toBe(expected.fraction);
   });
 
   it("does not report a larger LCA when a selected RGB channel is hidden", () => {

--- a/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
+++ b/__tests__/src/components/layout/lensDiagram/AnalysisDrawerContent.test.tsx
@@ -11,6 +11,7 @@ import type { Theme } from "../../../../../src/types/theme.js";
 const {
   mockAberrationsPanel,
   mockBokehTab,
+  mockChromaticTab,
   mockComaTab,
   mockDistortionTab,
   mockFocusBreathingTab,
@@ -22,6 +23,7 @@ const {
 } = vi.hoisted(() => ({
   mockAberrationsPanel: vi.fn(),
   mockBokehTab: vi.fn(),
+  mockChromaticTab: vi.fn(),
   mockComaTab: vi.fn(),
   mockDistortionTab: vi.fn(),
   mockFocusBreathingTab: vi.fn(),
@@ -51,6 +53,13 @@ vi.mock("../../../../../src/components/display/analysis/BokehTab.js", () => ({
   default: (props: Record<string, unknown>) => {
     mockBokehTab(props);
     return <div>Bokeh</div>;
+  },
+}));
+
+vi.mock("../../../../../src/components/display/analysis/ChromaticTab.js", () => ({
+  default: (props: Record<string, unknown>) => {
+    mockChromaticTab(props);
+    return <div>Chromatic</div>;
   },
 }));
 
@@ -118,6 +127,7 @@ describe("AnalysisDrawerContent", () => {
   beforeEach(() => {
     mockAberrationsPanel.mockReset();
     mockBokehTab.mockReset();
+    mockChromaticTab.mockReset();
     mockComaTab.mockReset();
     mockDistortionTab.mockReset();
     mockFocusBreathingTab.mockReset();
@@ -165,6 +175,15 @@ describe("AnalysisDrawerContent", () => {
     expect(mockAberrationsPanel).not.toHaveBeenCalled();
   });
 
+  it("maps the chromatic tab to ChromaticTab", () => {
+    render(<AnalysisDrawerContent {...baseProps} activeTab="chromatic" />);
+
+    expect(screen.getByText("Chromatic")).toBeTruthy();
+    expect(mockChromaticTab).toHaveBeenCalledTimes(1);
+    expect(mockChromaticTab.mock.calls[0][0].preparedState).toBe(mockPreparedState);
+    expect(mockAberrationsPanel).not.toHaveBeenCalled();
+  });
+
   it("maps the coma tab to ComaTab", () => {
     render(<AnalysisDrawerContent {...baseProps} activeTab="coma" aberrationT={0.37} />);
 
@@ -208,6 +227,14 @@ describe("AnalysisDrawerContent", () => {
     expect(screen.getByText(/Folded mirror optical path detected/)).toBeTruthy();
     expect(screen.getByText(/not available for folded mirror systems yet/)).toBeTruthy();
     expect(mockVignettingTab).not.toHaveBeenCalled();
+  });
+
+  it("guards the chromatic tab for folded optics until mirror validation is added", () => {
+    render(<AnalysisDrawerContent {...baseProps} L={{ ...baseProps.L, isFoldedOptics: true }} activeTab="chromatic" />);
+
+    expect(screen.getByText(/Folded mirror optical path detected/)).toBeTruthy();
+    expect(screen.getByText(/not available for folded mirror systems yet/)).toBeTruthy();
+    expect(mockChromaticTab).not.toHaveBeenCalled();
   });
 
   it("allows folded optics to use the mirror-safe aberrations tab", () => {

--- a/__tests__/src/components/layout/lensDiagram/DiagramViewport.test.tsx
+++ b/__tests__/src/components/layout/lensDiagram/DiagramViewport.test.tsx
@@ -224,6 +224,34 @@ describe("DiagramViewport", () => {
     expect(screen.queryByText("LCA Overlay")).toBeNull();
   });
 
+  it("uses axial spread data for the LCA inset and overlay when per-axis spreads are available", () => {
+    const offAxisSpread = { lcaMm: 0.4, tcaMm: 0.8, intercepts: {}, imgHeights: {} };
+    const onAxisSpread = { lcaMm: 0.1, tcaMm: 0.2, intercepts: {}, imgHeights: {} };
+    const { rerender } = render(
+      <DiagramViewport
+        {...baseProps}
+        showLcaOverlay
+        chromSpread={offAxisSpread}
+        chromaticSpreads={{ onAxis: null, offAxis: offAxisSpread }}
+      />,
+    );
+
+    expect(screen.queryByText("LCA Overlay")).toBeNull();
+    expect(mockDiagramSVG).toHaveBeenLastCalledWith(expect.objectContaining({ chromSpread: null }));
+
+    rerender(
+      <DiagramViewport
+        {...baseProps}
+        showLcaOverlay
+        chromSpread={offAxisSpread}
+        chromaticSpreads={{ onAxis: onAxisSpread, offAxis: offAxisSpread }}
+      />,
+    );
+
+    expect(screen.getByText("LCA Overlay")).toBeTruthy();
+    expect(mockDiagramSVG).toHaveBeenLastCalledWith(expect.objectContaining({ chromSpread: onAxisSpread }));
+  });
+
   it("shows the Petzval overlay independently of chromatic gating", () => {
     render(<DiagramViewport {...baseProps} showPetzvalOverlay showChromatic={false} chromSpread={null} />);
 

--- a/__tests__/src/optics/aberrationAnalysis.test.ts
+++ b/__tests__/src/optics/aberrationAnalysis.test.ts
@@ -630,7 +630,8 @@ describe("computeMeridionalComa", () => {
     expect(result!.samples[result!.samples.length - 1].clipped).toBe(true);
     expect(result!.lowerIntercept).toBeGreaterThanOrEqual(result!.minIntercept);
     expect(result!.upperIntercept).toBeLessThanOrEqual(result!.maxIntercept);
-    expect(result!.spanMm).toBeCloseTo(result!.upperIntercept - result!.lowerIntercept, 8);
+    expect(result!.signedOuterDeltaMm).toBeCloseTo(result!.upperRelativeIntercept - result!.lowerRelativeIntercept, 8);
+    expect(result!.spanMm).toBeCloseTo(result!.maxRelativeIntercept - result!.minRelativeIntercept, 8);
   });
 
   it("returns null when clipping removes one side of the pupil fan", () => {
@@ -682,6 +683,24 @@ describe("computeMeridionalComa", () => {
     const geometry = computeStateAwareOffAxisFieldGeometry(L, zPos, 0, 0, L.offAxisFieldFrac, fieldGeometry);
     expect(geometry).not.toBeNull();
     expect(result!.fieldAngleDeg).toBeCloseTo(geometry!.fieldAngleDeg, 8);
+    expect(result!.fieldFraction).toBeCloseTo(L.offAxisFieldFrac, 8);
+  });
+
+  it("allows the detailed coma fan field fraction to be selected", () => {
+    const L = build(Sonnar50f15Raw);
+    const { z: zPos } = doLayout(0, 0, L);
+    const { currentEPSD, currentPhysStopSD } = apertureAt(L, 0, 0);
+    const fieldGeometry = computeAnalysisFieldGeometryAtState(0, 0, L);
+
+    const result = computeComaAnalysis(L, zPos, 0, 0, currentEPSD, currentPhysStopSD, 0, fieldGeometry, {
+      comaDetailFieldFraction: 1,
+    });
+
+    expect(result.meridionalComa).not.toBeNull();
+    expect(result.sagittalComa).not.toBeNull();
+    expect(result.meridionalComa!.fieldFraction).toBe(1);
+    expect(result.sagittalComa!.fieldFraction).toBe(1);
+    expect(result.meridionalComa!.fieldAngleDeg).toBeCloseTo(fieldGeometry.halfFieldDeg, 8);
   });
 
   it("matches the shared tangential bundle trace at the configured field", () => {

--- a/__tests__/src/optics/aberrationAnalysis.test.ts
+++ b/__tests__/src/optics/aberrationAnalysis.test.ts
@@ -1595,7 +1595,7 @@ describe("computeFieldCurvature", () => {
     }
   });
 
-  it("includes all three channels (R, G, B) in chromatic shifts", () => {
+  it("includes all four spectral channels (R, G, B, V) in chromatic shifts", () => {
     const L = build(ApoLantharRaw);
     const { z: zPos } = doLayout(0, 0, L);
     const { currentEPSD, currentPhysStopSD } = apertureAt(L, 0, 0);
@@ -1606,7 +1606,7 @@ describe("computeFieldCurvature", () => {
     const usableFields = result!.fields.filter((f) => f.usable && f.chromaticFieldShifts !== null);
     for (const field of usableFields) {
       const channels = field.chromaticFieldShifts!.map((s) => s.channel);
-      expect(channels).toEqual(["R", "G", "B"]);
+      expect(channels).toEqual(["R", "G", "B", "V"]);
     }
   });
 });

--- a/__tests__/src/optics/analysis/chromatic.test.ts
+++ b/__tests__/src/optics/analysis/chromatic.test.ts
@@ -24,6 +24,7 @@ describe("chromatic analysis helpers", () => {
 
     const result = computeChromaticRayTraceAnalysis2(L, z, 0, 0, currentEPSD, currentPhysStopSD);
 
+    expect(result.channels).toEqual(["R", "G", "B", "V"]);
     expect(result.spreads.onAxis?.axis).toBe("onAxis");
     expect(result.spreads.offAxis?.axis).toBe("offAxis");
     expect(result.spreads.onAxis?.lcaMm).toBeGreaterThan(0);

--- a/__tests__/src/optics/analysis/chromatic.test.ts
+++ b/__tests__/src/optics/analysis/chromatic.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { buildChromaticPositiveElementLens } from "../testLensFixtures.js";
+import {
+  computeChromaticAnalysis2,
+  computeChromaticAnalysisForState2,
+  computeChromaticRayTraceAnalysis2,
+  computeLateralColorCurve2,
+  computeLongitudinalChromaticFocus2,
+  prepareRuntimeState,
+  summarizeChromaticFieldFocus2,
+} from "../../../../src/optics/compat.js";
+import { doLayout } from "../../../../src/optics/optics.js";
+import type { FieldCurvatureFieldResult, FieldCurvatureResult } from "../../../../src/optics/aberrationAnalysis.js";
+
+function chromaticFixture() {
+  const L = buildChromaticPositiveElementLens();
+  const { z } = doLayout(0, 0, L);
+  return { L, z, currentEPSD: L.EP.epSD, currentPhysStopSD: L.stopPhysSD };
+}
+
+describe("chromatic analysis helpers", () => {
+  it("computes axis-split ray-trace spreads for analysis callers", () => {
+    const { L, z, currentEPSD, currentPhysStopSD } = chromaticFixture();
+
+    const result = computeChromaticRayTraceAnalysis2(L, z, 0, 0, currentEPSD, currentPhysStopSD);
+
+    expect(result.spreads.onAxis?.axis).toBe("onAxis");
+    expect(result.spreads.offAxis?.axis).toBe("offAxis");
+    expect(result.spreads.onAxis?.lcaMm).toBeGreaterThan(0);
+    expect(result.spreads.offAxis?.tcaMm).toBeGreaterThanOrEqual(0);
+    expect(result.onAxisAttemptedRayCount).toBeGreaterThanOrEqual(3);
+    expect(result.offAxisAttemptedRayCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("computes longitudinal chromatic focus from the outermost usable marginal ray", () => {
+    const { L, z, currentEPSD, currentPhysStopSD } = chromaticFixture();
+
+    const result = computeLongitudinalChromaticFocus2(L, z, 0, 0, currentEPSD, currentPhysStopSD);
+
+    expect(result).not.toBeNull();
+    expect(result?.channels).toEqual(["R", "G", "B", "V"]);
+    expect(result?.referenceChannel).toBe("G");
+    expect(result?.spread.axis).toBe("onAxis");
+    expect(result?.spread.channels).toEqual(["R", "G", "B", "V"]);
+    expect(result?.longitudinalSpreadMm).toBeGreaterThan(0);
+    expect(result?.transverseSpreadMm).toBeGreaterThanOrEqual(0);
+    expect(result?.validChannelCount).toBeGreaterThanOrEqual(2);
+    expect(result?.samples.find((sample) => sample.channel === "G")?.relativeFocusShiftMm).toBeCloseTo(0);
+  });
+
+  it("computes lateral color as chief-ray image-height spread across fields", () => {
+    const { L, z, currentEPSD, currentPhysStopSD } = chromaticFixture();
+
+    const result = computeLateralColorCurve2(L, z, 0, 0, currentEPSD, currentPhysStopSD, 0, undefined, {
+      channels: ["R", "G", "B"],
+      fieldFractions: [0, 0.5, 1],
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.channels).toEqual(["R", "G", "B"]);
+    expect(result?.referenceChannel).toBe("G");
+    expect(result?.fields).toHaveLength(3);
+    expect(result?.fields[0].fieldFraction).toBe(0);
+    expect(result?.fields.some((field) => field.usable)).toBe(true);
+    expect(result?.maxLateralSpreadMm).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns null chromatic sections when fewer than two channels are selected", () => {
+    const { L, z, currentEPSD, currentPhysStopSD } = chromaticFixture();
+
+    const result = computeChromaticAnalysis2(L, z, 0, 0, currentEPSD, currentPhysStopSD, 0, undefined, {
+      channels: ["R"],
+    });
+
+    expect(result.longitudinalFocus).toBeNull();
+    expect(result.lateralColor).toBeNull();
+  });
+
+  it("matches the prepared-state chromatic analysis adapter", () => {
+    const { L, z, currentEPSD, currentPhysStopSD } = chromaticFixture();
+    const state = prepareRuntimeState(L, 0, 0);
+
+    expect(computeChromaticAnalysisForState2(state, currentEPSD, currentPhysStopSD)).toEqual(
+      computeChromaticAnalysis2(L, z, 0, 0, currentEPSD, currentPhysStopSD),
+    );
+  });
+
+  it("summarizes chromatic field-focus spread from existing field-curvature data", () => {
+    const field = (
+      fieldFraction: number,
+      shifts: FieldCurvatureFieldResult["chromaticFieldShifts"],
+    ): FieldCurvatureFieldResult =>
+      ({
+        fieldFraction,
+        label: `${fieldFraction * 100}%`,
+        fieldAngleDeg: fieldFraction * 20,
+        chromaticFieldShifts: shifts,
+        usable: true,
+      }) as FieldCurvatureFieldResult;
+    const result = {
+      fields: [
+        field(0, null),
+        field(1, [
+          { channel: "R", tangentialShiftMm: -0.05, sagittalShiftMm: -0.05 },
+          { channel: "G", tangentialShiftMm: 0, sagittalShiftMm: 0 },
+          { channel: "B", tangentialShiftMm: 0.1, sagittalShiftMm: 0.15 },
+        ]),
+      ],
+      curveFields: [
+        field(0.5, [
+          { channel: "R", tangentialShiftMm: -0.1, sagittalShiftMm: -0.05 },
+          { channel: "G", tangentialShiftMm: 0, sagittalShiftMm: 0.05 },
+          { channel: "B", tangentialShiftMm: 0.2, sagittalShiftMm: 0.4 },
+        ]),
+      ],
+    } as FieldCurvatureResult;
+
+    const summary = summarizeChromaticFieldFocus2(result);
+
+    expect(summary?.source).toBe("curve");
+    expect(summary?.maxTangentialSpreadMm).toBeCloseTo(0.3);
+    expect(summary?.maxSagittalSpreadMm).toBeCloseTo(0.45);
+    expect(summary?.maxFocusFieldFraction).toBe(0.5);
+    expect(summary?.edgeFocusSpreadMm).toBeCloseTo(0.2);
+  });
+});

--- a/__tests__/src/optics/analysisContext.test.ts
+++ b/__tests__/src/optics/analysisContext.test.ts
@@ -8,6 +8,7 @@ import {
   prepareRuntimeState,
 } from "../../../src/optics/compat.js";
 import { computeAnalysisFieldGeometryAtState, eflAtFocus, epAtZoom, fopenAtZoom } from "../../../src/optics/optics.js";
+import { buildChromaticPositiveElementLens } from "./testLensFixtures.js";
 import type { LensData } from "../../../src/types/optics.js";
 
 function build(raw: object) {
@@ -61,6 +62,11 @@ describe("analysis computation context", () => {
     expect(context.computeChromaticAnalysis()).toEqual(
       analysisJobsForState2.computeChromaticAnalysis(state, currentEPSD, currentPhysStopSD, fieldGeometry),
     );
+    expect(context.computeChromaticRayTraceAnalysis()).toEqual(
+      analysisJobsForState2.computeChromaticRayTraceAnalysis(state, currentEPSD, currentPhysStopSD, fieldGeometry, {
+        channels: ["R", "G", "B", "V"],
+      }),
+    );
     expect(context.computeBestFocusZ()).toEqual(
       analysisJobsForState2.computeBestFocusZ(state, currentEPSD, currentPhysStopSD),
     );
@@ -91,7 +97,34 @@ describe("analysis computation context", () => {
     expect(context.computeSphericalAberrationBlurCharacter()).toBe(context.computeSphericalAberrationBlurCharacter());
     expect(context.computeBokehPreviewPair()).toBe(context.computeBokehPreviewPair());
     expect(context.computeChromaticAnalysis()).toBe(context.computeChromaticAnalysis());
+    expect(context.computeChromaticRayTraceAnalysis()).toBe(context.computeChromaticRayTraceAnalysis());
     expect(context.computeFieldCurvatureBundle()).toBe(context.computeFieldCurvatureBundle());
+  });
+
+  it("applies interactive chromatic sampling through the cached context", () => {
+    const L = buildChromaticPositiveElementLens("analysis-context-chromatic-sampling");
+    const focusT = 0;
+    const zoomT = 0;
+    const state = prepareRuntimeState(L, focusT, zoomT);
+    const dynamicEFL = eflAtFocus(focusT, zoomT, L);
+    const { currentEPSD, currentPhysStopSD } = apertureAt(L, zoomT);
+    const context = createAnalysisComputationContext({
+      preparedState: state,
+      dynamicEFL,
+      currentEPSD,
+      currentPhysStopSD,
+      sampling: {
+        chromaticLongitudinalFractions: [0.95],
+        chromaticLateralFieldFractions: [0, 1],
+        chromaticRayTraceOnAxisFractions: [0.95],
+        chromaticRayTraceOffAxisFractions: [0.5],
+      },
+    });
+
+    expect(context.computeChromaticAnalysis().longitudinalFocus?.marginalFraction).toBe(0.95);
+    expect(context.computeChromaticAnalysis().lateralColor?.fieldFractions).toEqual([0, 1]);
+    expect(context.computeChromaticRayTraceAnalysis().onAxisAttemptedRayCount).toBeLessThanOrEqual(4);
+    expect(context.computeChromaticRayTraceAnalysis().offAxisAttemptedRayCount).toBeLessThanOrEqual(4);
   });
 
   it("normalizes null field geometry to undefined for job calls", () => {

--- a/__tests__/src/optics/analysisContext.test.ts
+++ b/__tests__/src/optics/analysisContext.test.ts
@@ -114,14 +114,14 @@ describe("analysis computation context", () => {
       currentEPSD,
       currentPhysStopSD,
       sampling: {
-        chromaticLongitudinalFractions: [0.95],
+        chromaticLongitudinalFractions: [0.5],
         chromaticLateralFieldFractions: [0, 1],
-        chromaticRayTraceOnAxisFractions: [0.95],
+        chromaticRayTraceOnAxisFractions: [0.5],
         chromaticRayTraceOffAxisFractions: [0.5],
       },
     });
 
-    expect(context.computeChromaticAnalysis().longitudinalFocus?.marginalFraction).toBe(0.95);
+    expect(context.computeChromaticAnalysis().longitudinalFocus?.marginalFraction).toBe(0.5);
     expect(context.computeChromaticAnalysis().lateralColor?.fieldFractions).toEqual([0, 1]);
     expect(context.computeChromaticRayTraceAnalysis().onAxisAttemptedRayCount).toBeLessThanOrEqual(4);
     expect(context.computeChromaticRayTraceAnalysis().offAxisAttemptedRayCount).toBeLessThanOrEqual(4);

--- a/__tests__/src/optics/analysisContext.test.ts
+++ b/__tests__/src/optics/analysisContext.test.ts
@@ -58,6 +58,9 @@ describe("analysis computation context", () => {
     expect(context.computeBokehPreviewPair()).toEqual(
       analysisJobsForState2.computeBokehPreviewPair(state, currentEPSD, currentPhysStopSD),
     );
+    expect(context.computeChromaticAnalysis()).toEqual(
+      analysisJobsForState2.computeChromaticAnalysis(state, currentEPSD, currentPhysStopSD, fieldGeometry),
+    );
     expect(context.computeBestFocusZ()).toEqual(
       analysisJobsForState2.computeBestFocusZ(state, currentEPSD, currentPhysStopSD),
     );
@@ -87,6 +90,7 @@ describe("analysis computation context", () => {
     expect(context.computeSphericalAberration()).toBe(context.computeSphericalAberration());
     expect(context.computeSphericalAberrationBlurCharacter()).toBe(context.computeSphericalAberrationBlurCharacter());
     expect(context.computeBokehPreviewPair()).toBe(context.computeBokehPreviewPair());
+    expect(context.computeChromaticAnalysis()).toBe(context.computeChromaticAnalysis());
     expect(context.computeFieldCurvatureBundle()).toBe(context.computeFieldCurvatureBundle());
   });
 

--- a/__tests__/src/optics/analysisJobs.test.ts
+++ b/__tests__/src/optics/analysisJobs.test.ts
@@ -62,9 +62,9 @@ describe("analysis job facade", () => {
     const state = prepareRuntimeState(L, focusT, zoomT);
     const { currentEPSD, currentPhysStopSD } = apertureAt(L, zoomT);
     const sampling = {
-      chromaticLongitudinalFractions: [0.95],
+      chromaticLongitudinalFractions: [0.5],
       chromaticLateralFieldFractions: [0, 1],
-      chromaticRayTraceOnAxisFractions: [0.95],
+      chromaticRayTraceOnAxisFractions: [0.5],
       chromaticRayTraceOffAxisFractions: [0.5],
     };
 
@@ -87,7 +87,7 @@ describe("analysis job facade", () => {
       },
     );
 
-    expect(analysis.longitudinalFocus?.marginalFraction).toBe(0.95);
+    expect(analysis.longitudinalFocus?.marginalFraction).toBe(0.5);
     expect(analysis.lateralColor?.fieldFractions).toEqual([0, 1]);
     expect(rayTrace.channels).toEqual(["R", "G", "B", "V"]);
     expect(rayTrace.onAxisAttemptedRayCount).toBeLessThanOrEqual(4);

--- a/__tests__/src/optics/analysisJobs.test.ts
+++ b/__tests__/src/optics/analysisJobs.test.ts
@@ -46,6 +46,12 @@ describe("analysis job facade", () => {
     expect(analysisJobsForState2.computeFieldCurvatureBundle(state, currentEPSD, currentPhysStopSD)).toEqual(
       analysisJobs2.computeFieldCurvatureBundle(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD),
     );
+    expect(analysisJobsForState2.computeChromaticRayTraceAnalysis(state, currentEPSD, currentPhysStopSD)).toEqual(
+      analysisJobs2.computeChromaticRayTraceAnalysis(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD),
+    );
+    expect(analysisJobsForState2.computeChromaticAnalysis(state, currentEPSD, currentPhysStopSD)).toEqual(
+      analysisJobs2.computeChromaticAnalysis(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD),
+    );
   });
 
   it("exposes bokeh and pupil work through the same prepared-state facade", () => {

--- a/__tests__/src/optics/analysisJobs.test.ts
+++ b/__tests__/src/optics/analysisJobs.test.ts
@@ -5,6 +5,7 @@ import buildLens from "../../../src/optics/buildLens.js";
 import { analysisJobs2, analysisJobsForState2, prepareRuntimeState } from "../../../src/optics/compat.js";
 import { eflAtFocus, epAtZoom, fopenAtZoom } from "../../../src/optics/optics.js";
 import { zPosForPreparedAnalysis2 } from "../../../src/optics/analysis/preparedStateAdapters.js";
+import { buildChromaticPositiveElementLens } from "./testLensFixtures.js";
 import type { LensData } from "../../../src/types/optics.js";
 
 function build(raw: object) {
@@ -52,6 +53,45 @@ describe("analysis job facade", () => {
     expect(analysisJobsForState2.computeChromaticAnalysis(state, currentEPSD, currentPhysStopSD)).toEqual(
       analysisJobs2.computeChromaticAnalysis(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD),
     );
+  });
+
+  it("applies reduced chromatic sampling through the job facade", () => {
+    const L = buildChromaticPositiveElementLens("analysis-jobs-chromatic-sampling");
+    const focusT = 0;
+    const zoomT = 0;
+    const state = prepareRuntimeState(L, focusT, zoomT);
+    const { currentEPSD, currentPhysStopSD } = apertureAt(L, zoomT);
+    const sampling = {
+      chromaticLongitudinalFractions: [0.95],
+      chromaticLateralFieldFractions: [0, 1],
+      chromaticRayTraceOnAxisFractions: [0.95],
+      chromaticRayTraceOffAxisFractions: [0.5],
+    };
+
+    const analysis = analysisJobsForState2.computeChromaticAnalysis(
+      state,
+      currentEPSD,
+      currentPhysStopSD,
+      undefined,
+      sampling,
+    );
+    const rayTrace = analysisJobsForState2.computeChromaticRayTraceAnalysis(
+      state,
+      currentEPSD,
+      currentPhysStopSD,
+      undefined,
+      {
+        channels: ["R", "G", "B", "V"],
+        onAxisFractions: sampling.chromaticRayTraceOnAxisFractions,
+        offAxisFractions: sampling.chromaticRayTraceOffAxisFractions,
+      },
+    );
+
+    expect(analysis.longitudinalFocus?.marginalFraction).toBe(0.95);
+    expect(analysis.lateralColor?.fieldFractions).toEqual([0, 1]);
+    expect(rayTrace.channels).toEqual(["R", "G", "B", "V"]);
+    expect(rayTrace.onAxisAttemptedRayCount).toBeLessThanOrEqual(4);
+    expect(rayTrace.offAxisAttemptedRayCount).toBeLessThanOrEqual(4);
   });
 
   it("exposes bokeh and pupil work through the same prepared-state facade", () => {

--- a/__tests__/src/optics/analysisJobs.test.ts
+++ b/__tests__/src/optics/analysisJobs.test.ts
@@ -88,7 +88,9 @@ describe("analysis job facade", () => {
     );
 
     expect(analysis.longitudinalFocus?.marginalFraction).toBe(0.5);
+    expect(analysis.longitudinalFocus?.channels).toEqual(["R", "G", "B", "V"]);
     expect(analysis.lateralColor?.fieldFractions).toEqual([0, 1]);
+    expect(analysis.lateralColor?.channels).toEqual(["R", "G", "B", "V"]);
     expect(rayTrace.channels).toEqual(["R", "G", "B", "V"]);
     expect(rayTrace.onAxisAttemptedRayCount).toBeLessThanOrEqual(4);
     expect(rayTrace.offAxisAttemptedRayCount).toBeLessThanOrEqual(4);

--- a/__tests__/src/optics/analysisQuality.test.ts
+++ b/__tests__/src/optics/analysisQuality.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+  INTERACTIVE_ANALYSIS_SAMPLING,
+  analysisSamplingForQuality,
+} from "../../../src/optics/analysis/analysisQuality.js";
+
+describe("analysis quality sampling", () => {
+  it("adds reduced chromatic sampling for interactive drawer updates", () => {
+    expect(analysisSamplingForQuality("settled")).toBeUndefined();
+    expect(analysisSamplingForQuality("interactive")).toBe(INTERACTIVE_ANALYSIS_SAMPLING);
+
+    expect(INTERACTIVE_ANALYSIS_SAMPLING.chromaticLongitudinalFractions).toEqual([0.95, 0.85, 0.75]);
+    expect(INTERACTIVE_ANALYSIS_SAMPLING.chromaticLateralFieldFractions).toEqual([0, 0.5, 1]);
+    expect(INTERACTIVE_ANALYSIS_SAMPLING.chromaticRayTraceOnAxisFractions).toEqual([0.95, 0.85]);
+    expect(INTERACTIVE_ANALYSIS_SAMPLING.chromaticRayTraceOffAxisFractions).toEqual([0.75, -0.75, 0.5, -0.5]);
+  });
+});

--- a/__tests__/src/optics/chromatic/analysis.test.ts
+++ b/__tests__/src/optics/chromatic/analysis.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import LENS_DEFAULTS from "../../../../src/lens-data/defaults.js";
+import Sonnar50f15Raw from "../../../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.js";
+import ApoLantharRaw from "../../../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.js";
+import buildLens from "../../../../src/optics/buildLens.js";
+import {
+  computeChromaticAnalysis,
+  computeLateralColorCurve,
+  computeLongitudinalChromaticFocus,
+} from "../../../../src/optics/chromatic/analysis.js";
+import { doLayout, epAtZoom, fopenAtZoom } from "../../../../src/optics/optics.js";
+import type { LensData, RuntimeLens } from "../../../../src/types/optics.js";
+
+function build(raw: object): RuntimeLens {
+  return buildLens({ ...LENS_DEFAULTS, ...raw } as LensData);
+}
+
+function apertureAt(L: RuntimeLens, zoomT: number, stopdownT = 0) {
+  const currentFOPEN = fopenAtZoom(zoomT, L);
+  const rawFNumber = L.FOPEN * Math.pow(L.maxFstop / L.FOPEN, stopdownT);
+  const fNumber = Math.max(rawFNumber, currentFOPEN);
+  return {
+    currentPhysStopSD: (L.stopPhysSD * L.FOPEN) / fNumber,
+    currentEPSD: (epAtZoom(zoomT, L) * L.FOPEN) / fNumber,
+  };
+}
+
+function finiteSpan(values: number[]): number {
+  return Math.max(...values) - Math.min(...values);
+}
+
+describe("chromatic analysis helpers", () => {
+  it("computes longitudinal focus shifts from the outermost usable marginal chromatic ray", () => {
+    const L = build(ApoLantharRaw);
+    const focusT = 0;
+    const zoomT = 0;
+    const { z: zPos } = doLayout(focusT, zoomT, L);
+    const { currentEPSD, currentPhysStopSD } = apertureAt(L, zoomT);
+
+    const result = computeLongitudinalChromaticFocus(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, 0, {
+      channels: ["R", "G", "B", "V"],
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.referenceChannel).toBe("G");
+    expect(result!.channels).toEqual(["R", "G", "B", "V"]);
+    expect(result!.validChannelCount).toBeGreaterThanOrEqual(2);
+    expect(result!.marginalFraction).toBeGreaterThan(0);
+    expect(result!.spread.axis).toBe("onAxis");
+    expect(result!.spread.fraction).toBe(result!.marginalFraction);
+    expect(result!.longitudinalSpreadUm).toBeCloseTo(result!.longitudinalSpreadMm * 1000, 9);
+
+    const focusValues = result!.samples
+      .map((sample) => sample.focusZ)
+      .filter((focusZ): focusZ is number => focusZ !== null);
+    expect(result!.longitudinalSpreadMm).toBeCloseTo(finiteSpan(focusValues), 9);
+    for (const sample of result!.samples.filter((sample) => sample.usable)) {
+      expect(sample.focusShiftMm).toBeCloseTo(sample.focusZ! - result!.imagePlaneZ, 9);
+    }
+  });
+
+  it("computes lateral color as chromatic chief-ray image-height spread across field", () => {
+    const L = build(Sonnar50f15Raw);
+    const focusT = 0;
+    const zoomT = 0;
+    const { z: zPos } = doLayout(focusT, zoomT, L);
+    const { currentEPSD, currentPhysStopSD } = apertureAt(L, zoomT, 0.25);
+
+    const result = computeLateralColorCurve(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, 0, undefined, {
+      channels: ["R", "G", "B"],
+      fieldFractions: [0, 0.5, 1],
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.channels).toEqual(["R", "G", "B"]);
+    expect(result!.fields).toHaveLength(3);
+    expect(result!.usableFieldCount).toBeGreaterThan(0);
+    expect(result!.maxLateralSpreadUm).toBeCloseTo(result!.maxLateralSpreadMm * 1000, 9);
+
+    const usableField = result!.fields.find((field) => field.usable);
+    expect(usableField).toBeTruthy();
+    const imageHeights = usableField!.samples
+      .map((sample) => sample.imageHeightMm)
+      .filter((height): height is number => height !== null);
+    expect(usableField!.lateralSpreadMm).toBeCloseTo(finiteSpan(imageHeights), 9);
+    expect(usableField!.samples.find((sample) => sample.channel === "G")?.relativeHeightMm).toBeCloseTo(0, 9);
+  });
+
+  it("returns combined chromatic analysis with nullable sections instead of throwing on insufficient channels", () => {
+    const L = build(Sonnar50f15Raw);
+    const focusT = 0;
+    const zoomT = 0;
+    const { z: zPos } = doLayout(focusT, zoomT, L);
+    const { currentEPSD, currentPhysStopSD } = apertureAt(L, zoomT, 0.25);
+
+    const full = computeChromaticAnalysis(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, 0, undefined, {
+      channels: ["R", "G", "B"],
+      fieldFractions: [0, 1],
+    });
+    expect(full.longitudinalFocus).not.toBeNull();
+    expect(full.lateralColor).not.toBeNull();
+
+    const oneChannel = computeChromaticAnalysis(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, 0, undefined, {
+      channels: ["G"],
+    });
+    expect(oneChannel.longitudinalFocus).toBeNull();
+    expect(oneChannel.lateralColor).toBeNull();
+  });
+});

--- a/__tests__/src/optics/chromatic/channels.test.ts
+++ b/__tests__/src/optics/chromatic/channels.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHROMATIC_CHANNEL_METADATA,
+  CHROMATIC_CHANNEL_ORDER,
+  chromaticChannelIndexLabel,
+  chromaticChannelWavelengthLabel,
+} from "../../../../src/optics/chromatic/channels.js";
+
+describe("chromatic channel metadata", () => {
+  it("keeps the public channel order and spectral-line labels stable", () => {
+    expect(CHROMATIC_CHANNEL_ORDER).toEqual(["R", "G", "B", "V"]);
+    expect(chromaticChannelWavelengthLabel("R")).toBe("C-line 656.3 nm");
+    expect(chromaticChannelWavelengthLabel("G")).toBe("d-line 587.6 nm");
+    expect(chromaticChannelWavelengthLabel("B")).toBe("F-line 486.1 nm");
+    expect(chromaticChannelWavelengthLabel("V")).toBe("g-line 435.8 nm");
+  });
+
+  it("maps display channels to index labels used by inspector readouts", () => {
+    expect(chromaticChannelIndexLabel("R")).toBe("nC");
+    expect(chromaticChannelIndexLabel("G")).toBe("nd");
+    expect(chromaticChannelIndexLabel("B")).toBe("nF");
+    expect(chromaticChannelIndexLabel("V")).toBe("ng");
+    expect(CHROMATIC_CHANNEL_METADATA.V.description).toContain("secondary-spectrum");
+  });
+});

--- a/__tests__/src/utils/state/lensReducer.test.ts
+++ b/__tests__/src/utils/state/lensReducer.test.ts
@@ -478,6 +478,11 @@ describe("lensReducer", () => {
       const next = lensReducer(state, { type: SET_ANALYSIS_TAB, tab: "summary" });
       expect(next.panels.analysisDrawerTab).toBe("summary");
     });
+
+    it("accepts the chromatic analysis tab", () => {
+      const next = lensReducer(state, { type: SET_ANALYSIS_TAB, tab: "chromatic" });
+      expect(next.panels.analysisDrawerTab).toBe("chromatic");
+    });
   });
 
   describe("SET_GROUP_MOVEMENT", () => {

--- a/__tests__/src/utils/state/lensViewUrlState.test.ts
+++ b/__tests__/src/utils/state/lensViewUrlState.test.ts
@@ -81,6 +81,15 @@ describe("lensViewUrlState", () => {
     expect(params.toString()).toBe("v=1&ad=1&tab=summary");
   });
 
+  it("round-trips the chromatic analysis tab", () => {
+    const parsed = parseLensViewQuery("?v=1&ad=1&tab=chromatic");
+    expect(parsed.analysisDrawerOpen).toBe(true);
+    expect(parsed.analysisDrawerTab).toBe("chromatic");
+
+    const params = buildLensViewQuery({ analysisDrawerOpen: true, analysisDrawerTab: "chromatic" });
+    expect(params.toString()).toBe("v=1&ad=1&tab=chromatic");
+  });
+
   it("builds minimal comparison query params", () => {
     const params = buildLensViewQuery({
       comparing: true,

--- a/__tests__/src/utils/state/preferences.test.ts
+++ b/__tests__/src/utils/state/preferences.test.ts
@@ -184,6 +184,9 @@ describe("loadPrefs", () => {
   it("loads analysisDrawerTab preference", () => {
     mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ analysisDrawerTab: "summary" }));
     expect(loadPrefs().analysisDrawerTab).toBe("summary");
+
+    mockLocalStorage.setItem(PREFS_KEY, JSON.stringify({ analysisDrawerTab: "chromatic" }));
+    expect(loadPrefs().analysisDrawerTab).toBe("chromatic");
   });
 
   it("ignores non-string analysisDrawerTab", () => {

--- a/agent_docs/benchmarks/README.md
+++ b/agent_docs/benchmarks/README.md
@@ -44,7 +44,7 @@ instead of creating another benchmark record.
 
 ## Coverage
 
-The benchmark suite currently measures 12 representative lenses across three scenarios:
+The benchmark suite currently measures 14 representative lenses across four scenarios:
 
 - simple classic prime
 - Voigtlander APO-Lanthar 50mm f/2
@@ -56,7 +56,9 @@ The benchmark suite currently measures 12 representative lenses across three sce
 - fisheye/projection path
 - large-format wide zoom
 - fully Sellmeier-covered complex APO zoom
+- Sigma APO Macro 180mm f/2.8 and 150mm f/2.8 heavy macro lenses
 - folded mirror/reference path
+- an `interactive-drag` scenario that uses reduced analysis sampling to represent slider-drag responsiveness
 
 Each run records:
 

--- a/src/benchmarks/opticsRenderingBenchmark.tsx
+++ b/src/benchmarks/opticsRenderingBenchmark.tsx
@@ -1187,7 +1187,10 @@ function spreadForAxis(
         marginalRays[ray.channel] = { y: ray.y, u: ray.u, clipped: false };
       }
     }
-    if (Object.keys(marginalRays).length >= 2) return computeChromaticSpread(marginalRays, IMG_MM, lastSurfaceZ);
+    const channels = Object.keys(marginalRays) as ChromaticChannel[];
+    if (channels.length >= 2) {
+      return { ...computeChromaticSpread(marginalRays, IMG_MM, lastSurfaceZ), axis, fraction, channels };
+    }
   }
 
   return null;

--- a/src/benchmarks/opticsRenderingBenchmark.tsx
+++ b/src/benchmarks/opticsRenderingBenchmark.tsx
@@ -44,6 +44,11 @@ import {
 import { computeCardinalElementsAtState } from "../optics/cardinalElements.js";
 import { computeElementShapes, createCoordinateTransforms } from "../optics/diagramGeometry.js";
 import { obstructionAwareRayFractionsForDensity } from "../optics/raySampling.js";
+import {
+  analysisSamplingForQuality,
+  type AnalysisQuality,
+  type AnalysisSamplingOptions,
+} from "../optics/analysis/analysisQuality.js";
 import { resetPerfProbe } from "../utils/perfProbe.js";
 import { LENS_CATALOG } from "../utils/catalog/lensCatalog.js";
 import themes from "../utils/theme/themes.js";
@@ -91,6 +96,8 @@ const DEFAULT_LENS_KEYS = [
   "canon-ef-8-15mm-f4l-fisheye-usm",
   "fujifilm-gf-20-35mm-f4-r-wr",
   "leica-apo-vario-elmarit-sl-90-280-f28-4",
+  "sigma-apo-macro-180mm-f28-os-hsm",
+  "sigma-apo-macro-150mm-f28-os-hsm",
   "reference-maksutov-cassegrain-meniscus",
 ] as const;
 
@@ -113,6 +120,7 @@ const SCENARIOS = [
     showOnAxis: true,
     showOffAxis: "trueAngle" as OffAxisMode,
     showChromatic: false,
+    analysisQuality: "settled" as AnalysisQuality,
   },
   {
     id: "stopped-close",
@@ -125,6 +133,7 @@ const SCENARIOS = [
     showOnAxis: true,
     showOffAxis: "trueAngle" as OffAxisMode,
     showChromatic: false,
+    analysisQuality: "settled" as AnalysisQuality,
   },
   {
     id: "tele-dense-chromatic",
@@ -137,6 +146,20 @@ const SCENARIOS = [
     showOnAxis: true,
     showOffAxis: "trueAngle" as OffAxisMode,
     showChromatic: true,
+    analysisQuality: "settled" as AnalysisQuality,
+  },
+  {
+    id: "interactive-drag",
+    focusT: 0.63,
+    zoomT: 0.75,
+    aberrationT: 0,
+    stopdownT: 0.2,
+    rayDensity: "dense" as RayDensity,
+    rayTracksF: false,
+    showOnAxis: true,
+    showOffAxis: "trueAngle" as OffAxisMode,
+    showChromatic: true,
+    analysisQuality: "interactive" as AnalysisQuality,
   },
 ] as const;
 
@@ -196,6 +219,7 @@ interface ScenarioSnapshot {
   fieldGeometry: FieldGeometryState | null;
   preparedState: PreparedOpticalState;
   analysisContext: AnalysisComputationContext;
+  analysisSampling?: AnalysisSamplingOptions;
 }
 
 /** Counts returned from ray work measurement. */
@@ -332,7 +356,7 @@ function measureMainScenario(
       };
     }),
     rays: measure("rays", () => computeRayWork(snapshot).output),
-    analysis: measure("analysis", () => computeAnalysisWork(snapshot)),
+    analysis: measure("analysis", () => computeAnalysisWork(buildScenarioSnapshot(L, scenario))),
     analysisBreakdown: measureAnalysisBreakdown(lensKey, scenario, snapshot, options),
     svgRender: measure("svgRender", () => renderDiagram(snapshot, rayWork)),
     totalCold: measure("totalCold", () => {
@@ -347,11 +371,12 @@ function measureMainScenario(
       };
     }),
     totalWarm: measure("totalWarm", () => {
-      const nextRayWork = computeRayWork(snapshot);
-      computeAnalysisWork(snapshot);
-      renderDiagram(snapshot, nextRayWork);
+      const nextSnapshot = buildScenarioSnapshot(L, scenario);
+      const nextRayWork = computeRayWork(nextSnapshot);
+      computeAnalysisWork(nextSnapshot);
+      renderDiagram(nextSnapshot, nextRayWork);
       return {
-        surfaces: snapshot.L.N,
+        surfaces: nextSnapshot.L.N,
         rays: nextRayWork.output.onAxisRays + nextRayWork.output.offAxisRays + nextRayWork.output.chromaticRays,
       };
     }),
@@ -401,12 +426,14 @@ function buildScenarioSnapshot(L: RuntimeLens, scenario: ScenarioConfig): Scenar
   computeCardinalElementsAtState(L, focusT, zoomT, zPos, IMG_MM, aberrationT);
 
   const preparedState = prepareRuntimeState(L, focusT, zoomT, aberrationT);
+  const analysisSampling = analysisSamplingForQuality(scenario.analysisQuality ?? "settled");
   const analysisContext = createAnalysisComputationContext({
     preparedState,
     dynamicEFL,
     currentEPSD,
     currentPhysStopSD,
     fieldGeometry,
+    sampling: analysisSampling,
   });
 
   return {
@@ -432,6 +459,7 @@ function buildScenarioSnapshot(L: RuntimeLens, scenario: ScenarioConfig): Scenar
     fieldGeometry,
     preparedState,
     analysisContext,
+    analysisSampling,
   };
 }
 
@@ -669,6 +697,7 @@ function computeAnalysisDistortionCurveWork(snapshot: ScenarioSnapshot): Benchma
     snapshot.dynamicEFL,
     snapshot.currentPhysStopSD,
     snapshot.fieldGeometry ?? undefined,
+    snapshot.analysisSampling,
   );
   return { distortionSamples: samples.length };
 }
@@ -679,6 +708,7 @@ function computeAnalysisDistortionGridWork(snapshot: ScenarioSnapshot): Benchmar
     snapshot.preparedState,
     snapshot.currentPhysStopSD,
     snapshot.fieldGeometry ?? undefined,
+    snapshot.analysisSampling,
   );
   return { distortionGridLines: grid.lines.length };
 }
@@ -690,6 +720,7 @@ function computeAnalysisVignettingWork(snapshot: ScenarioSnapshot): BenchmarkOut
     snapshot.currentEPSD,
     snapshot.currentPhysStopSD,
     snapshot.fieldGeometry ?? undefined,
+    snapshot.analysisSampling,
   );
   return { vignettingSamples: samples.length };
 }
@@ -698,7 +729,7 @@ function computeAnalysisVignettingWork(snapshot: ScenarioSnapshot): BenchmarkOut
 function computeAnalysisPupilsWork(snapshot: ScenarioSnapshot): BenchmarkOutput {
   const pupilProfiles = analysisJobsForState2.computeBothPupilAberrationProfiles(
     snapshot.preparedState,
-    undefined,
+    snapshot.analysisSampling?.pupilAberrationSampleCount ?? undefined,
     snapshot.fieldGeometry ?? undefined,
   );
   return { pupilSamples: pupilProfiles.ep.samples.length + pupilProfiles.xp.samples.length };
@@ -710,6 +741,7 @@ function computeAnalysisBokehPairWork(snapshot: ScenarioSnapshot): BenchmarkOutp
     snapshot.preparedState,
     snapshot.currentEPSD,
     snapshot.currentPhysStopSD,
+    snapshot.analysisSampling,
   );
   return {
     bokehInfinityFields: bokehPair.infinity?.fields.length ?? 0,
@@ -774,6 +806,7 @@ function measureAberrationPanels(
       snapshot.currentEPSD,
       snapshot.currentPhysStopSD,
       base,
+      snapshot.analysisSampling,
     );
     return describeComputationOutput(result);
   });
@@ -791,6 +824,7 @@ function measureAberrationPanels(
           snapshot.currentPhysStopSD,
           false,
           snapshot.fieldGeometry ?? undefined,
+          snapshot.analysisSampling,
         ),
       ),
     );
@@ -802,6 +836,7 @@ function measureAberrationPanels(
           snapshot.currentPhysStopSD,
           true,
           snapshot.fieldGeometry ?? undefined,
+          snapshot.analysisSampling,
         ),
       ),
     );
@@ -812,6 +847,7 @@ function measureAberrationPanels(
           snapshot.currentEPSD,
           snapshot.currentPhysStopSD,
           snapshot.fieldGeometry ?? undefined,
+          snapshot.analysisSampling,
         ),
       ),
     );
@@ -822,6 +858,7 @@ function measureAberrationPanels(
           snapshot.currentEPSD,
           snapshot.currentPhysStopSD,
           snapshot.fieldGeometry ?? undefined,
+          snapshot.analysisSampling,
         ),
       ),
     );
@@ -876,6 +913,7 @@ function computeAberrationDataValues(snapshot: ScenarioSnapshot): AberrationData
     snapshot.currentEPSD,
     snapshot.currentPhysStopSD,
     sphericalAberration,
+    snapshot.analysisSampling,
   );
   if (snapshot.L.isFoldedOptics) {
     return { sphericalAberration, saProfile, saBlurCharacter };
@@ -885,6 +923,7 @@ function computeAberrationDataValues(snapshot: ScenarioSnapshot): AberrationData
     snapshot.currentEPSD,
     snapshot.currentPhysStopSD,
     snapshot.fieldGeometry ?? undefined,
+    snapshot.analysisSampling,
   );
   const fieldCurvature = fieldCurvatureBundle.fieldCurvature;
   const chromaticFieldCurvature = fieldCurvatureBundle.chromaticFieldCurvature;
@@ -893,6 +932,7 @@ function computeAberrationDataValues(snapshot: ScenarioSnapshot): AberrationData
     snapshot.currentEPSD,
     snapshot.currentPhysStopSD,
     snapshot.fieldGeometry ?? undefined,
+    snapshot.analysisSampling,
   );
   return { sphericalAberration, saProfile, saBlurCharacter, fieldCurvature, chromaticFieldCurvature, coma };
 }

--- a/src/components/controls/ChromaticControls.tsx
+++ b/src/components/controls/ChromaticControls.tsx
@@ -5,6 +5,8 @@
  * individual R/G/B channel buttons for selective wavelength display.
  */
 import { toggleGroup, toggleBtn, chromChannelBtn } from "../../utils/style/styles.js";
+import { CHROMATIC_CHANNEL_METADATA } from "../../optics/chromatic/channels.js";
+import type { ChromaticChannel } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
 
 interface ChromaticControlsProps {
@@ -77,13 +79,25 @@ export default function ChromaticControls({
         <span>COLOR</span>
       </button>
       {showChromatic &&
-        [
-          { ch: "R", active: chromR, set: onChromRChange, color: t.rayChromR },
-          { ch: "G", active: chromG, set: onChromGChange, color: t.rayChromG },
-          { ch: "B", active: chromB, set: onChromBChange, color: t.rayChromB },
-          { ch: "V", active: chromV, set: onChromVChange, color: t.rayChromV },
-        ].map(({ ch, active, set, color }, idx) => (
-          <button key={ch} onClick={() => set?.(!active)} style={chromChannelBtn(t, active, idx < 3)}>
+        (
+          [
+            { ch: "R", active: chromR, set: onChromRChange, color: t.rayChromR },
+            { ch: "G", active: chromG, set: onChromGChange, color: t.rayChromG },
+            { ch: "B", active: chromB, set: onChromBChange, color: t.rayChromB },
+            { ch: "V", active: chromV, set: onChromVChange, color: t.rayChromV },
+          ] satisfies Array<{
+            ch: ChromaticChannel;
+            active: boolean;
+            set?: (value: boolean) => void;
+            color: string;
+          }>
+        ).map(({ ch, active, set, color }, idx) => (
+          <button
+            key={ch}
+            onClick={() => set?.(!active)}
+            style={chromChannelBtn(t, active, idx < 3)}
+            title={CHROMATIC_CHANNEL_METADATA[ch].wavelengthLabel}
+          >
             <span
               style={{
                 width: 6,

--- a/src/components/diagram/LCAInsetWidget.tsx
+++ b/src/components/diagram/LCAInsetWidget.tsx
@@ -13,7 +13,7 @@ import { computeLcaBarOffsets } from "../../optics/lcaScaling.js";
 
 const QUALITY_LABEL: Record<DispersionQuality, string> = {
   sellmeier: "Sellmeier",
-  lineIndices: "Measured (C/F)",
+  lineIndices: "Line indices",
   abbe: "Abbe approx",
   constant: "No dispersion",
   air: "",

--- a/src/components/diagram/LCAOverlayContent.tsx
+++ b/src/components/diagram/LCAOverlayContent.tsx
@@ -1,8 +1,9 @@
 /**
- * LCAOverlayContent — Enlarged longitudinal chromatic aberration visualization.
+ * LCAOverlayContent — Enlarged chromatic aberration visualization.
  *
- * Renders a standalone SVG with the LCAInsetWidget at a larger size, plus a
- * short description explaining what LCA represents. Used inside PanelOverlay.
+ * Renders a standalone SVG with the axial LCAInsetWidget at a larger size,
+ * plus a compact off-axis transverse color readout when that fan is present.
+ * Used inside PanelOverlay.
  */
 
 import type { ChromaticSpread, ChromaticSpreadByAxis } from "../../types/optics.js";
@@ -22,9 +23,16 @@ interface LCAOverlayContentProps {
 
 const SINGLE_SVG_W = 340;
 const SINGLE_SVG_H = 280;
-const DUAL_SVG_W = 220;
-const DUAL_SVG_H = 220;
 const MARGIN = 12;
+
+function formatUm(mm: number): string {
+  if (Math.abs(mm * 1000) >= 1) return `${Math.abs(mm * 1000).toFixed(0)} µm`;
+  return `${Math.abs(mm * 1000).toFixed(1)} µm`;
+}
+
+function formatSpreadUm(mm: number): string {
+  return mm !== 0 ? formatUm(mm) : "< 0.1 µm";
+}
 
 export default function LCAOverlayContent({
   chromSpread,
@@ -34,14 +42,10 @@ export default function LCAOverlayContent({
   t,
   dispersionQuality,
 }: LCAOverlayContentProps) {
-  const spreads = [
-    { label: "ON-AXIS", spread: chromaticSpreads?.onAxis ?? null },
-    { label: "OFF-AXIS", spread: chromaticSpreads?.offAxis ?? null },
-  ].filter((item): item is { label: string; spread: ChromaticSpread } => item.spread !== null);
-  const visibleSpreads = spreads.length > 0 ? spreads : [{ label: "ON-AXIS", spread: chromSpread }];
-  const dual = visibleSpreads.length > 1;
-  const svgW = dual ? DUAL_SVG_W : SINGLE_SVG_W;
-  const svgH = dual ? DUAL_SVG_H : SINGLE_SVG_H;
+  const onAxisSpread = chromaticSpreads ? chromaticSpreads.onAxis : chromSpread;
+  const offAxisSpread = chromaticSpreads?.offAxis ?? null;
+  const svgW = SINGLE_SVG_W;
+  const svgH = SINGLE_SVG_H;
 
   return (
     <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: "8px 20px 20px" }}>
@@ -53,30 +57,17 @@ export default function LCAOverlayContent({
           justifyContent: "center",
           gap: 14,
           minHeight: 0,
+          flexWrap: "wrap",
         }}
       >
-        {visibleSpreads.map(({ label, spread }) => (
-          <div key={label} style={{ flex: dual ? "1 1 0" : "0 1 auto", maxWidth: svgW, minWidth: 0 }}>
-            {dual && (
-              <div
-                style={{
-                  textAlign: "center",
-                  color: t.muted,
-                  fontSize: 11,
-                  letterSpacing: "0.12em",
-                  marginBottom: 4,
-                  fontFamily: "inherit",
-                }}
-              >
-                {label}
-              </div>
-            )}
+        {onAxisSpread ? (
+          <div style={{ flex: "0 1 auto", maxWidth: svgW, minWidth: 0 }}>
             <svg
               viewBox={`0 0 ${svgW} ${svgH}`}
               style={{ width: "100%", maxWidth: svgW, maxHeight: "100%", display: "block" }}
             >
               <LCAInsetWidget
-                chromSpread={spread}
+                chromSpread={onAxisSpread}
                 effectiveSC={effectiveSC}
                 IMG_MM={IMG_MM}
                 IX={0}
@@ -87,13 +78,55 @@ export default function LCAOverlayContent({
                 height={svgH - MARGIN * 2}
                 originX={MARGIN}
                 originY={MARGIN}
-                fontScale={dual ? 2.0 : 2.8}
+                fontScale={2.8}
                 dispersionQuality={dispersionQuality}
               />
             </svg>
           </div>
-        ))}
+        ) : (
+          <div style={{ color: t.muted, fontSize: 12, lineHeight: 1.5, textAlign: "center", maxWidth: 320 }}>
+            Axial LCA is unavailable for the active channel set or current ray state.
+          </div>
+        )}
+        {offAxisSpread && (
+          <div style={{ minWidth: 150, color: t.value, fontFamily: "inherit" }}>
+            <div
+              style={{
+                color: t.muted,
+                fontSize: 11,
+                letterSpacing: "0.12em",
+                marginBottom: 6,
+                textAlign: "center",
+              }}
+            >
+              OFF-AXIS TCA
+            </div>
+            <div style={{ fontSize: 22, fontWeight: 700, textAlign: "center", fontVariantNumeric: "tabular-nums" }}>
+              {formatSpreadUm(offAxisSpread.tcaMm)}
+            </div>
+            <div style={{ color: t.muted, fontSize: 11, lineHeight: 1.45, marginTop: 8, textAlign: "center" }}>
+              Transverse color is the surviving wavelength spread at the image plane for the displayed off-axis fan.
+            </div>
+          </div>
+        )}
       </div>
+      {chromaticSpreads?.onAxis && chromaticSpreads?.offAxis && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 14,
+            marginTop: 6,
+            color: t.muted,
+            fontSize: 10,
+            letterSpacing: "0.08em",
+          }}
+        >
+          <span>AXIAL LCA {formatSpreadUm(chromaticSpreads.onAxis.lcaMm)}</span>
+          <span>OFF-AXIS TCA {formatSpreadUm(chromaticSpreads.offAxis.tcaMm)}</span>
+        </div>
+      )}
       <p
         style={{
           margin: "12px 0 0",
@@ -104,13 +137,14 @@ export default function LCAOverlayContent({
         }}
       >
         <strong>Longitudinal Chromatic Aberration (LCA)</strong> measures how different wavelengths of light focus at
-        different distances along the optical axis. The colored bars show where{" "}
-        {CHROMATIC_CHANNEL_METADATA.R.description} ({CHROMATIC_CHANNEL_METADATA.R.wavelengthLabel}),{" "}
-        {CHROMATIC_CHANNEL_METADATA.G.description} ({CHROMATIC_CHANNEL_METADATA.G.wavelengthLabel}),{" "}
-        {CHROMATIC_CHANNEL_METADATA.B.description} ({CHROMATIC_CHANNEL_METADATA.B.wavelengthLabel}), and, when enabled,{" "}
-        {CHROMATIC_CHANNEL_METADATA.V.description} ({CHROMATIC_CHANNEL_METADATA.V.wavelengthLabel}) marginal rays cross
-        the axis relative to the reference focus. This is a geometric spectral-line trace; it is useful for comparing
-        correction strategy, but it is not a full-spectrum diffraction, sensor-stack, or production APO certification.
+        different distances along the optical axis. Off-axis TCA reports the color separation that remains at the image
+        plane for the displayed off-axis fan. The colored bars show where {CHROMATIC_CHANNEL_METADATA.R.description} (
+        {CHROMATIC_CHANNEL_METADATA.R.wavelengthLabel}), {CHROMATIC_CHANNEL_METADATA.G.description} (
+        {CHROMATIC_CHANNEL_METADATA.G.wavelengthLabel}), {CHROMATIC_CHANNEL_METADATA.B.description} (
+        {CHROMATIC_CHANNEL_METADATA.B.wavelengthLabel}), and, when enabled, {CHROMATIC_CHANNEL_METADATA.V.description} (
+        {CHROMATIC_CHANNEL_METADATA.V.wavelengthLabel}) marginal rays cross the axis relative to the reference focus.
+        This is a geometric spectral-line trace; it is useful for comparing correction strategy, but it is not a
+        full-spectrum diffraction, sensor-stack, or production APO certification.
       </p>
     </div>
   );

--- a/src/components/diagram/LCAOverlayContent.tsx
+++ b/src/components/diagram/LCAOverlayContent.tsx
@@ -8,6 +8,7 @@
 import type { ChromaticSpread, ChromaticSpreadByAxis } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
 import type { DispersionQuality } from "../../optics/dispersion.js";
+import { CHROMATIC_CHANNEL_METADATA } from "../../optics/chromatic/channels.js";
 import LCAInsetWidget from "./LCAInsetWidget.js";
 
 interface LCAOverlayContentProps {
@@ -103,10 +104,13 @@ export default function LCAOverlayContent({
         }}
       >
         <strong>Longitudinal Chromatic Aberration (LCA)</strong> measures how different wavelengths of light focus at
-        different distances along the optical axis. The colored bars show where red (C-line, 656 nm), green (d-line, 588
-        nm), blue (F-line, 486 nm), and — when enabled — violet (g-line, 436 nm) marginal rays cross the axis relative
-        to the reference focus. Apochromatic designs aim to bring three wavelengths to a common focus; the violet bar
-        reveals the residual <em>secondary spectrum</em> that distinguishes a true APO from an achromat.
+        different distances along the optical axis. The colored bars show where{" "}
+        {CHROMATIC_CHANNEL_METADATA.R.description} ({CHROMATIC_CHANNEL_METADATA.R.wavelengthLabel}),{" "}
+        {CHROMATIC_CHANNEL_METADATA.G.description} ({CHROMATIC_CHANNEL_METADATA.G.wavelengthLabel}),{" "}
+        {CHROMATIC_CHANNEL_METADATA.B.description} ({CHROMATIC_CHANNEL_METADATA.B.wavelengthLabel}), and, when enabled,{" "}
+        {CHROMATIC_CHANNEL_METADATA.V.description} ({CHROMATIC_CHANNEL_METADATA.V.wavelengthLabel}) marginal rays cross
+        the axis relative to the reference focus. This is a geometric spectral-line trace; it is useful for comparing
+        correction strategy, but it is not a full-spectrum diffraction, sensor-stack, or production APO certification.
       </p>
     </div>
   );

--- a/src/components/diagram/LCAOverlayContent.tsx
+++ b/src/components/diagram/LCAOverlayContent.tsx
@@ -1,8 +1,8 @@
 /**
  * LCAOverlayContent — Enlarged chromatic aberration visualization.
  *
- * Renders a standalone SVG with the axial LCAInsetWidget at a larger size,
- * plus a compact off-axis transverse color readout when that fan is present.
+ * Renders standalone SVG charts for axial LCA and, when the off-axis fan is
+ * present, image-plane TCA.
  * Used inside PanelOverlay.
  */
 
@@ -11,6 +11,7 @@ import type { Theme } from "../../types/theme.js";
 import type { DispersionQuality } from "../../optics/dispersion.js";
 import { CHROMATIC_CHANNEL_METADATA } from "../../optics/chromatic/channels.js";
 import LCAInsetWidget from "./LCAInsetWidget.js";
+import TCAInsetWidget from "./TCAInsetWidget.js";
 
 interface LCAOverlayContentProps {
   chromSpread: ChromaticSpread;
@@ -89,21 +90,22 @@ export default function LCAOverlayContent({
           </div>
         )}
         {offAxisSpread && (
-          <div style={{ minWidth: 150, color: t.value, fontFamily: "inherit" }}>
-            <div
-              style={{
-                color: t.muted,
-                fontSize: 11,
-                letterSpacing: "0.12em",
-                marginBottom: 6,
-                textAlign: "center",
-              }}
+          <div style={{ flex: "0 1 auto", maxWidth: svgW, minWidth: 0 }}>
+            <svg
+              viewBox={`0 0 ${svgW} ${svgH}`}
+              style={{ width: "100%", maxWidth: svgW, maxHeight: "100%", display: "block" }}
             >
-              OFF-AXIS TCA
-            </div>
-            <div style={{ fontSize: 22, fontWeight: 700, textAlign: "center", fontVariantNumeric: "tabular-nums" }}>
-              {formatSpreadUm(offAxisSpread.tcaMm)}
-            </div>
+              <TCAInsetWidget
+                chromSpread={offAxisSpread}
+                effectiveSC={effectiveSC}
+                t={t}
+                width={svgW - MARGIN * 2}
+                height={svgH - MARGIN * 2}
+                originX={MARGIN}
+                originY={MARGIN}
+                fontScale={2.8}
+              />
+            </svg>
             <div style={{ color: t.muted, fontSize: 11, lineHeight: 1.45, marginTop: 8, textAlign: "center" }}>
               Transverse color is the surviving wavelength spread at the image plane for the displayed off-axis fan.
             </div>
@@ -137,14 +139,15 @@ export default function LCAOverlayContent({
         }}
       >
         <strong>Longitudinal Chromatic Aberration (LCA)</strong> measures how different wavelengths of light focus at
-        different distances along the optical axis. Off-axis TCA reports the color separation that remains at the image
-        plane for the displayed off-axis fan. The colored bars show where {CHROMATIC_CHANNEL_METADATA.R.description} (
+        different distances along the optical axis. The axial LCA chart uses the outermost usable on-axis marginal trace
+        for the active channel set. Off-axis TCA reports the color separation that remains at the image plane for the
+        displayed off-axis fan. The colored bars show where {CHROMATIC_CHANNEL_METADATA.R.description} (
         {CHROMATIC_CHANNEL_METADATA.R.wavelengthLabel}), {CHROMATIC_CHANNEL_METADATA.G.description} (
         {CHROMATIC_CHANNEL_METADATA.G.wavelengthLabel}), {CHROMATIC_CHANNEL_METADATA.B.description} (
         {CHROMATIC_CHANNEL_METADATA.B.wavelengthLabel}), and, when enabled, {CHROMATIC_CHANNEL_METADATA.V.description} (
-        {CHROMATIC_CHANNEL_METADATA.V.wavelengthLabel}) marginal rays cross the axis relative to the reference focus.
-        This is a geometric spectral-line trace; it is useful for comparing correction strategy, but it is not a
-        full-spectrum diffraction, sensor-stack, or production APO certification.
+        {CHROMATIC_CHANNEL_METADATA.V.wavelengthLabel}) marginal rays cross the axis in the LCA chart and land at the
+        image plane in the TCA chart. This is a geometric spectral-line trace; it is useful for comparing correction
+        strategy, but it is not a full-spectrum diffraction, sensor-stack, or production APO certification.
       </p>
     </div>
   );

--- a/src/components/diagram/LCAOverlayContent.tsx
+++ b/src/components/diagram/LCAOverlayContent.tsx
@@ -25,6 +25,8 @@ interface LCAOverlayContentProps {
 const SINGLE_SVG_W = 340;
 const SINGLE_SVG_H = 280;
 const MARGIN = 12;
+const CHART_COLUMN_STYLE = { flex: `0 1 ${SINGLE_SVG_W}px`, width: SINGLE_SVG_W, maxWidth: "100%", minWidth: 0 };
+const CHART_SVG_STYLE = { width: "100%", height: "auto", display: "block" };
 
 function formatUm(mm: number): string {
   if (Math.abs(mm * 1000) >= 1) return `${Math.abs(mm * 1000).toFixed(0)} µm`;
@@ -62,11 +64,8 @@ export default function LCAOverlayContent({
         }}
       >
         {onAxisSpread ? (
-          <div style={{ flex: "0 1 auto", maxWidth: svgW, minWidth: 0 }}>
-            <svg
-              viewBox={`0 0 ${svgW} ${svgH}`}
-              style={{ width: "100%", maxWidth: svgW, maxHeight: "100%", display: "block" }}
-            >
+          <div style={CHART_COLUMN_STYLE}>
+            <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} style={CHART_SVG_STYLE}>
               <LCAInsetWidget
                 chromSpread={onAxisSpread}
                 effectiveSC={effectiveSC}
@@ -90,11 +89,8 @@ export default function LCAOverlayContent({
           </div>
         )}
         {offAxisSpread && (
-          <div style={{ flex: "0 1 auto", maxWidth: svgW, minWidth: 0 }}>
-            <svg
-              viewBox={`0 0 ${svgW} ${svgH}`}
-              style={{ width: "100%", maxWidth: svgW, maxHeight: "100%", display: "block" }}
-            >
+          <div style={CHART_COLUMN_STYLE}>
+            <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} style={CHART_SVG_STYLE}>
               <TCAInsetWidget
                 chromSpread={offAxisSpread}
                 effectiveSC={effectiveSC}

--- a/src/components/diagram/LCAOverlayContent.tsx
+++ b/src/components/diagram/LCAOverlayContent.tsx
@@ -6,6 +6,7 @@
  * Used inside PanelOverlay.
  */
 
+import type { CSSProperties } from "react";
 import type { ChromaticSpread, ChromaticSpreadByAxis } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
 import type { DispersionQuality } from "../../optics/dispersion.js";
@@ -27,6 +28,7 @@ const SINGLE_SVG_H = 280;
 const MARGIN = 12;
 const CHART_COLUMN_STYLE = { flex: `0 1 ${SINGLE_SVG_W}px`, width: SINGLE_SVG_W, maxWidth: "100%", minWidth: 0 };
 const CHART_SVG_STYLE = { width: "100%", height: "auto", display: "block" };
+const CHART_CAPTION_STYLE: CSSProperties = { fontSize: 11, lineHeight: 1.45, marginTop: 8, textAlign: "center" };
 
 function formatUm(mm: number): string {
   if (Math.abs(mm * 1000) >= 1) return `${Math.abs(mm * 1000).toFixed(0)} µm`;
@@ -82,6 +84,10 @@ export default function LCAOverlayContent({
                 dispersionQuality={dispersionQuality}
               />
             </svg>
+            <div style={{ ...CHART_CAPTION_STYLE, color: t.muted }}>
+              Longitudinal color is the wavelength focus spread along the optical axis for the active on-axis marginal
+              trace.
+            </div>
           </div>
         ) : (
           <div style={{ color: t.muted, fontSize: 12, lineHeight: 1.5, textAlign: "center", maxWidth: 320 }}>
@@ -102,7 +108,7 @@ export default function LCAOverlayContent({
                 fontScale={2.8}
               />
             </svg>
-            <div style={{ color: t.muted, fontSize: 11, lineHeight: 1.45, marginTop: 8, textAlign: "center" }}>
+            <div style={{ ...CHART_CAPTION_STYLE, color: t.muted }}>
               Transverse color is the surviving wavelength spread at the image plane for the displayed off-axis fan.
             </div>
           </div>
@@ -136,14 +142,15 @@ export default function LCAOverlayContent({
       >
         <strong>Longitudinal Chromatic Aberration (LCA)</strong> measures how different wavelengths of light focus at
         different distances along the optical axis. The axial LCA chart uses the outermost usable on-axis marginal trace
-        for the active channel set. Off-axis TCA reports the color separation that remains at the image plane for the
-        displayed off-axis fan. The colored bars show where {CHROMATIC_CHANNEL_METADATA.R.description} (
+        for the active channel set. <strong>Transverse Chromatic Aberration (TCA)</strong> measures how far those
+        wavelengths separate across image height at the current image plane; the off-axis TCA chart uses the displayed
+        off-axis fan. The colored bars show where {CHROMATIC_CHANNEL_METADATA.R.description} (
         {CHROMATIC_CHANNEL_METADATA.R.wavelengthLabel}), {CHROMATIC_CHANNEL_METADATA.G.description} (
         {CHROMATIC_CHANNEL_METADATA.G.wavelengthLabel}), {CHROMATIC_CHANNEL_METADATA.B.description} (
         {CHROMATIC_CHANNEL_METADATA.B.wavelengthLabel}), and, when enabled, {CHROMATIC_CHANNEL_METADATA.V.description} (
-        {CHROMATIC_CHANNEL_METADATA.V.wavelengthLabel}) marginal rays cross the axis in the LCA chart and land at the
-        image plane in the TCA chart. This is a geometric spectral-line trace; it is useful for comparing correction
-        strategy, but it is not a full-spectrum diffraction, sensor-stack, or production APO certification.
+        {CHROMATIC_CHANNEL_METADATA.V.wavelengthLabel}) marginal rays cross the axis in the LCA chart and where they
+        land at the image plane in the TCA chart. This is a geometric spectral-line trace; it is useful for comparing
+        correction strategy, but it is not a full-spectrum diffraction, sensor-stack, or production APO certification.
       </p>
     </div>
   );

--- a/src/components/diagram/TCAInsetWidget.tsx
+++ b/src/components/diagram/TCAInsetWidget.tsx
@@ -1,0 +1,152 @@
+/**
+ * TCAInsetWidget — Magnified inset showing transverse chromatic aberration.
+ *
+ * Displays each wavelength's image-plane height relative to the G/d-line
+ * reference. The chart matches the LCA inset visual language, but it plots
+ * lateral color instead of axial focus position.
+ */
+import type { ChromaticSpread, ChromaticChannel } from "../../types/optics.js";
+import type { Theme } from "../../types/theme.js";
+import { computeChromaticBarOffsets, REFERENCE_TCA_MM } from "../../optics/lcaScaling.js";
+
+function referenceHeight(imgHeights: Partial<Record<ChromaticChannel, number>>, fallback: number): number {
+  if (imgHeights.G !== undefined) return imgHeights.G;
+  const values = Object.values(imgHeights);
+  if (values.length === 0) return fallback;
+  return (Math.min(...values) + Math.max(...values)) / 2;
+}
+
+function channelColor(channel: ChromaticChannel, t: Theme): string {
+  if (channel === "R") return t.rayChromR;
+  if (channel === "G") return t.rayChromG;
+  if (channel === "B") return t.rayChromB;
+  return t.rayChromV;
+}
+
+function formatSpreadUm(mm: number): string {
+  const um = Math.abs(mm * 1000);
+  if (um === 0) return "< 0.1 \u00b5m";
+  return um >= 1 ? `${um.toFixed(0)} \u00b5m` : `${um.toFixed(1)} \u00b5m`;
+}
+
+interface TCAInsetWidgetProps {
+  chromSpread: ChromaticSpread;
+  effectiveSC: number;
+  t: Theme;
+  width?: number;
+  height?: number;
+  originX?: number;
+  originY?: number;
+  fontScale?: number;
+}
+
+export default function TCAInsetWidget({
+  chromSpread,
+  effectiveSC,
+  t,
+  width,
+  height,
+  originX = 0,
+  originY = 0,
+  fontScale = 1,
+}: TCAInsetWidgetProps) {
+  const insetW = width ?? 110;
+  const insetH = height ?? 100;
+  const reference = referenceHeight(chromSpread.imgHeights, 0);
+  const viewWidthPx = insetW - 24;
+  const { barOffsets, mag } = computeChromaticBarOffsets(
+    chromSpread.imgHeights,
+    reference,
+    viewWidthPx,
+    effectiveSC,
+    REFERENCE_TCA_MM,
+  );
+  const activeChans = (["R", "G", "B", "V"] as ChromaticChannel[]).filter(
+    (ch) => chromSpread.imgHeights[ch] !== undefined,
+  );
+  const midX = originX + insetW / 2;
+  const fs = (base: number) => base * fontScale;
+
+  const yTitle = originY + insetH * 0.14;
+  const ySubtitle = originY + insetH * 0.22;
+  const yLineTop = originY + insetH * 0.3;
+  const yAxis = originY + insetH * 0.4;
+  const yLineBot = originY + insetH * 0.56;
+  const yLabel = originY + insetH * 0.67;
+  const yMagnitude = originY + insetH * 0.82;
+  const yMagScale = originY + insetH * 0.95;
+
+  return (
+    <g>
+      <rect
+        x={originX}
+        y={originY}
+        width={insetW}
+        height={insetH}
+        rx={4}
+        fill={t.panelBg}
+        stroke={t.panelBorder}
+        strokeWidth={0.6}
+        opacity={0.94}
+      />
+      <text
+        x={midX}
+        y={yTitle}
+        textAnchor="middle"
+        fill={t.muted}
+        fontSize={fs(8.5)}
+        fontFamily="inherit"
+        style={{ letterSpacing: "0.1em" }}
+      >
+        TCA
+      </text>
+      <text x={midX} y={ySubtitle} textAnchor="middle" fill={t.muted} fontSize={fs(6.5)} fontFamily="inherit">
+        IMAGE HEIGHT
+      </text>
+      <line x1={originX + 6} y1={yAxis} x2={originX + insetW - 6} y2={yAxis} stroke={t.axis} strokeWidth={0.5} />
+      {activeChans.map((ch) => {
+        const offset = barOffsets[ch] ?? 0;
+        const color = channelColor(ch, t);
+        return (
+          <g key={ch}>
+            <line
+              x1={midX + offset}
+              y1={yLineTop}
+              x2={midX + offset}
+              y2={yLineBot}
+              stroke={color}
+              strokeWidth={2}
+              strokeLinecap="round"
+            />
+            <text
+              x={midX + offset}
+              y={yLabel}
+              textAnchor="middle"
+              fill={color}
+              fontSize={fs(8.5)}
+              fontFamily="inherit"
+              fontWeight={600}
+            >
+              {ch}
+            </text>
+          </g>
+        );
+      })}
+      <text
+        x={midX}
+        y={yMagnitude}
+        textAnchor="middle"
+        fill={t.value}
+        fontSize={fs(10)}
+        fontFamily="inherit"
+        fontWeight={600}
+      >
+        {formatSpreadUm(chromSpread.tcaMm)}
+      </text>
+      <text x={midX} y={yMagScale} textAnchor="middle" fill={t.muted} fontSize={fs(7.5)} fontFamily="inherit">
+        {Math.round(mag)}
+        {"\u00d7"}
+      </text>
+    </g>
+  );
+}

--- a/src/components/display/DiagramLegend.tsx
+++ b/src/components/display/DiagramLegend.tsx
@@ -10,7 +10,7 @@ import { halfFieldAtZoom } from "../../optics/optics.js";
 import { ENABLE_ASPH_DIAMOND_FILL, ENABLE_EDGE_PROJECTION } from "../../utils/featureFlags.js";
 import { collapseBtn } from "../../utils/style/styles.js";
 import CollapseButton from "../controls/CollapseButton.js";
-import type { RuntimeLens, ChromaticSpread } from "../../types/optics.js";
+import type { RuntimeLens, ChromaticSpread, ChromaticSpreadByAxis } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
 import type { OffAxisMode } from "../../types/state.js";
 import type { CSSProperties } from "react";
@@ -28,6 +28,7 @@ interface DiagramLegendProps {
   chromB: boolean;
   chromV: boolean;
   chromSpread: ChromaticSpread | null;
+  chromaticSpreads?: ChromaticSpreadByAxis;
   rayTracksF: boolean;
   legendExpanded: boolean;
   onLegendExpandedChange?: (expanded: boolean) => void;
@@ -47,12 +48,19 @@ export default function DiagramLegend({
   chromB,
   chromV,
   chromSpread,
+  chromaticSpreads,
   rayTracksF,
   legendExpanded,
   onLegendExpandedChange,
   onOpenAbbeDiagram,
 }: DiagramLegendProps) {
   const hasAbbeData = L.elements.some((e) => e.vd != null);
+  const axisSpreads = chromaticSpreads ?? { onAxis: chromSpread, offAxis: null };
+  const activeChannelCount = [chromR, chromG, chromB, chromV].filter(Boolean).length;
+  const hasMetricAxis = showOnAxis || showOffAxis !== "off";
+  const formatUm = (mm: number) =>
+    Math.abs(mm * 1000) >= 1 ? `${Math.abs(mm * 1000).toFixed(0)} µm` : `${Math.abs(mm * 1000).toFixed(1)} µm`;
+  const formatSpreadUm = (mm: number) => (mm !== 0 ? formatUm(mm) : "< 0.1 µm");
   return (
     <div style={{ padding: "6px 0" }}>
       <div
@@ -179,10 +187,14 @@ export default function DiagramLegend({
             (() => {
               const activeCh = [chromR && "R", chromG && "G", chromB && "B", chromV && "V"].filter(Boolean);
               const chromLabel = activeCh.length > 0 ? `Chromatic (${activeCh.join("/")})` : "Chromatic (none)";
-              const lcaStr =
-                chromSpread && chromSpread.lcaMm !== 0
-                  ? ` · LCA ${Math.abs(chromSpread.lcaMm * 1000) >= 1 ? Math.abs(chromSpread.lcaMm * 1000).toFixed(0) : Math.abs(chromSpread.lcaMm * 1000).toFixed(1)} µm`
-                  : "";
+              const summaryParts: string[] = [];
+              if (showOnAxis && axisSpreads.onAxis) {
+                summaryParts.push(`axial LCA ${formatSpreadUm(axisSpreads.onAxis.lcaMm)}`);
+              }
+              if (showOffAxis !== "off" && axisSpreads.offAxis) {
+                summaryParts.push(`off-axis TCA ${formatSpreadUm(axisSpreads.offAxis.tcaMm)}`);
+              }
+              const spreadSummary = summaryParts.length > 0 ? ` · ${summaryParts.join(" / ")}` : "";
               return (
                 <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
                   <svg width="22" height="17" viewBox="0 0 22 17">
@@ -193,7 +205,7 @@ export default function DiagramLegend({
                   </svg>
                   <span style={{ color: t.legendText }}>
                     {chromLabel}
-                    {lcaStr}
+                    {spreadSummary}
                   </span>
                 </div>
               );
@@ -207,7 +219,7 @@ export default function DiagramLegend({
               Abbe ↗
             </button>
           )}
-          {showChromatic && chromSpread && (
+          {showChromatic && hasMetricAxis && (
             <div
               style={{
                 display: "flex",
@@ -215,26 +227,12 @@ export default function DiagramLegend({
                 gap: 10,
                 marginTop: 4,
                 flexBasis: "100%",
+                flexWrap: "wrap",
               }}
             >
-              <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em" }}>LCA</span>
-              <span
-                style={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: t.value,
-                  fontVariantNumeric: "tabular-nums",
-                }}
-              >
-                {chromSpread.lcaMm !== 0
-                  ? Math.abs(chromSpread.lcaMm * 1000) >= 1
-                    ? `${Math.abs(chromSpread.lcaMm * 1000).toFixed(0)} µm`
-                    : `${Math.abs(chromSpread.lcaMm * 1000).toFixed(1)} µm`
-                  : "< 0.1 µm"}
-              </span>
-              {chromSpread.tcaMm !== 0 && (
+              {showOnAxis && (
                 <>
-                  <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", marginLeft: 6 }}>TCA</span>
+                  <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em" }}>AXIAL LCA</span>
                   <span
                     style={{
                       fontSize: 13,
@@ -243,9 +241,32 @@ export default function DiagramLegend({
                       fontVariantNumeric: "tabular-nums",
                     }}
                   >
-                    {Math.abs(chromSpread.tcaMm * 1000) >= 1
-                      ? `${Math.abs(chromSpread.tcaMm * 1000).toFixed(0)} µm`
-                      : `${Math.abs(chromSpread.tcaMm * 1000).toFixed(1)} µm`}
+                    {axisSpreads.onAxis
+                      ? formatSpreadUm(axisSpreads.onAxis.lcaMm)
+                      : activeChannelCount >= 2
+                        ? "unavailable"
+                        : "need 2 channels"}
+                  </span>
+                </>
+              )}
+              {showOffAxis !== "off" && (
+                <>
+                  <span style={{ fontSize: 10, color: t.label, letterSpacing: "0.1em", marginLeft: 6 }}>
+                    OFF-AXIS TCA
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: t.value,
+                      fontVariantNumeric: "tabular-nums",
+                    }}
+                  >
+                    {axisSpreads.offAxis
+                      ? formatSpreadUm(axisSpreads.offAxis.tcaMm)
+                      : activeChannelCount >= 2
+                        ? "unavailable"
+                        : "need 2 channels"}
                   </span>
                 </>
               )}

--- a/src/components/display/ElementInspector.tsx
+++ b/src/components/display/ElementInspector.tsx
@@ -7,8 +7,14 @@
  */
 
 import type { CSSProperties } from "react";
-import type { RuntimeLens, ElementData, ImagePlaneNormal, SurfaceData } from "../../types/optics.js";
+import type { RuntimeLens, ElementData, ImagePlaneNormal, SurfaceData, ChromaticChannel } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
+import type { DispersionQuality } from "../../optics/dispersion.js";
+import {
+  CHROMATIC_CHANNEL_METADATA,
+  CHROMATIC_CHANNEL_ORDER,
+  chromaticChannelIndexLabel,
+} from "../../optics/chromatic/channels.js";
 import { getAsphericEntriesForElement } from "./asphericElementUtils.js";
 
 interface ElementInspectorProps {
@@ -25,6 +31,14 @@ const INSPECTOR_GRID: CSSProperties = {
   gap: "3px 18px",
   fontSize: 10.5,
   lineHeight: 1.8,
+};
+
+const DISPERSION_QUALITY_LABEL: Record<DispersionQuality, string> = {
+  air: "Air",
+  sellmeier: "Sellmeier",
+  lineIndices: "Measured line indices",
+  abbe: "Abbe estimate",
+  constant: "No dispersion data",
 };
 
 function fmtNumber(value: number): string {
@@ -72,11 +86,39 @@ function surfaceSummary(surface: SurfaceData): string | null {
   return pieces.join(", ");
 }
 
+interface ElementDispersionRow {
+  surfaceLabel: string;
+  quality: DispersionQuality;
+  glassName: string | null;
+  indices: Record<ChromaticChannel, number>;
+}
+
+function elementDispersionRows(info: ElementData, L: RuntimeLens): ElementDispersionRow[] {
+  const rows: ElementDispersionRow[] = [];
+  for (const idx of surfaceIndexesForElement(info, L)) {
+    const entry = L.indexByIdx?.[idx];
+    if (!entry || entry.quality === "air") continue;
+    rows.push({
+      surfaceLabel: L.S[idx]?.label ?? String(idx + 1),
+      quality: entry.quality,
+      glassName: entry.glassEntry?.name ?? null,
+      indices: {
+        R: entry.fn("R"),
+        G: entry.fn("G"),
+        B: entry.fn("B"),
+        V: entry.fn("V"),
+      },
+    });
+  }
+  return rows;
+}
+
 export default function ElementInspector({ info, L, t, showChromatic, onOpenAsphericCompare }: ElementInspectorProps) {
   const foldedSurfaceRows = surfaceIndexesForElement(info, L)
     .map((idx) => ({ surface: L.S[idx], summary: surfaceSummary(L.S[idx]) }))
     .filter((row): row is { surface: SurfaceData; summary: string } => Boolean(row.summary));
   const imagePlane = L.isFoldedOptics && L.data.opticalPath?.imagePlane ? L.imagePlane : null;
+  const dispersionRows = showChromatic ? elementDispersionRows(info, L) : [];
 
   return (
     <div>
@@ -220,42 +262,61 @@ export default function ElementInspector({ info, L, t, showChromatic, onOpenAsph
           )}
         </div>
       )}
-      {showChromatic && info.vd && (
+      {showChromatic && dispersionRows.length > 0 && (
         <div style={{ ...INSPECTOR_GRID, marginTop: 4 }}>
-          <div>
-            <span style={{ color: t.propLabel }}>nF{"\u2212"}nC = </span>
-            <span style={{ color: t.value }}>{((info.nd - 1) / info.vd).toFixed(5)}</span>
-          </div>
-          <div>
-            <span style={{ color: t.propLabel }}>n</span>
-            <span style={{ color: t.rayChromR }}>R</span>
-            <span style={{ color: t.propLabel }}> = </span>
-            <span style={{ color: t.rayChromR }}>{(info.nd - (info.nd - 1) / (2 * info.vd)).toFixed(5)}</span>
-            <span style={{ color: t.propLabel, marginLeft: 8 }}> n</span>
-            <span style={{ color: t.rayChromB }}>B</span>
-            <span style={{ color: t.propLabel }}> = </span>
-            <span style={{ color: t.rayChromB }}>{(info.nd + (info.nd - 1) / (2 * info.vd)).toFixed(5)}</span>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
-            <span
-              style={{
-                width: 7,
-                height: 7,
-                borderRadius: "50%",
-                background: info.vd >= 55 ? t.chromDispLow : info.vd >= 35 ? t.chromDispMid : t.chromDispHigh,
-                display: "inline-block",
-                flexShrink: 0,
-              }}
-            />
-            <span
-              style={{
-                color: info.vd >= 55 ? t.chromDispLow : info.vd >= 35 ? t.chromDispMid : t.chromDispHigh,
-              }}
-            >
-              {info.vd >= 55 ? "Low dispersion" : info.vd >= 35 ? "Normal dispersion" : "High dispersion"}
-              {info.vd >= 65 ? " (ED)" : ""}
-            </span>
-          </div>
+          {dispersionRows.map((row) => (
+            <div key={row.surfaceLabel} style={{ display: "contents" }}>
+              <div>
+                <span style={{ color: t.propLabel }}>
+                  Dispersion{dispersionRows.length > 1 ? ` ${row.surfaceLabel}` : ""}:{" "}
+                </span>
+                <span style={{ color: t.value }}>
+                  {DISPERSION_QUALITY_LABEL[row.quality]}
+                  {row.glassName ? ` (${row.glassName})` : ""}
+                </span>
+              </div>
+              <div>
+                <span style={{ color: t.propLabel }}>nF{"\u2212"}nC = </span>
+                <span style={{ color: t.value }}>{(row.indices.B - row.indices.R).toFixed(5)}</span>
+              </div>
+              <div style={{ gridColumn: "1 / -1" }}>
+                {CHROMATIC_CHANNEL_ORDER.map((ch, idx) => {
+                  const color =
+                    ch === "R" ? t.rayChromR : ch === "G" ? t.rayChromG : ch === "B" ? t.rayChromB : t.rayChromV;
+                  return (
+                    <span key={ch} style={{ marginLeft: idx === 0 ? 0 : 10, whiteSpace: "nowrap" }}>
+                      <span style={{ color: t.propLabel }}>{chromaticChannelIndexLabel(ch)} </span>
+                      <span style={{ color }} title={CHROMATIC_CHANNEL_METADATA[ch].wavelengthLabel}>
+                        {row.indices[ch].toFixed(5)}
+                      </span>
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+          {info.vd && (
+            <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+              <span
+                style={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: "50%",
+                  background: info.vd >= 55 ? t.chromDispLow : info.vd >= 35 ? t.chromDispMid : t.chromDispHigh,
+                  display: "inline-block",
+                  flexShrink: 0,
+                }}
+              />
+              <span
+                style={{
+                  color: info.vd >= 55 ? t.chromDispLow : info.vd >= 35 ? t.chromDispMid : t.chromDispHigh,
+                }}
+              >
+                {info.vd >= 55 ? "Low dispersion" : info.vd >= 35 ? "Normal dispersion" : "High dispersion"}
+                {info.vd >= 65 ? " (ED)" : ""}
+              </span>
+            </div>
+          )}
         </div>
       )}
       {info.apdNote && (

--- a/src/components/display/analysis/ChromaticFieldCurvaturePlot.tsx
+++ b/src/components/display/analysis/ChromaticFieldCurvaturePlot.tsx
@@ -34,15 +34,15 @@ const PW = VB_W - ML - MR;
 const PH = VB_H - MT - MB;
 
 export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFieldCurvaturePlotProps) {
-  const markerFields = result.fields.filter((field) => field.usable && field.chromaticFieldShifts !== null);
-  const curveFields = result.curveFields.filter((field) => field.usable && field.chromaticFieldShifts !== null);
+  const markerFields = result.fields.filter(hasUsableChromaticShifts);
+  const curveFields = result.curveFields.filter(hasUsableChromaticShifts);
   const plotFields = curveFields.length > 0 ? curveFields : markerFields;
   if (plotFields.length < 2) return null;
 
   // Compute y-range from all chromatic shifts
   let maxShift = 0.1;
   for (const field of plotFields) {
-    for (const shift of field.chromaticFieldShifts!) {
+    for (const shift of finiteChromaticShifts(field)) {
       maxShift = Math.max(maxShift, Math.abs(shift.tangentialShiftMm), Math.abs(shift.sagittalShiftMm));
     }
   }
@@ -67,7 +67,7 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
   ) {
     return plotFields
       .map((field) => {
-        const shift = field.chromaticFieldShifts!.find((s) => s.channel === channel);
+        const shift = finiteChromaticShifts(field).find((s) => s.channel === channel);
         if (!shift) return null;
         return `${xScale(field.fieldFraction).toFixed(1)},${yScale(accessor(shift)).toFixed(1)}`;
       })
@@ -167,7 +167,7 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
       {channels.map((channel) => {
         const color = channelColors[channel];
         return markerFields.map((field) => {
-          const shift = field.chromaticFieldShifts!.find((s) => s.channel === channel);
+          const shift = finiteChromaticShifts(field).find((s) => s.channel === channel);
           if (!shift) return null;
           return (
             <g key={`${channel}-${field.fieldFraction}`}>
@@ -213,5 +213,19 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
         </text>
       </g>
     </svg>
+  );
+}
+
+function hasUsableChromaticShifts(field: FieldCurvatureResult["fields"][number]): boolean {
+  return field.usable && finiteChromaticShifts(field).length >= 2;
+}
+
+function finiteChromaticShifts(
+  field: FieldCurvatureResult["fields"][number],
+): NonNullable<FieldCurvatureResult["fields"][number]["chromaticFieldShifts"]> {
+  return (
+    field.chromaticFieldShifts?.filter(
+      (shift) => isFinite(shift.tangentialShiftMm) && isFinite(shift.sagittalShiftMm),
+    ) ?? []
   );
 }

--- a/src/components/display/analysis/ChromaticFieldCurvaturePlot.tsx
+++ b/src/components/display/analysis/ChromaticFieldCurvaturePlot.tsx
@@ -3,8 +3,9 @@
  * tangential and sagittal parabasal field-curve shifts across the field.
  *
  * Renders three pairs of tangential (solid) + sagittal (dashed) traces,
- * one per chromatic channel, to visualize how lateral color shifts the
- * focal surface at each field position.
+ * one per chromatic channel, to visualize wavelength-dependent best-focus
+ * shift at each field position. Lateral color is a separate image-height
+ * metric and should not be inferred from this focus-shift chart.
  */
 
 import type { FieldCurvatureResult } from "../../../optics/aberrationAnalysis.js";
@@ -78,7 +79,7 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
     <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
       <title>
         Chromatic field curvature. R, G, and B tangential (solid) and sagittal (dashed) parabasal field curves show how
-        dispersion shifts the focal surface per wavelength across the field.
+        dispersion shifts the best-focus surface per wavelength across the field.
       </title>
       <rect x={ML} y={MT} width={PW} height={PH} rx={3} fill={t.panelBg} stroke={t.panelBorder} strokeWidth={0.75} />
 

--- a/src/components/display/analysis/ChromaticFieldCurvaturePlot.tsx
+++ b/src/components/display/analysis/ChromaticFieldCurvaturePlot.tsx
@@ -1,14 +1,16 @@
 /**
- * ChromaticFieldCurvaturePlot — SVG chart showing per-wavelength (R/G/B)
+ * ChromaticFieldCurvaturePlot — SVG chart showing per-wavelength chromatic
  * tangential and sagittal parabasal field-curve shifts across the field.
  *
- * Renders three pairs of tangential (solid) + sagittal (dashed) traces,
- * one per chromatic channel, to visualize wavelength-dependent best-focus
+ * Renders tangential (solid) + sagittal (dashed) traces for each available
+ * chromatic channel to visualize wavelength-dependent best-focus
  * shift at each field position. Lateral color is a separate image-height
  * metric and should not be inferred from this focus-shift chart.
  */
 
 import type { FieldCurvatureResult } from "../../../optics/aberrationAnalysis.js";
+import { CHROMATIC_CHANNEL_ORDER } from "../../../optics/chromatic/channels.js";
+import type { ChromaticChannel } from "../../../types/optics.js";
 import type { Theme } from "../../../types/theme.js";
 import {
   centeredMmScale,
@@ -18,6 +20,7 @@ import {
   formatMmTick,
   symmetricMmTicks,
 } from "./charts/chartMath.js";
+import { chromaticChannelColor } from "./chromaticChartUtils.js";
 
 interface ChromaticFieldCurvaturePlotProps {
   result: FieldCurvatureResult;
@@ -53,16 +56,11 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
   const zeroY = yScale(0);
   const tickValues = symmetricMmTicks(yHalfRange);
 
-  const channelColors: Record<string, string> = {
-    R: t.rayChromR,
-    G: t.rayChromG,
-    B: t.rayChromB,
-  };
-
-  const channels = ["R", "G", "B"] as const;
+  const channels = CHROMATIC_CHANNEL_ORDER.filter((channel) => hasChannelShift(plotFields, channel));
+  if (channels.length < 2) return null;
 
   function buildPolyline(
-    channel: string,
+    channel: ChromaticChannel,
     accessor: (s: { tangentialShiftMm: number; sagittalShiftMm: number }) => number,
   ) {
     return plotFields
@@ -78,8 +76,8 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
   return (
     <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
       <title>
-        Chromatic field curvature. R, G, and B tangential (solid) and sagittal (dashed) parabasal field curves show how
-        dispersion shifts the best-focus surface per wavelength across the field.
+        Chromatic field curvature. {channels.join(", ")} tangential (solid) and sagittal (dashed) parabasal field curves
+        show how dispersion shifts the best-focus surface per wavelength across the field.
       </title>
       <rect x={ML} y={MT} width={PW} height={PH} rx={3} fill={t.panelBg} stroke={t.panelBorder} strokeWidth={0.75} />
 
@@ -133,7 +131,7 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
 
       {/* Tangential traces (solid) and sagittal traces (dashed) per channel */}
       {channels.map((channel) => {
-        const color = channelColors[channel];
+        const color = chromaticChannelColor(t, channel);
         const tangentialPts = buildPolyline(channel, (s) => s.tangentialShiftMm);
         const sagittalPts = buildPolyline(channel, (s) => s.sagittalShiftMm);
         return (
@@ -165,7 +163,7 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
 
       {/* Data point markers per channel */}
       {channels.map((channel) => {
-        const color = channelColors[channel];
+        const color = chromaticChannelColor(t, channel);
         return markerFields.map((field) => {
           const shift = finiteChromaticShifts(field).find((s) => s.channel === channel);
           if (!shift) return null;
@@ -188,8 +186,8 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
       {/* Legend */}
       <g transform={`translate(${ML + 6}, ${MT + 12})`}>
         {channels.map((channel, i) => {
-          const color = channelColors[channel];
-          const xOff = i * 72;
+          const color = chromaticChannelColor(t, channel);
+          const xOff = i * 62;
           return (
             <g key={channel} transform={`translate(${xOff}, 0)`}>
               <line x1={0} y1={0} x2={12} y2={0} stroke={color} strokeWidth={1.8} />
@@ -218,6 +216,10 @@ export default function ChromaticFieldCurvaturePlot({ result, t }: ChromaticFiel
 
 function hasUsableChromaticShifts(field: FieldCurvatureResult["fields"][number]): boolean {
   return field.usable && finiteChromaticShifts(field).length >= 2;
+}
+
+function hasChannelShift(fields: FieldCurvatureResult["fields"], channel: ChromaticChannel): boolean {
+  return fields.some((field) => finiteChromaticShifts(field).some((shift) => shift.channel === channel));
 }
 
 function finiteChromaticShifts(

--- a/src/components/display/analysis/ChromaticTab.tsx
+++ b/src/components/display/analysis/ChromaticTab.tsx
@@ -1,0 +1,312 @@
+import { useMemo } from "react";
+import { analysisJobsForState2, summarizeChromaticFieldFocus2 } from "../../../optics/compat.js";
+import { CHROMATIC_CHANNEL_ORDER } from "../../../optics/chromatic/channels.js";
+import { probe } from "../../../utils/perfProbe.js";
+import ChromaticFieldCurvaturePlot from "./ChromaticFieldCurvaturePlot.js";
+import LateralColorChart from "./LateralColorChart.js";
+import LongitudinalChromaticFocusChart from "./LongitudinalChromaticFocusChart.js";
+import { AnalysisEmptyState, AnalysisMetricRow } from "./analysisUi.js";
+import { formatUmMagnitude } from "./chromaticChartUtils.js";
+import usePreparedAnalysisState from "./usePreparedAnalysisState.js";
+import type { AnalysisComputationContext } from "../../../optics/compat.js";
+import type { FieldGeometryState } from "../../../optics/optics.js";
+import type { PreparedOpticalState } from "../../../optics/types.js";
+import type { RuntimeLens } from "../../../types/optics.js";
+import type { Theme } from "../../../types/theme.js";
+
+interface ChromaticTabProps {
+  L: RuntimeLens;
+  t: Theme;
+  focusT: number;
+  zoomT: number;
+  aberrationT?: number;
+  currentEPSD: number;
+  currentPhysStopSD: number;
+  fieldGeometry?: FieldGeometryState | null;
+  preparedState?: PreparedOpticalState | null;
+  analysisContext?: AnalysisComputationContext;
+}
+
+const sectionStyle = (t: Theme) => ({
+  borderTop: `1px solid ${t.panelBorder}`,
+  paddingTop: 14,
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: 10,
+});
+
+const sectionTitleStyle = (t: Theme) => ({
+  color: t.value,
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase" as const,
+  transition: "color 0.3s",
+});
+
+const sectionCopyStyle = (t: Theme) => ({
+  color: t.muted,
+  fontSize: 9,
+  lineHeight: 1.45,
+  transition: "color 0.3s",
+});
+
+const metricsStyle = {
+  display: "flex",
+  gap: 14,
+  flexWrap: "wrap" as const,
+  fontSize: 9.5,
+};
+
+export default function ChromaticTab({
+  L,
+  t,
+  focusT,
+  zoomT,
+  aberrationT = 0,
+  currentEPSD,
+  currentPhysStopSD,
+  fieldGeometry,
+  preparedState: preparedStateProp,
+  analysisContext,
+}: ChromaticTabProps) {
+  const preparedState = usePreparedAnalysisState({ L, focusT, zoomT, aberrationT, preparedState: preparedStateProp });
+  const analysis = useMemo(
+    () =>
+      probe(
+        "computeChromaticAnalysis",
+        () =>
+          analysisContext?.computeChromaticAnalysis() ??
+          analysisJobsForState2.computeChromaticAnalysis(
+            preparedState,
+            currentEPSD,
+            currentPhysStopSD,
+            fieldGeometry ?? undefined,
+          ),
+      ),
+    [analysisContext, preparedState, currentEPSD, currentPhysStopSD, fieldGeometry],
+  );
+  const fieldFocus = useMemo(
+    () =>
+      probe("computeChromaticFieldFocusSummary", () => {
+        const bundle =
+          analysisContext?.computeFieldCurvatureBundle() ??
+          analysisJobsForState2.computeFieldCurvatureBundle(
+            preparedState,
+            currentEPSD,
+            currentPhysStopSD,
+            fieldGeometry ?? undefined,
+          );
+        const result = bundle.chromaticFieldCurvature;
+        return { result, summary: summarizeChromaticFieldFocus2(result) };
+      }),
+    [analysisContext, preparedState, currentEPSD, currentPhysStopSD, fieldGeometry],
+  );
+  const rayTraceAnalysis = useMemo(
+    () =>
+      probe(
+        "computeChromaticRayTraceAnalysis",
+        () =>
+          analysisContext?.computeChromaticRayTraceAnalysis() ??
+          analysisJobsForState2.computeChromaticRayTraceAnalysis(
+            preparedState,
+            currentEPSD,
+            currentPhysStopSD,
+            fieldGeometry ?? undefined,
+            { channels: CHROMATIC_CHANNEL_ORDER },
+          ),
+      ),
+    [analysisContext, preparedState, currentEPSD, currentPhysStopSD, fieldGeometry],
+  );
+
+  const longitudinal = analysis.longitudinalFocus;
+  const lateral = analysis.lateralColor;
+  const offAxisRaySpread = rayTraceAnalysis.spreads.offAxis;
+  const edgeLateral = lateral?.fields.filter((field) => field.usable && field.lateralSpreadUm !== null).at(-1);
+
+  if (!longitudinal && !lateral && !fieldFocus.summary && !offAxisRaySpread) {
+    return <AnalysisEmptyState t={t}>Unable to compute chromatic diagnostics for this lens state.</AnalysisEmptyState>;
+  }
+
+  return (
+    <div style={{ padding: "8px 0" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 16, fontSize: 9.5 }}>
+        <section style={{ ...sectionStyle(t), borderTop: "none", paddingTop: 0 }}>
+          <span style={sectionTitleStyle(t)}>Chromatic Analysis</span>
+          <span style={sectionCopyStyle(t)}>
+            Geometric traces at C, d, F, and g spectral lines. These readouts report focus and image-height spread; they
+            do not classify apochromatic correction, diffraction, transmission, flare, or sensor response. Spectral set:
+            C-line 656.3 nm, d-line 587.6 nm, F-line 486.1 nm, g-line 435.8 nm.
+          </span>
+          <div style={metricsStyle}>
+            <AnalysisMetricRow
+              label="Axial LCA"
+              value={formatFiniteUm(longitudinal?.longitudinalSpreadUm)}
+              suffix={finiteUmSuffix(longitudinal?.longitudinalSpreadUm)}
+              note={longitudinal ? `${(longitudinal.marginalFraction * 100).toFixed(0)}% pupil` : undefined}
+              t={t}
+            />
+            <AnalysisMetricRow
+              label="On-axis image spread"
+              value={formatFiniteUm(longitudinal?.transverseSpreadUm)}
+              suffix={finiteUmSuffix(longitudinal?.transverseSpreadUm)}
+              note="sensor-plane ray heights"
+              t={t}
+            />
+            <AnalysisMetricRow
+              label="Max lateral color"
+              value={formatFiniteUm(lateral?.maxLateralSpreadUm)}
+              suffix={finiteUmSuffix(lateral?.maxLateralSpreadUm)}
+              note={lateral ? `${lateral.usableFieldCount}/${lateral.fields.length} fields` : undefined}
+              t={t}
+            />
+            <AnalysisMetricRow
+              label="Off-axis marginal TCA"
+              value={formatFiniteUm(offAxisRaySpread === null ? null : offAxisRaySpread.tcaMm * 1000)}
+              suffix={finiteUmSuffix(offAxisRaySpread === null ? null : offAxisRaySpread.tcaMm * 1000)}
+              note={offAxisRaySpread ? `${rayTraceAnalysis.offAxisFieldAngleDeg.toFixed(1)}° field` : undefined}
+              t={t}
+            />
+            <AnalysisMetricRow
+              label="Field focus spread"
+              value={formatFiniteUm(fieldFocus.summary ? fieldFocus.summary.maxFocusSpreadMm * 1000 : undefined)}
+              suffix={finiteUmSuffix(fieldFocus.summary ? fieldFocus.summary.maxFocusSpreadMm * 1000 : undefined)}
+              note={
+                fieldFocus.summary
+                  ? `${(fieldFocus.summary.maxFocusFieldFraction * 100).toFixed(0)}% field, ${fieldFocus.summary.source}`
+                  : undefined
+              }
+              t={t}
+            />
+          </div>
+        </section>
+
+        <section style={sectionStyle(t)}>
+          <span style={sectionTitleStyle(t)}>Longitudinal Color</span>
+          <span style={sectionCopyStyle(t)}>
+            On-axis LCA from the outermost usable marginal chromatic ray. The chart is relative to the selected
+            reference line, so common defocus is not counted as chromatic focus separation.
+          </span>
+          <LongitudinalChromaticFocusChart result={longitudinal} t={t} />
+          {longitudinal ? (
+            <div style={metricsStyle}>
+              <AnalysisMetricRow
+                label="Focus span"
+                value={formatFiniteUm(longitudinal.longitudinalSpreadUm)}
+                suffix={finiteUmSuffix(longitudinal.longitudinalSpreadUm)}
+                t={t}
+              />
+              <AnalysisMetricRow
+                label="Image span"
+                value={formatFiniteUm(longitudinal.transverseSpreadUm)}
+                suffix={finiteUmSuffix(longitudinal.transverseSpreadUm)}
+                note="at image plane"
+                t={t}
+              />
+              <AnalysisMetricRow
+                label="Ray height"
+                value={`${(longitudinal.marginalFraction * 100).toFixed(0)}%`}
+                note="of entrance pupil"
+                t={t}
+              />
+              <AnalysisMetricRow
+                label="Channels"
+                value={longitudinal.channels.join("/")}
+                note={`${longitudinal.validChannelCount} usable`}
+                t={t}
+              />
+            </div>
+          ) : null}
+        </section>
+
+        <section style={sectionStyle(t)}>
+          <span style={sectionTitleStyle(t)}>Lateral Color</span>
+          <span style={sectionCopyStyle(t)}>
+            Chief-ray image-height spread at the current image plane. This is chromatic magnification error across the
+            field, separate from axial focus shift.
+          </span>
+          <LateralColorChart result={lateral} t={t} />
+          {lateral ? (
+            <div style={metricsStyle}>
+              <AnalysisMetricRow
+                label="Max lateral color"
+                value={formatFiniteUm(lateral.maxLateralSpreadUm)}
+                suffix={finiteUmSuffix(lateral.maxLateralSpreadUm)}
+                t={t}
+              />
+              <AnalysisMetricRow
+                label="Edge lateral"
+                value={
+                  edgeLateral?.lateralSpreadUm === null || edgeLateral === undefined
+                    ? "n/a"
+                    : formatFiniteUm(edgeLateral.lateralSpreadUm)
+                }
+                suffix={finiteUmSuffix(edgeLateral?.lateralSpreadUm)}
+                t={t}
+              />
+              <AnalysisMetricRow label="Fields" value={`${lateral.usableFieldCount}/${lateral.fields.length}`} t={t} />
+              <AnalysisMetricRow label="Half field" value={lateral.halfFieldDeg.toFixed(1)} suffix="deg" t={t} />
+            </div>
+          ) : null}
+        </section>
+
+        <section style={sectionStyle(t)}>
+          <span style={sectionTitleStyle(t)}>Field-Focus Color</span>
+          <span style={sectionCopyStyle(t)}>
+            Wavelength-dependent tangential and sagittal best-focus separation from the real-ray field-curve solver.
+          </span>
+          {fieldFocus.result && fieldFocus.summary ? (
+            <>
+              <ChromaticFieldCurvaturePlot result={fieldFocus.result} t={t} />
+              <div style={metricsStyle}>
+                <AnalysisMetricRow
+                  label="Max focus"
+                  value={formatFiniteUm(fieldFocus.summary.maxFocusSpreadMm * 1000)}
+                  suffix={finiteUmSuffix(fieldFocus.summary.maxFocusSpreadMm * 1000)}
+                  t={t}
+                />
+                <AnalysisMetricRow
+                  label="Edge focus"
+                  value={
+                    fieldFocus.summary.edgeFocusSpreadMm === null
+                      ? "n/a"
+                      : formatFiniteUm(fieldFocus.summary.edgeFocusSpreadMm * 1000)
+                  }
+                  suffix={finiteUmSuffix(
+                    fieldFocus.summary.edgeFocusSpreadMm === null ? null : fieldFocus.summary.edgeFocusSpreadMm * 1000,
+                  )}
+                  t={t}
+                />
+                <AnalysisMetricRow
+                  label="Field"
+                  value={`${(fieldFocus.summary.maxFocusFieldFraction * 100).toFixed(0)}%`}
+                  note="largest spread"
+                  t={t}
+                />
+                <AnalysisMetricRow
+                  label="Source"
+                  value={fieldFocus.summary.source === "curve" ? "dense curve" : "checkpoints"}
+                  t={t}
+                />
+              </div>
+            </>
+          ) : (
+            <AnalysisEmptyState t={t}>No usable chromatic field-focus data for this lens state.</AnalysisEmptyState>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function isFiniteNumber(value: number | null | undefined): value is number {
+  return typeof value === "number" && isFinite(value);
+}
+
+function formatFiniteUm(value: number | null | undefined): string {
+  return isFiniteNumber(value) ? formatUmMagnitude(value) : "n/a";
+}
+
+function finiteUmSuffix(value: number | null | undefined): string | undefined {
+  return isFiniteNumber(value) ? "um" : undefined;
+}

--- a/src/components/display/analysis/ComaPreviewGrid.tsx
+++ b/src/components/display/analysis/ComaPreviewGrid.tsx
@@ -1,6 +1,6 @@
 /**
- * ComaPreviewGrid — Representative meridional coma previsualization shown as
- * a 2×2 SVG grid across the field.
+ * ComaPreviewGrid — Representative chief-ray-centered coma/spot footprint
+ * previsualization shown as a 2×2 SVG grid across the field.
  *
  * Each tile is centered on the chief-ray intercept for that field position so
  * users can compare the asymmetric footprint growth without conflating it with
@@ -311,7 +311,7 @@ function renderPointCloudTile(
       geometry={geometry}
       label={field.label}
       angleLabel={field.usable ? `${field.fieldAngleDeg.toFixed(1)}°` : "Unavailable"}
-      footerLines={style === "traced" ? ["Traced real-ray", "spot plot"] : ["Idealized", "coma sketch"]}
+      footerLines={style === "traced" ? ["Traced real-ray", "spot footprint"] : ["Schematic", "coma sketch"]}
       t={t}
     >
       <line
@@ -411,8 +411,8 @@ export default function ComaPreviewGrid({
       <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
         <title>
           {pointCloudStyle === "traced"
-            ? "Chief-ray-referenced real-ray spot grid. Each tile traces a fixed circular pupil pattern and plots tangential and sagittal image heights relative to the chief ray on a shared square spot scale."
-            : "Idealized coma comparison grid. Each tile converts the traced spot extent into a normalized textbook-style coma sketch on the same shared square spot scale."}
+            ? "Chief-ray-referenced real-ray spot footprint grid. Each tile traces a fixed circular pupil pattern and plots tangential and sagittal image heights relative to the chief ray on a shared square spot scale."
+            : "Schematic coma comparison grid. Each tile converts the traced spot extent into a normalized textbook-style coma sketch on the same shared square spot scale."}
         </title>
         {pointCloudResult.fields.map((field, index) =>
           renderPointCloudTile(field, index, pointCloudResult.sharedSpotHalfRangeMm, t, pointCloudStyle),
@@ -442,7 +442,7 @@ export default function ComaPreviewGrid({
               stroke={t.value}
               strokeWidth={1.1}
             />
-            <MultiLineText x={28} y={-2} lines={["Outline", "idealized footprint"]} fill={t.muted} fontSize={7.5} />
+            <MultiLineText x={28} y={-2} lines={["Outline", "schematic footprint"]} fill={t.muted} fontSize={7.5} />
           </g>
         )}
         <MultiLineText

--- a/src/components/display/analysis/ComaTab.tsx
+++ b/src/components/display/analysis/ComaTab.tsx
@@ -16,6 +16,16 @@ import MeridionalComaSection from "./aberrations/MeridionalComaSection.js";
 import SagittalComaSection from "./aberrations/SagittalComaSection.js";
 import useComaData from "./aberrations/useComaData.js";
 
+type ComaDetailFieldSelection = "default" | 0.25 | 0.5 | 0.75 | 1;
+
+const COMA_DETAIL_FIELD_OPTIONS: Array<{ value: ComaDetailFieldSelection; label: string }> = [
+  { value: "default", label: "Default" },
+  { value: 0.25, label: "25%" },
+  { value: 0.5, label: "50%" },
+  { value: 0.75, label: "75%" },
+  { value: 1, label: "100%" },
+];
+
 interface ComaTabProps {
   L: RuntimeLens;
   t: Theme;
@@ -43,6 +53,8 @@ export default function ComaTab({
   preparedState,
   analysisContext,
 }: ComaTabProps) {
+  const [detailFieldSelection, setDetailFieldSelection] = useState<ComaDetailFieldSelection>("default");
+  const detailFieldFraction = detailFieldSelection === "default" ? undefined : detailFieldSelection;
   const { comaResult, sagittalComaResult, comaPreviewResult } = useComaData({
     L,
     zPos,
@@ -51,6 +63,7 @@ export default function ComaTab({
     aberrationT,
     currentEPSD,
     currentPhysStopSD,
+    detailFieldFraction,
     fieldGeometry,
     preparedState,
     analysisContext,
@@ -59,10 +72,64 @@ export default function ComaTab({
   const [comaPreviewExpanded, setComaPreviewExpanded] = useState(true);
   const [comaExpanded, setComaExpanded] = useState(true);
   const [sagittalComaExpanded, setSagittalComaExpanded] = useState(true);
+  const defaultFieldLabel = `${Math.round(L.offAxisFieldFrac * 100)}%`;
 
   return (
     <div style={{ padding: "8px 0" }}>
       <div style={{ display: "flex", flexDirection: "column", gap: 16, fontSize: 9.5 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <span style={{ color: t.muted, fontSize: 10, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+            Detailed fan field
+          </span>
+          <div
+            role="group"
+            aria-label="Detailed coma fan field"
+            style={{
+              display: "inline-flex",
+              flexWrap: "wrap",
+              gap: 4,
+              padding: 3,
+              border: `1px solid ${t.panelBorder}`,
+              borderRadius: 6,
+              background: t.panelBg,
+            }}
+          >
+            {COMA_DETAIL_FIELD_OPTIONS.map((option) => {
+              const active = detailFieldSelection === option.value;
+              return (
+                <button
+                  key={String(option.value)}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setDetailFieldSelection(option.value)}
+                  style={{
+                    minWidth: option.value === "default" ? 68 : 44,
+                    border: `1px solid ${active ? t.value : "transparent"}`,
+                    borderRadius: 4,
+                    padding: "4px 7px",
+                    background: active ? t.value : "transparent",
+                    color: active ? t.panelBg : t.label,
+                    fontSize: 9,
+                    fontWeight: active ? 700 : 500,
+                    cursor: "pointer",
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                  title={
+                    option.value === "default"
+                      ? `Use this lens's authored off-axis field (${defaultFieldLabel})`
+                      : `Use ${option.label} of the current half-field`
+                  }
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+          <span style={{ color: t.muted, fontSize: 9, fontVariantNumeric: "tabular-nums" }}>
+            default {defaultFieldLabel}
+          </span>
+        </div>
+
         <ComaPreviewSection
           result={comaPreviewResult}
           expanded={comaPreviewExpanded}

--- a/src/components/display/analysis/LateralColorChart.tsx
+++ b/src/components/display/analysis/LateralColorChart.tsx
@@ -1,0 +1,118 @@
+import type { LateralColorCurveResult } from "../../../optics/compat.js";
+import type { ChromaticChannel } from "../../../types/optics.js";
+import type { Theme } from "../../../types/theme.js";
+import { AnalysisEmptyState } from "./analysisUi.js";
+import { SvgChartFrame, ChartLegend } from "./charts/SvgChartFrame.js";
+import {
+  createPlotArea,
+  fieldFractionTicks,
+  formatFieldFractionTick,
+  formatSignedCompactTick,
+  linearScale,
+  niceTicks,
+  svgPath,
+  symmetricDomain,
+} from "./charts/chartMath.js";
+import { chromaticChannelColor, chromaticChannelLegendLabel } from "./chromaticChartUtils.js";
+
+interface LateralColorChartProps {
+  result: LateralColorCurveResult | null;
+  t: Theme;
+  width?: number;
+  height?: number;
+}
+
+interface ChannelPoint {
+  fieldFraction: number;
+  shiftUm: number;
+}
+
+export default function LateralColorChart({ result, t, width = 320, height = 230 }: LateralColorChartProps) {
+  if (!result || result.fields.length < 2) {
+    return <AnalysisEmptyState t={t}>Not enough field data to plot lateral color.</AnalysisEmptyState>;
+  }
+
+  const channelPoints = new Map<ChromaticChannel, ChannelPoint[]>();
+  for (const channel of result.channels) {
+    channelPoints.set(channel, []);
+  }
+  for (const field of result.fields) {
+    if (!field.usable) continue;
+    for (const sample of field.samples) {
+      if (!sample.usable || sample.relativeHeightMm === null) continue;
+      channelPoints.get(sample.channel)?.push({
+        fieldFraction: field.fieldFraction,
+        shiftUm: sample.relativeHeightMm * 1000,
+      });
+    }
+  }
+
+  const plottedChannels = result.channels.filter((channel) => (channelPoints.get(channel)?.length ?? 0) >= 2);
+  if (plottedChannels.length < 2) {
+    return (
+      <AnalysisEmptyState t={t}>Not enough usable chromatic chief-ray data to plot lateral color.</AnalysisEmptyState>
+    );
+  }
+
+  const allShiftUm = plottedChannels.flatMap((channel) => channelPoints.get(channel)!.map((point) => point.shiftUm));
+  const maxAbsShiftUm = Math.max(1, ...allShiftUm.map((shift) => Math.abs(shift)));
+  const [yMin, yMax] = symmetricDomain(maxAbsShiftUm, 1.2, maxAbsShiftUm < 5 ? 1 : 5);
+  const area = createPlotArea(width, height, { top: 24, right: 22, bottom: 40, left: 54 });
+  const { margin, plotW, plotH } = area;
+  const xScale = linearScale(0, 1, margin.left, margin.left + plotW);
+  const yScale = linearScale(yMin, yMax, margin.top + plotH, margin.top);
+  const yTicks = niceTicks(yMin, yMax, 5);
+  const referenceLabel = chromaticChannelLegendLabel(result.referenceChannel);
+
+  return (
+    <SvgChartFrame
+      area={area}
+      t={t}
+      xTicks={fieldFractionTicks()}
+      yTicks={yTicks}
+      xScale={xScale}
+      yScale={yScale}
+      xTickLabel={formatFieldFractionTick}
+      yTickLabel={formatSignedCompactTick}
+      xLabel="Field position"
+      yLabel={`Height from ${referenceLabel} (um)`}
+      referenceLines={[{ value: 0, label: referenceLabel, opacity: 0.6 }]}
+    >
+      {plottedChannels.map((channel) => {
+        const points = channelPoints.get(channel)!;
+        const pathD = svgPath(
+          points,
+          (point) => xScale(point.fieldFraction),
+          (point) => yScale(point.shiftUm),
+        );
+        const color = chromaticChannelColor(t, channel);
+        return (
+          <g key={channel}>
+            <path d={pathD} fill="none" stroke={color} strokeWidth={1.7} strokeLinejoin="round" />
+            {points.map((point) => (
+              <circle
+                key={`${channel}-${point.fieldFraction}`}
+                cx={xScale(point.fieldFraction)}
+                cy={yScale(point.shiftUm)}
+                r={2.4}
+                fill={color}
+                stroke={t.panelBg}
+                strokeWidth={0.6}
+              />
+            ))}
+          </g>
+        );
+      })}
+
+      <ChartLegend
+        x={margin.left + plotW - 4}
+        y={margin.top + 8}
+        t={t}
+        items={plottedChannels.map((channel) => ({
+          label: chromaticChannelLegendLabel(channel),
+          color: chromaticChannelColor(t, channel),
+        }))}
+      />
+    </SvgChartFrame>
+  );
+}

--- a/src/components/display/analysis/LongitudinalChromaticFocusChart.tsx
+++ b/src/components/display/analysis/LongitudinalChromaticFocusChart.tsx
@@ -1,0 +1,93 @@
+import type { LongitudinalChromaticFocusResult } from "../../../optics/compat.js";
+import type { Theme } from "../../../types/theme.js";
+import { AnalysisEmptyState } from "./analysisUi.js";
+import { SvgChartFrame } from "./charts/SvgChartFrame.js";
+import {
+  createPlotArea,
+  formatSignedCompactTick,
+  linearScale,
+  niceTicks,
+  symmetricDomain,
+} from "./charts/chartMath.js";
+import { chromaticChannelColor, chromaticChannelLegendLabel } from "./chromaticChartUtils.js";
+
+interface LongitudinalChromaticFocusChartProps {
+  result: LongitudinalChromaticFocusResult | null;
+  t: Theme;
+  width?: number;
+  height?: number;
+}
+
+export default function LongitudinalChromaticFocusChart({
+  result,
+  t,
+  width = 320,
+  height = 220,
+}: LongitudinalChromaticFocusChartProps) {
+  const samples = result?.samples.filter((sample) => sample.usable && sample.relativeFocusShiftMm !== null) ?? [];
+
+  if (!result || samples.length < 2) {
+    return <AnalysisEmptyState t={t}>Not enough chromatic focus data to plot axial LCA.</AnalysisEmptyState>;
+  }
+
+  const area = createPlotArea(width, height, { top: 24, right: 20, bottom: 44, left: 54 });
+  const { margin, plotW, plotH } = area;
+  const shiftsUm = samples.map((sample) => (sample.relativeFocusShiftMm ?? 0) * 1000);
+  const maxAbsShiftUm = Math.max(1, ...shiftsUm.map((shift) => Math.abs(shift)));
+  const [yMin, yMax] = symmetricDomain(maxAbsShiftUm, 1.2, maxAbsShiftUm < 5 ? 1 : 5);
+  const xScale = linearScale(0, samples.length - 1, margin.left, margin.left + plotW);
+  const yScale = linearScale(yMin, yMax, margin.top + plotH, margin.top);
+  const yTicks = niceTicks(yMin, yMax, 5);
+  const pathD = samples
+    .map((sample, index) => {
+      const command = index === 0 ? "M" : "L";
+      return `${command}${xScale(index).toFixed(1)},${yScale((sample.relativeFocusShiftMm ?? 0) * 1000).toFixed(1)}`;
+    })
+    .join(" ");
+  const referenceLabel = chromaticChannelLegendLabel(result.referenceChannel);
+
+  return (
+    <SvgChartFrame
+      area={area}
+      t={t}
+      xTicks={samples.map((_sample, index) => index)}
+      yTicks={yTicks}
+      xScale={xScale}
+      yScale={yScale}
+      xTickLabel={(index) => samples[index]?.channel ?? ""}
+      yTickLabel={formatSignedCompactTick}
+      xLabel="Spectral channel"
+      yLabel={`Focus from ${referenceLabel} (um)`}
+      referenceLines={[{ value: 0, label: referenceLabel, opacity: 0.6 }]}
+    >
+      <path d={pathD} fill="none" stroke={t.sliderAccent} strokeWidth={1.4} strokeLinejoin="round" />
+
+      {samples.map((sample, index) => {
+        const shiftUm = (sample.relativeFocusShiftMm ?? 0) * 1000;
+        return (
+          <g key={sample.channel}>
+            <circle
+              cx={xScale(index)}
+              cy={yScale(shiftUm)}
+              r={3}
+              fill={chromaticChannelColor(t, sample.channel)}
+              stroke={t.panelBg}
+              strokeWidth={0.75}
+            />
+            <text
+              x={xScale(index)}
+              y={yScale(shiftUm) + (shiftUm >= 0 ? -9 : 13)}
+              textAnchor="middle"
+              fill={t.value}
+              fontSize={8}
+              fontWeight={600}
+              fontFamily="inherit"
+            >
+              {chromaticChannelLegendLabel(sample.channel)}
+            </text>
+          </g>
+        );
+      })}
+    </SvgChartFrame>
+  );
+}

--- a/src/components/display/analysis/MeridionalComaPlot.tsx
+++ b/src/components/display/analysis/MeridionalComaPlot.tsx
@@ -2,10 +2,9 @@
  * MeridionalComaPlot — Compact 2D meridional coma visualization for the
  * Aberrations drawer.
  *
- * Plots dense image-plane intercept heights against pupil sample position and
- * marks the image-plane axis so the top/bottom asymmetry is immediately
- * visible. This is intentionally a meridional-only diagnostic, not a full
- * 2D spot diagram.
+ * Plots dense chief-ray-relative image-plane intercept heights against pupil
+ * sample position. This is intentionally a tangential/meridional 1D
+ * diagnostic, not a full 2D spot diagram.
  */
 
 import type { MeridionalComaResult } from "../../../optics/aberrationAnalysis.js";
@@ -38,7 +37,7 @@ export function formatComaSpan(spanUm: number): string {
 export default function MeridionalComaPlot({ result, t }: MeridionalComaPlotProps) {
   const yHalfRange = Math.max(
     MIN_Y_RANGE_MM,
-    Math.max(Math.abs(result.minIntercept), Math.abs(result.maxIntercept)) * 1.1,
+    Math.max(Math.abs(result.minRelativeIntercept), Math.abs(result.maxRelativeIntercept)) * 1.1,
   );
   const zeroY = MT + PH / 2;
 
@@ -46,11 +45,12 @@ export default function MeridionalComaPlot({ result, t }: MeridionalComaPlotProp
   const yScale = centeredMmScale(MT, PH, yHalfRange);
 
   const validSamples = result.samples.filter(
-    (sample): sample is typeof sample & { imageHeight: number } => sample.imageHeight !== null && !sample.clipped,
+    (sample): sample is typeof sample & { imageHeight: number; relativeImageHeight: number } =>
+      sample.imageHeight !== null && sample.relativeImageHeight !== null && !sample.clipped,
   );
 
   const polylinePoints = validSamples
-    .map((sample) => `${xScale(sample.pupilFraction).toFixed(1)},${yScale(sample.imageHeight).toFixed(1)}`)
+    .map((sample) => `${xScale(sample.pupilFraction).toFixed(1)},${yScale(sample.relativeImageHeight).toFixed(1)}`)
     .join(" ");
 
   const tickValues = symmetricMmTicks(yHalfRange).filter((tick) => Math.abs(tick) < yHalfRange);
@@ -58,8 +58,8 @@ export default function MeridionalComaPlot({ result, t }: MeridionalComaPlotProp
   return (
     <svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ display: "block", width: "100%", maxWidth: VB_W, height: "auto" }}>
       <title>
-        Tangential ray fan. Dense off-axis pupil samples are projected onto the image plane relative to the chief ray to
-        show asymmetric spread, not a full 2D spot diagram.
+        Tangential ray fan. Dense off-axis pupil samples are projected onto the image plane and plotted relative to the
+        chief ray to show asymmetric spread, not a full 2D spot diagram.
       </title>
       <rect x={ML} y={MT} width={PW} height={PH} rx={3} fill={t.panelBg} stroke={t.panelBorder} strokeWidth={0.75} />
 
@@ -110,7 +110,7 @@ export default function MeridionalComaPlot({ result, t }: MeridionalComaPlotProp
         <circle
           key={sample.index}
           cx={xScale(sample.pupilFraction)}
-          cy={yScale(sample.imageHeight)}
+          cy={yScale(sample.relativeImageHeight)}
           r={2.2}
           fill={Math.abs(sample.pupilFraction) < 1e-9 ? t.label : t.value}
         />

--- a/src/components/display/analysis/SagittalComaPlot.tsx
+++ b/src/components/display/analysis/SagittalComaPlot.tsx
@@ -1,9 +1,9 @@
 /**
  * SagittalComaPlot — Compact sagittal coma visualization for the Aberrations drawer.
  *
- * Plots x-coordinate image-plane intercepts against pupil fraction for the
- * sagittal fan. Mirrors the structure of MeridionalComaPlot but uses sagittal
- * (x-axis) data instead of tangential (y-axis).
+ * Plots chief-ray-relative x-coordinate image-plane intercepts against pupil
+ * fraction for the sagittal fan. Mirrors the structure of MeridionalComaPlot
+ * but uses sagittal (x-axis) data instead of tangential (y-axis).
  */
 
 import type { SagittalComaResult } from "../../../optics/aberrationAnalysis.js";
@@ -36,7 +36,7 @@ export function formatSagittalComaSpan(spanUm: number): string {
 export default function SagittalComaPlot({ result, t }: SagittalComaPlotProps) {
   const yHalfRange = Math.max(
     MIN_Y_RANGE_MM,
-    Math.max(Math.abs(result.minIntercept), Math.abs(result.maxIntercept)) * 1.1,
+    Math.max(Math.abs(result.minRelativeIntercept), Math.abs(result.maxRelativeIntercept)) * 1.1,
   );
   const zeroY = MT + PH / 2;
 
@@ -44,11 +44,12 @@ export default function SagittalComaPlot({ result, t }: SagittalComaPlotProps) {
   const yScale = centeredMmScale(MT, PH, yHalfRange);
 
   const validSamples = result.samples.filter(
-    (sample): sample is typeof sample & { imageX: number } => sample.imageX !== null && !sample.clipped,
+    (sample): sample is typeof sample & { imageX: number; relativeImageX: number } =>
+      sample.imageX !== null && sample.relativeImageX !== null && !sample.clipped,
   );
 
   const polylinePoints = validSamples
-    .map((sample) => `${xScale(sample.pupilFraction).toFixed(1)},${yScale(sample.imageX).toFixed(1)}`)
+    .map((sample) => `${xScale(sample.pupilFraction).toFixed(1)},${yScale(sample.relativeImageX).toFixed(1)}`)
     .join(" ");
 
   const tickValues = symmetricMmTicks(yHalfRange).filter((tick) => Math.abs(tick) < yHalfRange);
@@ -117,7 +118,7 @@ export default function SagittalComaPlot({ result, t }: SagittalComaPlotProps) {
         <rect
           key={sample.index}
           x={xScale(sample.pupilFraction) - 2.2}
-          y={yScale(sample.imageX) - 2.2}
+          y={yScale(sample.relativeImageX) - 2.2}
           width={4.4}
           height={4.4}
           rx={0.8}

--- a/src/components/display/analysis/aberrations/ComaPreviewSection.tsx
+++ b/src/components/display/analysis/aberrations/ComaPreviewSection.tsx
@@ -39,9 +39,9 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
       }}
     >
       <SectionHeader
-        title="Spot Diagram (Real-Ray)"
-        helpLabel="Spot diagram help"
-        helpText="This spot-diagram section now works in two panes. The left pane traces a denser fixed circular pupil pattern at the center and at 25%, 50%, and 75% of the current half-field on a shared square spot scale, then overlays centroid and RMS spot-radius cues. The right pane converts the same measured footprint extents into an idealized textbook-style coma sketch so users can compare the traced spot against the standard schematic view. The summary row also reports the outer-field tail bias and sagittal-to-tangential span ratio derived directly from the traced point cloud."
+        title="Chief-Ray Spot Footprints"
+        helpLabel="Spot footprint help"
+        helpText="The traced pane samples a fixed circular pupil pattern at representative fields and plots each image-plane hit relative to the chief ray. These real-ray footprints include coma plus defocus, astigmatism, clipping, and higher-order aberrations. The schematic pane is not another trace; it converts the measured footprint extents into a textbook-style coma sketch for visual comparison."
         expanded={expanded}
         onToggle={onToggle}
         theme={theme}
@@ -50,9 +50,8 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
       {expanded ? (
         <>
           <span style={{ fontSize: 9, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-            Left: a higher-resolution chief-ray-referenced real-ray spot grid with equal tangential / sagittal scale,
-            centroid, and RMS radius cues. Right: an idealized textbook-style coma sketch normalized to that same
-            measured scale so the traced footprint can be compared against the standard schematic shape.
+            Left: chief-ray-referenced real-ray spot footprints with equal tangential / sagittal scale, centroid, and
+            RMS radius cues. Right: a schematic coma comparison normalized to that same measured scale.
           </span>
 
           {result ? (
@@ -66,13 +65,13 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
               >
                 <div style={{ flex: "1 1 320px", minWidth: 0, display: "flex", flexDirection: "column", gap: 6 }}>
                   <span style={{ fontSize: 8.5, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-                    Traced real-ray spot diagram
+                    Traced real-ray spot footprints
                   </span>
                   <ComaPreviewGrid result={result} t={theme} mode="pointCloud" pointCloudStyle="traced" />
                 </div>
                 <div style={{ flex: "1 1 320px", minWidth: 0, display: "flex", flexDirection: "column", gap: 6 }}>
                   <span style={{ fontSize: 8.5, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-                    Idealized coma comparison
+                    Schematic coma comparison
                   </span>
                   <ComaPreviewGrid result={result} t={theme} mode="pointCloud" pointCloudStyle="idealized" />
                 </div>
@@ -103,7 +102,7 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
                 </div>
                 <div
                   style={{ display: "flex", alignItems: "center", gap: 8 }}
-                  title="Shared square spot half-range used to normalize all four traced and idealized coma tiles."
+                  title="Shared square spot half-range used to normalize all representative traced and schematic tiles."
                 >
                   <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
                     RANGE
@@ -120,6 +119,75 @@ export default function ComaPreviewSection({ result, expanded, onToggle, theme }
                     ±{formatComaSpan(result.sharedSpotHalfRangeMm * 1000)}
                   </span>
                 </div>
+                {outerField ? (
+                  <div
+                    style={{ display: "flex", alignItems: "center", gap: 8 }}
+                    title="Outermost usable field weighted RMS radius around the traced spot centroid."
+                  >
+                    <span
+                      style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}
+                    >
+                      OUTER RMS
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 600,
+                        color: theme.value,
+                        fontVariantNumeric: "tabular-nums",
+                        transition: "color 0.3s",
+                      }}
+                    >
+                      {formatComaSpan(outerField.rmsRadiusUm)}
+                    </span>
+                  </div>
+                ) : null}
+                {outerField ? (
+                  <div
+                    style={{ display: "flex", alignItems: "center", gap: 8 }}
+                    title="Outermost usable field tangential span from the chief-ray-referenced point cloud."
+                  >
+                    <span
+                      style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}
+                    >
+                      T SPAN
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 600,
+                        color: theme.value,
+                        fontVariantNumeric: "tabular-nums",
+                        transition: "color 0.3s",
+                      }}
+                    >
+                      {formatComaSpan(outerField.tangentialSpanUm)}
+                    </span>
+                  </div>
+                ) : null}
+                {outerField ? (
+                  <div
+                    style={{ display: "flex", alignItems: "center", gap: 8 }}
+                    title="Outermost usable field sagittal span from the chief-ray-referenced point cloud."
+                  >
+                    <span
+                      style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}
+                    >
+                      S SPAN
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 600,
+                        color: theme.value,
+                        fontVariantNumeric: "tabular-nums",
+                        transition: "color 0.3s",
+                      }}
+                    >
+                      {formatComaSpan(outerField.sagittalSpanUm)}
+                    </span>
+                  </div>
+                ) : null}
                 {outerField ? (
                   <div
                     style={{ display: "flex", alignItems: "center", gap: 8 }}

--- a/src/components/display/analysis/aberrations/FieldCurvatureSection.tsx
+++ b/src/components/display/analysis/aberrations/FieldCurvatureSection.tsx
@@ -55,8 +55,8 @@ export default function FieldCurvatureSection({ result, expanded, onToggle, them
                 <>
                   <ChromaticFieldCurvaturePlot result={result} t={theme} />
                   <span style={{ fontSize: 8.5, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-                    Per-wavelength field curves. Each color shows tangential (solid) and sagittal (dashed) shift. Wider
-                    R/B separation indicates stronger chromatic field curvature.
+                    Per-wavelength best-focus curves. Each color shows tangential (solid) and sagittal (dashed) focus
+                    shift. Wider R/B separation indicates stronger chromatic focus variation across the field.
                   </span>
                 </>
               ) : null}

--- a/src/components/display/analysis/aberrations/MeridionalComaSection.tsx
+++ b/src/components/display/analysis/aberrations/MeridionalComaSection.tsx
@@ -10,6 +10,10 @@ interface MeridionalComaSectionProps {
   theme: Theme;
 }
 
+function formatField(result: MeridionalComaResult): string {
+  return `${Math.round(result.fieldFraction * 100)}% / ${result.fieldAngleDeg.toFixed(1)}°`;
+}
+
 export default function MeridionalComaSection({ result, expanded, onToggle, theme }: MeridionalComaSectionProps) {
   return (
     <div
@@ -24,7 +28,7 @@ export default function MeridionalComaSection({ result, expanded, onToggle, them
       <SectionHeader
         title="Tangential Ray Fan"
         helpLabel="Tangential ray fan help"
-        helpText="Tangential ray fan at the configured off-axis field. This is the tangential or meridional ray-aberration view: chief-ray-referenced image height versus tangential pupil coordinate. It is useful for reading coma-like asymmetry, but it is not a full 2D spot diagram."
+        helpText="Tangential ray fan at the selected off-axis field. This is a 1D transverse ray-aberration view: chief-ray-relative image y versus tangential pupil coordinate. It helps reveal coma-like asymmetry, but it is not a full 2D spot diagram or a pure Seidel coma coefficient."
         expanded={expanded}
         onToggle={onToggle}
         theme={theme}
@@ -33,8 +37,9 @@ export default function MeridionalComaSection({ result, expanded, onToggle, them
       {expanded ? (
         <>
           <span style={{ fontSize: 9, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-            Tangential ray fan using a dense off-axis meridional pupil sweep. This is a 1D chief-ray-referenced
-            ray-aberration plot, not a full 2D spot diagram.
+            Tangential ray fan using a dense off-axis meridional pupil sweep at the selected field. Values are plotted
+            relative to the traced chief ray, so the zero line is the chief-ray intercept rather than absolute frame
+            height.
           </span>
 
           {result ? (
@@ -50,10 +55,10 @@ export default function MeridionalComaSection({ result, expanded, onToggle, them
               >
                 <div
                   style={{ display: "flex", alignItems: "center", gap: 8 }}
-                  title="Meridional coma span: upper outer valid image-plane intercept minus lower outer valid intercept."
+                  title="Tangential fan span: maximum minus minimum chief-ray-relative y-intercept across valid samples."
                 >
                   <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
-                    COMA SPAN
+                    FAN SPAN
                   </span>
                   <span
                     style={{
@@ -65,6 +70,25 @@ export default function MeridionalComaSection({ result, expanded, onToggle, them
                     }}
                   >
                     {formatComaSpan(result.spanUm)}
+                  </span>
+                </div>
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: 8 }}
+                  title="Signed upper-minus-lower outer ray delta, still measured relative to the chief ray."
+                >
+                  <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
+                    OUTER DELTA
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: theme.value,
+                      fontVariantNumeric: "tabular-nums",
+                      transition: "color 0.3s",
+                    }}
+                  >
+                    {formatComaSpan(result.signedOuterDeltaUm)}
                   </span>
                 </div>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -80,7 +104,7 @@ export default function MeridionalComaSection({ result, expanded, onToggle, them
                       transition: "color 0.3s",
                     }}
                   >
-                    {result.fieldAngleDeg.toFixed(1)}°
+                    {formatField(result)}
                   </span>
                 </div>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>

--- a/src/components/display/analysis/aberrations/SagittalComaSection.tsx
+++ b/src/components/display/analysis/aberrations/SagittalComaSection.tsx
@@ -10,6 +10,10 @@ interface SagittalComaSectionProps {
   theme: Theme;
 }
 
+function formatField(result: SagittalComaResult): string {
+  return `${Math.round(result.fieldFraction * 100)}% / ${result.fieldAngleDeg.toFixed(1)}°`;
+}
+
 export default function SagittalComaSection({ result, expanded, onToggle, theme }: SagittalComaSectionProps) {
   return (
     <div
@@ -24,7 +28,7 @@ export default function SagittalComaSection({ result, expanded, onToggle, theme 
       <SectionHeader
         title="Sagittal Ray Fan"
         helpLabel="Sagittal ray fan help"
-        helpText="Sagittal ray fan at the configured off-axis field. This is the sagittal ray-aberration view: chief-ray-referenced image x versus sagittal pupil coordinate. Compare it with the tangential ray fan above to see directional asymmetry."
+        helpText="Sagittal ray fan at the selected off-axis field. This is a 1D transverse ray-aberration view: chief-ray-relative image x versus sagittal pupil coordinate. Compare it with the tangential fan to see directional asymmetry."
         expanded={expanded}
         onToggle={onToggle}
         theme={theme}
@@ -33,8 +37,8 @@ export default function SagittalComaSection({ result, expanded, onToggle, theme 
       {expanded ? (
         <>
           <span style={{ fontSize: 9, color: theme.muted, lineHeight: 1.4, transition: "color 0.3s" }}>
-            Sagittal ray fan using a dense off-axis sagittal pupil sweep. This is a 1D chief-ray-referenced
-            ray-aberration plot orthogonal to the tangential plane.
+            Sagittal ray fan using a dense off-axis sagittal pupil sweep at the selected field. Values are plotted
+            relative to the traced chief ray, orthogonal to the tangential plane.
           </span>
 
           {result ? (
@@ -50,10 +54,10 @@ export default function SagittalComaSection({ result, expanded, onToggle, theme 
               >
                 <div
                   style={{ display: "flex", alignItems: "center", gap: 8 }}
-                  title="Sagittal coma span: right outer valid x-intercept minus left outer valid x-intercept."
+                  title="Sagittal fan span: maximum minus minimum chief-ray-relative x-intercept across valid samples."
                 >
                   <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
-                    COMA SPAN
+                    FAN SPAN
                   </span>
                   <span
                     style={{
@@ -65,6 +69,25 @@ export default function SagittalComaSection({ result, expanded, onToggle, theme 
                     }}
                   >
                     {formatSagittalComaSpan(result.spanUm)}
+                  </span>
+                </div>
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: 8 }}
+                  title="Signed right-minus-left outer ray delta, still measured relative to the chief ray."
+                >
+                  <span style={{ fontSize: 10, color: theme.label, letterSpacing: "0.1em", transition: "color 0.3s" }}>
+                    OUTER DELTA
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: theme.value,
+                      fontVariantNumeric: "tabular-nums",
+                      transition: "color 0.3s",
+                    }}
+                  >
+                    {formatSagittalComaSpan(result.signedOuterDeltaUm)}
                   </span>
                 </div>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -80,7 +103,7 @@ export default function SagittalComaSection({ result, expanded, onToggle, theme 
                       transition: "color 0.3s",
                     }}
                   >
-                    {result.fieldAngleDeg.toFixed(1)}°
+                    {formatField(result)}
                   </span>
                 </div>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>

--- a/src/components/display/analysis/aberrations/useComaData.ts
+++ b/src/components/display/analysis/aberrations/useComaData.ts
@@ -15,6 +15,7 @@ interface Params {
   aberrationT?: number;
   currentEPSD: number;
   currentPhysStopSD: number;
+  detailFieldFraction?: number;
   fieldGeometry?: FieldGeometryState | null;
   preparedState?: PreparedOpticalState | null;
   analysisContext?: AnalysisComputationContext;
@@ -28,37 +29,61 @@ export default function useComaData({
   aberrationT = 0,
   currentEPSD,
   currentPhysStopSD,
+  detailFieldFraction,
   fieldGeometry,
   preparedState,
   analysisContext,
 }: Params) {
   return useMemo(() => {
+    const comaSampling =
+      detailFieldFraction === undefined ? undefined : { comaDetailFieldFraction: detailFieldFraction };
+    const contextState = analysisContext?.preparedState ?? preparedState;
     const {
       meridionalComa: comaResult,
       sagittalComa: sagittalComaResult,
       pointCloudPreview: comaPreviewResult,
-    } = analysisContext
+    } = analysisContext && comaSampling === undefined
       ? probe("computeComaAnalysis", () => analysisContext.computeComaAnalysis())
-      : preparedState
+      : contextState
         ? probe("computeComaAnalysis", () =>
-            analysisJobsForState2.computeComaAnalysis(
-              preparedState,
-              currentEPSD,
-              currentPhysStopSD,
-              fieldGeometry ?? undefined,
-            ),
+            comaSampling === undefined
+              ? analysisJobsForState2.computeComaAnalysis(
+                  contextState,
+                  currentEPSD,
+                  currentPhysStopSD,
+                  fieldGeometry ?? undefined,
+                )
+              : analysisJobsForState2.computeComaAnalysis(
+                  contextState,
+                  currentEPSD,
+                  currentPhysStopSD,
+                  fieldGeometry ?? undefined,
+                  comaSampling,
+                ),
           )
         : probe("computeComaAnalysis", () =>
-            computeComaAnalysis(
-              L,
-              zPos,
-              focusT,
-              zoomT,
-              currentEPSD,
-              currentPhysStopSD,
-              aberrationT,
-              fieldGeometry ?? undefined,
-            ),
+            comaSampling === undefined
+              ? computeComaAnalysis(
+                  L,
+                  zPos,
+                  focusT,
+                  zoomT,
+                  currentEPSD,
+                  currentPhysStopSD,
+                  aberrationT,
+                  fieldGeometry ?? undefined,
+                )
+              : computeComaAnalysis(
+                  L,
+                  zPos,
+                  focusT,
+                  zoomT,
+                  currentEPSD,
+                  currentPhysStopSD,
+                  aberrationT,
+                  fieldGeometry ?? undefined,
+                  comaSampling,
+                ),
           );
     return { comaResult, sagittalComaResult, comaPreviewResult };
   }, [
@@ -69,6 +94,7 @@ export default function useComaData({
     aberrationT,
     currentEPSD,
     currentPhysStopSD,
+    detailFieldFraction,
     fieldGeometry,
     preparedState,
     analysisContext,

--- a/src/components/display/analysis/chromaticChartUtils.ts
+++ b/src/components/display/analysis/chromaticChartUtils.ts
@@ -1,0 +1,33 @@
+import { chromaticChannelIndexLabel } from "../../../optics/chromatic/channels.js";
+import type { ChromaticChannel } from "../../../types/optics.js";
+import type { Theme } from "../../../types/theme.js";
+
+export function chromaticChannelColor(t: Theme, channel: ChromaticChannel): string {
+  if (channel === "R") return t.rayChromR;
+  if (channel === "G") return t.rayChromG;
+  if (channel === "B") return t.rayChromB;
+  return t.rayChromV;
+}
+
+export function chromaticChannelLegendLabel(channel: ChromaticChannel): string {
+  return `${channel} ${chromaticChannelIndexLabel(channel)}`;
+}
+
+export function formatSignedUm(value: number): string {
+  if (!isFinite(value)) return "n/a";
+  if (Math.abs(value) < 0.05) return "0";
+  const sign = value > 0 ? "+" : "";
+  const abs = Math.abs(value);
+  if (abs >= 100) return `${sign}${value.toFixed(0)}`;
+  if (abs >= 10) return `${sign}${value.toFixed(1)}`;
+  return `${sign}${value.toFixed(2)}`;
+}
+
+export function formatUmMagnitude(value: number): string {
+  if (!isFinite(value)) return "n/a";
+  const abs = Math.abs(value);
+  if (abs < 0.05) return "0";
+  if (abs >= 100) return abs.toFixed(0);
+  if (abs >= 10) return abs.toFixed(1);
+  return abs.toFixed(2);
+}

--- a/src/components/hooks/useChromaticRays.ts
+++ b/src/components/hooks/useChromaticRays.ts
@@ -2,9 +2,9 @@
  * useChromaticRays — Computes chromatic ray fan segments and aberration spread.
  *
  * Traces density-derived axial and off-axis ray fans through wavelength-dependent
- * refractive indices (R/G/B channels). Axial rays feed the LCA/TCA spread metric;
- * off-axis chromatic rays share the same state-aware field geometry as the
- * monochrome off-axis fan.
+ * refractive indices for the selected spectral-line channels. Axial rays feed
+ * the LCA readout; off-axis rays feed the transverse color readout using the
+ * same state-aware field geometry as the monochrome off-axis fan.
  */
 import { useMemo } from "react";
 import {
@@ -84,8 +84,9 @@ function spreadForAxis(
         marginalRays[r.channel] = { y: r.y, u: r.u, clipped: false };
       }
     }
-    if (Object.keys(marginalRays).length >= 2) {
-      return computeChromaticSpread(marginalRays, IMG_MM, lastSurfaceZ);
+    const channels = Object.keys(marginalRays) as ChromaticChannel[];
+    if (channels.length >= 2) {
+      return { ...computeChromaticSpread(marginalRays, IMG_MM, lastSurfaceZ), axis, fraction, channels };
     }
   }
 

--- a/src/components/hooks/useChromaticRays.ts
+++ b/src/components/hooks/useChromaticRays.ts
@@ -2,13 +2,15 @@
  * useChromaticRays — Computes chromatic ray fan segments and aberration spread.
  *
  * Traces density-derived axial and off-axis ray fans through wavelength-dependent
- * refractive indices for the selected spectral-line channels. Axial rays feed
- * the LCA readout; off-axis rays feed the transverse color readout using the
- * same state-aware field geometry as the monochrome off-axis fan.
+ * refractive indices for the selected spectral-line channels. Axial rays draw
+ * the on-axis fan while a dedicated marginal-focus search feeds the LCA readout;
+ * off-axis rays feed the transverse color readout using the same state-aware
+ * field geometry as the monochrome off-axis fan.
  */
 import { useMemo } from "react";
 import {
   computeChromaticSpread,
+  computeLongitudinalChromaticFocus,
   offsetVectorFieldRay,
   traceRayChromatic,
   traceRayVectorChromatic,
@@ -61,6 +63,19 @@ interface UseChromaticRaysResult {
   chromSpread: ChromaticSpread | null;
   chromaticSpreads: ChromaticSpreadByAxis;
   error: unknown;
+}
+
+const DISPLAY_LCA_FALLBACK_FRACTIONS = [0.97, 0.95, 0.9, 0.85, 0.8] as const;
+
+function longitudinalFractionsForDisplay(L: RuntimeLens, currentEPSD: number): number[] {
+  const fractions: number[] = [...DISPLAY_LCA_FALLBACK_FRACTIONS];
+  for (const fraction of obstructionAwareRayFractionsForDensity(L, L.rayFractions, "normal", currentEPSD)) {
+    const absolute = Math.abs(fraction);
+    if (absolute > 1e-12 && !fractions.some((value) => Math.abs(value - absolute) < 1e-12)) {
+      fractions.push(absolute);
+    }
+  }
+  return fractions.sort((a, b) => b - a);
 }
 
 function spreadForAxis(
@@ -271,19 +286,57 @@ export default function useChromaticRays({
 
   const chromaticRays = chromaticResult.segments;
 
-  /* Compute LCA (longitudinal chromatic aberration) and TCA (transverse)
-   * from each visible marginal chromatic ray fan. Requires at least 2 active channels. */
-  const chromaticSpreads = useMemo((): ChromaticSpreadByAxis => {
-    const empty = { onAxis: null, offAxis: null };
-    if (!L || !showChromatic || chromaticRays.length === 0) return empty;
+  const onAxisChromSpread = useMemo((): ChromaticSpread | null => {
+    if (!L || !showChromatic || !showOnAxis || chromaticResult.error) return null;
     const channels = filterChannels(chromR, chromG, chromB, chromV);
-    if (channels.length < 2) return empty;
+    if (channels.length < 2) return null;
+    return (
+      computeLongitudinalChromaticFocus(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT, {
+        channels,
+        longitudinalFractions: longitudinalFractionsForDisplay(L, currentEPSD),
+      })?.spread ?? null
+    );
+  }, [
+    showChromatic,
+    showOnAxis,
+    chromR,
+    chromG,
+    chromB,
+    chromV,
+    chromaticResult.error,
+    L,
+    zPos,
+    focusT,
+    zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+    aberrationT,
+  ]);
+
+  const offAxisChromSpread = useMemo((): ChromaticSpread | null => {
+    if (!L || !showChromatic || chromaticResult.error) return null;
+    const channels = filterChannels(chromR, chromG, chromB, chromV);
+    if (channels.length < 2) return null;
     const lastSurfaceZ = movementTransform ? movementTransform.point(zPos[L.N - 1], 0)[0] : zPos[L.N - 1];
-    return {
-      onAxis: spreadForAxis(chromaticRays, "onAxis", IMG_MM, lastSurfaceZ),
-      offAxis: spreadForAxis(chromaticRays, "offAxis", IMG_MM, lastSurfaceZ),
-    };
-  }, [showChromatic, chromR, chromG, chromB, chromV, chromaticRays, IMG_MM, zPos, L, movementTransform]);
+    return spreadForAxis(chromaticRays, "offAxis", IMG_MM, lastSurfaceZ);
+  }, [
+    showChromatic,
+    chromR,
+    chromG,
+    chromB,
+    chromV,
+    chromaticRays,
+    chromaticResult.error,
+    IMG_MM,
+    zPos,
+    L,
+    movementTransform,
+  ]);
+
+  const chromaticSpreads = useMemo(
+    (): ChromaticSpreadByAxis => ({ onAxis: onAxisChromSpread, offAxis: offAxisChromSpread }),
+    [onAxisChromSpread, offAxisChromSpread],
+  );
 
   const chromSpread = chromaticSpreads.onAxis ?? chromaticSpreads.offAxis;
 

--- a/src/components/layout/DiagramControlPanel.tsx
+++ b/src/components/layout/DiagramControlPanel.tsx
@@ -8,7 +8,7 @@
 import DiagramControls from "../controls/DiagramControls.js";
 import ElementInspector from "../display/ElementInspector.js";
 import DiagramLegend from "../display/DiagramLegend.js";
-import type { RuntimeLens, ElementData, ChromaticSpread } from "../../types/optics.js";
+import type { RuntimeLens, ElementData, ChromaticSpread, ChromaticSpreadByAxis } from "../../types/optics.js";
 import type { Theme } from "../../types/theme.js";
 import type { OffAxisMode } from "../../types/state.js";
 import type { GroupMovementMode } from "../../types/groupMovement.js";
@@ -66,6 +66,7 @@ interface DiagramControlPanelProps {
   chromB: boolean;
   chromV: boolean;
   chromSpread: ChromaticSpread | null;
+  chromaticSpreads?: ChromaticSpreadByAxis;
   rayTracksF: boolean;
   onOpenAbbeDiagram: () => void;
   onOpenAsphericCompare?: (eid: number) => void;
@@ -119,6 +120,7 @@ export default function DiagramControlPanel({
   chromB,
   chromV,
   chromSpread,
+  chromaticSpreads,
   rayTracksF,
   onOpenAbbeDiagram,
   onOpenAsphericCompare,
@@ -214,6 +216,7 @@ export default function DiagramControlPanel({
             chromB={chromB}
             chromV={chromV}
             chromSpread={chromSpread}
+            chromaticSpreads={chromaticSpreads}
             rayTracksF={rayTracksF}
             legendExpanded={legendExpanded}
             onLegendExpandedChange={onLegendExpandedChange}

--- a/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
+++ b/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
@@ -1,7 +1,8 @@
-import { useDeferredValue, useEffect, useMemo, useRef, type ReactNode } from "react";
+import { useDeferredValue, useMemo, type ReactNode } from "react";
 import { ANALYSIS_TAB_RENDERERS } from "./analysisTabRenderers.js";
 import usePreparedAnalysisState from "../../display/analysis/usePreparedAnalysisState.js";
 import { createAnalysisComputationContext } from "../../../optics/compat.js";
+import { analysisSamplingForQuality, type AnalysisQuality } from "../../../optics/analysis/analysisQuality.js";
 import type { RuntimeLens } from "../../../types/optics.js";
 import type { Theme } from "../../../types/theme.js";
 import type { FieldGeometryState } from "../../../optics/optics.js";
@@ -67,14 +68,9 @@ export default function AnalysisDrawerContent({
     }),
     [dFocusT, dZoomT, dAberrationT, dEPSD, dStopSD, dDynamicEFL, dFieldGeometry],
   );
-  const lastSettledInputsRef = useRef(deferredInputs);
-
-  useEffect(() => {
-    if (sliderInteracting) return;
-    lastSettledInputsRef.current = deferredInputs;
-  }, [sliderInteracting, deferredInputs]);
-
-  const analysisInputs = sliderInteracting ? lastSettledInputsRef.current : deferredInputs;
+  const analysisInputs = deferredInputs;
+  const analysisQuality: AnalysisQuality = sliderInteracting ? "interactive" : "settled";
+  const analysisSampling = useMemo(() => analysisSamplingForQuality(analysisQuality), [analysisQuality]);
   const preparedState = usePreparedAnalysisState({
     L,
     focusT: analysisInputs.focusT,
@@ -89,8 +85,9 @@ export default function AnalysisDrawerContent({
         currentEPSD: analysisInputs.currentEPSD,
         currentPhysStopSD: analysisInputs.currentPhysStopSD,
         fieldGeometry: analysisInputs.fieldGeometry,
+        sampling: analysisSampling,
       }),
-    [preparedState, analysisInputs],
+    [preparedState, analysisInputs, analysisSampling],
   );
   const projection = L.projection ?? { kind: "rectilinear" };
   const noticeStyle = {

--- a/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
+++ b/src/components/layout/lensDiagram/AnalysisDrawerContent.tsx
@@ -28,7 +28,7 @@ interface AnalysisDrawerContentProps {
   onAberrationsExpandedChange: (expanded: boolean) => void;
 }
 
-const FOLDED_OPTICS_UNSUPPORTED_TABS = new Set<AnalysisTabId>(["coma", "distortion", "vignetting"]);
+const FOLDED_OPTICS_UNSUPPORTED_TABS = new Set<AnalysisTabId>(["chromatic", "coma", "distortion", "vignetting"]);
 
 export default function AnalysisDrawerContent({
   activeTab,

--- a/src/components/layout/lensDiagram/DiagramViewport.tsx
+++ b/src/components/layout/lensDiagram/DiagramViewport.tsx
@@ -137,6 +137,8 @@ export default function DiagramViewport({
   /* Aggregate per-surface dispersion quality across the lens (worst-link tier).
      Cheap to recompute on every render — walks indexByIdx once. */
   const dispersionQuality = useMemo(() => summarizeDispersionQuality(L), [L]);
+  const onAxisChromSpread = chromaticSpreads ? chromaticSpreads.onAxis : chromSpread;
+  const overlayChromSpread = chromaticSpreads ? chromaticSpreads.onAxis : chromSpread;
   const selectedAsphericElementId = useMemo(() => {
     if (isWide || sel == null || !onOpenAsphericCompare) return null;
     return elementHasAsphericSurface(L, sel) ? sel : null;
@@ -209,7 +211,7 @@ export default function DiagramViewport({
         rays={rays}
         offAxisRays={offAxisRays}
         chromaticRays={chromaticRays}
-        chromSpread={chromSpread}
+        chromSpread={onAxisChromSpread}
         dispersionQuality={dispersionQuality}
         showOnAxis={showOnAxis}
         showOffAxis={showOffAxis}
@@ -254,10 +256,10 @@ export default function DiagramViewport({
       />
 
       {/* Overlays — hidden in zoom/pan mode */}
-      {!zoomPanActive && showLcaOverlay && showChromatic && chromSpread ? (
+      {!zoomPanActive && showLcaOverlay && showChromatic && overlayChromSpread ? (
         <PanelOverlay onClose={onCloseLcaOverlay} theme={t}>
           <LCAOverlayContent
-            chromSpread={chromSpread}
+            chromSpread={overlayChromSpread}
             chromaticSpreads={chromaticSpreads}
             effectiveSC={effectiveSC}
             IMG_MM={IMG_MM}

--- a/src/components/layout/lensDiagram/LensDiagramLoadedState.tsx
+++ b/src/components/layout/lensDiagram/LensDiagramLoadedState.tsx
@@ -242,6 +242,7 @@ export default function LensDiagramLoadedState({
               chromB={chromB}
               chromV={chromV}
               chromSpread={chromSpread ?? null}
+              chromaticSpreads={chromaticSpreads}
               rayTracksF={rayTracksF}
               onOpenAbbeDiagram={overlays.openAbbeDiagram}
               onOpenAsphericCompare={overlays.openAsphCompare}

--- a/src/components/layout/lensDiagram/analysisTabRenderers.tsx
+++ b/src/components/layout/lensDiagram/analysisTabRenderers.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import AberrationsPanel from "../../display/analysis/AberrationsPanel.js";
 import BokehTab from "../../display/analysis/BokehTab.js";
+import ChromaticTab from "../../display/analysis/ChromaticTab.js";
 import ComaTab from "../../display/analysis/ComaTab.js";
 import DistortionTab from "../../display/analysis/DistortionTab.js";
 import FocusBreathingTab from "../../display/analysis/FocusBreathingTab.js";
@@ -77,6 +78,20 @@ export const ANALYSIS_TAB_RENDERERS: Record<AnalysisTabId, AnalysisTabRenderer> 
       analysisContext={analysisContext}
       expanded={aberrationsExpanded}
       onExpandedChange={onAberrationsExpandedChange}
+    />
+  ),
+  chromatic: ({ L, t, preparedState, analysisContext, inputs }) => (
+    <ChromaticTab
+      L={L}
+      t={t}
+      focusT={inputs.focusT}
+      zoomT={inputs.zoomT}
+      aberrationT={inputs.aberrationT}
+      currentEPSD={inputs.currentEPSD}
+      currentPhysStopSD={inputs.currentPhysStopSD}
+      fieldGeometry={inputs.fieldGeometry}
+      preparedState={preparedState}
+      analysisContext={analysisContext}
     />
   ),
   coma: ({ L, t, zPos, preparedState, analysisContext, inputs }) => (

--- a/src/components/layout/lensDiagram/analysisTabs.ts
+++ b/src/components/layout/lensDiagram/analysisTabs.ts
@@ -3,6 +3,7 @@ import type { AnalysisTab } from "../AnalysisDrawer.js";
 export const ANALYSIS_TABS = [
   { id: "summary", label: "SUMMARY" },
   { id: "aberrations", label: "ABERRATIONS" },
+  { id: "chromatic", label: "CHROMATIC" },
   { id: "coma", label: "COMA" },
   { id: "bokeh", label: "BOKEH" },
   { id: "distortion", label: "DISTORTION" },

--- a/src/optics/aberration/bokeh.ts
+++ b/src/optics/aberration/bokeh.ts
@@ -39,6 +39,7 @@ import {
   type BokehRadialProfile,
   type BokehRadialProfileBin,
 } from "./types.js";
+import type { AnalysisSamplingOptions } from "../analysis/analysisQuality.js";
 
 /* ── Constants ── */
 
@@ -151,6 +152,7 @@ function buildBokehTraceContext(
   currentEPSD: number,
   currentPhysStopSD: number,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): BokehTraceContext {
   const layout = doLayout(focusT, zoomT, L, aberrationT);
   return {
@@ -160,7 +162,7 @@ function buildBokehTraceContext(
     layout,
     bestFocusZ: computeBestFocusZFromLayout(L, layout, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT),
     fieldGeometryState: computeAnalysisFieldGeometryAtState(focusT, zoomT, L, aberrationT),
-    circularPupilSamples: sampleCircularPupil(BOKEH_CIRCULAR_PUPIL_RING_SAMPLES),
+    circularPupilSamples: sampleCircularPupil(sampling.bokehRingSamples ?? BOKEH_CIRCULAR_PUPIL_RING_SAMPLES),
   };
 }
 
@@ -591,10 +593,12 @@ function computeBokehPreviewFromContext(
   currentEPSD: number,
   currentPhysStopSD: number,
   label: string,
+  sampling: AnalysisSamplingOptions = {},
 ): BokehPreviewResult | null {
   const defocusDelta = sensorZ - context.layout.imgZ;
+  const fieldFractions = sampling.bokehFieldFractions ?? BOKEH_PREVIEW_FIELD_FRACTIONS;
 
-  const fields: BokehFieldResult[] = BOKEH_PREVIEW_FIELD_FRACTIONS.map((fieldFraction) => {
+  const fields: BokehFieldResult[] = fieldFractions.map((fieldFraction) => {
     const result = computeBokehFieldFootprintFromContext(
       L,
       context,
@@ -651,14 +655,16 @@ export function computeBokehPreview(
   currentPhysStopSD: number,
   label: string,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): BokehPreviewResult | null {
   return computeBokehPreviewFromContext(
     L,
-    buildBokehTraceContext(L, traceFocusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT),
+    buildBokehTraceContext(L, traceFocusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT, sampling),
     sensorZ,
     currentEPSD,
     currentPhysStopSD,
     label,
+    sampling,
   );
 }
 
@@ -690,12 +696,13 @@ export function computeBokehPreviewPair(
   currentEPSD: number,
   currentPhysStopSD: number,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): BokehPreviewPair {
   const contextCache = new Map<number, BokehTraceContext>();
   const getContext = (contextFocusT: number): BokehTraceContext => {
     const cached = contextCache.get(contextFocusT);
     if (cached) return cached;
-    const next = buildBokehTraceContext(L, contextFocusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT);
+    const next = buildBokehTraceContext(L, contextFocusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT, sampling);
     contextCache.set(contextFocusT, next);
     return next;
   };
@@ -724,6 +731,7 @@ export function computeBokehPreviewPair(
     currentEPSD,
     currentPhysStopSD,
     "Infinity",
+    sampling,
   );
 
   /*
@@ -746,6 +754,7 @@ export function computeBokehPreviewPair(
     currentEPSD,
     currentPhysStopSD,
     "Near Focus",
+    sampling,
   );
 
   return { infinity, nearFocus };

--- a/src/optics/aberration/coma.ts
+++ b/src/optics/aberration/coma.ts
@@ -34,10 +34,11 @@ import {
   MERIDIONAL_COMA_SAMPLE_COUNT,
 } from "./types.js";
 import {
-  computeStateAwareOffAxisFieldGeometry,
+  computeProjectionAwareOffAxisFieldGeometry,
+  isOffAxisVectorFieldGeometry,
   traceOffAxisBundleFromSamples,
   type OffAxisBundle,
-  type OffAxisFieldGeometry,
+  type ProjectionAwareOffAxisFieldGeometry,
 } from "./offAxis.js";
 import type { AnalysisSamplingOptions } from "../analysis/analysisQuality.js";
 
@@ -83,8 +84,12 @@ interface MeridionalComaFieldFootprint {
   maxRelativeIntercept: number;
   lowerIntercept: number;
   upperIntercept: number;
+  lowerRelativeIntercept: number;
+  upperRelativeIntercept: number;
   spanMm: number;
   spanUm: number;
+  signedOuterDeltaMm: number;
+  signedOuterDeltaUm: number;
   samples: MeridionalComaFieldSample[];
 }
 
@@ -109,6 +114,12 @@ interface ComaPointCloudFieldFootprint {
   centroidSagittalImageHeight: number;
   rmsRadiusMm: number;
   rmsRadiusUm: number;
+  tangentialSpanMm: number;
+  tangentialSpanUm: number;
+  sagittalSpanMm: number;
+  sagittalSpanUm: number;
+  centroidOffsetMm: number;
+  centroidOffsetUm: number;
   tailDirection: ComaTailDirection;
   tailSkewRatio: number;
   sagittalToTangentialRatio: number;
@@ -150,6 +161,11 @@ function fixedComaPreviewFieldMeta(fieldFractions: readonly number[]): ComaPrevi
       COMA_PREVIEW_FIELD_LABELS[fieldFraction as (typeof COMA_PREVIEW_FIELD_FRACTIONS)[number]] ??
       `${(fieldFraction * 100).toFixed(0)}%`,
   }));
+}
+
+function comaDetailFieldFraction(L: RuntimeLens, sampling: AnalysisSamplingOptions): number {
+  const candidate = sampling.comaDetailFieldFraction ?? L.offAxisFieldFrac;
+  return isFinite(candidate) && candidate >= 0 && candidate <= 1 ? candidate : L.offAxisFieldFrac;
 }
 
 function buildComaShapeDescriptor(
@@ -198,10 +214,10 @@ function traceComaFieldBundle(
   fieldFraction: number,
   traceContext: ComaTraceContext,
   samples: readonly OrthogonalPupilSample[] | readonly CircularPupilSample[],
-): { geometry: OffAxisFieldGeometry; bundle: OffAxisBundle } | null {
+): { geometry: ProjectionAwareOffAxisFieldGeometry; bundle: OffAxisBundle } | null {
   if (currentEPSD <= 0 || L.N < 1) return null;
 
-  const geometry = computeStateAwareOffAxisFieldGeometry(
+  const geometry = computeProjectionAwareOffAxisFieldGeometry(
     L,
     zPos,
     focusT,
@@ -229,20 +245,25 @@ function traceComaFieldBundle(
 }
 
 function buildMeridionalComaFieldFootprintFromBundle(
-  geometry: OffAxisFieldGeometry,
+  geometry: ProjectionAwareOffAxisFieldGeometry,
   bundle: OffAxisBundle,
   currentEPSD: number,
   samples: readonly OrthogonalPupilSample[],
 ): MeridionalComaFieldFootprint | null {
+  const centerIntercept = bundle.chiefRay.imagePoint.y;
+  const vectorGeometry = isOffAxisVectorFieldGeometry(geometry);
   const tracedSamplesByIndex = new Map(bundle.samples.map((sample) => [sample.sourceSampleIndex, sample]));
   const resolvedSamples: MeridionalComaFieldSample[] = samples.map((sample) => {
     const tracedSample = tracedSamplesByIndex.get(sample.index);
+    const imageHeight = tracedSample?.imagePoint.y ?? null;
     return {
       index: sample.index,
       pupilFraction: sample.pupilFraction,
-      launchHeight: geometry.yChief + sample.yFraction * currentEPSD,
-      imageHeight: tracedSample?.imagePoint.y ?? null,
-      relativeImageHeight: null,
+      launchHeight:
+        tracedSample?.launchY ??
+        (vectorGeometry ? sample.yFraction * currentEPSD : geometry.yChief + sample.yFraction * currentEPSD),
+      imageHeight,
+      relativeImageHeight: imageHeight === null ? null : imageHeight - centerIntercept,
       clipped: tracedSample === undefined,
     };
   });
@@ -252,24 +273,18 @@ function buildMeridionalComaFieldFootprintFromBundle(
   );
   if (validSamples.length < 3) return null;
 
-  const centerSample =
-    validSamples.find((sample) => Math.abs(sample.pupilFraction) < 1e-9) ??
-    validSamples.reduce((best, sample) =>
-      Math.abs(sample.pupilFraction) < Math.abs(best.pupilFraction) ? sample : best,
-    );
-  const centerIntercept = centerSample.imageHeight;
-
-  for (const sample of resolvedSamples) {
-    sample.relativeImageHeight = sample.imageHeight === null ? null : sample.imageHeight - centerIntercept;
-  }
-
   const lowerSample = validSamples.find((sample) => sample.pupilFraction < 0) ?? null;
   const upperSample = [...validSamples].reverse().find((sample) => sample.pupilFraction > 0) ?? null;
   if (!lowerSample || !upperSample) return null;
 
   const intercepts = validSamples.map((sample) => sample.imageHeight);
-  const relativeIntercepts = validSamples.map((sample) => sample.imageHeight - centerIntercept);
-  const spanMm = upperSample.imageHeight - lowerSample.imageHeight;
+  const relativeIntercepts = validSamples.map((sample) => sample.relativeImageHeight ?? 0);
+  const minRelativeIntercept = Math.min(...relativeIntercepts);
+  const maxRelativeIntercept = Math.max(...relativeIntercepts);
+  const lowerRelativeIntercept = lowerSample.imageHeight - centerIntercept;
+  const upperRelativeIntercept = upperSample.imageHeight - centerIntercept;
+  const signedOuterDeltaMm = upperRelativeIntercept - lowerRelativeIntercept;
+  const spanMm = maxRelativeIntercept - minRelativeIntercept;
 
   return {
     fieldFraction: geometry.fieldFraction,
@@ -280,30 +295,37 @@ function buildMeridionalComaFieldFootprintFromBundle(
     centerIntercept,
     minIntercept: Math.min(...intercepts),
     maxIntercept: Math.max(...intercepts),
-    minRelativeIntercept: Math.min(...relativeIntercepts),
-    maxRelativeIntercept: Math.max(...relativeIntercepts),
+    minRelativeIntercept,
+    maxRelativeIntercept,
     lowerIntercept: lowerSample.imageHeight,
     upperIntercept: upperSample.imageHeight,
+    lowerRelativeIntercept,
+    upperRelativeIntercept,
     spanMm,
     spanUm: spanMm * 1000,
+    signedOuterDeltaMm,
+    signedOuterDeltaUm: signedOuterDeltaMm * 1000,
     samples: resolvedSamples,
   };
 }
 
 function buildSagittalComaResultFromBundle(
-  geometry: OffAxisFieldGeometry,
+  geometry: ProjectionAwareOffAxisFieldGeometry,
   bundle: OffAxisBundle,
   currentEPSD: number,
   samples: readonly OrthogonalPupilSample[],
 ): SagittalComaResult | null {
+  const centerIntercept = bundle.chiefRay.imagePoint.x;
   const tracedSamplesByIndex = new Map(bundle.samples.map((sample) => [sample.sourceSampleIndex, sample]));
   const resolvedSamples: SagittalComaSample[] = samples.map((sample) => {
     const tracedSample = tracedSamplesByIndex.get(sample.index);
+    const imageX = tracedSample?.imagePoint.x ?? null;
     return {
       index: sample.index,
       pupilFraction: sample.pupilFraction,
-      launchX: sample.xFraction * currentEPSD,
-      imageX: tracedSample?.imagePoint.x ?? null,
+      launchX: tracedSample?.launchX ?? sample.xFraction * currentEPSD,
+      imageX,
+      relativeImageX: imageX === null ? null : imageX - centerIntercept,
       clipped: tracedSample === undefined,
     };
   });
@@ -312,21 +334,21 @@ function buildSagittalComaResultFromBundle(
   );
   if (validSamples.length < 3) return null;
 
-  const centerSample =
-    validSamples.find((sample) => Math.abs(sample.pupilFraction) < 1e-9) ??
-    validSamples.reduce((best, sample) =>
-      Math.abs(sample.pupilFraction) < Math.abs(best.pupilFraction) ? sample : best,
-    );
-  const centerIntercept = centerSample.imageX;
-
   const lowerSample = validSamples.find((sample) => sample.pupilFraction < 0) ?? null;
   const upperSample = [...validSamples].reverse().find((sample) => sample.pupilFraction > 0) ?? null;
   if (!lowerSample || !upperSample) return null;
 
   const intercepts = validSamples.map((sample) => sample.imageX);
-  const spanMm = upperSample.imageX - lowerSample.imageX;
+  const relativeIntercepts = validSamples.map((sample) => sample.relativeImageX ?? 0);
+  const minRelativeIntercept = Math.min(...relativeIntercepts);
+  const maxRelativeIntercept = Math.max(...relativeIntercepts);
+  const lowerRelativeIntercept = lowerSample.imageX - centerIntercept;
+  const upperRelativeIntercept = upperSample.imageX - centerIntercept;
+  const signedOuterDeltaMm = upperRelativeIntercept - lowerRelativeIntercept;
+  const spanMm = maxRelativeIntercept - minRelativeIntercept;
 
   return {
+    fieldFraction: geometry.fieldFraction,
     fieldAngleDeg: geometry.fieldAngleDeg,
     sampleCount: bundle.sampleCount,
     validSampleCount: validSamples.length,
@@ -334,16 +356,22 @@ function buildSagittalComaResultFromBundle(
     centerIntercept,
     minIntercept: Math.min(...intercepts),
     maxIntercept: Math.max(...intercepts),
+    minRelativeIntercept,
+    maxRelativeIntercept,
     spanMm,
     spanUm: spanMm * 1000,
+    signedOuterDeltaMm,
+    signedOuterDeltaUm: signedOuterDeltaMm * 1000,
     lowerIntercept: lowerSample.imageX,
     upperIntercept: upperSample.imageX,
+    lowerRelativeIntercept,
+    upperRelativeIntercept,
     samples: resolvedSamples,
   };
 }
 
 function buildComaPointCloudFieldFootprintFromBundle(
-  geometry: OffAxisFieldGeometry,
+  geometry: ProjectionAwareOffAxisFieldGeometry,
   bundle: OffAxisBundle,
 ): ComaPointCloudFieldFootprint | null {
   const points: ComaPointCloudPoint[] = bundle.samples.map((sample, index) => ({
@@ -376,6 +404,9 @@ function buildComaPointCloudFieldFootprintFromBundle(
   const maxRelativeTangentialImageHeight = Math.max(...tangentialHeights);
   const minRelativeSagittalImageHeight = Math.min(...sagittalHeights);
   const maxRelativeSagittalImageHeight = Math.max(...sagittalHeights);
+  const tangentialSpanMm = maxRelativeTangentialImageHeight - minRelativeTangentialImageHeight;
+  const sagittalSpanMm = maxRelativeSagittalImageHeight - minRelativeSagittalImageHeight;
+  const centroidOffsetMm = Math.hypot(centroidTangentialImageHeight, centroidSagittalImageHeight);
   const { tailDirection, tailSkewRatio, sagittalToTangentialRatio } = buildComaShapeDescriptor(
     bundle.chiefRay.imagePoint.y,
     minRelativeTangentialImageHeight,
@@ -400,6 +431,12 @@ function buildComaPointCloudFieldFootprintFromBundle(
     centroidSagittalImageHeight,
     rmsRadiusMm,
     rmsRadiusUm: rmsRadiusMm * 1000,
+    tangentialSpanMm,
+    tangentialSpanUm: tangentialSpanMm * 1000,
+    sagittalSpanMm,
+    sagittalSpanUm: sagittalSpanMm * 1000,
+    centroidOffsetMm,
+    centroidOffsetUm: centroidOffsetMm * 1000,
     tailDirection,
     tailSkewRatio,
     sagittalToTangentialRatio,
@@ -477,6 +514,12 @@ function emptyComaPointCloudPreviewFieldResult(
     centroidSagittalImageHeight: 0,
     rmsRadiusMm: 0,
     rmsRadiusUm: 0,
+    tangentialSpanMm: 0,
+    tangentialSpanUm: 0,
+    sagittalSpanMm: 0,
+    sagittalSpanUm: 0,
+    centroidOffsetMm: 0,
+    centroidOffsetUm: 0,
     tailDirection: "balanced",
     tailSkewRatio: 1,
     sagittalToTangentialRatio: 0,
@@ -510,6 +553,12 @@ function comaPointCloudPreviewFieldResultFromFootprint({
     centroidSagittalImageHeight: footprint.centroidSagittalImageHeight,
     rmsRadiusMm: footprint.rmsRadiusMm,
     rmsRadiusUm: footprint.rmsRadiusUm,
+    tangentialSpanMm: footprint.tangentialSpanMm,
+    tangentialSpanUm: footprint.tangentialSpanUm,
+    sagittalSpanMm: footprint.sagittalSpanMm,
+    sagittalSpanUm: footprint.sagittalSpanUm,
+    centroidOffsetMm: footprint.centroidOffsetMm,
+    centroidOffsetUm: footprint.centroidOffsetUm,
     tailDirection: footprint.tailDirection,
     tailSkewRatio: footprint.tailSkewRatio,
     sagittalToTangentialRatio: footprint.sagittalToTangentialRatio,
@@ -774,12 +823,13 @@ export function computeMeridionalComa(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
-    L.offAxisFieldFrac,
+    comaDetailFieldFraction(L, sampling),
     traceContext,
   );
   if (footprint === null || footprint.fieldAngleDeg <= 0) return null;
 
   return {
+    fieldFraction: footprint.fieldFraction,
     fieldAngleDeg: footprint.fieldAngleDeg,
     sampleCount: footprint.sampleCount,
     validSampleCount: footprint.validSampleCount,
@@ -787,11 +837,17 @@ export function computeMeridionalComa(
     centerIntercept: footprint.centerIntercept,
     minIntercept: footprint.minIntercept,
     maxIntercept: footprint.maxIntercept,
+    minRelativeIntercept: footprint.minRelativeIntercept,
+    maxRelativeIntercept: footprint.maxRelativeIntercept,
     spanMm: footprint.spanMm,
     spanUm: footprint.spanUm,
+    signedOuterDeltaMm: footprint.signedOuterDeltaMm,
+    signedOuterDeltaUm: footprint.signedOuterDeltaUm,
     lowerIntercept: footprint.lowerIntercept,
     upperIntercept: footprint.upperIntercept,
-    samples: footprint.samples.map(({ relativeImageHeight: _relativeImageHeight, ...sample }) => sample),
+    lowerRelativeIntercept: footprint.lowerRelativeIntercept,
+    upperRelativeIntercept: footprint.upperRelativeIntercept,
+    samples: footprint.samples,
   };
 }
 
@@ -861,7 +917,7 @@ export function computeSagittalComa(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
-    L.offAxisFieldFrac,
+    comaDetailFieldFraction(L, sampling),
     buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry, sampling),
   );
 }
@@ -932,6 +988,7 @@ export function computeComaAnalysis(
   sampling: AnalysisSamplingOptions = {},
 ): ComaAnalysisResult {
   const traceContext = buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry, sampling);
+  const detailedFieldFraction = comaDetailFieldFraction(L, sampling);
   const meridionalFootprint = computeMeridionalComaFieldFootprint(
     L,
     zPos,
@@ -939,7 +996,7 @@ export function computeComaAnalysis(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
-    L.offAxisFieldFrac,
+    detailedFieldFraction,
     traceContext,
   );
 
@@ -948,6 +1005,7 @@ export function computeComaAnalysis(
       meridionalFootprint === null || meridionalFootprint.fieldAngleDeg <= 0
         ? null
         : {
+            fieldFraction: meridionalFootprint.fieldFraction,
             fieldAngleDeg: meridionalFootprint.fieldAngleDeg,
             sampleCount: meridionalFootprint.sampleCount,
             validSampleCount: meridionalFootprint.validSampleCount,
@@ -955,13 +1013,17 @@ export function computeComaAnalysis(
             centerIntercept: meridionalFootprint.centerIntercept,
             minIntercept: meridionalFootprint.minIntercept,
             maxIntercept: meridionalFootprint.maxIntercept,
+            minRelativeIntercept: meridionalFootprint.minRelativeIntercept,
+            maxRelativeIntercept: meridionalFootprint.maxRelativeIntercept,
             spanMm: meridionalFootprint.spanMm,
             spanUm: meridionalFootprint.spanUm,
+            signedOuterDeltaMm: meridionalFootprint.signedOuterDeltaMm,
+            signedOuterDeltaUm: meridionalFootprint.signedOuterDeltaUm,
             lowerIntercept: meridionalFootprint.lowerIntercept,
             upperIntercept: meridionalFootprint.upperIntercept,
-            samples: meridionalFootprint.samples.map(
-              ({ relativeImageHeight: _relativeImageHeight, ...sample }) => sample,
-            ),
+            lowerRelativeIntercept: meridionalFootprint.lowerRelativeIntercept,
+            upperRelativeIntercept: meridionalFootprint.upperRelativeIntercept,
+            samples: meridionalFootprint.samples,
           },
     sagittalComa: computeSagittalComaResultAtField(
       L,
@@ -970,7 +1032,7 @@ export function computeComaAnalysis(
       zoomT,
       currentEPSD,
       currentPhysStopSD,
-      L.offAxisFieldFrac,
+      detailedFieldFraction,
       traceContext,
     ),
     pointCloudPreview: computeComaPointCloudPreviewFromContext(

--- a/src/optics/aberration/coma.ts
+++ b/src/optics/aberration/coma.ts
@@ -39,6 +39,7 @@ import {
   type OffAxisBundle,
   type OffAxisFieldGeometry,
 } from "./offAxis.js";
+import type { AnalysisSamplingOptions } from "../analysis/analysisQuality.js";
 
 const COMA_PREVIEW_MIN_SHARED_HALF_RANGE_MM = 0.01;
 const COMA_POINT_CLOUD_MIN_VALID_SAMPLES = 5;
@@ -57,10 +58,11 @@ interface ComaTraceContext {
   tangentialPupilSamples: OrthogonalPupilSample[];
   sagittalPupilSamples: OrthogonalPupilSample[];
   circularPupilSamples: CircularPupilSample[];
+  fieldFractions: readonly number[];
 }
 
 interface ComaPreviewFieldMeta {
-  fieldFraction: (typeof COMA_PREVIEW_FIELD_FRACTIONS)[number];
+  fieldFraction: number;
   label: string;
 }
 
@@ -87,7 +89,7 @@ interface MeridionalComaFieldFootprint {
 }
 
 interface FixedComaPreviewFootprint {
-  fieldFraction: (typeof COMA_PREVIEW_FIELD_FRACTIONS)[number];
+  fieldFraction: number;
   label: string;
   footprint: MeridionalComaFieldFootprint | null;
 }
@@ -114,7 +116,7 @@ interface ComaPointCloudFieldFootprint {
 }
 
 interface FixedComaPointCloudPreviewFootprint {
-  fieldFraction: (typeof COMA_PREVIEW_FIELD_FRACTIONS)[number];
+  fieldFraction: number;
   label: string;
   footprint: ComaPointCloudFieldFootprint | null;
 }
@@ -125,20 +127,28 @@ function buildComaTraceContext(
   zoomT: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): ComaTraceContext {
+  const meridionalSampleCount = Math.max(3, Math.round(sampling.comaFanSampleCount ?? MERIDIONAL_COMA_SAMPLE_COUNT));
+  const circularPupilSamples = sampleCircularPupil(
+    sampling.comaRingSamples ?? COMA_PREVIEW_CIRCULAR_PUPIL_RING_SAMPLES,
+  );
   return {
     aberrationT,
     fieldGeometryState: fieldGeometry ?? computeAnalysisFieldGeometryAtState(focusT, zoomT, L, aberrationT),
-    tangentialPupilSamples: sampleOrthogonalPupilFan(MERIDIONAL_COMA_SAMPLE_COUNT, "tangential"),
-    sagittalPupilSamples: sampleOrthogonalPupilFan(MERIDIONAL_COMA_SAMPLE_COUNT, "sagittal"),
-    circularPupilSamples: sampleCircularPupil(COMA_PREVIEW_CIRCULAR_PUPIL_RING_SAMPLES),
+    tangentialPupilSamples: sampleOrthogonalPupilFan(meridionalSampleCount, "tangential"),
+    sagittalPupilSamples: sampleOrthogonalPupilFan(meridionalSampleCount, "sagittal"),
+    circularPupilSamples,
+    fieldFractions: sampling.comaFieldFractions ?? COMA_PREVIEW_FIELD_FRACTIONS,
   };
 }
 
-function fixedComaPreviewFieldMeta(): ComaPreviewFieldMeta[] {
-  return COMA_PREVIEW_FIELD_FRACTIONS.map((fieldFraction) => ({
+function fixedComaPreviewFieldMeta(fieldFractions: readonly number[]): ComaPreviewFieldMeta[] {
+  return fieldFractions.map((fieldFraction) => ({
     fieldFraction,
-    label: COMA_PREVIEW_FIELD_LABELS[fieldFraction],
+    label:
+      COMA_PREVIEW_FIELD_LABELS[fieldFraction as (typeof COMA_PREVIEW_FIELD_FRACTIONS)[number]] ??
+      `${(fieldFraction * 100).toFixed(0)}%`,
   }));
 }
 
@@ -397,20 +407,23 @@ function buildComaPointCloudFieldFootprintFromBundle(
   };
 }
 
-function emptyComaPreviewFieldResult({ fieldFraction, label }: ComaPreviewFieldMeta): ComaPreviewFieldResult {
+function emptyComaPreviewFieldResult(
+  { fieldFraction, label }: ComaPreviewFieldMeta,
+  sampleCount = MERIDIONAL_COMA_SAMPLE_COUNT,
+): ComaPreviewFieldResult {
   return {
     fieldFraction,
     label,
     fieldAngleDeg: 0,
-    sampleCount: MERIDIONAL_COMA_SAMPLE_COUNT,
+    sampleCount,
     validSampleCount: 0,
-    clippedSampleCount: MERIDIONAL_COMA_SAMPLE_COUNT,
+    clippedSampleCount: sampleCount,
     chiefIntercept: 0,
     minRelativeIntercept: 0,
     maxRelativeIntercept: 0,
-    samples: Array.from({ length: MERIDIONAL_COMA_SAMPLE_COUNT }, (_, index) => ({
+    samples: Array.from({ length: sampleCount }, (_, index) => ({
       index,
-      pupilFraction: -1 + (2 * index) / (MERIDIONAL_COMA_SAMPLE_COUNT - 1),
+      pupilFraction: sampleCount > 1 ? -1 + (2 * index) / (sampleCount - 1) : 0,
       launchHeight: 0,
       imageHeight: null,
       relativeImageHeight: null,
@@ -444,17 +457,17 @@ function comaPreviewFieldResultFromFootprint({
   };
 }
 
-function emptyComaPointCloudPreviewFieldResult({
-  fieldFraction,
-  label,
-}: ComaPreviewFieldMeta): ComaPointCloudPreviewFieldResult {
+function emptyComaPointCloudPreviewFieldResult(
+  { fieldFraction, label }: ComaPreviewFieldMeta,
+  sampleCount = COMA_PREVIEW_POINT_CLOUD_SAMPLE_COUNT,
+): ComaPointCloudPreviewFieldResult {
   return {
     fieldFraction,
     label,
     fieldAngleDeg: 0,
-    sampleCount: COMA_PREVIEW_POINT_CLOUD_SAMPLE_COUNT,
+    sampleCount,
     validSampleCount: 0,
-    clippedSampleCount: COMA_PREVIEW_POINT_CLOUD_SAMPLE_COUNT,
+    clippedSampleCount: sampleCount,
     chiefIntercept: 0,
     minRelativeTangentialImageHeight: 0,
     maxRelativeTangentialImageHeight: 0,
@@ -602,7 +615,7 @@ function buildFixedComaPreviewFootprints(
   currentPhysStopSD: number,
   traceContext: ComaTraceContext,
 ): FixedComaPreviewFootprint[] {
-  return fixedComaPreviewFieldMeta().map(({ fieldFraction, label }) => ({
+  return fixedComaPreviewFieldMeta(traceContext.fieldFractions).map(({ fieldFraction, label }) => ({
     fieldFraction,
     label,
     footprint: computeMeridionalComaFieldFootprint(
@@ -627,7 +640,7 @@ function buildFixedComaPointCloudPreviewFootprints(
   currentPhysStopSD: number,
   traceContext: ComaTraceContext,
 ): FixedComaPointCloudPreviewFootprint[] {
-  return fixedComaPreviewFieldMeta().map(({ fieldFraction, label }) => ({
+  return fixedComaPreviewFieldMeta(traceContext.fieldFractions).map(({ fieldFraction, label }) => ({
     fieldFraction,
     label,
     footprint: computeComaPointCloudFieldFootprint(
@@ -673,7 +686,7 @@ function computeComaPreviewFromContext(
   );
 
   return {
-    fieldFractions: COMA_PREVIEW_FIELD_FRACTIONS,
+    fieldFractions: traceContext.fieldFractions,
     fields,
     sharedRelativeHalfRangeMm,
     usableFieldCount: usableFields.length,
@@ -717,7 +730,7 @@ function computeComaPointCloudPreviewFromContext(
   const sharedSpotHalfRangeMm = Math.max(sharedTangentialHalfRangeMm, sharedSagittalHalfRangeMm);
 
   return {
-    fieldFractions: COMA_PREVIEW_FIELD_FRACTIONS,
+    fieldFractions: traceContext.fieldFractions,
     fields,
     sharedTangentialHalfRangeMm,
     sharedSagittalHalfRangeMm,
@@ -751,8 +764,9 @@ export function computeMeridionalComa(
   currentPhysStopSD: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): MeridionalComaResult | null {
-  const traceContext = buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry);
+  const traceContext = buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry, sampling);
   const footprint = computeMeridionalComaFieldFootprint(
     L,
     zPos,
@@ -803,6 +817,7 @@ export function computeComaPreview(
   currentPhysStopSD: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): ComaPreviewResult | null {
   return computeComaPreviewFromContext(
     L,
@@ -811,7 +826,7 @@ export function computeComaPreview(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
-    buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry),
+    buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry, sampling),
   );
 }
 
@@ -837,6 +852,7 @@ export function computeSagittalComa(
   currentPhysStopSD: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): SagittalComaResult | null {
   return computeSagittalComaResultAtField(
     L,
@@ -846,7 +862,7 @@ export function computeSagittalComa(
     currentEPSD,
     currentPhysStopSD,
     L.offAxisFieldFrac,
-    buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry),
+    buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry, sampling),
   );
 }
 
@@ -875,6 +891,7 @@ export function computeComaPointCloudPreview(
   currentPhysStopSD: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): ComaPointCloudPreviewResult | null {
   return computeComaPointCloudPreviewFromContext(
     L,
@@ -883,7 +900,7 @@ export function computeComaPointCloudPreview(
     zoomT,
     currentEPSD,
     currentPhysStopSD,
-    buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry),
+    buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry, sampling),
   );
 }
 
@@ -912,8 +929,9 @@ export function computeComaAnalysis(
   currentPhysStopSD: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): ComaAnalysisResult {
-  const traceContext = buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry);
+  const traceContext = buildComaTraceContext(L, focusT, zoomT, aberrationT, fieldGeometry, sampling);
   const meridionalFootprint = computeMeridionalComaFieldFootprint(
     L,
     zPos,

--- a/src/optics/aberration/fieldCurvature.ts
+++ b/src/optics/aberration/fieldCurvature.ts
@@ -27,6 +27,7 @@ import {
   type OffAxisFieldGeometry,
 } from "./offAxis.js";
 import { bestRelativeFocusPlane, type TransverseFocusHit } from "./shared.js";
+import { CHROMATIC_CHANNEL_ORDER } from "../chromatic/channels.js";
 import type { AnalysisSamplingOptions } from "../analysis/analysisQuality.js";
 
 const FIELD_CURVATURE_MIN_SHARED_HALF_RANGE_MM = 0.1;
@@ -137,9 +138,7 @@ function petzvalShiftAtImageHeight(imageHeight: number, petzvalSum: number): num
   return -(radius - Math.sign(radius) * Math.sqrt(underRoot));
 }
 
-// Field-curvature shift is a longitudinal-focus metric on the C/d/F triplet only;
-// g-line (V) tracing is supported by the engine but not analyzed here.
-const CHROMATIC_CHANNELS: ("R" | "G" | "B")[] = ["R", "G", "B"];
+const CHROMATIC_FIELD_CHANNELS: readonly ChromaticChannel[] = CHROMATIC_CHANNEL_ORDER;
 
 function parabasalPupilFraction(entrancePupilSemiDiameter: number): number {
   if (!isFinite(entrancePupilSemiDiameter) || entrancePupilSemiDiameter <= 0) {
@@ -325,7 +324,7 @@ function computeChromaticFieldShifts(
 ): ChromaticFieldShift[] | null {
   const shifts: ChromaticFieldShift[] = [];
 
-  for (const channel of CHROMATIC_CHANNELS) {
+  for (const channel of CHROMATIC_FIELD_CHANNELS) {
     const fieldFocus = computeStandardizedFieldFocus(
       L,
       geometry,

--- a/src/optics/aberration/fieldCurvature.ts
+++ b/src/optics/aberration/fieldCurvature.ts
@@ -13,6 +13,7 @@ import {
 } from "./types.js";
 import {
   computeAnalysisFieldGeometryAtState,
+  sampleOrthogonalPupilFan,
   thick,
   traceChiefRelativeSkewRay,
   traceChiefRelativeSkewRayChromatic,
@@ -22,10 +23,11 @@ import {
   bestFocusPlaneForDirection,
   computeStateAwareOffAxisFieldGeometry,
   traceOffAxisChiefRay,
-  traceOrthogonalOffAxisBundle,
+  traceOffAxisBundleFromSamples,
   type OffAxisFieldGeometry,
 } from "./offAxis.js";
 import { bestRelativeFocusPlane, type TransverseFocusHit } from "./shared.js";
+import type { AnalysisSamplingOptions } from "../analysis/analysisQuality.js";
 
 const FIELD_CURVATURE_MIN_SHARED_HALF_RANGE_MM = 0.1;
 const FIELD_CURVATURE_PARABASAL_RAY_HEIGHT_MM = 0.01;
@@ -265,10 +267,10 @@ function computeDiagnosticFieldFocus(
   currentEPSD: number,
   currentPhysStopSD: number,
   aberrationT = 0,
+  sampleCount = MERIDIONAL_COMA_SAMPLE_COUNT,
 ): DiagnosticFieldFocus | null {
-  const tangentialBundle = traceOrthogonalOffAxisBundle(
-    "tangential",
-    MERIDIONAL_COMA_SAMPLE_COUNT,
+  const tangentialBundle = traceOffAxisBundleFromSamples(
+    sampleOrthogonalPupilFan(sampleCount, "tangential"),
     geometry,
     L,
     focusT,
@@ -278,9 +280,8 @@ function computeDiagnosticFieldFocus(
     undefined,
     aberrationT,
   );
-  const sagittalBundle = traceOrthogonalOffAxisBundle(
-    "sagittal",
-    MERIDIONAL_COMA_SAMPLE_COUNT,
+  const sagittalBundle = traceOffAxisBundleFromSamples(
+    sampleOrthogonalPupilFan(sampleCount, "sagittal"),
     geometry,
     L,
     focusT,
@@ -301,9 +302,9 @@ function computeDiagnosticFieldFocus(
   const validSampleCount = Math.min(tangentialBundle.validSampleCount, sagittalBundle.validSampleCount);
 
   return {
-    sampleCount: MERIDIONAL_COMA_SAMPLE_COUNT,
+    sampleCount,
     validSampleCount,
-    clippedSampleCount: MERIDIONAL_COMA_SAMPLE_COUNT - validSampleCount,
+    clippedSampleCount: sampleCount - validSampleCount,
     tangentialBestFocusZ,
     sagittalBestFocusZ,
     tangentialShiftMm,
@@ -358,6 +359,7 @@ function computeFieldCurvatureField(
   chromatic: boolean,
   stateGeometry: FieldGeometryState,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): FieldCurvatureFieldResult {
   if (currentEPSD <= 0 || L.N < 1) return emptyFieldCurvatureFieldResult(meta);
 
@@ -392,6 +394,7 @@ function computeFieldCurvatureField(
     currentEPSD,
     currentPhysStopSD,
     aberrationT,
+    sampling.fieldCurvatureDiagnosticSampleCount,
   );
   const chiefImageHeight = standardizedFieldFocus.chiefImageHeight;
   const petzvalShiftMm = petzvalShiftAtImageHeight(chiefImageHeight, L.petzvalSum) ?? 0;
@@ -473,8 +476,8 @@ function buildFieldCurvatureResult(
   }
 
   return {
-    fieldFractions: FIELD_CURVATURE_FIELD_FRACTIONS,
-    curveFieldFractions: FIELD_CURVATURE_CURVE_FIELD_FRACTIONS,
+    fieldFractions: fields.map((field) => field.fieldFraction),
+    curveFieldFractions: curveFields.map((field) => field.fieldFraction),
     fields,
     curveFields,
     usableFieldCount: usableFields.length,
@@ -497,6 +500,7 @@ function computeFieldCurvatureBase(
   currentPhysStopSD: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): { result: FieldCurvatureResult | null; stateGeometry: FieldGeometryState; imagePlaneZ: number } {
   if (currentEPSD <= 0 || L.N < 1) {
     return {
@@ -511,7 +515,9 @@ function computeFieldCurvatureBase(
   const stateGeometry = fieldGeometry ?? computeAnalysisFieldGeometryAtState(focusT, zoomT, L, aberrationT);
   if (!isFinite(imagePlaneZ)) return { result: null, stateGeometry, imagePlaneZ };
 
-  const fields = fieldCurvatureFieldMeta(FIELD_CURVATURE_FIELD_FRACTIONS).map((meta) =>
+  const fieldFractions = sampling.fieldCurvatureFieldFractions ?? FIELD_CURVATURE_FIELD_FRACTIONS;
+  const curveFieldFractions = sampling.fieldCurvatureCurveFieldFractions ?? FIELD_CURVATURE_CURVE_FIELD_FRACTIONS;
+  const fields = fieldCurvatureFieldMeta(fieldFractions).map((meta) =>
     computeFieldCurvatureField(
       L,
       zPos,
@@ -523,9 +529,10 @@ function computeFieldCurvatureBase(
       false,
       stateGeometry,
       aberrationT,
+      sampling,
     ),
   );
-  const curveFields = fieldCurvatureFieldMeta(FIELD_CURVATURE_CURVE_FIELD_FRACTIONS).map((meta) =>
+  const curveFields = fieldCurvatureFieldMeta(curveFieldFractions).map((meta) =>
     computeFieldCurvatureField(
       L,
       zPos,
@@ -537,6 +544,7 @@ function computeFieldCurvatureBase(
       false,
       stateGeometry,
       aberrationT,
+      sampling,
     ),
   );
 
@@ -645,6 +653,7 @@ export function computeFieldCurvatureBundle(
   currentPhysStopSD: number,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): FieldCurvatureBundleResult {
   const base = computeFieldCurvatureBase(
     L,
@@ -655,6 +664,7 @@ export function computeFieldCurvatureBundle(
     currentPhysStopSD,
     aberrationT,
     fieldGeometry,
+    sampling,
   );
   return {
     fieldCurvature: base.result,
@@ -699,6 +709,7 @@ export function computeFieldCurvature(
   chromatic = false,
   aberrationT = 0,
   fieldGeometry?: FieldGeometryState,
+  sampling: AnalysisSamplingOptions = {},
 ): FieldCurvatureResult | null {
   const base = computeFieldCurvatureBase(
     L,
@@ -709,6 +720,7 @@ export function computeFieldCurvature(
     currentPhysStopSD,
     aberrationT,
     fieldGeometry,
+    sampling,
   );
   if (!chromatic) return base.result;
   return buildChromaticFieldCurvatureFromBase(

--- a/src/optics/aberration/spherical.ts
+++ b/src/optics/aberration/spherical.ts
@@ -14,6 +14,7 @@ import type {
   SphericalAberrationResult,
 } from "./types.js";
 import { BOKEH_CIRCULAR_PUPIL_RING_SAMPLES } from "./types.js";
+import type { AnalysisSamplingOptions } from "../analysis/analysisQuality.js";
 import { buildBokehRadialProfile, classifyBokehBrightnessCharacter } from "./bokeh.js";
 import { computeStateAwareOffAxisFieldGeometry, traceOffAxisBundleFromSamples, type OffAxisBundle } from "./offAxis.js";
 import { NEAR_AXIS_REAL_FRAC } from "./types.js";
@@ -319,6 +320,7 @@ export function computeSphericalAberrationBlurCharacter(
   currentPhysStopSD: number,
   baseResult: Pick<SphericalAberrationResult, "bestFocusZ" | "longitudinalSaMm"> | null = null,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): SphericalAberrationBlurCharacterResult | null {
   if (currentEPSD <= 0 || L.N < 1) return null;
 
@@ -334,7 +336,7 @@ export function computeSphericalAberrationBlurCharacter(
   if (geometry === null) return null;
 
   const bundle = traceOffAxisBundleFromSamples(
-    sampleCircularPupil(BOKEH_CIRCULAR_PUPIL_RING_SAMPLES),
+    sampleCircularPupil(sampling.sphericalBlurRingSamples ?? BOKEH_CIRCULAR_PUPIL_RING_SAMPLES),
     geometry,
     L,
     focusT,

--- a/src/optics/aberration/types.ts
+++ b/src/optics/aberration/types.ts
@@ -55,11 +55,13 @@ export interface MeridionalComaSample {
   pupilFraction: number;
   launchHeight: number;
   imageHeight: number | null;
+  relativeImageHeight: number | null;
   clipped: boolean;
 }
 
 /** Dense meridional coma analysis result for the current lens state. */
 export interface MeridionalComaResult {
+  fieldFraction: number;
   fieldAngleDeg: number;
   sampleCount: number;
   validSampleCount: number;
@@ -67,10 +69,16 @@ export interface MeridionalComaResult {
   centerIntercept: number;
   minIntercept: number;
   maxIntercept: number;
+  minRelativeIntercept: number;
+  maxRelativeIntercept: number;
   spanMm: number;
   spanUm: number;
+  signedOuterDeltaMm: number;
+  signedOuterDeltaUm: number;
   lowerIntercept: number;
   upperIntercept: number;
+  lowerRelativeIntercept: number;
+  upperRelativeIntercept: number;
   samples: MeridionalComaSample[];
 }
 
@@ -80,11 +88,13 @@ export interface SagittalComaSample {
   pupilFraction: number;
   launchX: number;
   imageX: number | null;
+  relativeImageX: number | null;
   clipped: boolean;
 }
 
 /** Dense sagittal coma analysis result for the current lens state. */
 export interface SagittalComaResult {
+  fieldFraction: number;
   fieldAngleDeg: number;
   sampleCount: number;
   validSampleCount: number;
@@ -92,10 +102,16 @@ export interface SagittalComaResult {
   centerIntercept: number;
   minIntercept: number;
   maxIntercept: number;
+  minRelativeIntercept: number;
+  maxRelativeIntercept: number;
   spanMm: number;
   spanUm: number;
+  signedOuterDeltaMm: number;
+  signedOuterDeltaUm: number;
   lowerIntercept: number;
   upperIntercept: number;
+  lowerRelativeIntercept: number;
+  upperRelativeIntercept: number;
   samples: SagittalComaSample[];
 }
 
@@ -151,6 +167,12 @@ export interface ComaPointCloudPreviewFieldResult {
   centroidSagittalImageHeight: number;
   rmsRadiusMm: number;
   rmsRadiusUm: number;
+  tangentialSpanMm: number;
+  tangentialSpanUm: number;
+  sagittalSpanMm: number;
+  sagittalSpanUm: number;
+  centroidOffsetMm: number;
+  centroidOffsetUm: number;
   tailDirection: ComaTailDirection;
   tailSkewRatio: number;
   sagittalToTangentialRatio: number;

--- a/src/optics/aberration/types.ts
+++ b/src/optics/aberration/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { DEFAULT_ORTHOGONAL_PUPIL_FAN_SAMPLE_COUNT } from "../optics.js";
+import type { ChromaticChannel } from "../../types/optics.js";
 
 /** One sample point on the real-ray transverse SA profile curve. */
 export interface SAProfilePoint {
@@ -199,7 +200,7 @@ export interface ComaAnalysisResult {
 
 /** Per-channel chromatic focus shift at a single field position. */
 export interface ChromaticFieldShift {
-  channel: "R" | "G" | "B";
+  channel: ChromaticChannel;
   tangentialShiftMm: number;
   sagittalShiftMm: number;
 }

--- a/src/optics/analysis/aberrations.ts
+++ b/src/optics/analysis/aberrations.ts
@@ -19,6 +19,7 @@ import {
 import type { FieldGeometryState } from "../optics.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { PreparedOpticalState } from "../types.js";
+import type { AnalysisSamplingOptions } from "./analysisQuality.js";
 import { zPosForPreparedAnalysis2 } from "./preparedStateAdapters.js";
 
 function zPosFromState(state: PreparedOpticalState): number[] {
@@ -90,6 +91,7 @@ export function computeSphericalAberrationBlurCharacterForState2(
   currentEPSD: number,
   currentPhysStopSD: number,
   baseResult: Parameters<typeof computeSphericalAberrationBlurCharacter>[6] = null,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeSphericalAberrationBlurCharacter(
     state.lens.runtime,
@@ -100,6 +102,7 @@ export function computeSphericalAberrationBlurCharacterForState2(
     currentPhysStopSD,
     baseResult,
     state.aberrationT,
+    sampling,
   );
 }
 
@@ -122,6 +125,7 @@ export function computeFieldCurvatureForState2(
   currentPhysStopSD: number,
   chromatic = false,
   fieldGeometry?: FieldGeometryState,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeFieldCurvature(
     state.lens.runtime,
@@ -133,6 +137,7 @@ export function computeFieldCurvatureForState2(
     chromatic,
     state.aberrationT,
     fieldGeometry,
+    sampling,
   );
 }
 
@@ -153,6 +158,7 @@ export function computeFieldCurvatureBundleForState2(
   currentEPSD: number,
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeFieldCurvatureBundle(
     state.lens.runtime,
@@ -163,6 +169,7 @@ export function computeFieldCurvatureBundleForState2(
     currentPhysStopSD,
     state.aberrationT,
     fieldGeometry,
+    sampling,
   );
 }
 
@@ -183,6 +190,7 @@ export function computeComaAnalysisForState2(
   currentEPSD: number,
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeComaAnalysis(
     state.lens.runtime,
@@ -193,6 +201,7 @@ export function computeComaAnalysisForState2(
     currentPhysStopSD,
     state.aberrationT,
     fieldGeometry,
+    sampling,
   );
 }
 

--- a/src/optics/analysis/analysisContext.ts
+++ b/src/optics/analysis/analysisContext.ts
@@ -49,6 +49,7 @@ export interface AnalysisComputationContext extends AnalysisComputationContextPa
     typeof analysisJobsForState2.computeSphericalAberrationBlurCharacter
   >;
   computeFieldCurvatureBundle: () => ReturnType<typeof analysisJobsForState2.computeFieldCurvatureBundle>;
+  computeChromaticAnalysis: () => ReturnType<typeof analysisJobsForState2.computeChromaticAnalysis>;
   computeComaAnalysis: () => ReturnType<typeof analysisJobsForState2.computeComaAnalysis>;
 }
 
@@ -84,6 +85,7 @@ export function createAnalysisComputationContext({
     | ReturnType<typeof analysisJobsForState2.computeSphericalAberrationBlurCharacter>
     | undefined;
   let fieldCurvatureBundle: ReturnType<typeof analysisJobsForState2.computeFieldCurvatureBundle> | undefined;
+  let chromaticAnalysis: ReturnType<typeof analysisJobsForState2.computeChromaticAnalysis> | undefined;
   let comaAnalysis: ReturnType<typeof analysisJobsForState2.computeComaAnalysis> | undefined;
 
   return {
@@ -164,6 +166,14 @@ export function createAnalysisComputationContext({
     },
     computeFieldCurvatureBundle: () =>
       (fieldCurvatureBundle ??= analysisJobsForState2.computeFieldCurvatureBundle(
+        preparedState,
+        currentEPSD,
+        currentPhysStopSD,
+        resolvedFieldGeometry,
+        sampling,
+      )),
+    computeChromaticAnalysis: () =>
+      (chromaticAnalysis ??= analysisJobsForState2.computeChromaticAnalysis(
         preparedState,
         currentEPSD,
         currentPhysStopSD,

--- a/src/optics/analysis/analysisContext.ts
+++ b/src/optics/analysis/analysisContext.ts
@@ -189,7 +189,11 @@ export function createAnalysisComputationContext({
         currentEPSD,
         currentPhysStopSD,
         resolvedFieldGeometry,
-        { channels: CHROMATIC_CHANNEL_ORDER },
+        {
+          channels: CHROMATIC_CHANNEL_ORDER,
+          onAxisFractions: sampling.chromaticRayTraceOnAxisFractions,
+          offAxisFractions: sampling.chromaticRayTraceOffAxisFractions,
+        },
       )),
     computeComaAnalysis: () =>
       (comaAnalysis ??= analysisJobsForState2.computeComaAnalysis(

--- a/src/optics/analysis/analysisContext.ts
+++ b/src/optics/analysis/analysisContext.ts
@@ -9,6 +9,7 @@
 import { analysisJobsForState2 } from "./analysisJobs.js";
 import type { FieldGeometryState } from "../optics.js";
 import type { PreparedOpticalState } from "../types.js";
+import type { AnalysisSamplingOptions } from "./analysisQuality.js";
 
 /**
  * Shared inputs for a set of analysis computations at one focus/zoom/aperture state.
@@ -25,6 +26,7 @@ export interface AnalysisComputationContextParams {
   currentEPSD: number;
   currentPhysStopSD: number;
   fieldGeometry?: FieldGeometryState | null;
+  sampling?: AnalysisSamplingOptions;
 }
 
 /**
@@ -66,6 +68,7 @@ export function createAnalysisComputationContext({
   currentEPSD,
   currentPhysStopSD,
   fieldGeometry = null,
+  sampling = {},
 }: AnalysisComputationContextParams): AnalysisComputationContext {
   const resolvedFieldGeometry = fieldGeometry ?? undefined;
   let opticalSummary: ReturnType<typeof analysisJobsForState2.computeOpticalSummary> | undefined;
@@ -103,6 +106,7 @@ export function createAnalysisComputationContext({
         dynamicEFL,
         currentPhysStopSD,
         resolvedFieldGeometry,
+        sampling,
       )),
     computeDistortionFieldGrid: () =>
       (distortionFieldGrid ??= analysisJobsForState2.computeDistortionFieldGrid(
@@ -116,11 +120,12 @@ export function createAnalysisComputationContext({
         currentEPSD,
         currentPhysStopSD,
         resolvedFieldGeometry,
+        sampling,
       )),
     computeBothPupilAberrationProfiles: () =>
       (pupilProfiles ??= analysisJobsForState2.computeBothPupilAberrationProfiles(
         preparedState,
-        undefined,
+        sampling.pupilAberrationSampleCount ?? undefined,
         resolvedFieldGeometry,
       )),
     computeBokehPreviewPair: () =>
@@ -128,6 +133,7 @@ export function createAnalysisComputationContext({
         preparedState,
         currentEPSD,
         currentPhysStopSD,
+        sampling,
       )),
     computeBestFocusZ: () =>
       (bestFocusZ ??= analysisJobsForState2.computeBestFocusZ(preparedState, currentEPSD, currentPhysStopSD)),
@@ -151,6 +157,7 @@ export function createAnalysisComputationContext({
           currentEPSD,
           currentPhysStopSD,
           sphericalAberration,
+          sampling,
         );
       }
       return sphericalAberrationBlurCharacter;
@@ -161,6 +168,7 @@ export function createAnalysisComputationContext({
         currentEPSD,
         currentPhysStopSD,
         resolvedFieldGeometry,
+        sampling,
       )),
     computeComaAnalysis: () =>
       (comaAnalysis ??= analysisJobsForState2.computeComaAnalysis(
@@ -168,6 +176,7 @@ export function createAnalysisComputationContext({
         currentEPSD,
         currentPhysStopSD,
         resolvedFieldGeometry,
+        sampling,
       )),
   };
 }

--- a/src/optics/analysis/analysisContext.ts
+++ b/src/optics/analysis/analysisContext.ts
@@ -7,6 +7,7 @@
  */
 
 import { analysisJobsForState2 } from "./analysisJobs.js";
+import { CHROMATIC_CHANNEL_ORDER } from "../chromatic/channels.js";
 import type { FieldGeometryState } from "../optics.js";
 import type { PreparedOpticalState } from "../types.js";
 import type { AnalysisSamplingOptions } from "./analysisQuality.js";
@@ -50,6 +51,7 @@ export interface AnalysisComputationContext extends AnalysisComputationContextPa
   >;
   computeFieldCurvatureBundle: () => ReturnType<typeof analysisJobsForState2.computeFieldCurvatureBundle>;
   computeChromaticAnalysis: () => ReturnType<typeof analysisJobsForState2.computeChromaticAnalysis>;
+  computeChromaticRayTraceAnalysis: () => ReturnType<typeof analysisJobsForState2.computeChromaticRayTraceAnalysis>;
   computeComaAnalysis: () => ReturnType<typeof analysisJobsForState2.computeComaAnalysis>;
 }
 
@@ -86,6 +88,7 @@ export function createAnalysisComputationContext({
     | undefined;
   let fieldCurvatureBundle: ReturnType<typeof analysisJobsForState2.computeFieldCurvatureBundle> | undefined;
   let chromaticAnalysis: ReturnType<typeof analysisJobsForState2.computeChromaticAnalysis> | undefined;
+  let chromaticRayTraceAnalysis: ReturnType<typeof analysisJobsForState2.computeChromaticRayTraceAnalysis> | undefined;
   let comaAnalysis: ReturnType<typeof analysisJobsForState2.computeComaAnalysis> | undefined;
 
   return {
@@ -179,6 +182,14 @@ export function createAnalysisComputationContext({
         currentPhysStopSD,
         resolvedFieldGeometry,
         sampling,
+      )),
+    computeChromaticRayTraceAnalysis: () =>
+      (chromaticRayTraceAnalysis ??= analysisJobsForState2.computeChromaticRayTraceAnalysis(
+        preparedState,
+        currentEPSD,
+        currentPhysStopSD,
+        resolvedFieldGeometry,
+        { channels: CHROMATIC_CHANNEL_ORDER },
       )),
     computeComaAnalysis: () =>
       (comaAnalysis ??= analysisJobsForState2.computeComaAnalysis(

--- a/src/optics/analysis/analysisJobs.ts
+++ b/src/optics/analysis/analysisJobs.ts
@@ -8,6 +8,7 @@
 import type { FieldGeometryState } from "../optics.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { PreparedOpticalState } from "../types.js";
+import type { AnalysisSamplingOptions } from "./analysisQuality.js";
 import {
   computeComaAnalysisForState2,
   computeFieldCurvatureBundle2,
@@ -55,8 +56,19 @@ export const analysisJobs2 = {
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
     aberrationT = 0,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeDistortionCurve2(L, zPos, focusT, zoomT, dynamicEFL, currentPhysStopSD, fieldGeometry, aberrationT);
+    return computeDistortionCurve2(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      dynamicEFL,
+      currentPhysStopSD,
+      fieldGeometry,
+      aberrationT,
+      sampling,
+    );
   },
 
   computeDistortionFieldGrid(
@@ -67,8 +79,9 @@ export const analysisJobs2 = {
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
     aberrationT = 0,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeDistortionFieldGrid2(L, zPos, focusT, zoomT, currentPhysStopSD, fieldGeometry, aberrationT);
+    return computeDistortionFieldGrid2(L, zPos, focusT, zoomT, currentPhysStopSD, fieldGeometry, aberrationT, sampling);
   },
 
   computeVignettingCurve(
@@ -80,8 +93,19 @@ export const analysisJobs2 = {
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
     aberrationT = 0,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeVignettingCurve2(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, fieldGeometry, aberrationT);
+    return computeVignettingCurve2(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      fieldGeometry,
+      aberrationT,
+      sampling,
+    );
   },
 
   computeFieldCurvatureBundle(
@@ -93,6 +117,7 @@ export const analysisJobs2 = {
     currentPhysStopSD: number,
     aberrationT = 0,
     fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
   ) {
     return computeFieldCurvatureBundle2(
       L,
@@ -103,6 +128,7 @@ export const analysisJobs2 = {
       currentPhysStopSD,
       aberrationT,
       fieldGeometry,
+      sampling,
     );
   },
 
@@ -124,8 +150,9 @@ export const analysisJobs2 = {
     currentEPSD: number,
     currentPhysStopSD: number,
     aberrationT = 0,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeBokehPreviewPair2(L, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT);
+    return computeBokehPreviewPair2(L, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT, sampling);
   },
 
   computeBothPupilAberrationProfiles(
@@ -162,8 +189,15 @@ export const analysisJobsForState2 = {
     currentEPSD: number,
     currentPhysStopSD: number,
     baseResult: Parameters<typeof computeSphericalAberrationBlurCharacterForState2>[3] = null,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeSphericalAberrationBlurCharacterForState2(state, currentEPSD, currentPhysStopSD, baseResult);
+    return computeSphericalAberrationBlurCharacterForState2(
+      state,
+      currentEPSD,
+      currentPhysStopSD,
+      baseResult,
+      sampling,
+    );
   },
 
   computeFieldCurvature(
@@ -172,8 +206,9 @@ export const analysisJobsForState2 = {
     currentPhysStopSD: number,
     chromatic = false,
     fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeFieldCurvatureForState2(state, currentEPSD, currentPhysStopSD, chromatic, fieldGeometry);
+    return computeFieldCurvatureForState2(state, currentEPSD, currentPhysStopSD, chromatic, fieldGeometry, sampling);
   },
 
   computeFieldCurvatureBundle(
@@ -181,8 +216,9 @@ export const analysisJobsForState2 = {
     currentEPSD: number,
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeFieldCurvatureBundleForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry);
+    return computeFieldCurvatureBundleForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry, sampling);
   },
 
   computeComaAnalysis(
@@ -190,16 +226,22 @@ export const analysisJobsForState2 = {
     currentEPSD: number,
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeComaAnalysisForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry);
+    return computeComaAnalysisForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry, sampling);
   },
 
   computeBestFocusZ(state: PreparedOpticalState, currentEPSD: number, currentPhysStopSD: number) {
     return computeBestFocusZForState2(state, currentEPSD, currentPhysStopSD);
   },
 
-  computeBokehPreviewPair(state: PreparedOpticalState, currentEPSD: number, currentPhysStopSD: number) {
-    return computeBokehPreviewPairForState2(state, currentEPSD, currentPhysStopSD);
+  computeBokehPreviewPair(
+    state: PreparedOpticalState,
+    currentEPSD: number,
+    currentPhysStopSD: number,
+    sampling?: AnalysisSamplingOptions,
+  ) {
+    return computeBokehPreviewPairForState2(state, currentEPSD, currentPhysStopSD, sampling);
   },
 
   computeOpticalSummary(
@@ -217,16 +259,18 @@ export const analysisJobsForState2 = {
     dynamicEFL: number,
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeDistortionCurveForState2(state, dynamicEFL, currentPhysStopSD, fieldGeometry);
+    return computeDistortionCurveForState2(state, dynamicEFL, currentPhysStopSD, fieldGeometry, sampling);
   },
 
   computeDistortionFieldGrid(
     state: PreparedOpticalState,
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeDistortionFieldGridForState2(state, currentPhysStopSD, fieldGeometry);
+    return computeDistortionFieldGridForState2(state, currentPhysStopSD, fieldGeometry, sampling);
   },
 
   computeVignettingCurve(
@@ -234,8 +278,9 @@ export const analysisJobsForState2 = {
     currentEPSD: number,
     currentPhysStopSD: number,
     fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
   ) {
-    return computeVignettingCurveForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry);
+    return computeVignettingCurveForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry, sampling);
   },
 
   computeBothPupilAberrationProfiles(

--- a/src/optics/analysis/analysisJobs.ts
+++ b/src/optics/analysis/analysisJobs.ts
@@ -29,6 +29,7 @@ import {
   computeChromaticAnalysisForState2,
   computeChromaticRayTraceAnalysis2,
   computeChromaticRayTraceAnalysisForState2,
+  type ChromaticRayTraceAnalysisOptions2,
 } from "./chromatic.js";
 import {
   computeDistortionCurve2,
@@ -172,8 +173,18 @@ export const analysisJobs2 = {
     currentEPSD: number,
     currentPhysStopSD: number,
     aberrationT = 0,
+    options?: ChromaticRayTraceAnalysisOptions2,
   ) {
-    return computeChromaticRayTraceAnalysis2(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT);
+    return computeChromaticRayTraceAnalysis2(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      aberrationT,
+      options,
+    );
   },
 
   computeBestFocusZ(
@@ -282,8 +293,9 @@ export const analysisJobsForState2 = {
     currentEPSD: number,
     currentPhysStopSD: number,
     _fieldGeometry?: FieldGeometryState,
+    options?: ChromaticRayTraceAnalysisOptions2,
   ) {
-    return computeChromaticRayTraceAnalysisForState2(state, currentEPSD, currentPhysStopSD);
+    return computeChromaticRayTraceAnalysisForState2(state, currentEPSD, currentPhysStopSD, options);
   },
 
   computeComaAnalysis(

--- a/src/optics/analysis/analysisJobs.ts
+++ b/src/optics/analysis/analysisJobs.ts
@@ -25,6 +25,12 @@ import {
   computeBokehPreviewPairForState2,
 } from "./bokeh.js";
 import {
+  computeChromaticAnalysis2,
+  computeChromaticAnalysisForState2,
+  computeChromaticRayTraceAnalysis2,
+  computeChromaticRayTraceAnalysisForState2,
+} from "./chromatic.js";
+import {
   computeDistortionCurve2,
   computeDistortionCurveForState2,
   computeDistortionFieldGrid2,
@@ -132,6 +138,44 @@ export const analysisJobs2 = {
     );
   },
 
+  computeChromaticAnalysis(
+    L: RuntimeLens,
+    zPos: number[],
+    focusT: number,
+    zoomT: number,
+    currentEPSD: number,
+    currentPhysStopSD: number,
+    aberrationT = 0,
+    fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
+  ) {
+    return computeChromaticAnalysis2(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      aberrationT,
+      fieldGeometry,
+      {
+        fieldFractions: sampling?.fieldCurvatureFieldFractions,
+      },
+    );
+  },
+
+  computeChromaticRayTraceAnalysis(
+    L: RuntimeLens,
+    zPos: number[],
+    focusT: number,
+    zoomT: number,
+    currentEPSD: number,
+    currentPhysStopSD: number,
+    aberrationT = 0,
+  ) {
+    return computeChromaticRayTraceAnalysis2(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, aberrationT);
+  },
+
   computeBestFocusZ(
     L: RuntimeLens,
     focusT: number,
@@ -219,6 +263,27 @@ export const analysisJobsForState2 = {
     sampling?: AnalysisSamplingOptions,
   ) {
     return computeFieldCurvatureBundleForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry, sampling);
+  },
+
+  computeChromaticAnalysis(
+    state: PreparedOpticalState,
+    currentEPSD: number,
+    currentPhysStopSD: number,
+    fieldGeometry?: FieldGeometryState,
+    sampling?: AnalysisSamplingOptions,
+  ) {
+    return computeChromaticAnalysisForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry, {
+      fieldFractions: sampling?.fieldCurvatureFieldFractions,
+    });
+  },
+
+  computeChromaticRayTraceAnalysis(
+    state: PreparedOpticalState,
+    currentEPSD: number,
+    currentPhysStopSD: number,
+    _fieldGeometry?: FieldGeometryState,
+  ) {
+    return computeChromaticRayTraceAnalysisForState2(state, currentEPSD, currentPhysStopSD);
   },
 
   computeComaAnalysis(

--- a/src/optics/analysis/analysisJobs.ts
+++ b/src/optics/analysis/analysisJobs.ts
@@ -160,7 +160,8 @@ export const analysisJobs2 = {
       aberrationT,
       fieldGeometry,
       {
-        fieldFractions: sampling?.fieldCurvatureFieldFractions,
+        longitudinalFractions: sampling?.chromaticLongitudinalFractions,
+        fieldFractions: sampling?.chromaticLateralFieldFractions ?? sampling?.fieldCurvatureFieldFractions,
       },
     );
   },
@@ -284,7 +285,8 @@ export const analysisJobsForState2 = {
     sampling?: AnalysisSamplingOptions,
   ) {
     return computeChromaticAnalysisForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry, {
-      fieldFractions: sampling?.fieldCurvatureFieldFractions,
+      longitudinalFractions: sampling?.chromaticLongitudinalFractions,
+      fieldFractions: sampling?.chromaticLateralFieldFractions ?? sampling?.fieldCurvatureFieldFractions,
     });
   },
 

--- a/src/optics/analysis/analysisJobs.ts
+++ b/src/optics/analysis/analysisJobs.ts
@@ -31,6 +31,7 @@ import {
   computeChromaticRayTraceAnalysisForState2,
   type ChromaticRayTraceAnalysisOptions2,
 } from "./chromatic.js";
+import { CHROMATIC_CHANNEL_ORDER } from "../chromatic/channels.js";
 import {
   computeDistortionCurve2,
   computeDistortionCurveForState2,
@@ -160,6 +161,7 @@ export const analysisJobs2 = {
       aberrationT,
       fieldGeometry,
       {
+        channels: CHROMATIC_CHANNEL_ORDER,
         longitudinalFractions: sampling?.chromaticLongitudinalFractions,
         fieldFractions: sampling?.chromaticLateralFieldFractions ?? sampling?.fieldCurvatureFieldFractions,
       },
@@ -285,6 +287,7 @@ export const analysisJobsForState2 = {
     sampling?: AnalysisSamplingOptions,
   ) {
     return computeChromaticAnalysisForState2(state, currentEPSD, currentPhysStopSD, fieldGeometry, {
+      channels: CHROMATIC_CHANNEL_ORDER,
       longitudinalFractions: sampling?.chromaticLongitudinalFractions,
       fieldFractions: sampling?.chromaticLateralFieldFractions ?? sampling?.fieldCurvatureFieldFractions,
     });

--- a/src/optics/analysis/analysisQuality.ts
+++ b/src/optics/analysis/analysisQuality.ts
@@ -10,6 +10,7 @@ export interface AnalysisSamplingOptions {
   pupilAberrationSampleCount?: number;
   bokehFieldFractions?: readonly number[];
   bokehRingSamples?: readonly number[];
+  comaDetailFieldFraction?: number;
   comaFieldFractions?: readonly number[];
   comaRingSamples?: readonly number[];
   comaFanSampleCount?: number;

--- a/src/optics/analysis/analysisQuality.ts
+++ b/src/optics/analysis/analysisQuality.ts
@@ -1,0 +1,43 @@
+export type AnalysisQuality = "settled" | "interactive";
+
+export interface AnalysisSamplingOptions {
+  distortionCurveSampleCount?: number;
+  distortionGridSegmentCount?: number;
+  distortionGridLineCoordinates?: readonly number[];
+  distortionPupilCorrectionSampleCount?: number;
+  vignettingFieldSampleCount?: number;
+  vignettingPupilSampleCount?: number;
+  pupilAberrationSampleCount?: number;
+  bokehFieldFractions?: readonly number[];
+  bokehRingSamples?: readonly number[];
+  comaFieldFractions?: readonly number[];
+  comaRingSamples?: readonly number[];
+  comaFanSampleCount?: number;
+  fieldCurvatureFieldFractions?: readonly number[];
+  fieldCurvatureCurveFieldFractions?: readonly number[];
+  fieldCurvatureDiagnosticSampleCount?: number;
+  sphericalBlurRingSamples?: readonly number[];
+}
+
+export const INTERACTIVE_ANALYSIS_SAMPLING: AnalysisSamplingOptions = {
+  distortionCurveSampleCount: 9,
+  distortionGridSegmentCount: 9,
+  distortionGridLineCoordinates: [-1, 0, 1],
+  distortionPupilCorrectionSampleCount: 5,
+  vignettingFieldSampleCount: 7,
+  vignettingPupilSampleCount: 48,
+  pupilAberrationSampleCount: 7,
+  bokehFieldFractions: [0, 0.5, 1],
+  bokehRingSamples: [1, 8, 16, 24],
+  comaFieldFractions: [0, 0.5, 1],
+  comaRingSamples: [1, 8, 16],
+  comaFanSampleCount: 9,
+  fieldCurvatureFieldFractions: [0, 0.5, 1],
+  fieldCurvatureCurveFieldFractions: [0, 0.25, 0.5, 0.75, 1],
+  fieldCurvatureDiagnosticSampleCount: 9,
+  sphericalBlurRingSamples: [1, 8, 16, 24],
+};
+
+export function analysisSamplingForQuality(quality: AnalysisQuality): AnalysisSamplingOptions | undefined {
+  return quality === "interactive" ? INTERACTIVE_ANALYSIS_SAMPLING : undefined;
+}

--- a/src/optics/analysis/analysisQuality.ts
+++ b/src/optics/analysis/analysisQuality.ts
@@ -16,6 +16,10 @@ export interface AnalysisSamplingOptions {
   fieldCurvatureFieldFractions?: readonly number[];
   fieldCurvatureCurveFieldFractions?: readonly number[];
   fieldCurvatureDiagnosticSampleCount?: number;
+  chromaticLongitudinalFractions?: readonly number[];
+  chromaticLateralFieldFractions?: readonly number[];
+  chromaticRayTraceOnAxisFractions?: readonly number[];
+  chromaticRayTraceOffAxisFractions?: readonly number[];
   sphericalBlurRingSamples?: readonly number[];
 }
 
@@ -35,6 +39,10 @@ export const INTERACTIVE_ANALYSIS_SAMPLING: AnalysisSamplingOptions = {
   fieldCurvatureFieldFractions: [0, 0.5, 1],
   fieldCurvatureCurveFieldFractions: [0, 0.25, 0.5, 0.75, 1],
   fieldCurvatureDiagnosticSampleCount: 9,
+  chromaticLongitudinalFractions: [0.95, 0.85, 0.75],
+  chromaticLateralFieldFractions: [0, 0.5, 1],
+  chromaticRayTraceOnAxisFractions: [0.95, 0.85],
+  chromaticRayTraceOffAxisFractions: [0.75, -0.75, 0.5, -0.5],
   sphericalBlurRingSamples: [1, 8, 16, 24],
 };
 

--- a/src/optics/analysis/bokeh.ts
+++ b/src/optics/analysis/bokeh.ts
@@ -14,6 +14,7 @@ import {
   describeBokehDefocusSide,
 } from "../aberration/bokeh.js";
 import type { PreparedOpticalState } from "../types.js";
+import type { AnalysisSamplingOptions } from "./analysisQuality.js";
 
 /**
  * Compute the best-focus image plane for bokeh sampling from a prepared state.
@@ -50,6 +51,7 @@ export function computeBokehPreviewPairForState2(
   state: PreparedOpticalState,
   currentEPSD: number,
   currentPhysStopSD: number,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeBokehPreviewPair(
     state.lens.runtime,
@@ -58,6 +60,7 @@ export function computeBokehPreviewPairForState2(
     currentEPSD,
     currentPhysStopSD,
     state.aberrationT,
+    sampling,
   );
 }
 

--- a/src/optics/analysis/chromatic.ts
+++ b/src/optics/analysis/chromatic.ts
@@ -321,7 +321,9 @@ function channelSpan(
 }
 
 function chromaticFieldSummary(field: FieldCurvatureFieldResult): ChromaticFieldFocusFieldSummary2 | null {
-  const shifts = field.chromaticFieldShifts;
+  const shifts = field.chromaticFieldShifts?.filter(
+    (shift) => isFinite(shift.tangentialShiftMm) && isFinite(shift.sagittalShiftMm),
+  );
   if (!field.usable || !shifts || shifts.length < 2) return null;
   const tangential = channelSpan(shifts, "tangentialShiftMm");
   const sagittal = channelSpan(shifts, "sagittalShiftMm");

--- a/src/optics/analysis/chromatic.ts
+++ b/src/optics/analysis/chromatic.ts
@@ -1,0 +1,417 @@
+/**
+ * Chromatic analysis adapter — prepared-state wrappers and ray-trace summaries.
+ */
+
+import {
+  computeChromaticAnalysis,
+  computeLateralColorCurve,
+  computeLongitudinalChromaticFocus,
+  type ChromaticAnalysisOptions,
+} from "../chromatic/analysis.js";
+import { computeChromaticSpread2, traceRayChromatic2 } from "../chromatic/chromaticTrace.js";
+import { CHROMATIC_CHANNEL_ORDER } from "../chromatic/channels.js";
+import {
+  computeProjectionAwareOffAxisFieldGeometry,
+  isOffAxisVectorFieldGeometry,
+  type ProjectionAwareOffAxisFieldGeometry,
+} from "../aberration/offAxis.js";
+import { offsetVectorFieldRay2 as offsetVectorFieldRay } from "../field/fieldGeometry.js";
+import type { FieldGeometryState } from "../optics.js";
+import { traceChiefRelativeSkewRayChromatic } from "../rayTrace.js";
+import { traceSkewRayVectorChromatic2 } from "../trace/rayAdapters.js";
+import { thick } from "../layout.js";
+import type { ChromaticChannel, ChromaticSpread, ChromaticSpreadByAxis, RuntimeLens } from "../../types/optics.js";
+import type { PreparedOpticalState } from "../types.js";
+import type { FieldCurvatureFieldResult, FieldCurvatureResult } from "../aberration/types.js";
+import { zPosForPreparedAnalysis2 } from "./preparedStateAdapters.js";
+
+export type {
+  ChromaticAnalysisOptions,
+  ChromaticAnalysisResult,
+  LateralColorChannelSample,
+  LateralColorCurveResult,
+  LateralColorFieldSample,
+  LongitudinalChromaticFocusResult,
+  LongitudinalChromaticFocusSample,
+} from "../chromatic/analysis.js";
+
+const DEFAULT_ON_AXIS_FRACTIONS = [0.97, 0.95, 0.9, 0.85, 0.8] as const;
+const DEFAULT_OFF_AXIS_FRACTIONS = [0.75, 0.5, 0.25, -0.75, -0.5, -0.25] as const;
+
+export interface ChromaticRayTraceAnalysisOptions2 {
+  channels?: readonly ChromaticChannel[];
+  onAxisFractions?: readonly number[];
+  offAxisFractions?: readonly number[];
+  offAxisFieldFraction?: number;
+}
+
+export interface ChromaticRayTraceAnalysis2 {
+  channels: readonly ChromaticChannel[];
+  spreads: ChromaticSpreadByAxis;
+  offAxisFieldAngleDeg: number;
+  onAxisAttemptedRayCount: number;
+  offAxisAttemptedRayCount: number;
+}
+
+export interface ChromaticChannelSpan2 {
+  minChannel: ChromaticChannel;
+  maxChannel: ChromaticChannel;
+  minShiftMm: number;
+  maxShiftMm: number;
+  spreadMm: number;
+  spreadUm: number;
+}
+
+export interface ChromaticFieldFocusFieldSummary2 {
+  fieldFraction: number;
+  label: string;
+  fieldAngleDeg: number;
+  tangential: ChromaticChannelSpan2;
+  sagittal: ChromaticChannelSpan2;
+  maxFocusSpreadMm: number;
+  maxFocusSpreadUm: number;
+}
+
+export interface ChromaticFieldFocusSummary2 {
+  source: "curve" | "fields";
+  fields: ChromaticFieldFocusFieldSummary2[];
+  usableFieldCount: number;
+  maxTangentialSpreadMm: number;
+  maxSagittalSpreadMm: number;
+  maxFocusSpreadMm: number;
+  maxFocusFieldFraction: number;
+  edgeFocusSpreadMm: number | null;
+}
+
+function zPosFromState(state: PreparedOpticalState): number[] {
+  return zPosForPreparedAnalysis2(state);
+}
+
+function normalizeChannels(channels: readonly ChromaticChannel[] | undefined): ChromaticChannel[] {
+  const requested = new Set(channels ?? ["R", "G", "B"]);
+  return CHROMATIC_CHANNEL_ORDER.filter((channel) => requested.has(channel));
+}
+
+function normalizeSignedFractions(fractions: readonly number[] | undefined, fallback: readonly number[]): number[] {
+  const values = (fractions ?? fallback)
+    .filter((fraction) => isFinite(fraction) && Math.abs(fraction) > 1e-9)
+    .map((fraction) => Math.max(-1, Math.min(1, fraction)));
+  return Array.from(new Set(values)).sort((a, b) => {
+    const absDelta = Math.abs(b) - Math.abs(a);
+    return Math.abs(absDelta) > 1e-12 ? absDelta : b - a;
+  });
+}
+
+function currentImagePlaneZ(
+  L: RuntimeLens,
+  zPos: readonly number[],
+  focusT: number,
+  zoomT: number,
+  aberrationT: number,
+): number | null {
+  if (L.N < 1) return null;
+  if (L.isFoldedOptics) return isFinite(L.imagePlane.z) ? L.imagePlane.z : null;
+  const imagePlaneZ = zPos[L.N - 1] + thick(L.N - 1, focusT, zoomT, L, aberrationT);
+  return isFinite(imagePlaneZ) ? imagePlaneZ : null;
+}
+
+function traceOffAxisChromaticMarginal(
+  geometry: ProjectionAwareOffAxisFieldGeometry,
+  fraction: number,
+  channel: ChromaticChannel,
+  L: RuntimeLens,
+  focusT: number,
+  zoomT: number,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  aberrationT: number,
+): { y: number; u: number; clipped: boolean } {
+  if (isOffAxisVectorFieldGeometry(geometry)) {
+    const ray = traceSkewRayVectorChromatic2(
+      offsetVectorFieldRay(geometry.vectorLaunch, 0, fraction * currentEPSD),
+      geometry.zPos,
+      currentPhysStopSD,
+      true,
+      L,
+      channel,
+      focusT,
+      zoomT,
+      aberrationT,
+    );
+    return { y: ray.y, u: ray.uy, clipped: ray.clipped };
+  }
+
+  const ray = traceChiefRelativeSkewRayChromatic(
+    0,
+    fraction,
+    geometry.yChief,
+    geometry.uField,
+    currentEPSD,
+    focusT,
+    zoomT,
+    currentPhysStopSD,
+    true,
+    L,
+    channel,
+    aberrationT,
+  );
+  return { y: ray.y, u: ray.uy, clipped: ray.clipped };
+}
+
+function computeSpreadFromFractions(
+  fractions: readonly number[],
+  channels: readonly ChromaticChannel[],
+  imagePlaneZ: number,
+  lastSurfaceZ: number,
+  axis: "onAxis" | "offAxis",
+  trace: (fraction: number, channel: ChromaticChannel) => { y: number; u: number; clipped: boolean },
+): { spread: ChromaticSpread | null; attemptedRayCount: number } {
+  let attemptedRayCount = 0;
+
+  for (const fraction of fractions) {
+    const marginalRays: Partial<Record<ChromaticChannel, { y: number; u: number; clipped: boolean }>> = {};
+
+    for (const channel of channels) {
+      attemptedRayCount++;
+      const ray = trace(fraction, channel);
+      if (!ray.clipped && Math.abs(ray.u) > 1e-15) {
+        marginalRays[channel] = { y: ray.y, u: ray.u, clipped: false };
+      }
+    }
+
+    const validChannels = Object.keys(marginalRays) as ChromaticChannel[];
+    if (validChannels.length >= 2) {
+      return {
+        spread: {
+          ...computeChromaticSpread2(marginalRays, imagePlaneZ, lastSurfaceZ),
+          axis,
+          fraction,
+          channels: validChannels,
+        },
+        attemptedRayCount,
+      };
+    }
+  }
+
+  return { spread: null, attemptedRayCount };
+}
+
+export function computeChromaticRayTraceAnalysis2(
+  L: RuntimeLens,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  aberrationT = 0,
+  options: ChromaticRayTraceAnalysisOptions2 = {},
+): ChromaticRayTraceAnalysis2 {
+  const channels = normalizeChannels(options.channels);
+  const empty = {
+    channels,
+    spreads: { onAxis: null, offAxis: null },
+    offAxisFieldAngleDeg: 0,
+    onAxisAttemptedRayCount: 0,
+    offAxisAttemptedRayCount: 0,
+  };
+  if (channels.length < 2 || currentEPSD <= 0 || L.N < 1) return empty;
+
+  const imagePlaneZ = currentImagePlaneZ(L, zPos, focusT, zoomT, aberrationT);
+  if (imagePlaneZ === null) return empty;
+  const lastSurfaceZ = zPos[L.N - 1];
+  const onAxis = computeSpreadFromFractions(
+    normalizeSignedFractions(options.onAxisFractions, DEFAULT_ON_AXIS_FRACTIONS),
+    channels,
+    imagePlaneZ,
+    lastSurfaceZ,
+    "onAxis",
+    (fraction, channel) => {
+      const ray = traceRayChromatic2(
+        fraction * currentEPSD,
+        0,
+        zPos,
+        focusT,
+        zoomT,
+        currentPhysStopSD,
+        true,
+        L,
+        channel,
+        aberrationT,
+      );
+      return { y: ray.y, u: ray.u, clipped: ray.clipped };
+    },
+  );
+
+  const offAxisFieldFraction = Math.max(0, Math.min(1, options.offAxisFieldFraction ?? L.offAxisFieldFrac ?? 0.7));
+  const geometry = computeProjectionAwareOffAxisFieldGeometry(
+    L,
+    zPos,
+    focusT,
+    zoomT,
+    offAxisFieldFraction,
+    undefined,
+    aberrationT,
+  );
+  const offAxis =
+    geometry === null
+      ? { spread: null, attemptedRayCount: 0 }
+      : computeSpreadFromFractions(
+          normalizeSignedFractions(options.offAxisFractions, DEFAULT_OFF_AXIS_FRACTIONS),
+          channels,
+          imagePlaneZ,
+          lastSurfaceZ,
+          "offAxis",
+          (fraction, channel) =>
+            traceOffAxisChromaticMarginal(
+              geometry,
+              fraction,
+              channel,
+              L,
+              focusT,
+              zoomT,
+              currentEPSD,
+              currentPhysStopSD,
+              aberrationT,
+            ),
+        );
+
+  return {
+    channels,
+    spreads: { onAxis: onAxis.spread, offAxis: offAxis.spread },
+    offAxisFieldAngleDeg: geometry?.fieldAngleDeg ?? 0,
+    onAxisAttemptedRayCount: onAxis.attemptedRayCount,
+    offAxisAttemptedRayCount: offAxis.attemptedRayCount,
+  };
+}
+
+export function computeChromaticRayTraceAnalysisForState2(
+  state: PreparedOpticalState,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  options?: ChromaticRayTraceAnalysisOptions2,
+): ChromaticRayTraceAnalysis2 {
+  return computeChromaticRayTraceAnalysis2(
+    state.lens.runtime,
+    zPosFromState(state),
+    state.focusT,
+    state.zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+    state.aberrationT,
+    options,
+  );
+}
+
+function channelSpan(
+  shifts: NonNullable<FieldCurvatureFieldResult["chromaticFieldShifts"]>,
+  direction: "tangentialShiftMm" | "sagittalShiftMm",
+): ChromaticChannelSpan2 {
+  const sorted = [...shifts].sort((a, b) => a[direction] - b[direction]);
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  const spreadMm = max[direction] - min[direction];
+  return {
+    minChannel: min.channel,
+    maxChannel: max.channel,
+    minShiftMm: min[direction],
+    maxShiftMm: max[direction],
+    spreadMm,
+    spreadUm: spreadMm * 1000,
+  };
+}
+
+function chromaticFieldSummary(field: FieldCurvatureFieldResult): ChromaticFieldFocusFieldSummary2 | null {
+  const shifts = field.chromaticFieldShifts;
+  if (!field.usable || !shifts || shifts.length < 2) return null;
+  const tangential = channelSpan(shifts, "tangentialShiftMm");
+  const sagittal = channelSpan(shifts, "sagittalShiftMm");
+  const maxFocusSpreadMm = Math.max(tangential.spreadMm, sagittal.spreadMm);
+  return {
+    fieldFraction: field.fieldFraction,
+    label: field.label,
+    fieldAngleDeg: field.fieldAngleDeg,
+    tangential,
+    sagittal,
+    maxFocusSpreadMm,
+    maxFocusSpreadUm: maxFocusSpreadMm * 1000,
+  };
+}
+
+export function summarizeChromaticFieldFocus2(result: FieldCurvatureResult | null): ChromaticFieldFocusSummary2 | null {
+  if (result === null) return null;
+
+  const curveSummaries = result.curveFields
+    .map(chromaticFieldSummary)
+    .filter((field): field is ChromaticFieldFocusFieldSummary2 => field !== null);
+  const fieldSummaries = result.fields
+    .map(chromaticFieldSummary)
+    .filter((field): field is ChromaticFieldFocusFieldSummary2 => field !== null);
+  const source: ChromaticFieldFocusSummary2["source"] = curveSummaries.length > 0 ? "curve" : "fields";
+  const fields = source === "curve" ? curveSummaries : fieldSummaries;
+  if (fields.length === 0) return null;
+
+  const maxFocusField = fields.reduce((best, field) => (field.maxFocusSpreadMm > best.maxFocusSpreadMm ? field : best));
+  const edgeFocusSpreadMm =
+    fieldSummaries.length > 0 ? fieldSummaries[fieldSummaries.length - 1].maxFocusSpreadMm : null;
+
+  return {
+    source,
+    fields,
+    usableFieldCount: fields.length,
+    maxTangentialSpreadMm: Math.max(...fields.map((field) => field.tangential.spreadMm)),
+    maxSagittalSpreadMm: Math.max(...fields.map((field) => field.sagittal.spreadMm)),
+    maxFocusSpreadMm: maxFocusField.maxFocusSpreadMm,
+    maxFocusFieldFraction: maxFocusField.fieldFraction,
+    edgeFocusSpreadMm,
+  };
+}
+
+/**
+ * Compatibility wrapper for combined chromatic analysis.
+ *
+ * @param args - same arguments as `computeChromaticAnalysis`
+ * @returns longitudinal focus plus lateral color summaries
+ */
+export function computeChromaticAnalysis2(...args: Parameters<typeof computeChromaticAnalysis>) {
+  return computeChromaticAnalysis(...args);
+}
+
+/** Compatibility wrapper for on-axis longitudinal chromatic focus. */
+export function computeLongitudinalChromaticFocus2(...args: Parameters<typeof computeLongitudinalChromaticFocus>) {
+  return computeLongitudinalChromaticFocus(...args);
+}
+
+/** Compatibility wrapper for off-axis lateral color curves. */
+export function computeLateralColorCurve2(...args: Parameters<typeof computeLateralColorCurve>) {
+  return computeLateralColorCurve(...args);
+}
+
+/**
+ * Compute combined chromatic analysis for a prepared state.
+ *
+ * @param state - prepared optical state for the current sliders
+ * @param currentEPSD - entrance-pupil semi-diameter in mm
+ * @param currentPhysStopSD - physical stop semi-diameter in mm
+ * @param fieldGeometry - optional solved-chief-ray field geometry for the same state
+ * @param options - optional channel and field/fraction sampling controls
+ * @returns longitudinal focus plus lateral color summaries
+ */
+export function computeChromaticAnalysisForState2(
+  state: PreparedOpticalState,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  fieldGeometry?: FieldGeometryState,
+  options?: ChromaticAnalysisOptions,
+) {
+  return computeChromaticAnalysis(
+    state.lens.runtime,
+    zPosFromState(state),
+    state.focusT,
+    state.zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+    state.aberrationT,
+    fieldGeometry,
+    options,
+  );
+}

--- a/src/optics/analysis/chromatic.ts
+++ b/src/optics/analysis/chromatic.ts
@@ -88,7 +88,7 @@ function zPosFromState(state: PreparedOpticalState): number[] {
 }
 
 function normalizeChannels(channels: readonly ChromaticChannel[] | undefined): ChromaticChannel[] {
-  const requested = new Set(channels ?? ["R", "G", "B"]);
+  const requested = new Set(channels ?? CHROMATIC_CHANNEL_ORDER);
   return CHROMATIC_CHANNEL_ORDER.filter((channel) => requested.has(channel));
 }
 

--- a/src/optics/analysis/distortion.ts
+++ b/src/optics/analysis/distortion.ts
@@ -8,6 +8,7 @@ import { computeDistortionCurve, computeDistortionFieldGrid } from "../distortio
 import type { FieldGeometryState } from "../optics.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { PreparedOpticalState } from "../types.js";
+import type { AnalysisSamplingOptions } from "./analysisQuality.js";
 import { zPosForPreparedAnalysis2 } from "./preparedStateAdapters.js";
 
 /**
@@ -28,6 +29,7 @@ export function computeDistortionCurveForState2(
   dynamicEFL: number,
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeDistortionCurve(
     state.lens.runtime,
@@ -38,6 +40,7 @@ export function computeDistortionCurveForState2(
     currentPhysStopSD,
     fieldGeometry,
     state.aberrationT,
+    sampling,
   );
 }
 
@@ -53,6 +56,7 @@ export function computeDistortionFieldGridForState2(
   state: PreparedOpticalState,
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeDistortionFieldGrid(
     state.lens.runtime,
@@ -62,6 +66,7 @@ export function computeDistortionFieldGridForState2(
     currentPhysStopSD,
     fieldGeometry,
     state.aberrationT,
+    sampling,
   );
 }
 
@@ -87,8 +92,19 @@ export function computeDistortionCurve2(
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
   aberrationT = 0,
+  sampling?: AnalysisSamplingOptions,
 ) {
-  return computeDistortionCurve(L, zPos, focusT, zoomT, dynamicEFL, currentPhysStopSD, fieldGeometry, aberrationT);
+  return computeDistortionCurve(
+    L,
+    zPos,
+    focusT,
+    zoomT,
+    dynamicEFL,
+    currentPhysStopSD,
+    fieldGeometry,
+    aberrationT,
+    sampling,
+  );
 }
 
 /**
@@ -111,6 +127,7 @@ export function computeDistortionFieldGrid2(
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
   aberrationT = 0,
+  sampling?: AnalysisSamplingOptions,
 ) {
-  return computeDistortionFieldGrid(L, zPos, focusT, zoomT, currentPhysStopSD, fieldGeometry, aberrationT);
+  return computeDistortionFieldGrid(L, zPos, focusT, zoomT, currentPhysStopSD, fieldGeometry, aberrationT, sampling);
 }

--- a/src/optics/analysis/vignetting.ts
+++ b/src/optics/analysis/vignetting.ts
@@ -8,6 +8,7 @@ import type { FieldGeometryState } from "../optics.js";
 import { computeVignettingCurve } from "../vignetteAnalysis.js";
 import type { RuntimeLens } from "../../types/optics.js";
 import type { PreparedOpticalState } from "../types.js";
+import type { AnalysisSamplingOptions } from "./analysisQuality.js";
 import { zPosForPreparedAnalysis2 } from "./preparedStateAdapters.js";
 
 /**
@@ -27,6 +28,7 @@ export function computeVignettingCurveForState2(
   currentEPSD: number,
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
+  sampling?: AnalysisSamplingOptions,
 ) {
   return computeVignettingCurve(
     state.lens.runtime,
@@ -37,6 +39,7 @@ export function computeVignettingCurveForState2(
     currentPhysStopSD,
     fieldGeometry,
     state.aberrationT,
+    sampling,
   );
 }
 
@@ -62,6 +65,17 @@ export function computeVignettingCurve2(
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
   aberrationT = 0,
+  sampling?: AnalysisSamplingOptions,
 ) {
-  return computeVignettingCurve(L, zPos, focusT, zoomT, currentEPSD, currentPhysStopSD, fieldGeometry, aberrationT);
+  return computeVignettingCurve(
+    L,
+    zPos,
+    focusT,
+    zoomT,
+    currentEPSD,
+    currentPhysStopSD,
+    fieldGeometry,
+    aberrationT,
+    sampling,
+  );
 }

--- a/src/optics/chromatic/analysis.ts
+++ b/src/optics/chromatic/analysis.ts
@@ -1,0 +1,421 @@
+/**
+ * Chromatic analysis helpers — pure longitudinal focus and lateral color sweeps.
+ *
+ * These helpers keep chromatic analysis out of React rendering. They reuse the
+ * same exact chromatic tracing and projection-aware field launch paths as the
+ * diagram rays, but return compact data contracts for analysis tabs.
+ */
+
+import type { ChromaticChannel, ChromaticSpread, RuntimeLens } from "../../types/optics.js";
+import { computeProjectionAwareOffAxisFieldGeometry, traceOffAxisChiefRay } from "../aberration/offAxis.js";
+import {
+  computeAnalysisFieldGeometryAtState2 as computeAnalysisFieldGeometryAtState,
+  type FieldGeometryState2 as FieldGeometryState,
+} from "../field/fieldGeometry.js";
+import { thick } from "../layout.js";
+import { computeChromaticSpread2, traceRayChromatic2 } from "./chromaticTrace.js";
+import { CHROMATIC_CHANNEL_ORDER } from "./channels.js";
+
+export const DEFAULT_CHROMATIC_ANALYSIS_CHANNELS = CHROMATIC_CHANNEL_ORDER;
+export const DEFAULT_LONGITUDINAL_CHROMATIC_FRACTIONS = [0.97, 0.95, 0.9, 0.85, 0.8] as const;
+export const DEFAULT_LATERAL_COLOR_FIELD_FRACTIONS = [0, 0.25, 0.5, 0.75, 1] as const;
+
+export interface ChromaticAnalysisOptions {
+  channels?: readonly ChromaticChannel[];
+  longitudinalFractions?: readonly number[];
+  fieldFractions?: readonly number[];
+}
+
+export interface LongitudinalChromaticFocusSample {
+  channel: ChromaticChannel;
+  focusZ: number | null;
+  focusShiftMm: number | null;
+  relativeFocusShiftMm: number | null;
+  imageHeightMm: number | null;
+  relativeImageHeightMm: number | null;
+  usable: boolean;
+  clipped: boolean;
+}
+
+export interface LongitudinalChromaticFocusResult {
+  channels: readonly ChromaticChannel[];
+  referenceChannel: ChromaticChannel;
+  marginalFraction: number;
+  imagePlaneZ: number;
+  lastSurfaceZ: number;
+  longitudinalSpreadMm: number;
+  longitudinalSpreadUm: number;
+  transverseSpreadMm: number;
+  transverseSpreadUm: number;
+  spread: ChromaticSpread;
+  samples: LongitudinalChromaticFocusSample[];
+  validChannelCount: number;
+}
+
+export interface LateralColorChannelSample {
+  channel: ChromaticChannel;
+  imageHeightMm: number | null;
+  relativeHeightMm: number | null;
+  usable: boolean;
+  clipped: boolean;
+}
+
+export interface LateralColorFieldSample {
+  fieldFraction: number;
+  label: string;
+  fieldAngleDeg: number;
+  referenceChannel: ChromaticChannel;
+  referenceImageHeightMm: number | null;
+  lateralSpreadMm: number | null;
+  lateralSpreadUm: number | null;
+  samples: LateralColorChannelSample[];
+  validChannelCount: number;
+  usable: boolean;
+}
+
+export interface LateralColorCurveResult {
+  channels: readonly ChromaticChannel[];
+  referenceChannel: ChromaticChannel;
+  fieldFractions: readonly number[];
+  fields: LateralColorFieldSample[];
+  usableFieldCount: number;
+  maxLateralSpreadMm: number;
+  maxLateralSpreadUm: number;
+  imagePlaneZ: number;
+  halfFieldDeg: number;
+}
+
+export interface ChromaticAnalysisResult {
+  longitudinalFocus: LongitudinalChromaticFocusResult | null;
+  lateralColor: LateralColorCurveResult | null;
+}
+
+function normalizeChannels(channels: readonly ChromaticChannel[] | undefined): ChromaticChannel[] {
+  const requested = new Set(channels ?? DEFAULT_CHROMATIC_ANALYSIS_CHANNELS);
+  return CHROMATIC_CHANNEL_ORDER.filter((channel) => requested.has(channel));
+}
+
+function normalizeFractions(
+  fractions: readonly number[] | undefined,
+  fallback: readonly number[],
+  { allowZero }: { allowZero: boolean },
+): number[] {
+  const values = (fractions ?? fallback)
+    .filter((value) => isFinite(value) && (allowZero ? value >= 0 : value > 0))
+    .map((value) => Math.max(0, Math.min(1, value)));
+  return Array.from(new Set(values));
+}
+
+function referenceChannelFor(channels: readonly ChromaticChannel[]): ChromaticChannel {
+  return channels.includes("G") ? "G" : (channels[0] ?? "G");
+}
+
+function labelForFieldFraction(fieldFraction: number): string {
+  const percent = fieldFraction * 100;
+  return `${Number(percent.toFixed(percent % 1 === 0 ? 0 : 2))}%`;
+}
+
+function span(values: number[]): number | null {
+  if (values.length < 2) return null;
+  return Math.max(...values) - Math.min(...values);
+}
+
+function currentImagePlaneZ(
+  L: RuntimeLens,
+  zPos: readonly number[],
+  focusT: number,
+  zoomT: number,
+  aberrationT: number,
+): number | null {
+  if (L.N < 1) return null;
+  const lastSurfaceZ = zPos[L.N - 1];
+  if (L.isFoldedOptics) return isFinite(L.imagePlane.z) ? L.imagePlane.z : null;
+  const imagePlaneZ = lastSurfaceZ + thick(L.N - 1, focusT, zoomT, L, aberrationT);
+  return isFinite(imagePlaneZ) ? imagePlaneZ : null;
+}
+
+/**
+ * Compute axial chromatic focus from the outermost usable on-axis marginal ray.
+ *
+ * The result is an LCA-style focus summary by spectral channel. It searches
+ * inward through marginal fractions so clipped wide-open rays do not make the
+ * analysis unusable.
+ */
+export function computeLongitudinalChromaticFocus(
+  L: RuntimeLens,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  aberrationT = 0,
+  options: ChromaticAnalysisOptions = {},
+): LongitudinalChromaticFocusResult | null {
+  const channels = normalizeChannels(options.channels);
+  if (channels.length < 2 || currentEPSD <= 0 || L.N < 1) return null;
+
+  const imagePlaneZ = currentImagePlaneZ(L, zPos, focusT, zoomT, aberrationT);
+  if (imagePlaneZ === null) return null;
+  const lastSurfaceZ = zPos[L.N - 1];
+  const fractions = normalizeFractions(options.longitudinalFractions, DEFAULT_LONGITUDINAL_CHROMATIC_FRACTIONS, {
+    allowZero: false,
+  });
+
+  for (const marginalFraction of fractions) {
+    const marginalRays: Partial<Record<ChromaticChannel, { y: number; u: number; clipped: boolean }>> = {};
+    const clippedByChannel: Partial<Record<ChromaticChannel, boolean>> = {};
+
+    for (const channel of channels) {
+      const ray = traceRayChromatic2(
+        marginalFraction * currentEPSD,
+        0,
+        zPos,
+        focusT,
+        zoomT,
+        currentPhysStopSD,
+        true,
+        L,
+        channel,
+        aberrationT,
+      );
+      clippedByChannel[channel] = ray.clipped;
+      if (!ray.clipped && Math.abs(ray.u) > 1e-15) {
+        marginalRays[channel] = { y: ray.y, u: ray.u, clipped: false };
+      }
+    }
+
+    const validChannels = Object.keys(marginalRays) as ChromaticChannel[];
+    if (validChannels.length < 2) continue;
+
+    const spread = computeChromaticSpread2(marginalRays, imagePlaneZ, lastSurfaceZ);
+    const referenceChannel = referenceChannelFor(channels);
+    const referenceFocusZ = spread.intercepts[referenceChannel] ?? null;
+    const referenceImageHeight = spread.imgHeights[referenceChannel] ?? null;
+    const samples = channels.map((channel): LongitudinalChromaticFocusSample => {
+      const focusZ = spread.intercepts[channel] ?? null;
+      const imageHeightMm = spread.imgHeights[channel] ?? null;
+      return {
+        channel,
+        focusZ,
+        focusShiftMm: focusZ === null ? null : focusZ - imagePlaneZ,
+        relativeFocusShiftMm: focusZ === null || referenceFocusZ === null ? null : focusZ - referenceFocusZ,
+        imageHeightMm,
+        relativeImageHeightMm:
+          imageHeightMm === null || referenceImageHeight === null ? null : imageHeightMm - referenceImageHeight,
+        usable: focusZ !== null,
+        clipped: clippedByChannel[channel] ?? true,
+      };
+    });
+
+    return {
+      channels,
+      referenceChannel,
+      marginalFraction,
+      imagePlaneZ,
+      lastSurfaceZ,
+      longitudinalSpreadMm: spread.lcaMm,
+      longitudinalSpreadUm: spread.lcaMm * 1000,
+      transverseSpreadMm: spread.tcaMm,
+      transverseSpreadUm: spread.tcaMm * 1000,
+      spread: { ...spread, axis: "onAxis", fraction: marginalFraction, channels: validChannels },
+      samples,
+      validChannelCount: validChannels.length,
+    };
+  }
+
+  return null;
+}
+
+function emptyLateralField(
+  fieldFraction: number,
+  referenceChannel: ChromaticChannel,
+  channels: readonly ChromaticChannel[],
+): LateralColorFieldSample {
+  return {
+    fieldFraction,
+    label: labelForFieldFraction(fieldFraction),
+    fieldAngleDeg: 0,
+    referenceChannel,
+    referenceImageHeightMm: null,
+    lateralSpreadMm: null,
+    lateralSpreadUm: null,
+    samples: channels.map((channel) => ({
+      channel,
+      imageHeightMm: null,
+      relativeHeightMm: null,
+      usable: false,
+      clipped: true,
+    })),
+    validChannelCount: 0,
+    usable: false,
+  };
+}
+
+function computeLateralColorField(
+  L: RuntimeLens,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  fieldFraction: number,
+  referenceChannel: ChromaticChannel,
+  channels: readonly ChromaticChannel[],
+  stateGeometry: FieldGeometryState,
+  aberrationT: number,
+): LateralColorFieldSample {
+  const geometry = computeProjectionAwareOffAxisFieldGeometry(
+    L,
+    zPos,
+    focusT,
+    zoomT,
+    fieldFraction,
+    stateGeometry,
+    aberrationT,
+  );
+  if (geometry === null) return emptyLateralField(fieldFraction, referenceChannel, channels);
+
+  const rawSamples = channels.map((channel) => {
+    const chiefRay = traceOffAxisChiefRay(
+      geometry,
+      L,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      channel,
+      aberrationT,
+    );
+    return {
+      channel,
+      imageHeightMm: chiefRay?.imagePoint.y ?? null,
+      clipped: chiefRay === null,
+    };
+  });
+  const referenceImageHeightMm =
+    rawSamples.find((sample) => sample.channel === referenceChannel)?.imageHeightMm ?? null;
+  const validHeights = rawSamples
+    .map((sample) => sample.imageHeightMm)
+    .filter((height): height is number => height !== null);
+  const lateralSpreadMm = span(validHeights);
+
+  return {
+    fieldFraction,
+    label: labelForFieldFraction(fieldFraction),
+    fieldAngleDeg: geometry.fieldAngleDeg,
+    referenceChannel,
+    referenceImageHeightMm,
+    lateralSpreadMm,
+    lateralSpreadUm: lateralSpreadMm === null ? null : lateralSpreadMm * 1000,
+    samples: rawSamples.map((sample) => ({
+      channel: sample.channel,
+      imageHeightMm: sample.imageHeightMm,
+      relativeHeightMm:
+        sample.imageHeightMm === null || referenceImageHeightMm === null
+          ? null
+          : sample.imageHeightMm - referenceImageHeightMm,
+      usable: sample.imageHeightMm !== null,
+      clipped: sample.clipped,
+    })),
+    validChannelCount: validHeights.length,
+    usable: lateralSpreadMm !== null,
+  };
+}
+
+/**
+ * Compute lateral color as chromatic chief-ray image-height spread across field.
+ *
+ * Lateral color is evaluated independently from the axial LCA ray. It measures
+ * chromatic magnification change at the image plane rather than focus shift.
+ */
+export function computeLateralColorCurve(
+  L: RuntimeLens,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  aberrationT = 0,
+  fieldGeometry?: FieldGeometryState,
+  options: ChromaticAnalysisOptions = {},
+): LateralColorCurveResult | null {
+  const channels = normalizeChannels(options.channels);
+  if (channels.length < 2 || currentEPSD <= 0 || L.N < 1) return null;
+
+  const imagePlaneZ = currentImagePlaneZ(L, zPos, focusT, zoomT, aberrationT);
+  if (imagePlaneZ === null) return null;
+
+  const stateGeometry = fieldGeometry ?? computeAnalysisFieldGeometryAtState(focusT, zoomT, L, aberrationT);
+  const referenceChannel = referenceChannelFor(channels);
+  const fieldFractions = normalizeFractions(options.fieldFractions, DEFAULT_LATERAL_COLOR_FIELD_FRACTIONS, {
+    allowZero: true,
+  });
+  const fields = fieldFractions.map((fieldFraction) =>
+    computeLateralColorField(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      fieldFraction,
+      referenceChannel,
+      channels,
+      stateGeometry,
+      aberrationT,
+    ),
+  );
+  const usableFields = fields.filter((field) => field.usable && field.lateralSpreadMm !== null);
+  if (usableFields.length === 0) return null;
+
+  const maxLateralSpreadMm = Math.max(...usableFields.map((field) => field.lateralSpreadMm ?? 0));
+
+  return {
+    channels,
+    referenceChannel,
+    fieldFractions,
+    fields,
+    usableFieldCount: usableFields.length,
+    maxLateralSpreadMm,
+    maxLateralSpreadUm: maxLateralSpreadMm * 1000,
+    imagePlaneZ,
+    halfFieldDeg: stateGeometry.halfFieldDeg,
+  };
+}
+
+/** Compute both first-class chromatic analysis summaries for one optical state. */
+export function computeChromaticAnalysis(
+  L: RuntimeLens,
+  zPos: number[],
+  focusT: number,
+  zoomT: number,
+  currentEPSD: number,
+  currentPhysStopSD: number,
+  aberrationT = 0,
+  fieldGeometry?: FieldGeometryState,
+  options: ChromaticAnalysisOptions = {},
+): ChromaticAnalysisResult {
+  return {
+    longitudinalFocus: computeLongitudinalChromaticFocus(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      aberrationT,
+      options,
+    ),
+    lateralColor: computeLateralColorCurve(
+      L,
+      zPos,
+      focusT,
+      zoomT,
+      currentEPSD,
+      currentPhysStopSD,
+      aberrationT,
+      fieldGeometry,
+      options,
+    ),
+  };
+}

--- a/src/optics/chromatic/channels.ts
+++ b/src/optics/chromatic/channels.ts
@@ -1,0 +1,56 @@
+import type { ChromaticChannel } from "../../types/optics.js";
+import { LINE_NM } from "../glassCatalog.js";
+
+export interface ChromaticChannelMetadata {
+  id: ChromaticChannel;
+  displayLabel: ChromaticChannel;
+  spectralLine: "C" | "d" | "F" | "g";
+  wavelengthNm: number;
+  wavelengthLabel: string;
+  description: string;
+}
+
+export const CHROMATIC_CHANNEL_ORDER = Object.freeze(["R", "G", "B", "V"] as const);
+
+export const CHROMATIC_CHANNEL_METADATA: Readonly<Record<ChromaticChannel, ChromaticChannelMetadata>> = Object.freeze({
+  R: Object.freeze({
+    id: "R",
+    displayLabel: "R",
+    spectralLine: "C",
+    wavelengthNm: LINE_NM.C,
+    wavelengthLabel: "C-line 656.3 nm",
+    description: "red C-line",
+  }),
+  G: Object.freeze({
+    id: "G",
+    displayLabel: "G",
+    spectralLine: "d",
+    wavelengthNm: LINE_NM.d,
+    wavelengthLabel: "d-line 587.6 nm",
+    description: "green d-line",
+  }),
+  B: Object.freeze({
+    id: "B",
+    displayLabel: "B",
+    spectralLine: "F",
+    wavelengthNm: LINE_NM.F,
+    wavelengthLabel: "F-line 486.1 nm",
+    description: "blue F-line",
+  }),
+  V: Object.freeze({
+    id: "V",
+    displayLabel: "V",
+    spectralLine: "g",
+    wavelengthNm: LINE_NM.g,
+    wavelengthLabel: "g-line 435.8 nm",
+    description: "violet g-line secondary-spectrum probe",
+  }),
+});
+
+export function chromaticChannelWavelengthLabel(channel: ChromaticChannel): string {
+  return CHROMATIC_CHANNEL_METADATA[channel].wavelengthLabel;
+}
+
+export function chromaticChannelIndexLabel(channel: ChromaticChannel): string {
+  return `n${CHROMATIC_CHANNEL_METADATA[channel].spectralLine}`;
+}

--- a/src/optics/chromatic/indexResolver.ts
+++ b/src/optics/chromatic/indexResolver.ts
@@ -5,19 +5,19 @@
  */
 
 import type { ChromaticChannel, RuntimeLens } from "../../types/optics.js";
-import { LINE_NM } from "../glassCatalog.js";
 import type { PreparedOpticalState } from "../types.js";
 import { normalizeRuntimeLens } from "../prescription/normalizeLensData.js";
+import { CHROMATIC_CHANNEL_METADATA, CHROMATIC_CHANNEL_ORDER } from "./channels.js";
 
 /** Chromatic channels traced by the engine: C, d, F, and g spectral lines. */
-export const CHROMATIC_CHANNELS_2 = Object.freeze(["R", "G", "B", "V"] as const);
+export const CHROMATIC_CHANNELS_2 = CHROMATIC_CHANNEL_ORDER;
 
 /** Per-channel wavelength in nanometers, keyed to standard Fraunhofer lines. */
 export const CHANNEL_WAVELENGTH_NM_2: Readonly<Record<ChromaticChannel, number>> = Object.freeze({
-  R: LINE_NM.C,
-  G: LINE_NM.d,
-  B: LINE_NM.F,
-  V: LINE_NM.g,
+  R: CHROMATIC_CHANNEL_METADATA.R.wavelengthNm,
+  G: CHROMATIC_CHANNEL_METADATA.G.wavelengthNm,
+  B: CHROMATIC_CHANNEL_METADATA.B.wavelengthNm,
+  V: CHROMATIC_CHANNEL_METADATA.V.wavelengthNm,
 });
 
 /**

--- a/src/optics/compat.ts
+++ b/src/optics/compat.ts
@@ -299,6 +299,27 @@ export {
   computeSphericalAberrationForState2,
 } from "./analysis/aberrations.js";
 export {
+  computeChromaticAnalysis2,
+  computeChromaticAnalysisForState2,
+  computeChromaticRayTraceAnalysis2,
+  computeChromaticRayTraceAnalysisForState2,
+  computeLateralColorCurve2,
+  computeLongitudinalChromaticFocus2,
+  summarizeChromaticFieldFocus2,
+  type ChromaticAnalysisOptions,
+  type ChromaticAnalysisResult,
+  type ChromaticChannelSpan2,
+  type ChromaticFieldFocusFieldSummary2,
+  type ChromaticFieldFocusSummary2,
+  type ChromaticRayTraceAnalysis2,
+  type ChromaticRayTraceAnalysisOptions2,
+  type LateralColorChannelSample,
+  type LateralColorCurveResult,
+  type LateralColorFieldSample,
+  type LongitudinalChromaticFocusResult,
+  type LongitudinalChromaticFocusSample,
+} from "./analysis/chromatic.js";
+export {
   buildBokehDensityGrid2,
   buildBokehRadialProfile2,
   classifyBokehBrightnessCharacter2,

--- a/src/optics/compat.ts
+++ b/src/optics/compat.ts
@@ -10,8 +10,42 @@ import type { LayoutResult, LensData, RuntimeLens } from "../types/optics.js";
 import type { EngineLens, PreparedOpticalState } from "./types.js";
 import { normalizeRuntimeLens, withLensDefaults } from "./prescription/normalizeLensData.js";
 import { prepareState } from "./state/prepareState.js";
+import type { PreparedStateCache } from "./state/cache.js";
 
 const ENGINE_LENS_BY_RUNTIME = new WeakMap<RuntimeLens, EngineLens>();
+const PREPARED_STATE_CACHE_BY_RUNTIME = new WeakMap<RuntimeLens, PreparedStateCache>();
+const PREPARED_STATE_CACHE_LIMIT = 96;
+
+function preparedStateCacheForRuntime(L: RuntimeLens): PreparedStateCache {
+  const cached = PREPARED_STATE_CACHE_BY_RUNTIME.get(L);
+  if (cached) return cached;
+
+  const byKey = new Map<string, PreparedOpticalState>();
+  const cache: PreparedStateCache = {
+    get(cacheKey) {
+      const state = byKey.get(cacheKey);
+      if (state) {
+        byKey.delete(cacheKey);
+        byKey.set(cacheKey, state);
+      }
+      return state;
+    },
+    set(cacheKey, state) {
+      if (byKey.has(cacheKey)) byKey.delete(cacheKey);
+      byKey.set(cacheKey, state);
+      while (byKey.size > PREPARED_STATE_CACHE_LIMIT) {
+        const oldestKey = byKey.keys().next().value;
+        if (oldestKey === undefined) break;
+        byKey.delete(oldestKey);
+      }
+    },
+    clear() {
+      byKey.clear();
+    },
+  };
+  PREPARED_STATE_CACHE_BY_RUNTIME.set(L, cache);
+  return cache;
+}
 
 /**
  * Build and register a RuntimeLens from defaulted lens data.
@@ -57,7 +91,9 @@ export function prepareRuntimeState(
   zoomT: number,
   aberrationT = 0,
 ): PreparedOpticalState {
-  return prepareState(engineLensFromRuntime(L), focusT, zoomT, aberrationT);
+  return prepareState(engineLensFromRuntime(L), focusT, zoomT, aberrationT, {
+    cache: preparedStateCacheForRuntime(L),
+  });
 }
 
 /**

--- a/src/optics/distortionAnalysis.ts
+++ b/src/optics/distortionAnalysis.ts
@@ -36,6 +36,7 @@ import {
 } from "./projection.js";
 import type { FieldGeometryState, SkewRayTraceResult } from "./optics.js";
 import { isHeavyLensForRayWork } from "./raySampling.js";
+import type { AnalysisSamplingOptions } from "./analysis/analysisQuality.js";
 import type { RuntimeLens } from "../types/optics.js";
 
 /** A single sample point on the distortion curve. */
@@ -90,6 +91,11 @@ export interface DistortionFieldGridResult {
 const SAMPLE_COUNT = 21;
 const DISTORTION_GRID_LINE_COORDINATES = [-1, -0.5, 0, 0.5, 1] as const;
 const DISTORTION_GRID_SEGMENT_COUNT = 17;
+
+function clampedSampleCount(value: number | undefined, fallback: number, minimum: number): number {
+  if (value === undefined) return fallback;
+  return Math.max(minimum, Math.round(value));
+}
 
 interface DistortionReference {
   geometry: ReturnType<typeof computeFieldGeometryAtState>;
@@ -206,15 +212,17 @@ export function computeDistortionCurve(
   _currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): DistortionSample[] {
   const reference = computeDistortionReference(L, zPos, focusT, zoomT, fieldGeometry, aberrationT);
   if (reference === null) return [];
 
   const samples: DistortionSample[] = [];
+  const sampleCount = clampedSampleCount(sampling.distortionCurveSampleCount, SAMPLE_COUNT, 3);
   const edgeAbsHeight = Math.abs(reference.edgeImageHeight);
   const targetImageHeights = Array.from(
-    { length: SAMPLE_COUNT - 1 },
-    (_, index) => -edgeAbsHeight * ((index + 1) / (SAMPLE_COUNT - 1)),
+    { length: sampleCount - 1 },
+    (_, index) => -edgeAbsHeight * ((index + 1) / (sampleCount - 1)),
   );
   const solvedFieldAngles = solveFieldAnglesForImageHeightsAccurate(
     targetImageHeights,
@@ -226,8 +234,8 @@ export function computeDistortionCurve(
     aberrationT,
   );
 
-  for (let i = 0; i < SAMPLE_COUNT; i++) {
-    const normalizedImageHeight = i / (SAMPLE_COUNT - 1);
+  for (let i = 0; i < sampleCount; i++) {
+    const normalizedImageHeight = i / (sampleCount - 1);
     if (i === 0) {
       samples.push({
         fieldAngleDeg: 0,
@@ -292,11 +300,14 @@ function buildPupilCorrectionTable(
   zoomT: number,
   L: RuntimeLens,
   aberrationT = 0,
+  sampleCountOverride?: number,
 ): PupilCorrectionEntry[] {
   const table: PupilCorrectionEntry[] = [];
-  const sampleCount = isHeavyLensForRayWork(L)
-    ? PUPIL_CORRECTION_SAMPLE_COUNT_HEAVY
-    : PUPIL_CORRECTION_SAMPLE_COUNT_FULL;
+  const sampleCount = clampedSampleCount(
+    sampleCountOverride,
+    isHeavyLensForRayWork(L) ? PUPIL_CORRECTION_SAMPLE_COUNT_HEAVY : PUPIL_CORRECTION_SAMPLE_COUNT_FULL,
+    2,
+  );
   for (let i = 0; i < sampleCount; i++) {
     const angleDeg = (i / (sampleCount - 1)) * reference.geometry.halfFieldDeg;
     const launch = projectionLaunchSlopeForField(L, angleDeg);
@@ -566,6 +577,7 @@ export function computeDistortionFieldGrid(
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): DistortionFieldGridResult {
   const reference = computeDistortionReference(L, zPos, focusT, zoomT, fieldGeometry, aberrationT);
   if (reference === null) {
@@ -577,18 +589,24 @@ export function computeDistortionFieldGrid(
     };
   }
 
-  const axisSamples = Array.from(
-    { length: DISTORTION_GRID_SEGMENT_COUNT },
-    (_, index) => -1 + (2 * index) / (DISTORTION_GRID_SEGMENT_COUNT - 1),
-  );
+  const segmentCount = clampedSampleCount(sampling.distortionGridSegmentCount, DISTORTION_GRID_SEGMENT_COUNT, 3);
+  const axisSamples = Array.from({ length: segmentCount }, (_, index) => -1 + (2 * index) / (segmentCount - 1));
 
-  const pupilCorrection = buildPupilCorrectionTable(reference, focusT, zoomT, L, aberrationT);
+  const pupilCorrection = buildPupilCorrectionTable(
+    reference,
+    focusT,
+    zoomT,
+    L,
+    aberrationT,
+    sampling.distortionPupilCorrectionSampleCount,
+  );
+  const gridLineCoordinates = sampling.distortionGridLineCoordinates ?? DISTORTION_GRID_LINE_COORDINATES;
 
   return {
     idealFieldRadius: reference.idealFieldRadius,
     referenceKind: reference.projectionReference.kind,
     referenceLabel: reference.projectionReference.label,
-    lines: DISTORTION_GRID_LINE_COORDINATES.flatMap((coordinate) => {
+    lines: gridLineCoordinates.flatMap((coordinate) => {
       const vertical: DistortionGridLine = {
         orientation: "vertical",
         idealCoordinate: coordinate,

--- a/src/optics/lcaScaling.ts
+++ b/src/optics/lcaScaling.ts
@@ -1,9 +1,9 @@
 /**
- * lcaScaling — Fixed-reference scaling for LCA bar visualisation.
+ * lcaScaling — Fixed-reference scaling for chromatic bar visualisations.
  *
  * Provides a consistent magnification so that lenses with larger chromatic
  * aberration display wider bars and well-corrected lenses display narrower
- * bars.  The scale is anchored to REFERENCE_LCA_MM: a lens whose maximum
+ * bars.  The LCA scale is anchored to REFERENCE_LCA_MM: a lens whose maximum
  * channel offset equals that value will fill ~70 % of the available width.
  *
  * Extracted as a pure function so the same logic can drive both the small
@@ -14,7 +14,10 @@ import type { ChromaticChannel } from "../types/optics.js";
 /** Typical moderate LCA in mm — sets the "full width" reference point. */
 export const REFERENCE_LCA_MM = 0.15;
 
-/** Pixel offsets and applied magnification for one LCA bar visualization. */
+/** Typical moderate TCA in mm — sets the lateral-color chart reference point. */
+export const REFERENCE_TCA_MM = 0.01;
+
+/** Pixel offsets and applied magnification for one chromatic bar visualization. */
 export interface LcaBarResult {
   /** Pixel offset from centre for each active channel. */
   barOffsets: Partial<Record<ChromaticChannel, number>>;
@@ -25,32 +28,34 @@ export interface LcaBarResult {
 }
 
 /**
- * Compute pixel offsets for each wavelength bar relative to the G-line
- * reference, using a fixed reference scale.
+ * Compute pixel offsets for each wavelength bar relative to a reference channel,
+ * using a fixed reference scale.
  *
- * @param intercepts       Per-channel axial intercept positions (mm).
- * @param referenceIntercept  G-line intercept (or IMG_MM fallback).
- * @param viewWidthPx      Total pixel width available for bars.
- * @param effectiveSC      Horizontal scale factor (px / mm).
+ * @param values            Per-channel axial intercepts or image heights (mm).
+ * @param referenceValue    Reference-channel value, usually G/d-line.
+ * @param viewWidthPx       Total pixel width available for bars.
+ * @param effectiveSC       Horizontal scale factor (px / mm).
+ * @param referenceOffsetMm Offset that fills about 70 % of the half-width.
  * @returns per-channel pixel offsets, magnification, and clamp flag
  */
-export function computeLcaBarOffsets(
-  intercepts: Partial<Record<ChromaticChannel, number>>,
-  referenceIntercept: number,
+export function computeChromaticBarOffsets(
+  values: Partial<Record<ChromaticChannel, number>>,
+  referenceValue: number,
   viewWidthPx: number,
   effectiveSC: number,
+  referenceOffsetMm: number,
 ): LcaBarResult {
   const halfWidth = viewWidthPx / 2;
 
-  // Fixed magnification: REFERENCE_LCA_MM of offset fills 70 % of the half-width.
-  const baseMag = (halfWidth * 0.7) / (REFERENCE_LCA_MM * effectiveSC);
+  // Fixed magnification: referenceOffsetMm of offset fills 70 % of the half-width.
+  const baseMag = (halfWidth * 0.7) / (referenceOffsetMm * effectiveSC);
 
   const barOffsets: Partial<Record<ChromaticChannel, number>> = {};
   let maxAbsPx = 0;
 
   for (const ch of ["R", "G", "B", "V"] as ChromaticChannel[]) {
-    if (intercepts[ch] === undefined) continue;
-    const px = (intercepts[ch] - referenceIntercept) * baseMag * effectiveSC;
+    if (values[ch] === undefined) continue;
+    const px = (values[ch] - referenceValue) * baseMag * effectiveSC;
     barOffsets[ch] = px;
     maxAbsPx = Math.max(maxAbsPx, Math.abs(px));
   }
@@ -69,4 +74,13 @@ export function computeLcaBarOffsets(
   }
 
   return { barOffsets, mag, clamped };
+}
+
+export function computeLcaBarOffsets(
+  intercepts: Partial<Record<ChromaticChannel, number>>,
+  referenceIntercept: number,
+  viewWidthPx: number,
+  effectiveSC: number,
+): LcaBarResult {
+  return computeChromaticBarOffsets(intercepts, referenceIntercept, viewWidthPx, effectiveSC, REFERENCE_LCA_MM);
 }

--- a/src/optics/optics.ts
+++ b/src/optics/optics.ts
@@ -66,7 +66,12 @@ export {
 export {
   CHANNEL_WAVELENGTH_NM_2 as CHANNEL_WAVELENGTH_NM,
   CHROMATIC_CHANNELS_2 as CHROMATIC_CHANNELS,
+  computeChromaticAnalysis2 as computeChromaticAnalysis,
+  computeChromaticRayTraceAnalysis2 as computeChromaticRayTraceAnalysis,
   computeChromaticSpread2 as computeChromaticSpread,
+  computeLateralColorCurve2 as computeLateralColorCurve,
+  computeLongitudinalChromaticFocus2 as computeLongitudinalChromaticFocus,
+  summarizeChromaticFieldFocus2 as summarizeChromaticFieldFocus,
   wavelengthNd2 as wavelengthNd,
   type SurfaceIndexResolver2 as SurfaceIndexResolver,
 } from "./compat.js";

--- a/src/optics/vignetteAnalysis.ts
+++ b/src/optics/vignetteAnalysis.ts
@@ -32,6 +32,7 @@ import {
 import { projectionLaunchSlopeForField } from "./projection.js";
 import type { FieldGeometryState } from "./optics.js";
 import { isHeavyLensForRayWork } from "./raySampling.js";
+import type { AnalysisSamplingOptions } from "./analysis/analysisQuality.js";
 import type { RuntimeLens } from "../types/optics.js";
 
 /** A single sample on the vignetting / relative-illumination curve. */
@@ -90,6 +91,7 @@ export function computeVignettingCurve(
   currentPhysStopSD: number,
   fieldGeometry?: FieldGeometryState,
   aberrationT = 0,
+  sampling: AnalysisSamplingOptions = {},
 ): VignettingSample[] {
   if (currentEPSD <= 0 || L.N < 1) return [];
 
@@ -103,8 +105,18 @@ export function computeVignettingCurve(
   /* Adaptive field sampling: ~3° spacing, min 7 samples.  Ultra-wide lenses
    * (>50° half-field) get denser sampling to capture rapid vignetting onset
    * near the field edge. */
-  const fieldSamples = Math.max(Math.ceil(halfFieldDeg / 3) + 1, 7);
-  const nPupil = isHeavyLensForRayWork(L) ? N_PUPIL_HEAVY : N_PUPIL_FULL;
+  const fieldSamples =
+    sampling.vignettingFieldSampleCount !== undefined
+      ? Math.max(Math.round(sampling.vignettingFieldSampleCount), 3)
+      : Math.max(Math.ceil(halfFieldDeg / 3) + 1, 7);
+  const nPupil = Math.max(
+    sampling.vignettingPupilSampleCount !== undefined
+      ? Math.round(sampling.vignettingPupilSampleCount)
+      : isHeavyLensForRayWork(L)
+        ? N_PUPIL_HEAVY
+        : N_PUPIL_FULL,
+    3,
+  );
 
   /* ── Raw geometric transmission per field sample ── */
   const rawGT: number[] = [];

--- a/src/types/optics.ts
+++ b/src/types/optics.ts
@@ -462,6 +462,9 @@ export interface ChromaticSpread {
   tcaMm: number;
   intercepts: Partial<Record<ChromaticChannel, number>>;
   imgHeights: Partial<Record<ChromaticChannel, number>>;
+  axis?: "onAxis" | "offAxis";
+  fraction?: number;
+  channels?: ChromaticChannel[];
 }
 
 export interface ChromaticSpreadByAxis {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -17,6 +17,7 @@ export const DESKTOP_VIEWS = ["diagram", "both", "analysis"] as const;
 export const ANALYSIS_TAB_IDS = [
   "summary",
   "aberrations",
+  "chromatic",
   "coma",
   "bokeh",
   "distortion",

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -22,6 +22,16 @@ export const CHANGELOG: ChangelogEntry[] = [
   // ── 2026-05-30 ──────────────────────────────────────────────────────────
   {
     date: "2026-05-30",
+    type: "feature",
+    summary: "Added chromatic analysis charts for LCA, lateral color, and field-focus color",
+  },
+  {
+    date: "2026-05-30",
+    type: "fix",
+    summary: "Fixed LCA and TCA displays to use matching charts with violet-channel traces",
+  },
+  {
+    date: "2026-05-30",
     type: "lens",
     summary: "Added three Sigma macro lenses",
   },


### PR DESCRIPTION
## Summary

- Added a Chromatic Analysis tray with longitudinal color, lateral color, and field-focus color charts.
- Updated the LCA overlay path to use the dedicated longitudinal chromatic focus trace and promoted off-axis TCA from a number to a matching chart.
- Included the violet g-line channel across chromatic tray charts and field-focus color analysis.
- Refined coma diagnostics and added interactive sampling so expensive analysis updates stay responsive while sliders move.
- Added changelog entries for the new chromatic analysis charts and corrected LCA/TCA displays.

## Why

The previous chromatic displays mixed charted LCA with numeric-only TCA and did not consistently include the V/g-line channel. This made the chromatic readouts less complete and harder to compare across the diagram overlay and analysis drawer.

## Validation

- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test`