### PR TITLE
Add Olympus OM telephoto lens batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart TD
 
 ## Current Scope
 
-- `349` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
+- `352` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Canon, Carl Zeiss Jena, Carl Zeiss Oberkochen, Fujifilm,
   Hasselblad, Laowa, Leica, Minolta, Nikon, Olympus, Panasonic, Pentax, Ricoh, Schneider-Kreuznach, Sigma, Sony,
   Vivitar, and Voigtländer

--- a/agent_docs/generated/catalog-mismatches.generated.md
+++ b/agent_docs/generated/catalog-mismatches.generated.md
@@ -13,10 +13,10 @@ with words like "probable" or "approx").
 
 ## Summary
 
-- **357** lenses scanned
-- **4033** glass surfaces examined
-- **4027** surfaces with non-empty `glass` strings
-- **3253** of those resolved to a catalog entry
+- **360** lenses scanned
+- **4068** glass surfaces examined
+- **4062** surfaces with non-empty `glass` strings
+- **3277** of those resolved to a catalog entry
 - **0** mismatches found (0.0% of resolved surfaces)
 - **0** distinct lens files affected
 

--- a/agent_docs/generated/glass-coverage-opportunities.generated.md
+++ b/agent_docs/generated/glass-coverage-opportunities.generated.md
@@ -9,13 +9,13 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **357** lenses scanned (**349** visible)
-- **3253 / 4033** non-air surfaces use strict catalog Sellmeier data (80.7%)
-- **3277 / 4033** non-air surfaces use trusted chromatic data (Sellmeier or measured line indices, 81.3%)
+- **360** lenses scanned (**352** visible)
+- **3277 / 4068** non-air surfaces use strict catalog Sellmeier data (80.6%)
+- **3301 / 4068** non-air surfaces use trusted chromatic data (Sellmeier or measured line indices, 81.1%)
 - **0** mismatch surfaces in Sweep 1 across **0** lens files
 - **0** Sweep 1 surfaces have a matching untracked local patent PDF
-- **203** code-only missing-Sellmeier elements in Sweep 2
-- **127** unresolved named-token elements in Sweep 2B
+- **206** code-only missing-Sellmeier elements in Sweep 2
+- **132** unresolved named-token elements in Sweep 2B
 - **0** Tier A proprietary backfill rows in Sweep 3
 
 ## Sweep 1 - Relabel Mismatches
@@ -125,6 +125,7 @@ These are efficient follow-up targets after mismatch blockers because one or two
 | [SIGMA 35mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma35mmf14DGHSMA.data.ts) | 84.6% (11/13) | 84.6% (11/13) | 2 | abbe: 2 |
 | [Nikon AF Nikkor 28mm f/2.8D](../../src/lens-data/nikon/NikonAFNikkor28mmf28D.data.ts) | 83.3% (5/6) | 83.3% (5/6) | 1 | abbe: 1 |
 | [NIKON REFLEX-NIKKOR 500mm f/8 (New)](../../src/lens-data/nikon/NikonReflexNikkor500mmf8New.data.ts) | 83.3% (5/6) | 83.3% (5/6) | 1 | abbe: 1 |
+| [OLYMPUS F.ZUIKO AUTO-T 200mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoT200mmf5.data.ts) | 83.3% (5/6) | 83.3% (5/6) | 1 | abbe: 1 |
 | [PENTAX 110 24mm f/2.8](../../src/lens-data/pentax/Pentax11024mmf28.data.ts) | 83.3% (5/6) | 83.3% (5/6) | 1 | abbe: 1 |
 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR III)](../../src/lens-data/ricoh/RicohGR328f28.data.ts) | 83.3% (5/6) | 83.3% (5/6) | 1 | abbe: 1 |
 | [LEICA SUMMILUX 28mm f/1.7 ASPH. (Leica Q, Q2, Q3)](../../src/lens-data/leica/Leica28mmf17.data.ts) | 81.8% (9/11) | 81.8% (9/11) | 2 | abbe: 2 |
@@ -165,9 +166,9 @@ Add catalog entries only when public coefficient-backed vendor data is available
 | 493836 | 2 | 1 | Missing from untracked local patents/ references (US4786152, 4786152) | No reviewed-sidecar hit | [MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) Element 1 (1.49310 / 83.55)<br>[MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) Element 2 (1.49310 / 83.55) |
 | 511605 | 2 | 1 | patents/US4258985.pdf | No reviewed-sidecar hit | [MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) Element 2 (1.51110 / 60.49)<br>[MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) Element 3 (1.51110 / 60.49) |
 | 514428 | 2 | 1 | patents/JP2016021011A.pdf | All representative rows reviewed | [NIKON AF-S NIKKOR 20mm f/1.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS20mmf18G.data.ts) LS cement layer (1.51400 / 42.80)<br>[NIKON AF-S NIKKOR 20mm f/1.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS20mmf18G.data.ts) Rear doublet cement layer (1.51400 / 42.80) |
+| 569632 | 2 | 1 | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit | [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) Element 4 (1.56873 / 63.20)<br>[OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) Element 7 (1.56873 / 63.20) |
 | 585594 | 2 | 1 | patents/JP2023039817A.pdf | All representative rows reviewed | [SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) Element 11 (1.58547 / 59.40)<br>[SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) Element 12 (1.58547 / 59.40) |
 | 586609 | 2 | 1 | patents/US7301711.pdf | No reviewed-sidecar hit | [PENTAX DA* 16-50mm f/2.8 ED AL[IF] SDM](../../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) Element 10 (1.58636 / 60.90)<br>[PENTAX DA* 16-50mm f/2.8 ED AL[IF] SDM](../../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) Element 15 (1.58636 / 60.90) |
-| 620586 | 2 | 1 | patents/US4303314.pdf | All representative rows reviewed | [NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) Element 1 (1.62041 / 58.60)<br>[NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) Element 2 (1.62041 / 58.60) |
 
 ## Sweep 2B - Named Tokens Missing Catalog Resolution
 
@@ -191,6 +192,7 @@ These unresolved catalog-style labels are often better first catalog targets tha
 | SF5 | 2 | 2 | patents/US3108152.pdf<br>patents/JP_2002090622_A.pdf | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) Element 4 (1.67764 / 32.00; abbe)<br>[VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) Element 4 (1.67270 / 32.20; abbe) |
 | TAF1 | 2 | 2 | patents/JP2012063403A.pdf<br>patents/US10191254.pdf | [SIGMA APO MACRO 150mm f/2.8 EX DG OS HSM](../../src/lens-data/sigma/SigmaAPOMacro150mmf28OSHSM.data.ts) Element 5 (1.77250 / 49.62; lineIndices)<br>[SONY FE 28mm f/2](../../src/lens-data/sony/SonyFE28mmf2.data.ts) Element 5 (1.77250 / 49.50; abbe) |
 | E-FDS3HT | 2 | 1 | patents/WO2022097401A1.pdf | [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) Element 7 (1.94595 / 17.98; abbe)<br>[NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) Element 13 (1.94595 / 17.98; abbe) |
+| H-K6 | 2 | 1 | Missing from untracked local patents/ references (US4568150, 4568150) | [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) Element 8 (1.51112 / 60.48; abbe)<br>[OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) Element 14 (1.51112 / 60.48; abbe) |
 | H-ZLAF4A | 2 | 1 | patents/CN210573001U.pdf | [LAOWA 24mm f/14 2× Macro Probe](../../src/lens-data/laowa/Laowa24mmf14Probe.data.ts) Element 1 (1.83481 / 42.72; abbe)<br>[LAOWA 24mm f/14 2× Macro Probe](../../src/lens-data/laowa/Laowa24mmf14Probe.data.ts) Element 27 (1.83481 / 42.72; abbe) |
 | K-LAFK50 | 2 | 1 | patents/US20150192839A1.pdf | [PANASONIC LEICA DG NOCTICRON 42.5mm f/1.2 ASPH POWER O.I.S.](../../src/lens-data/panasonic/PanasonicDGNocticron42mmf12.data.ts) Element 8 (1.77010 / 49.70; lineIndices)<br>[PANASONIC LEICA DG NOCTICRON 42.5mm f/1.2 ASPH POWER O.I.S.](../../src/lens-data/panasonic/PanasonicDGNocticron42mmf12.data.ts) Element 11 (1.77010 / 49.70; lineIndices) |
 | N-LAF2 | 2 | 1 | Missing from untracked local patents/ references (DE2359156A1, DE2359156, 2359156) | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) Pre-stop negative meniscus (1.74400 / 44.77; abbe)<br>[CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) Positive doublet front element (1.74400 / 44.77; abbe) |
@@ -199,7 +201,6 @@ These unresolved catalog-style labels are often better first catalog targets tha
 | SK18 | 2 | 1 | patents/US2681594.pdf | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) Element 5 (1.63850 / 55.50; abbe)<br>[CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) Element 6 (1.63850 / 55.50; abbe) |
 | BACD14 | 1 | 1 | patents/US5267086.pdf | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) Element 1 (1.65844 / 50.90; abbe) |
 | BACD8 | 1 | 1 | patents/US4046459A.pdf | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) Element 1 (1.61117 / 55.90; abbe) |
-| BK3 | 1 | 1 | patents/US3975089.pdf | [VIVITAR SERIES 1 35-85mm f/2.8 VMC](../../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) Element 6 (1.49800 / 65.10; abbe) |
 
 ## Sweep 3 - Proprietary Line-Index Backfill
 

--- a/agent_docs/generated/sellmeier-coverage.generated.md
+++ b/agent_docs/generated/sellmeier-coverage.generated.md
@@ -10,18 +10,18 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **357** lenses scanned
-- **349** visible lenses scanned
+- **360** lenses scanned
+- **352** visible lenses scanned
 - **105** lenses fully covered by trusted chromatic data
 - **105** visible lenses fully covered by trusted chromatic data
 - **99** lenses fully covered by strict Sellmeier data
 - **99** visible lenses fully covered by strict Sellmeier data
 - **6** lenses fully covered only after measured line-index data
 - **6** visible lenses fully covered only after measured line-index data
-- **3253 / 4033** non-air surfaces use strict catalog Sellmeier data
-- **80.7%** strict Sellmeier surface coverage overall
-- **3277 / 4033** non-air surfaces use trusted chromatic data
-- **81.3%** trusted chromatic coverage overall
+- **3277 / 4068** non-air surfaces use strict catalog Sellmeier data
+- **80.6%** strict Sellmeier surface coverage overall
+- **3301 / 4068** non-air surfaces use trusted chromatic data
+- **81.1%** trusted chromatic coverage overall
 
 ## Fully Strict Sellmeier Lenses
 
@@ -245,172 +245,175 @@ Fully strict and line-index-complete trusted lenses are listed above; this table
 | 93 | [SIGMA 35mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma35mmf14DGHSMA.data.ts) | 84.6% | 84.6% | 11/13 | 11/13 | 2 | abbe: 2 |
 | 94 | [Nikon AF Nikkor 28mm f/2.8D](../../src/lens-data/nikon/NikonAFNikkor28mmf28D.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
 | 95 | [NIKON REFLEX-NIKKOR 500mm f/8 (New)](../../src/lens-data/nikon/NikonReflexNikkor500mmf8New.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 96 | [PENTAX 110 24mm f/2.8](../../src/lens-data/pentax/Pentax11024mmf28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 97 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR III)](../../src/lens-data/ricoh/RicohGR328f28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 98 | [NIKON NIKKOR Z 24-70mm f/2.8 S](../../src/lens-data/nikon/NikonZ2470f28.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
-| 99 | [NIKON NIKKOR Z 35mm f/1.2 S](../../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
-| 100 | [LEICA SUMMILUX 28mm f/1.7 ASPH. (Leica Q, Q2, Q3)](../../src/lens-data/leica/Leica28mmf17.data.ts) | 81.8% | 81.8% | 9/11 | 9/11 | 2 | abbe: 2 |
-| 101 | [NIKON AF-S NIKKOR 20mm f/1.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS20mmf18G.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 102 | [Nikon AI Zoom-Nikkor 35–105mm f/3.5–4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35105mmf3545.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 103 | [NIKON NIKKOR Z 24-120mm f/4 S](../../src/lens-data/nikon/NikonNikkorZ24120mmf4S.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 104 | [PENTAX DA* 16-50mm f/2.8 ED AL[IF] SDM](../../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 105 | [CANON SERENAR 100mm f/3.5 I](../../src/lens-data/canon/CanonSerenar100mmf35.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
-| 106 | [NIKON 35mm f/2.8 (Nikon L35AF)](../../src/lens-data/nikon/NikonL35AF35mmf28.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
-| 107 | [FUJIFILM FUJINON 35mm f/4 (Fujifilm GFX100RF)](../../src/lens-data/fujifilm/FujifilmGFX100RF35mmf4.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 108 | [FUJIFILM FUJINON XF 23mm f/2 R WR](../../src/lens-data/fujifilm/FujifilmXF23mmf2RWR.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 109 | [LEICA ELMARIT-TL 18mm f/2.8 ASPH.](../../src/lens-data/leica/LeicaElmaritTL18mmf28.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 110 | [OLYMPUS OM J. ZUIKO AUTO-W 24mm f/2](../../src/lens-data/olympus/OlympusZuiko24mmf2J.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 111 | [OLYMPUS OM ZUIKO 16mm f/3.5 Fisheye](../../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 112 | [VOIGTLÄNDER ULTRON Vintage Line 28mm f/2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 113 | [NIKON AF-S NIKKOR 14-24mm f/2.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.ts) | 80.0% | 80.0% | 12/15 | 12/15 | 3 | abbe: 3 |
-| 114 | [MINOLTA AF 28-75mm f/2.8 (D)](../../src/lens-data/minolta/MinoltaAF2875mmf28D.data.ts) | 80.0% | 80.0% | 16/20 | 16/20 | 4 | abbe: 4 |
+| 96 | [OLYMPUS F.ZUIKO AUTO-T 200mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoT200mmf5.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 97 | [PENTAX 110 24mm f/2.8](../../src/lens-data/pentax/Pentax11024mmf28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 98 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR III)](../../src/lens-data/ricoh/RicohGR328f28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 99 | [NIKON NIKKOR Z 24-70mm f/2.8 S](../../src/lens-data/nikon/NikonZ2470f28.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
+| 100 | [NIKON NIKKOR Z 35mm f/1.2 S](../../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
+| 101 | [LEICA SUMMILUX 28mm f/1.7 ASPH. (Leica Q, Q2, Q3)](../../src/lens-data/leica/Leica28mmf17.data.ts) | 81.8% | 81.8% | 9/11 | 9/11 | 2 | abbe: 2 |
+| 102 | [NIKON AF-S NIKKOR 20mm f/1.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS20mmf18G.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 103 | [Nikon AI Zoom-Nikkor 35–105mm f/3.5–4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35105mmf3545.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 104 | [NIKON NIKKOR Z 24-120mm f/4 S](../../src/lens-data/nikon/NikonNikkorZ24120mmf4S.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 105 | [PENTAX DA* 16-50mm f/2.8 ED AL[IF] SDM](../../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 106 | [CANON SERENAR 100mm f/3.5 I](../../src/lens-data/canon/CanonSerenar100mmf35.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
+| 107 | [NIKON 35mm f/2.8 (Nikon L35AF)](../../src/lens-data/nikon/NikonL35AF35mmf28.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
+| 108 | [FUJIFILM FUJINON 35mm f/4 (Fujifilm GFX100RF)](../../src/lens-data/fujifilm/FujifilmGFX100RF35mmf4.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 109 | [FUJIFILM FUJINON XF 23mm f/2 R WR](../../src/lens-data/fujifilm/FujifilmXF23mmf2RWR.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 110 | [LEICA ELMARIT-TL 18mm f/2.8 ASPH.](../../src/lens-data/leica/LeicaElmaritTL18mmf28.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 111 | [OLYMPUS OM J. ZUIKO AUTO-W 24mm f/2](../../src/lens-data/olympus/OlympusZuiko24mmf2J.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 112 | [OLYMPUS OM ZUIKO 16mm f/3.5 Fisheye](../../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 113 | [VOIGTLÄNDER ULTRON Vintage Line 28mm f/2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 114 | [NIKON AF-S NIKKOR 14-24mm f/2.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.ts) | 80.0% | 80.0% | 12/15 | 12/15 | 3 | abbe: 3 |
+| 115 | [MINOLTA AF 28-75mm f/2.8 (D)](../../src/lens-data/minolta/MinoltaAF2875mmf28D.data.ts) | 80.0% | 80.0% | 16/20 | 16/20 | 4 | abbe: 4 |
 |  | **75-79.9% coverage** |  |  |  |  |  |  |
-| 115 | [NIKON AF-S NIKKOR 24mm f/1.4 G ED](../../src/lens-data/nikon/NikonNikkorAFS24mmf14G.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
-| 116 | [SIGMA 85mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma85mmf14Art.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
-| 117 | [CARL ZEISS DISTAGON T* 35mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf14.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 118 | [HASSELBLAD HC 150mm f/3.2](../../src/lens-data/hasselblad/HasselbladHC150mmf32.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 119 | [NIKON NIKKOR-N AUTO 28mm f/2](../../src/lens-data/nikon/NikonNikkorN28mmf2.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 120 | [PENTAX FA 31mm f/1.8 AL Limited](../../src/lens-data/pentax/PentaxFA31mmf18ALLtd.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 121 | [SONY E 30mm f/3.5 Macro](../../src/lens-data/sony/SonySEL30mmf35.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 122 | [SIGMA 50mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma50mmf14DGHSMA.data.ts) | 76.9% | 76.9% | 10/13 | 10/13 | 3 | abbe: 3 |
-| 123 | [NIKON NIKKOR Z 100-400mm f/4.5-5.6 VR S](../../src/lens-data/nikon/NikonNikkorZ100400f4556.data.ts) | 76.9% | 76.9% | 20/26 | 20/26 | 6 | abbe: 6 |
-| 124 | [CANON RF 24-50mm f/4.5-6.3 IS STM](../../src/lens-data/canon/CanonRF2450mmf463.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
-| 125 | [OLYMPUS M.ZUIKO DIGITAL 14-42mm f/3.5-5.6 II R](../../src/lens-data/olympus/OlympusMZuiko1442mmf3556II.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
-| 126 | [SIGMA 45mm f/2.8 DG DN | Contemporary](../../src/lens-data/sigma/Sigma45mmf28DGDN.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
-| 127 | [NIKON FISHEYE-NIKKOR 6mm f/2.8](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
-| 128 | [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
-| 129 | [LAOWA 12mm f/2.8 Zero-D](../../src/lens-data/laowa/Laowa12mmf28ZeroD.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
-| 130 | [Nikon AI Zoom-Nikkor 50-135mm f/3.5S](../../src/lens-data/nikon/NikonAIZoomNikko50135mmf35S.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 116 | [NIKON AF-S NIKKOR 24mm f/1.4 G ED](../../src/lens-data/nikon/NikonNikkorAFS24mmf14G.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
+| 117 | [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
+| 118 | [SIGMA 85mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma85mmf14Art.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
+| 119 | [CARL ZEISS DISTAGON T* 35mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf14.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 120 | [HASSELBLAD HC 150mm f/3.2](../../src/lens-data/hasselblad/HasselbladHC150mmf32.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 121 | [NIKON NIKKOR-N AUTO 28mm f/2](../../src/lens-data/nikon/NikonNikkorN28mmf2.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 122 | [PENTAX FA 31mm f/1.8 AL Limited](../../src/lens-data/pentax/PentaxFA31mmf18ALLtd.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 123 | [SONY E 30mm f/3.5 Macro](../../src/lens-data/sony/SonySEL30mmf35.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 124 | [SIGMA 50mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma50mmf14DGHSMA.data.ts) | 76.9% | 76.9% | 10/13 | 10/13 | 3 | abbe: 3 |
+| 125 | [NIKON NIKKOR Z 100-400mm f/4.5-5.6 VR S](../../src/lens-data/nikon/NikonNikkorZ100400f4556.data.ts) | 76.9% | 76.9% | 20/26 | 20/26 | 6 | abbe: 6 |
+| 126 | [CANON RF 24-50mm f/4.5-6.3 IS STM](../../src/lens-data/canon/CanonRF2450mmf463.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
+| 127 | [OLYMPUS M.ZUIKO DIGITAL 14-42mm f/3.5-5.6 II R](../../src/lens-data/olympus/OlympusMZuiko1442mmf3556II.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
+| 128 | [SIGMA 45mm f/2.8 DG DN | Contemporary](../../src/lens-data/sigma/Sigma45mmf28DGDN.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
+| 129 | [NIKON FISHEYE-NIKKOR 6mm f/2.8](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
+| 130 | [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 131 | [LAOWA 12mm f/2.8 Zero-D](../../src/lens-data/laowa/Laowa12mmf28ZeroD.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 132 | [Nikon AI Zoom-Nikkor 50-135mm f/3.5S](../../src/lens-data/nikon/NikonAIZoomNikko50135mmf35S.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
 |  | **70-74.9% coverage** |  |  |  |  |  |  |
-| 131 | [CANON RF 50mm f/1.2 L USM](../../src/lens-data/canon/CanonRF50mmf12L.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
-| 132 | [SIGMA 35mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
-| 133 | [PANASONIC LUMIX S 20-60mm f/3.5-5.6](../../src/lens-data/panasonic/PanasonicLumixS2060mmf3556.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
-| 134 | [PANASONIC LUMIX S 35mm f/1.8](../../src/lens-data/panasonic/PanasonicS35mmf18.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
-| 135 | [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) | 72.2% | 72.2% | 13/18 | 13/18 | 5 | abbe: 5 |
-| 136 | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 137 | [CANON New FD 50mm f/1.2](../../src/lens-data/canon/CanonFDn50f12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 138 | [CANON SERENAR 85mm f/1.5](../../src/lens-data/canon/CanonSerenar85mmf15.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 139 | [FUJIFILM FUJINON 18.5mm f/2.8 (Fujifilm X70)](../../src/lens-data/fujifilm/FujifilmX7018mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 140 | [NIKON AI-S NIKKOR 50mm f/1.2](../../src/lens-data/nikon/NikonAISNikkor50mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 141 | [OLYMPUS G.ZUIKO AUTO-S 55mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS55mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 142 | [PANASONIC LUMIX G 14mm f/2.5 II ASPH](../../src/lens-data/panasonic/PanasonicG14mmf25II.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 143 | [SIGMA 24mm f/2.8 (Sigma DP2x)](../../src/lens-data/sigma/SigmaDP2X24mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 144 | [LAOWA 65mm f/2.8 2× Ultra Macro APO](../../src/lens-data/laowa/Laowa65mmf28MacroAPO.data.ts) | 71.4% | 71.4% | 10/14 | 10/14 | 4 | abbe: 4 |
-| 145 | [FUJIFILM FUJINON XF 60mm f/2.4 R Macro](../../src/lens-data/fujifilm/FujifilmXF60mmf24R.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 146 | [Nikon AI Micro-Nikkor 105mm f/2.8S](../../src/lens-data/nikon/NikonAIMicroNikkor105mmf28S.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 147 | [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 148 | [SIGMA 50mm f/2.8 (Sigma DP3 Merrill)](../../src/lens-data/sigma/SigmaDP3M50mmf28.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 149 | [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) | 70.0% | 70.0% | 14/20 | 14/20 | 6 | abbe: 6 |
+| 133 | [CANON RF 50mm f/1.2 L USM](../../src/lens-data/canon/CanonRF50mmf12L.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
+| 134 | [SIGMA 35mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
+| 135 | [PANASONIC LUMIX S 20-60mm f/3.5-5.6](../../src/lens-data/panasonic/PanasonicLumixS2060mmf3556.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
+| 136 | [PANASONIC LUMIX S 35mm f/1.8](../../src/lens-data/panasonic/PanasonicS35mmf18.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
+| 137 | [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) | 72.2% | 72.2% | 13/18 | 13/18 | 5 | abbe: 5 |
+| 138 | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 139 | [CANON New FD 50mm f/1.2](../../src/lens-data/canon/CanonFDn50f12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 140 | [CANON SERENAR 85mm f/1.5](../../src/lens-data/canon/CanonSerenar85mmf15.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 141 | [FUJIFILM FUJINON 18.5mm f/2.8 (Fujifilm X70)](../../src/lens-data/fujifilm/FujifilmX7018mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 142 | [NIKON AI-S NIKKOR 50mm f/1.2](../../src/lens-data/nikon/NikonAISNikkor50mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 143 | [OLYMPUS G.ZUIKO AUTO-S 55mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS55mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 144 | [PANASONIC LUMIX G 14mm f/2.5 II ASPH](../../src/lens-data/panasonic/PanasonicG14mmf25II.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 145 | [SIGMA 24mm f/2.8 (Sigma DP2x)](../../src/lens-data/sigma/SigmaDP2X24mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 146 | [LAOWA 65mm f/2.8 2× Ultra Macro APO](../../src/lens-data/laowa/Laowa65mmf28MacroAPO.data.ts) | 71.4% | 71.4% | 10/14 | 10/14 | 4 | abbe: 4 |
+| 147 | [FUJIFILM FUJINON XF 60mm f/2.4 R Macro](../../src/lens-data/fujifilm/FujifilmXF60mmf24R.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 148 | [Nikon AI Micro-Nikkor 105mm f/2.8S](../../src/lens-data/nikon/NikonAIMicroNikkor105mmf28S.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 149 | [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 150 | [SIGMA 50mm f/2.8 (Sigma DP3 Merrill)](../../src/lens-data/sigma/SigmaDP3M50mmf28.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 151 | [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) | 70.0% | 70.0% | 14/20 | 14/20 | 6 | abbe: 6 |
 |  | **65-69.9% coverage** |  |  |  |  |  |  |
-| 150 | [SIGMA 10-18mm f/2.8 DC DN | Contemporary](../../src/lens-data/sigma/Sigma1018mmf28DCDN.data.ts) | 69.2% | 69.2% | 9/13 | 9/13 | 4 | abbe: 4 |
-| 151 | [NIKON Gyogyotto 20mm f/8](../../src/lens-data/nikon/NikonGyogyotto20mmf8.data.ts) | 66.7% | 66.7% | 2/3 | 2/3 | 1 | abbe: 1 |
-| 152 | [CANON SERENAR 28mm f/3.5](../../src/lens-data/canon/CanonSerenar28mmf35.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 153 | [LEICA MACRO-ELMARIT-R 60mm f/2.8](../../src/lens-data/leica/LeicaMacroElmaritR60mmf28.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 154 | [NIKON AI NIKKOR 135mm f/2](../../src/lens-data/nikon/NikonAI135mmf2.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 155 | [NIKON REFLEX-NIKKOR·C 500mm f/8](../../src/lens-data/nikon/NikonReflexNikkorC500mmf8.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 156 | [SCHNEIDER-KREUZNACH APO-SYMMAR 100mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 157 | [SCHNEIDER-KREUZNACH SUPER-SYMMAR XL 110mm f/5.6 ASPHERIC](../../src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 158 | [CANON FD 35mm f/2 S.S.C. (I)](../../src/lens-data/canon/CanonFD35mmf2.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 159 | [HASSELBLAD HC Macro 120mm f/4](../../src/lens-data/hasselblad/HasselbladHC120mmf4Macro.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 160 | [NIKON AF-S NIKKOR 58mm f/1.4 G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 161 | [HASSELBLAD XCD 90mm f/2.5 V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 66.7% | 66.7% | 8/9 | 8/9 | 4 | constant: 3, abbe: 1 |
-| 162 | [VIVITAR SERIES 1 35-85mm f/2.8 VMC](../../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) | 66.7% | 66.7% | 8/12 | 8/12 | 4 | abbe: 4 |
+| 152 | [SIGMA 10-18mm f/2.8 DC DN | Contemporary](../../src/lens-data/sigma/Sigma1018mmf28DCDN.data.ts) | 69.2% | 69.2% | 9/13 | 9/13 | 4 | abbe: 4 |
+| 153 | [NIKON Gyogyotto 20mm f/8](../../src/lens-data/nikon/NikonGyogyotto20mmf8.data.ts) | 66.7% | 66.7% | 2/3 | 2/3 | 1 | abbe: 1 |
+| 154 | [CANON SERENAR 28mm f/3.5](../../src/lens-data/canon/CanonSerenar28mmf35.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 155 | [LEICA MACRO-ELMARIT-R 60mm f/2.8](../../src/lens-data/leica/LeicaMacroElmaritR60mmf28.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 156 | [NIKON AI NIKKOR 135mm f/2](../../src/lens-data/nikon/NikonAI135mmf2.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 157 | [NIKON REFLEX-NIKKOR·C 500mm f/8](../../src/lens-data/nikon/NikonReflexNikkorC500mmf8.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 158 | [SCHNEIDER-KREUZNACH APO-SYMMAR 100mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 159 | [SCHNEIDER-KREUZNACH SUPER-SYMMAR XL 110mm f/5.6 ASPHERIC](../../src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 160 | [CANON FD 35mm f/2 S.S.C. (I)](../../src/lens-data/canon/CanonFD35mmf2.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 161 | [HASSELBLAD HC Macro 120mm f/4](../../src/lens-data/hasselblad/HasselbladHC120mmf4Macro.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 162 | [NIKON AF-S NIKKOR 58mm f/1.4 G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 163 | [HASSELBLAD XCD 90mm f/2.5 V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 66.7% | 66.7% | 8/9 | 8/9 | 4 | constant: 3, abbe: 1 |
+| 164 | [VIVITAR SERIES 1 35-85mm f/2.8 VMC](../../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) | 66.7% | 66.7% | 8/12 | 8/12 | 4 | abbe: 4 |
 |  | **60-64.9% coverage** |  |  |  |  |  |  |
-| 163 | [NIKON AF NIKKOR 28mm f/1.4 D](../../src/lens-data/nikon/NikonAF28f14D.data.ts) | 63.6% | 63.6% | 7/11 | 7/11 | 4 | abbe: 4 |
-| 164 | [FUJIFILM FUJINON 23mm f/2 (Fujifilm X100V)](../../src/lens-data/fujifilm/FujifilmX100V23mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 165 | [LEICA ELMARIT-R 28mm f/2.8](../../src/lens-data/leica/LeicaElmarit28mmf28.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 166 | [NIKON AI NIKKOR 35mm f/2](../../src/lens-data/nikon/NikonAINikkor35mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 167 | [NIKON NIKKOR Z 40mm f/2](../../src/lens-data/nikon/NikonNikkorZ40mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 168 | [SONY PLANAR T* 50mm f/1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 169 | [NIKON AF ZOOM-MICRO NIKKOR ED 70-180mm f/4.5-5.6D](../../src/lens-data/nikon/NikonAFZoomMicro70180mmf4556D.data.ts) | 61.1% | 61.1% | 11/18 | 11/18 | 7 | abbe: 7 |
-| 170 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 61.1% | 61.1% | 11/17 | 11/17 | 7 | abbe: 6, constant: 1 |
-| 171 | [OLYMPUS E.ZUIKO AUTO-T 135mm f/3.5](../../src/lens-data/olympus/OlympusZuiko135mmf35.data.ts) | 60.0% | 60.0% | 3/5 | 3/5 | 2 | abbe: 2 |
-| 172 | [MINOLTA AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
-| 173 | [OLYMPUS ZUIKO AUTO-FISHEYE 8mm f/2.8](../../src/lens-data/olympus/OlympusZuikoAutoFisheye8mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
-| 174 | [NIKON AF-S NIKKOR 28-300mm f/3.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS28300mmf3556G.data.ts) | 60.0% | 60.0% | 12/20 | 12/20 | 8 | abbe: 8 |
+| 165 | [NIKON AF NIKKOR 28mm f/1.4 D](../../src/lens-data/nikon/NikonAF28f14D.data.ts) | 63.6% | 63.6% | 7/11 | 7/11 | 4 | abbe: 4 |
+| 166 | [FUJIFILM FUJINON 23mm f/2 (Fujifilm X100V)](../../src/lens-data/fujifilm/FujifilmX100V23mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 167 | [LEICA ELMARIT-R 28mm f/2.8](../../src/lens-data/leica/LeicaElmarit28mmf28.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 168 | [NIKON AI NIKKOR 35mm f/2](../../src/lens-data/nikon/NikonAINikkor35mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 169 | [NIKON NIKKOR Z 40mm f/2](../../src/lens-data/nikon/NikonNikkorZ40mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 170 | [SONY PLANAR T* 50mm f/1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 171 | [NIKON AF ZOOM-MICRO NIKKOR ED 70-180mm f/4.5-5.6D](../../src/lens-data/nikon/NikonAFZoomMicro70180mmf4556D.data.ts) | 61.1% | 61.1% | 11/18 | 11/18 | 7 | abbe: 7 |
+| 172 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 61.1% | 61.1% | 11/17 | 11/17 | 7 | abbe: 6, constant: 1 |
+| 173 | [OLYMPUS E.ZUIKO AUTO-T 135mm f/3.5](../../src/lens-data/olympus/OlympusZuiko135mmf35.data.ts) | 60.0% | 60.0% | 3/5 | 3/5 | 2 | abbe: 2 |
+| 174 | [MINOLTA AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
+| 175 | [OLYMPUS ZUIKO AUTO-FISHEYE 8mm f/2.8](../../src/lens-data/olympus/OlympusZuikoAutoFisheye8mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
+| 176 | [NIKON AF-S NIKKOR 28-300mm f/3.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS28300mmf3556G.data.ts) | 60.0% | 60.0% | 12/20 | 12/20 | 8 | abbe: 8 |
 |  | **55-59.9% coverage** |  |  |  |  |  |  |
-| 175 | [CARL ZEISS B-DISTAGON 35mm f/4 (Contarex)](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf4.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 176 | [CARL ZEISS CONTAREX PLANAR 55mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissContarexPlanar55mmf14.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 177 | [MINOLTA AF Reflex 500mm f/8](../../src/lens-data/minolta/MinoltaAFReflex500mmf8.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 178 | [NIKON NIKKOR 28mm f/2.8 (Nikon 28Ti)](../../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 179 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR / GR II)](../../src/lens-data/ricoh/RicohGR218mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 180 | [SONY FE 14mm f/1.8 GM](../../src/lens-data/sony/SonyFE14mmf18GM.data.ts) | 57.1% | 57.1% | 8/14 | 8/14 | 6 | abbe: 6 |
-| 181 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 56.3% | 56.3% | 9/16 | 9/16 | 7 | abbe: 7 |
-| 182 | [OLYMPUS ZUIKO AUTO-MACRO 50mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro50mmf2.data.ts) | 55.6% | 55.6% | 5/9 | 5/9 | 4 | abbe: 4 |
+| 177 | [CARL ZEISS B-DISTAGON 35mm f/4 (Contarex)](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf4.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 178 | [CARL ZEISS CONTAREX PLANAR 55mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissContarexPlanar55mmf14.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 179 | [MINOLTA AF Reflex 500mm f/8](../../src/lens-data/minolta/MinoltaAFReflex500mmf8.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 180 | [NIKON NIKKOR 28mm f/2.8 (Nikon 28Ti)](../../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 181 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR / GR II)](../../src/lens-data/ricoh/RicohGR218mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 182 | [SONY FE 14mm f/1.8 GM](../../src/lens-data/sony/SonyFE14mmf18GM.data.ts) | 57.1% | 57.1% | 8/14 | 8/14 | 6 | abbe: 6 |
+| 183 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 56.3% | 56.3% | 9/16 | 9/16 | 7 | abbe: 7 |
+| 184 | [OLYMPUS ZUIKO AUTO-MACRO 50mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro50mmf2.data.ts) | 55.6% | 55.6% | 5/9 | 5/9 | 4 | abbe: 4 |
 |  | **50-54.9% coverage** |  |  |  |  |  |  |
-| 183 | [PENTAX HD D FA* 50mm f/1.4 SDM AW](../../src/lens-data/pentax/PentaxDFA50mmf14SDM.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
-| 184 | [Nikon AI Zoom-Nikkor 35-200mm f/3.5-4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35200mmf3545S.data.ts) | 52.9% | 52.9% | 9/17 | 9/17 | 8 | abbe: 8 |
-| 185 | [MINOLTA AF 70-200mm f/2.8 APO G (D) SSM](../../src/lens-data/minolta/MinoltaAF70200mmf28APO.data.ts) | 52.6% | 52.6% | 10/19 | 10/19 | 9 | abbe: 9 |
-| 186 | [CARL ZEISS HOLOGON 15mm f/8 (Contarex Hologon / Leica M)](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) | 50.0% | 50.0% | 2/3 | 2/3 | 2 | abbe: 2 |
-| 187 | [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 188 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 189 | [NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 190 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
-| 191 | [VIVITAR SERIES 1 200mm f/3.0 VMC](../../src/lens-data/vivitar/VivitarSeries1200mmf3.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
-| 192 | [MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
-| 193 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 50.0% | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
-| 194 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 195 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 196 | [NIKON AF-P DX NIKKOR 10-20mm f/4.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
+| 185 | [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
+| 186 | [PENTAX HD D FA* 50mm f/1.4 SDM AW](../../src/lens-data/pentax/PentaxDFA50mmf14SDM.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
+| 187 | [Nikon AI Zoom-Nikkor 35-200mm f/3.5-4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35200mmf3545S.data.ts) | 52.9% | 52.9% | 9/17 | 9/17 | 8 | abbe: 8 |
+| 188 | [MINOLTA AF 70-200mm f/2.8 APO G (D) SSM](../../src/lens-data/minolta/MinoltaAF70200mmf28APO.data.ts) | 52.6% | 52.6% | 10/19 | 10/19 | 9 | abbe: 9 |
+| 189 | [CARL ZEISS HOLOGON 15mm f/8 (Contarex Hologon / Leica M)](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) | 50.0% | 50.0% | 2/3 | 2/3 | 2 | abbe: 2 |
+| 190 | [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 191 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 192 | [NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 193 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
+| 194 | [VIVITAR SERIES 1 200mm f/3.0 VMC](../../src/lens-data/vivitar/VivitarSeries1200mmf3.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
+| 195 | [MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
+| 196 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 50.0% | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
+| 197 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 198 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 199 | [NIKON AF-P DX NIKKOR 10-20mm f/4.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
 |  | **45-49.9% coverage** |  |  |  |  |  |  |
-| 197 | [SIGMA 17-40mm f/1.8 DC | Art](../../src/lens-data/sigma/Sigma1740mmf18DCA.data.ts) | 47.1% | 47.1% | 8/17 | 8/17 | 9 | abbe: 9 |
-| 198 | [Nikon AI Zoom-Nikkor 25-50mm f/4](../../src/lens-data/nikon/NikonAIZoomNikkor2550mmf4.data.ts) | 45.5% | 45.5% | 5/11 | 5/11 | 6 | abbe: 6 |
-| 199 | [Nikon AI Zoom-Nikkor 360-1200mm f/11 ED](../../src/lens-data/nikon/NikonAIZoomNikkor3601200mmf11ED.data.ts) | 45.0% | 45.0% | 9/20 | 9/20 | 11 | abbe: 11 |
+| 200 | [SIGMA 17-40mm f/1.8 DC | Art](../../src/lens-data/sigma/Sigma1740mmf18DCA.data.ts) | 47.1% | 47.1% | 8/17 | 8/17 | 9 | abbe: 9 |
+| 201 | [Nikon AI Zoom-Nikkor 25-50mm f/4](../../src/lens-data/nikon/NikonAIZoomNikkor2550mmf4.data.ts) | 45.5% | 45.5% | 5/11 | 5/11 | 6 | abbe: 6 |
+| 202 | [Nikon AI Zoom-Nikkor 360-1200mm f/11 ED](../../src/lens-data/nikon/NikonAIZoomNikkor3601200mmf11ED.data.ts) | 45.0% | 45.0% | 9/20 | 9/20 | 11 | abbe: 11 |
 |  | **40-44.9% coverage** |  |  |  |  |  |  |
-| 200 | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 201 | [MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 202 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 203 | [CARL ZEISS JENA BIOGON 35mm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 204 | [MINOLTA AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 205 | [SONY SONNAR T* FE 35mm f/2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 206 | [LAOWA 58mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
-| 207 | [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 208 | [NIKON AI NIKKOR 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 209 | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 210 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 203 | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 204 | [MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 205 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 206 | [CARL ZEISS JENA BIOGON 35mm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 207 | [MINOLTA AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 208 | [SONY SONNAR T* FE 35mm f/2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 209 | [LAOWA 58mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
+| 210 | [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 211 | [NIKON AI NIKKOR 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 212 | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 213 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
 |  | **35-39.9% coverage** |  |  |  |  |  |  |
-| 211 | [NIKON AF-P NIKKOR 70-300mm f/4.5-5.6 E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
-| 212 | [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
-| 213 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
-| 214 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
-| 215 | [NIKON NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
-| 216 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
-| 217 | [SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
+| 214 | [NIKON AF-P NIKKOR 70-300mm f/4.5-5.6 E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
+| 215 | [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
+| 216 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
+| 217 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
+| 218 | [NIKON NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
+| 219 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
+| 220 | [SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
 |  | **30-34.9% coverage** |  |  |  |  |  |  |
-| 218 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 219 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 220 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 221 | [NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 222 | [PENTAX DA 70mm f/2.4 Limited](../../src/lens-data/pentax/PentaxDA70mmf24Limited.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 223 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 224 | [SIGMA 85mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
-| 225 | [NIKON AF-S DX NIKKOR 55-200mm f/4-5.6 G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
-| 226 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
+| 221 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 222 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 223 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 224 | [NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 225 | [PENTAX DA 70mm f/2.4 Limited](../../src/lens-data/pentax/PentaxDA70mmf24Limited.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 226 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 227 | [SIGMA 85mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
+| 228 | [NIKON AF-S DX NIKKOR 55-200mm f/4-5.6 G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
+| 229 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
 |  | **25-29.9% coverage** |  |  |  |  |  |  |
-| 227 | [LEICA ELMARIT-R 35mm f/2.8](../../src/lens-data/leica/LeicaElmaritR35mmf28.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
-| 228 | [NIKON W-NIKKOR 35mm f/1.8](../../src/lens-data/nikon/NikonWNikkor35mmf18.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
+| 230 | [LEICA ELMARIT-R 35mm f/2.8](../../src/lens-data/leica/LeicaElmaritR35mmf28.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
+| 231 | [NIKON W-NIKKOR 35mm f/1.8](../../src/lens-data/nikon/NikonWNikkor35mmf18.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
 |  | **20-24.9% coverage** |  |  |  |  |  |  |
-| 229 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
+| 232 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
 |  | **15-19.9% coverage** |  |  |  |  |  |  |
-| 230 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
-| 231 | [SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
+| 233 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
+| 234 | [SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
 |  | **10-14.9% coverage** |  |  |  |  |  |  |
-| 232 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
-| 233 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 235 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 236 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
 |  | **0-4.9% coverage** |  |  |  |  |  |  |
-| 234 | [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) *(hidden)* | 0.0% | 0.0% | 0/3 | 0/3 | 1 | abbe: 1 |
-| 235 | [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) *(hidden)* | 0.0% | 0.0% | 0/1 | 0/1 | 1 | abbe: 1 |
-| 236 | [CARL ZEISS JENA TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 237 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 238 | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) | 0.0% | 0.0% | 0/5 | 0/5 | 5 | abbe: 5 |
-| 239 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 240 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 241 | [LEICA SUMMICRON-R 50mm f/2](../../src/lens-data/leica/LeicaSummicronR50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 242 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 243 | [NIKON AI NIKKOR 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 244 | [CARL ZEISS JENA SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 245 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 246 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
+| 237 | [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) *(hidden)* | 0.0% | 0.0% | 0/3 | 0/3 | 1 | abbe: 1 |
+| 238 | [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) *(hidden)* | 0.0% | 0.0% | 0/1 | 0/1 | 1 | abbe: 1 |
+| 239 | [CARL ZEISS JENA TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 240 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 241 | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) | 0.0% | 0.0% | 0/5 | 0/5 | 5 | abbe: 5 |
+| 242 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 243 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 244 | [LEICA SUMMICRON-R 50mm f/2](../../src/lens-data/leica/LeicaSummicronR50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 245 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 246 | [NIKON AI NIKKOR 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 247 | [CARL ZEISS JENA SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 248 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 249 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
 
 ## Missing Surface Details
 
@@ -1013,6 +1016,12 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 |---|---|---|---|---|
 | 13 | Third rear corrector element | abbe | `Unmatched (lanthanum dense flint, patent 796/410; nearest current class S-LAH52 / K-LaSFn3)` | Explicit unmatched/proprietary annotation |
 
+### [OLYMPUS F.ZUIKO AUTO-T 200mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoT200mmf5.data.ts) - 83.3% trusted (5/6); 83.3% Sellmeier (5/6) - US 3,804,494
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 4 | Element 3 | abbe | `K10 (Schott)` | No catalog match |
+
 ### [PENTAX 110 24mm f/2.8](../../src/lens-data/pentax/Pentax11024mmf28.data.ts) - 83.3% trusted (5/6); 83.3% Sellmeier (5/6) - US 4,223,982
 
 | Surface | Element | Runtime quality | Glass annotation | Reason |
@@ -1158,6 +1167,14 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 | 13 | L23a | abbe | `LBC3N class (606637 phosphate crown)` | No catalog match |
 | 14 | Cement layer 1 | abbe | `Patent cement medium (nd=1.51400, νd=42.83)` | No catalog match |
 | 19 | Cement layer 2 | abbe | `Patent cement medium (nd=1.51400, νd=42.83)` | No catalog match |
+
+### [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) - 78.6% trusted (11/14); 78.6% Sellmeier (11/14) - US 4,568,150
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 13 | Element 8 | abbe | `511605 crown class (CDGM H-K6 / legacy OHARA NSL7)` | No catalog match |
+| 17 | Element 10 | abbe | `500660 crown class (CDGM H-K2 / OHARA BSL4)` | No catalog match |
+| 25 | Element 14 | abbe | `511605 crown class (CDGM H-K6 / legacy OHARA NSL7)` | No catalog match |
 
 ### [SIGMA 85mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma85mmf14Art.data.ts) - 78.6% trusted (11/14); 78.6% Sellmeier (11/14) - JP2018-5099A
 
@@ -1710,6 +1727,18 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 | 9 | Element 5 | abbe | `683447 — barium/lanthanum flint family (patent nd=1.68250, νd=44.65; no exact public catalog match)` | No catalog match |
 | 12 | Element 7 | abbe | `LAC14 (773/497)` | No catalog match |
 | 14 | Element 8 | abbe | `LAC14 (773/497)` | No catalog match |
+
+### [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) - 53.3% trusted (8/15); 53.3% Sellmeier (8/15) - US 4,025,167
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 6 | Element 4 | abbe | `569632 — dense crown (patent glass code)` | No catalog match |
+| 8 | Element 5 | abbe | `FD140 (HOYA) / PBH14 (OHARA) class` | No catalog match |
+| 9 | Element 6 | abbe | `PSK53A / K-PSKn2 class` | No catalog match |
+| 11 | Element 7 | abbe | `569632 — dense crown (patent glass code)` | No catalog match |
+| 13 | Element 8 | abbe | `K-SSK9 (Sumita) / BSM28 class` | No catalog match |
+| 16 | Element 10 | abbe | `498650 — borosilicate crown (patent glass code)` | No catalog match |
+| 21 | Element 13 | abbe | `F8 class (Hikari / HOYA)` | No catalog match |
 
 ### [PENTAX HD D FA* 50mm f/1.4 SDM AW](../../src/lens-data/pentax/PentaxDFA50mmf14SDM.data.ts) - 53.3% trusted (8/15); 53.3% Sellmeier (8/15) - US 2019/0250367 A1
 

--- a/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
@@ -9,10 +9,10 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **357** lenses scanned
-- **303** total code-only elements found
-- **203** elements in this report
-- **82** distinct lens files affected
+- **360** lenses scanned
+- **306** total code-only elements found
+- **206** elements in this report
+- **83** distinct lens files affected
 
 ## Codes by Frequency
 
@@ -36,6 +36,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 518603 | 2 | 2 | patents/US4770511.pdf<br>patents/US4699475.pdf | All representative rows reviewed |
 | 531559 | 2 | 2 | patents/US20200142167A1.pdf<br>patents/WO2021039813A1.pdf | All representative rows reviewed |
 | 561453 | 2 | 2 | patents/US20020075570A1.pdf<br>patents/US3376091.pdf | 1/2 representative rows reviewed |
+| 569632 | 2 | 1 | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
 | 585594 | 2 | 1 | patents/JP2023039817A.pdf | All representative rows reviewed |
 | 586609 | 2 | 1 | patents/US7301711.pdf | No reviewed-sidecar hit |
 | 620586 | 2 | 1 | patents/US4303314.pdf | All representative rows reviewed |
@@ -53,6 +54,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 933209 | 2 | 2 | patents/WO2021199923A1.pdf<br>patents/JP2023039817A.pdf | All representative rows reviewed |
 | 465658 | 1 | 1 | patents/US4189212.pdf | No reviewed-sidecar hit |
 | 487698 | 1 | 1 | patents/US3838911.pdf | All representative rows reviewed |
+| 498650 | 1 | 1 | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
 | 504667 | 1 | 1 | patents/US2721499.pdf | All representative rows reviewed |
 | 511509 | 1 | 1 | patents/US4266860.pdf | No reviewed-sidecar hit |
 | 514530 | 1 | 1 | patents/JP2016021011A.pdf | All representative rows reviewed |
@@ -617,6 +619,14 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality | localPatentStatus | reviewedSidecarStatus |
 |---|---|---|---|---|---|---|---|
 | L5 (Element 5) | 9 | `683447 — barium/lanthanum flint family (patent nd=1.68250, νd=44.65; no exact public catalog match)` | 1.68250 / 44.65 | No catalog entry | abbe | patents/US4708445.pdf | Reviewed sidecar hit |
+
+### [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) - US 4,025,167
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality | localPatentStatus | reviewedSidecarStatus |
+|---|---|---|---|---|---|---|---|
+| L4 (Element 4) | 6 | `569632 — dense crown (patent glass code)` | 1.56873 / 63.20 | No catalog entry | abbe | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
+| L7 (Element 7) | 11 | `569632 — dense crown (patent glass code)` | 1.56873 / 63.20 | No catalog entry | abbe | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
+| L10 (Element 10) | 16 | `498650 — borosilicate crown (patent glass code)` | 1.49831 / 65.00 | No catalog entry | abbe | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
 
 ### [OLYMPUS ZUIKO DIGITAL ED 14-35mm f/2.0 SWD](../../src/lens-data/olympus/OlympusMZuiko1435mmf2ED.data.ts) - US 8,081,392 B2
 

--- a/agent_docs/generated/six-digit-glass-codes.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes.generated.md
@@ -9,10 +9,10 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **357** lenses scanned
-- **303** total code-only elements found
-- **303** elements in this report
-- **107** distinct lens files affected
+- **360** lenses scanned
+- **306** total code-only elements found
+- **306** elements in this report
+- **108** distinct lens files affected
 
 ## Codes by Frequency
 
@@ -51,6 +51,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 519699 | 2 | 1 | patents/WO2022097401A1.pdf | No reviewed-sidecar hit |
 | 531559 | 2 | 2 | patents/US20200142167A1.pdf<br>patents/WO2021039813A1.pdf | All representative rows reviewed |
 | 561453 | 2 | 2 | patents/US20020075570A1.pdf<br>patents/US3376091.pdf | 1/2 representative rows reviewed |
+| 569632 | 2 | 1 | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
 | 585594 | 2 | 1 | patents/JP2023039817A.pdf | All representative rows reviewed |
 | 586609 | 2 | 1 | patents/US7301711.pdf | No reviewed-sidecar hit |
 | 603380 | 2 | 1 | Missing from untracked local patents/ references (JP2020173366A, JP2020173366, 2020173366) | No reviewed-sidecar hit |
@@ -74,6 +75,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | 003193 | 1 | 1 | patents/US20180246292A1.pdf | No reviewed-sidecar hit |
 | 465658 | 1 | 1 | patents/US4189212.pdf | No reviewed-sidecar hit |
 | 487698 | 1 | 1 | patents/US3838911.pdf | All representative rows reviewed |
+| 498650 | 1 | 1 | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
 | 504667 | 1 | 1 | patents/US2721499.pdf | All representative rows reviewed |
 | 511509 | 1 | 1 | patents/US4266860.pdf | No reviewed-sidecar hit |
 | 514530 | 1 | 1 | patents/JP2016021011A.pdf | All representative rows reviewed |
@@ -843,6 +845,14 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality | localPatentStatus | reviewedSidecarStatus |
 |---|---|---|---|---|---|---|---|
 | L5 (Element 5) | 9 | `683447 — barium/lanthanum flint family (patent nd=1.68250, νd=44.65; no exact public catalog match)` | 1.68250 / 44.65 | No catalog entry | abbe | patents/US4708445.pdf | Reviewed sidecar hit |
+
+### [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) - US 4,025,167
+
+| Element | Surfaces | Code-only annotation | Stored nd/vd | Catalog/Sellmeier status | Dispersion quality | localPatentStatus | reviewedSidecarStatus |
+|---|---|---|---|---|---|---|---|
+| L4 (Element 4) | 6 | `569632 — dense crown (patent glass code)` | 1.56873 / 63.20 | No catalog entry | abbe | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
+| L7 (Element 7) | 11 | `569632 — dense crown (patent glass code)` | 1.56873 / 63.20 | No catalog entry | abbe | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
+| L10 (Element 10) | 16 | `498650 — borosilicate crown (patent glass code)` | 1.49831 / 65.00 | No catalog entry | abbe | Missing from untracked local patents/ references (US4025167, 4025167) | No reviewed-sidecar hit |
 
 ### [OLYMPUS ZUIKO DIGITAL ED 14-35mm f/2.0 SWD](../../src/lens-data/olympus/OlympusMZuiko1435mmf2ED.data.ts) - US 8,081,392 B2
 

--- a/agent_docs/generated/unresolved-glass.generated.md
+++ b/agent_docs/generated/unresolved-glass.generated.md
@@ -8,11 +8,11 @@ or per-lens patent backfills.
 
 ## Summary
 
-- **357** lenses scanned
-- **4033** non-air surfaces examined
-- **4037** element glass declarations examined
-- **621** non-explicit-unmatched annotations did not resolve
-- **213** distinct unresolved glass-like tokens found
+- **360** lenses scanned
+- **4068** non-air surfaces examined
+- **4072** element glass declarations examined
+- **632** non-explicit-unmatched annotations did not resolve
+- **221** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency
 
@@ -26,8 +26,10 @@ or per-lens patent backfills.
 | 744495 | 3 | 3 | |
 | 863248 | 3 | 1 | |
 | S-TIF6 | 3 | 3 | |
+| 511605 | 2 | 1 | |
 | 514428 | 2 | 1 | |
 | 531559 | 2 | 2 | |
+| 569632 | 2 | 1 | |
 | 585594 | 2 | 1 | |
 | 620586 | 2 | 1 | |
 | 666356 | 2 | 1 | |
@@ -41,6 +43,8 @@ or per-lens patent backfills.
 | 861230 | 2 | 1 | |
 | E-FDS3HT | 2 | 1 | |
 | F7 | 2 | 2 | |
+| F8 | 2 | 2 | |
+| H-K6 | 2 | 1 | |
 | H-LAF3 | 2 | 2 | |
 | H-ZLAF4A | 2 | 1 | |
 | K-LAFK50 | 2 | 1 | |
@@ -63,6 +67,8 @@ or per-lens patent backfills.
 | 157957 | 1 | 1 | |
 | 182080 | 1 | 1 | |
 | 487698 | 1 | 1 | |
+| 498650 | 1 | 1 | |
+| 500660 | 1 | 1 | |
 | 514530 | 1 | 1 | |
 | 518523 | 1 | 1 | |
 | 518635 | 1 | 1 | |
@@ -157,10 +163,10 @@ or per-lens patent backfills.
 | E-FEL6 | 1 | 1 | |
 | E-FPL51 | 1 | 1 | |
 | F3 | 1 | 1 | |
-| F8 | 1 | 1 | |
 | FCD10A | 1 | 1 | |
 | FCD500 | 1 | 1 | |
 | FCD915 | 1 | 1 | |
+| H-K2 | 1 | 1 | |
 | H-K8 | 1 | 1 | |
 | H-K9L | 1 | 1 | |
 | H-LAF51 | 1 | 1 | |
@@ -182,7 +188,9 @@ or per-lens patent backfills.
 | H-ZLAF75B | 1 | 1 | |
 | H-ZLAF92 | 1 | 1 | |
 | K-BASF5 | 1 | 1 | |
+| K-PSKN2 | 1 | 1 | |
 | K-SFS5 | 1 | 1 | |
+| K-SSK9 | 1 | 1 | |
 | L-BBH1 | 1 | 1 | |
 | L-LAH83 | 1 | 1 | |
 | L-LAH85 | 1 | 1 | |
@@ -285,6 +293,11 @@ or per-lens patent backfills.
 - [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) 29: `S-TIF6 (OHARA)`
 - [RICOH GR LENS A12 28mm f/2.5 (Ricoh GXR A12)](../../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) 10: `S-TIF6 (OHARA) / N-SF5 (SCHOTT)`
 
+### 511605 — 2 occurrences
+
+- [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) 13: `511605 crown class (CDGM H-K6 / legacy OHARA NSL7)`
+- [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) 25: `511605 crown class (CDGM H-K6 / legacy OHARA NSL7)`
+
 ### 514428 — 2 occurrences
 
 - [NIKON AF-S NIKKOR 20mm f/1.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS20mmf18G.data.ts) 9: `514428 — patent cement layer (nd=1.51400, νd=42.8)`
@@ -294,6 +307,11 @@ or per-lens patent backfills.
 
 - [CANON RF 24-240mm f/4-6.3 IS USM](../../src/lens-data/canon/CanonRF24240mmf463.data.ts) 25A: `531559 - moldable barium light crown (patent nd=1.53110, vd=55.9)`
 - [NIKON AF-P DX NIKKOR 10-20mm f/4.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) 25: `531559 - patent-specified crown-like glass (theta_gF=0.5684; unresolved)`
+
+### 569632 — 2 occurrences
+
+- [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) 6: `569632 — dense crown (patent glass code)`
+- [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) 11: `569632 — dense crown (patent glass code)`
 
 ### 585594 — 2 occurrences
 
@@ -359,6 +377,16 @@ or per-lens patent backfills.
 
 - [CANON SERENAR 28mm f/3.5](../../src/lens-data/canon/CanonSerenar28mmf35.data.ts) 4: `F7 (Schott)`
 - [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) 10: `F7 (Schott)`
+
+### F8 — 2 occurrences
+
+- [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) 3: `F8 historical (Schott, discontinued)`
+- [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) 21: `F8 class (Hikari / HOYA)`
+
+### H-K6 — 2 occurrences
+
+- [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) 13: `511605 crown class (CDGM H-K6 / legacy OHARA NSL7)`
+- [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) 25: `511605 crown class (CDGM H-K6 / legacy OHARA NSL7)`
 
 ### H-LAF3 — 2 occurrences
 
@@ -466,6 +494,14 @@ or per-lens patent backfills.
 ### 487698 — 1 occurrence
 
 - [OLYMPUS E.ZUIKO AUTO-T 135mm f/3.5](../../src/lens-data/olympus/OlympusZuiko135mmf35.data.ts) 3: `487698 — FK/FSL low-dispersion crown class (patent nd=1.48749, νd=69.8; no exact modern coefficient-backed match)`
+
+### 498650 — 1 occurrence
+
+- [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) 16: `498650 — borosilicate crown (patent glass code)`
+
+### 500660 — 1 occurrence
+
+- [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) 17: `500660 crown class (CDGM H-K2 / OHARA BSL4)`
 
 ### 514530 — 1 occurrence
 
@@ -843,10 +879,6 @@ or per-lens patent backfills.
 
 - [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) 3: `612372 F (≈ Schott F3 legacy)`
 
-### F8 — 1 occurrence
-
-- [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) 3: `F8 historical (Schott, discontinued)`
-
 ### FCD10A — 1 occurrence
 
 - [SIGMA 35mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) 11: `HOYA FCD10A (459/902)`
@@ -858,6 +890,10 @@ or per-lens patent backfills.
 ### FCD915 — 1 occurrence
 
 - [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) 20: `FCD915 (HOYA)`
+
+### H-K2 — 1 occurrence
+
+- [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) 17: `500660 crown class (CDGM H-K2 / OHARA BSL4)`
 
 ### H-K8 — 1 occurrence
 
@@ -943,9 +979,17 @@ or per-lens patent backfills.
 
 - [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) 1: `603/425 barium flint; Sumita K-BaSF5-equivalent`
 
+### K-PSKN2 — 1 occurrence
+
+- [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) 9: `PSK53A / K-PSKn2 class`
+
 ### K-SFS5 — 1 occurrence
 
 - [VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) 7: `SF5 (Schott) / K-SFS5 (Sumita)`
+
+### K-SSK9 — 1 occurrence
+
+- [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) 13: `K-SSK9 (Sumita) / BSM28 class`
 
 ### L-BBH1 — 1 occurrence
 

--- a/src/lens-data/olympus/OlympusZuikoAutoT200mmf5.analysis.md
+++ b/src/lens-data/olympus/OlympusZuikoAutoT200mmf5.analysis.md
@@ -1,0 +1,153 @@
+# Olympus F.Zuiko Auto-T 200mm f/5
+
+## Patent Reference and Design Identification
+
+**Patent:** US 3,804,494  
+**Filed:** September 28, 1972  
+**Granted:** April 16, 1974  
+**Priority:** October 1, 1971 (Japan, 46-76236)  
+**Inventor:** Keiichi Ito  
+**Assignee:** Olympus Optical Company Limited, Tokyo, Japan  
+**Title:** Telephoto Lens Systems Having Small Telephoto Ratio  
+**Claims:** 3  
+**Worked examples:** 2  
+**Embodiment analyzed:** Example 1 / Claim 2, corresponding to FIG. 1 and FIGS. 2A-2D
+
+The prescription transcribes Example 1 of US 3,804,494, scaled uniformly by 2x from the patent's normalized f = 100 mm prescription to the 200 mm production focal length. The patent identifies Example 1 as a six-lens telephoto system in which lenses 5 and 6 are slightly air-spaced; Claim 2 repeats the same f = 100 mm, 2ω = 12°10′, F/5, f123 = 69.75 mm, f4 = -80.48 mm, and back-focus 25.5 mm prescription.
+
+The identification as the Olympus F.Zuiko Auto-T 200mm f/5 rests on convergent evidence:
+
+1. **Element and group count.** Example 1 is six elements in five air-spaced groups: L1, L2+L3 cemented, L4, L5, and L6. Example 2 cements L5 and L6 and therefore gives six elements in four groups, which does not match the documented production formula.
+2. **Focal length.** The patent prescription is normalized to 100 mm. Scaling all radii and thicknesses by 2x yields a 200 mm design.
+3. **Maximum aperture.** The patent example is F/5, matching the production lens designation.
+4. **Field coverage.** The patent field is 2ω = 12°10′. At the 200 mm scale, this corresponds to an image semi-field of about 21.3 mm, or 42.5 mm full diagonal coverage, close to the nominal 43.3 mm diagonal of the 135 format.
+5. **Production specification match.** Archival Olympus-system specification tables list the F.Zuiko Auto-T 1:5 f = 200 mm as 6 elements in 5 groups, 12° angle of view, f/5-f/32, 2.5 m minimum focus, 49 mm filter, 105 mm length, and 62 mm maximum diameter. The optical track implied by the scaled patent prescription is 150 mm from first surface to film plane, which is consistent with a roughly 105 mm lens length plus the 46 mm OM flange distance.
+
+## Optical Architecture
+
+The design is a compact all-spherical telephoto with a positive front group and a negative rear group. Group I contains four elements: a positive low-index meniscus L1, a cemented negative-positive doublet L2+L3, and a high-index negative L4. Group II contains the strong negative relay pair L5 and L6, separated by a small air gap in Example 1.
+
+At the patent scale, the front group has a computed focal length of +69.74 mm and the rear group has a computed focal length of -85.52 mm. The large 25 mm patent-scale air gap between L4 and L5 separates these powers. After 2x scaling, this becomes a 50 mm air gap, and the data file inserts a synthetic aperture stop at its midpoint because the patent gives F/5 but does not publish a diaphragm coordinate or stop surface.
+
+The architectural purpose is stated directly by the patent: reducing telephoto ratio requires increasing positive front-group power and negative rear-group power, but that makes aberration correction harder. Example 1 reaches a telephoto ratio of 0.75 at the patent scale, since (49.5 + 25.5) / 100 = 0.75. The 2x production-scale file preserves the same ratio: the first-surface-to-image optical track is 150 mm for a 200 mm lens.
+
+## Element-by-Element Analysis
+
+### L1 — Positive Meniscus, Convex to Object
+
+nd = 1.4875, νd = 70.2. Glass: S-FSL5 (OHARA) / N-FK5 class. f = +161.10 mm at production scale.
+
+L1 is the low-index positive collector at the front of the system. Its object-side surface is the stronger surface, and the meniscus form bends the incoming beam without making the first element a high-index, high-curvature biconvex lens. The patent's first condition requires n1 < 1.55, and L1 satisfies that requirement.
+
+The glass is a close catalog match to OHARA S-FSL5, with current catalog values nd = 1.48749 and νd = 70.23. This is also the N-FK5 class in the Schott cross-reference family. The low dispersion reduces the chromatic burden placed on the following cemented doublet.
+
+### L2 + L3 — Cemented Doublet, Negative Meniscus + Positive Meniscus
+
+L2: nd = 1.7283, νd = 28.5. Glass: S-TIH10 (OHARA) / SF10 class. f = -135.37 mm at production scale.  
+L3: nd = 1.5014, νd = 56.4. Glass: K10 class (Schott; 501/564). f = +78.91 mm at production scale.  
+Cemented net: f = +205.67 mm at production scale.
+
+The cemented doublet is the main front-group chromatic corrector. L2 is a high-index, high-dispersion flint; L3 is a crown. Their cemented junction at the steep positive radius R4 provides a strong chromatic lever without adding an air-spaced surface.
+
+The patent's second condition requires n2 - n3 > 0.2. The Example 1 prescription gives 1.7283 - 1.5014 = 0.2269, so the condition is satisfied. The patent states that this index contrast is used to correct spherical aberration associated with the first condition.
+
+L2 matches OHARA S-TIH10 within ordinary rounding: the current catalog lists nd = 1.72825 and νd = 28.46. L3 matches Schott K10 class, with Schott listing nd = 1.50137 and νd = 56.41. No current OHARA, HOYA, Sumita, HIKARI, or CDGM catalog match was found at the same nd/νd pair, so the data file labels L3 as K10 class rather than as a Japanese catalog glass.
+
+### L4 — Plano-Concave Negative
+
+nd = 1.7440, νd = 44.8. Glass: S-LAM2 (OHARA) / LAF2 class. f = -160.94 mm at production scale.
+
+L4 is the negative lens at the rear of the front group. It has a plane front surface and a concave rear surface, concentrating its negative power at the exit from Group I. In isolation it nearly cancels much of L1's positive power; in the full front group, however, it is essential to reaching the patent's f123 value and Petzval balance.
+
+The patent's fourth condition uses f4 and f123. The table gives f123 = 69.75 mm and f4 = -80.48 mm at the patent scale. Direct paraxial tracing shows that the stated f123 corresponds to the full front group L1-L4, not the literal L1-L3 subsystem. The L1-L3 subsystem alone computes to about +45.46 mm, while L1-L4 computes to +69.74 mm. This is an internal notation weakness in the patent: the wording says "first, second and third lenses," but the numerical value is the front-group composite.
+
+The glass matches OHARA S-LAM2 within rounding; current catalog data list nd = 1.74400 and νd = 44.78. Its high index allows strong negative power with a comparatively mild rear radius.
+
+### L5 — Negative Meniscus, Concave to Object
+
+nd = 1.7130, νd = 54.0. Glass: S-LAL8 (OHARA) / LAK8 class. f = -39.75 mm at production scale.
+
+L5 is the dominant negative element of the rear telephoto group. The strong object-side concave surface supplies most of the negative relay power needed to move the rear principal point forward and shorten the physical track.
+
+The glass matches OHARA S-LAL8 within rounding. Current OHARA data list nd = 1.71300 and νd = 53.87; older six-digit glass-code comparisons also place it in the 713/539 LAK8 family. In the patent's first condition, n5 - n6 must exceed 0.07. Example 1 gives 1.7130 - 1.5927 = 0.1203, so the rear-group index split satisfies the condition.
+
+### L6 — Biconvex Positive
+
+nd = 1.5927, νd = 35.5. Glass: S-FTM16 (OHARA) / F16 class. f = +58.78 mm at production scale.
+
+L6 is the positive partner to L5. Its front surface is very weak, while its rear surface carries most of the positive power. The result is still a net negative rear group, but L6 moderates L5's aberrations and gives chromatic balancing leverage.
+
+The patent's third condition requires 25 > ν5 - ν6 > 15. Example 1 gives 54.0 - 35.5 = 18.5, placing the rear pair inside the required interval. OHARA S-FTM16 is the closest catalog match; current catalog data list nd = 1.59270 and νd = 35.31. The patent's νd = 35.5 is slightly rounded relative to that catalog value, so this is treated as a close catalog match rather than a perfectly exact νd match.
+
+## Glass Identification and Selection
+
+| Element | Patent nd | Patent νd | Catalog identification | Catalog check | Role |
+|---|---:|---:|---|---|---|
+| L1 | 1.4875 | 70.2 | S-FSL5 (OHARA) / N-FK5 class | OHARA nd 1.48749, νd 70.23 | Low-dispersion positive collector |
+| L2 | 1.7283 | 28.5 | S-TIH10 (OHARA) / SF10 class | OHARA nd 1.72825, νd 28.46 | Dense flint in cemented doublet |
+| L3 | 1.5014 | 56.4 | K10 class (Schott; 501/564) | Schott nd 1.50137, νd 56.41 | Crown in cemented doublet |
+| L4 | 1.7440 | 44.8 | S-LAM2 (OHARA) / LAF2 class | OHARA nd 1.74400, νd 44.78 | High-index negative front-group corrector |
+| L5 | 1.7130 | 54.0 | S-LAL8 (OHARA) / LAK8 class | OHARA nd 1.71300, νd 53.87 | Strong negative rear relay |
+| L6 | 1.5927 | 35.5 | S-FTM16 (OHARA) / F16 class | OHARA nd 1.59270, νd 35.31 | Positive rear-group partner |
+
+The chromatic correction is split across two paired regions. The front doublet uses a dense flint against a moderate-dispersion crown to correct the positive front group. The rear group uses the νd separation between L5 and L6 to balance axial color against lateral color, exactly as condition (3) describes.
+
+The data file includes catalog nC, nF, and ng values for the OHARA-matched glasses where current catalog values are available. The stored nd and νd remain the patent values, because the prescription itself is the primary source for tracing.
+
+## Focus Mechanism
+
+The patent publishes only the infinity-focus prescription. It gives no variable-spacing table and does not describe a focusing group. The production Olympus OM lens is a manual unit-focus telephoto with a 2.5 m minimum focus distance.
+
+The data file therefore represents focusing as unit focus: the glass spacings remain fixed, and only the final back-focus gap varies. The infinity BFD is the scaled patent value of 51.0 mm. For the close-focus slider endpoint, the BFD is set to 71.04 mm, derived by solving the thick-lens finite-conjugate focus condition for a 2.5 m object distance measured from the film plane. This close-focus value is an implementation estimate, not patent-published data, and it does not alter any patent-published internal glass spacing.
+
+## Conditional Expressions
+
+The patent defines four conditions. Example 1 satisfies all of them.
+
+**Condition 1:** n1 < 1.55, n3 < 1.55; n2 > 1.7, n4 > 1.7; n5 - n6 > 0.07.
+
+| Sub-condition | Example 1 value | Result |
+|---|---:|---|
+| n1 < 1.55 | 1.4875 | satisfied |
+| n3 < 1.55 | 1.5014 | satisfied |
+| n2 > 1.7 | 1.7283 | satisfied |
+| n4 > 1.7 | 1.7440 | satisfied |
+| n5 - n6 > 0.07 | 0.1203 | satisfied |
+
+**Condition 2:** n2 - n3 > 0.2. Example 1 gives 0.2269, so the condition is satisfied.
+
+**Condition 3:** 25 > ν5 - ν6 > 15. Example 1 gives 18.5, so the condition is satisfied. The body text contains an OCR-prone line where the lower failure limit can read as "5" in text extraction, but the printed condition and claims state 15.
+
+**Condition 4:** 0.8 < |f4 / f123| < 5.0. Using the patent's own f4 = -80.48 mm and f123 = 69.75 mm gives |f4 / f123| = 1.154, so the condition is satisfied. The computed f123 match requires treating f123 as the complete front-group focal length, as noted above.
+
+## Verification Summary
+
+The prescription was independently re-entered and checked by paraxial y-u tracing and ABCD matrix calculations before the corrected files were written.
+
+| Quantity | Patent value | Computed at patent scale | Production-scale value used in data |
+|---|---:|---:|---:|
+| Effective focal length | 100.0 mm | 100.0096 mm | 200.019 mm |
+| Back focal distance | 25.5 mm | 25.4969 mm | 51.0 mm patent-scaled BFD |
+| First-surface-to-image track | 75.0 mm | 74.9969 mm | 150.0 mm |
+| Telephoto ratio | 0.75 | 0.7499 | 0.75 |
+| Front group focal length | 69.75 mm | 69.7408 mm | 139.482 mm |
+| Rear group focal length | not stated | -85.5233 mm | -171.047 mm |
+| L4 focal length | -80.48 mm | -80.4704 mm | -160.941 mm |
+| Petzval sum | not stated | +0.0003352 mm^-1 | +0.0001676 mm^-1 after 2x scale |
+
+The Petzval sum was computed surface-by-surface as Σ φ / (n n′). The patent's stated design problem is that the rear group's strong negative power drives the rear Petzval contribution negative; Example 1 counters that with a positive front-group contribution while holding telephoto ratio below 0.8.
+
+The aperture-stop placement in the data file is not a patent value. It is a midpoint insertion in the L4-L5 air gap, and its semi-diameter is solved so that the computed entrance pupil corresponds to F/5. The patent does not provide clear apertures, so all surface semi-diameters in the data file are constrained estimates rather than transcribed patent values.
+
+## Design Heritage and Context
+
+US 3,804,494 is consistent with the compact telephoto priorities of the early Olympus OM system. The patent's purpose is not merely to make a 200 mm lens, but to make a telephoto lens whose telephoto ratio is less than 0.8 while maintaining workable aberration correction. Example 1 reaches that target with six spherical elements and without using a cemented rear doublet.
+
+The production lens's compactness follows directly from the scaled patent track. A 150 mm optical track measured to the film plane corresponds closely to a 105 mm physical lens length plus the OM system flange distance. This agreement is a stronger identification point than barrel length alone, because it ties the patent's total track to the actual SLR mount geometry.
+
+## Sources
+
+- US 3,804,494, "Telephoto Lens Systems Having Small Telephoto Ratio," Keiichi Ito, assigned to Olympus Optical Company Limited, granted April 16, 1974.
+- MIR-hosted Olympus OM-System Zuiko 200 mm f/5 specification page, used only for production-spec cross-checks: 6 elements / 5 groups, 12° angle of view, f/5-f/32, 2.5 m minimum focus, 49 mm filter, 105 mm length, 62 mm maximum diameter, and 380 g weight.
+- OHARA current optical glass catalog entries for S-FSL5, S-TIH10, S-LAM2, S-LAL8, and S-FTM16.
+- SCHOTT K10 optical glass datasheet / catalog entry for the 501/564 crown-glass match.

--- a/src/lens-data/olympus/OlympusZuikoAutoT200mmf5.data.ts
+++ b/src/lens-data/olympus/OlympusZuikoAutoT200mmf5.data.ts
@@ -1,0 +1,171 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║        LENS DATA — OLYMPUS F.ZUIKO AUTO-T 200mm f/5               ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 3,804,494, Example 1 / Claim 2 (Olympus / Ito).   ║
+ * ║  Six-element, five-group all-spherical telephoto lens.             ║
+ * ║  Focus: unit-focus production lens; patent is infinity-only.       ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    The patent prescription is normalized to f = 100 mm. All radii, ║
+ * ║    axial thicknesses, air spaces, BFD, and estimated semi-diameters ║
+ * ║    are scaled ×2 to represent the 200 mm production lens.          ║
+ * ║                                                                    ║
+ * ║  NOTE ON APERTURE STOP:                                            ║
+ * ║    The patent gives F/5 but does not publish a stop surface or stop ║
+ * ║    coordinate. The STO surface below is a synthetic diaphragm       ║
+ * ║    inserted at the midpoint of the large L4-L5 air gap. Its semi-   ║
+ * ║    diameter is paraxially solved to give an entrance-pupil diameter ║
+ * ║    consistent with f/5 at the computed EFL.                         ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    The patent does not list clear apertures. SDs are conservative  ║
+ * ║    estimates constrained by the 49 mm production filter thread,     ║
+ * ║    the f/5 on-axis marginal bundle, edge thickness, and cross-gap   ║
+ * ║    sag clearance. Off-axis full-field vignetting is expected and    ║
+ * ║    consistent with the compact barrel.                              ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "olympus-zuiko-auto-t-200mm-f5",
+  maker: "Olympus",
+  name: "OLYMPUS F.ZUIKO AUTO-T 200mm f/5",
+  subtitle: "US 3,804,494 Example 1 — Olympus / Keiichi Ito",
+  specs: ["6 elements / 5 groups", "f ≈ 200.02 mm", "F/5", "2ω = 12°10′", "All-spherical"],
+
+  focalLengthMarketing: 200,
+  focalLengthDesign: 200.019,
+  apertureMarketing: 5,
+  apertureDesign: 5,
+  lensMounts: ["olympus-om"],
+  imageFormat: "135-full-frame",
+  patentYear: 1974,
+  elementCount: 6,
+  groupCount: 5,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.4875,
+      vd: 70.2,
+      fl: 161.1,
+      glass: "S-FSL5 (OHARA)",
+      nC: 1.48534,
+      nF: 1.49228,
+      ng: 1.49596,
+      role: "Low-index front positive meniscus; main front collector with low dispersion.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.7283,
+      vd: 28.5,
+      fl: -135.37,
+      glass: "S-TIH10 (OHARA)",
+      nC: 1.72086,
+      nF: 1.74645,
+      ng: 1.762,
+      cemented: "D1",
+      role: "High-index dense-flint component of the cemented chromatic-correction doublet.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.5014,
+      vd: 56.4,
+      fl: 78.91,
+      glass: "K10 (Schott)",
+      cemented: "D1",
+      role: "Crown component of the cemented doublet; restores positive power after L2.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Plano-Concave Negative",
+      nd: 1.744,
+      vd: 44.8,
+      fl: -160.94,
+      glass: "S-LAM2 (OHARA)",
+      nC: 1.73905,
+      nF: 1.75566,
+      ng: 1.76506,
+      role: "High-index negative corrector closing the positive front group.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.713,
+      vd: 54.0,
+      fl: -39.75,
+      glass: "S-LAL8 (OHARA)",
+      nC: 1.70897,
+      nF: 1.72221,
+      ng: 1.72943,
+      role: "Strong negative relay element in the rear telephoto group.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.5927,
+      vd: 35.5,
+      fl: 58.78,
+      glass: "S-FTM16 (OHARA)",
+      nC: 1.58779,
+      nF: 1.60458,
+      ng: 1.61454,
+      role: "Positive light-flint partner to L5 in the rear negative group.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 54.74, d: 6.0, nd: 1.4875, elemId: 1, sd: 23.0 },
+    { label: "2", R: 174.18, d: 3.0, nd: 1.0, elemId: 0, sd: 22.0 },
+    { label: "3", R: 48.94, d: 3.0, nd: 1.7283, elemId: 2, sd: 21.0 },
+    { label: "4", R: 31.86, d: 6.0, nd: 1.5014, elemId: 3, sd: 19.2 },
+    { label: "5", R: 153.34, d: 20.0, nd: 1.0, elemId: 0, sd: 19.2 },
+    { label: "6", R: 1e15, d: 3.0, nd: 1.744, elemId: 4, sd: 17.5 },
+    { label: "7", R: 119.74, d: 25.0, nd: 1.0, elemId: 0, sd: 17.0 },
+    { label: "STO", R: 1e15, d: 25.0, nd: 1.0, elemId: 0, sd: 8.741 },
+    { label: "8", R: -24.1, d: 2.0, nd: 1.713, elemId: 5, sd: 13.0 },
+    { label: "9", R: -166.48, d: 1.0, nd: 1.0, elemId: 0, sd: 13.5 },
+    { label: "10", R: 711.18, d: 5.0, nd: 1.5927, elemId: 6, sd: 14.5 },
+    { label: "11", R: -36.54, d: 51.0, nd: 1.0, elemId: 0, sd: 15.0 },
+  ],
+
+  asph: {},
+  var: {
+    "11": [51.0, 71.04],
+  },
+  varLabels: [["11", "BF"]],
+  focusDescription:
+    "Unit focus. The patent publishes only the infinity prescription; the close-focus BFD is estimated from the 2.5 m production MFD.",
+  groups: [
+    { text: "FRONT I", fromSurface: "1", toSurface: "7" },
+    { text: "REAR II", fromSurface: "8", toSurface: "11" },
+  ],
+  doublets: [{ text: "D1", fromSurface: "3", toSurface: "5" }],
+
+  closeFocusM: 2.5,
+  nominalFno: 5,
+  fstopSeries: [5, 5.6, 8, 11, 16, 22, 32],
+  maxFstop: 32,
+  scFill: 0.58,
+  yScFill: 0.62,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.analysis.md
+++ b/src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.analysis.md
@@ -1,0 +1,206 @@
+## Patent Reference and Design Identification
+
+**Patent:** US 4,568,150  
+**Application Number:** US 594,317  
+**Title:** Zoom Lens System  
+**Filed:** March 28, 1984; priority JP 58-61566, April 9, 1983  
+**Granted:** February 4, 1986  
+**Inventors:** Kazuo Ikari; Tooru Fujii  
+**Assignee:** Olympus Optical Co., Ltd., Tokyo, Japan  
+**Classification:** G02B 9/64; G02B 15/22  
+**Claims:** 9  
+**Worked examples:** 6  
+**Embodiment analyzed:** Embodiment 4, claim 7
+
+US 4,568,150 discloses a four-group zoom lens in which Groups I, II, and III form a varifocal subsystem and Group IV is a relay lens. The patent presents two structural variants. Embodiments 1 and 2 correspond to FIG. 1 and use 13 elements in 10 air-separated groups. Embodiments 3 through 6 correspond to FIG. 2 and use 14 elements in 11 air-separated groups. Embodiment 4 is the prescription reproduced here.
+
+The production identification to the Olympus OM-System Zuiko Auto-Zoom 65-200 mm f/4 rests on convergent evidence rather than a model name in the patent. Embodiment 4 has 14 elements in 11 air-separated groups, matching the published construction of the production lens. Its patent focal lengths are 66.923, 113.941, and 194.149 mm, which correspond to the marketed 65-200 mm range after ordinary product rounding. The data-file stop placement computes to approximately F/4.24, close to the marketed constant f/4 aperture; this is an inferred aperture, not an explicit patent table value. The image height implied by the wide-end half field is 21.6 mm, matching the 35 mm full-frame diagonal semi-field. The patent also identifies Group I as the focusing group, consistent with a manual front-group focus mechanism.
+
+The exact choice among Embodiments 3-6 cannot be proven from surviving public product specifications alone, because all four FIG. 2 embodiments share the same broad layout and zoom range. Embodiment 4 is nevertheless a defensible production match and is the embodiment explicitly claimed in claim 7.
+
+## Optical Architecture
+
+The design is a mechanically compensated four-group telephoto-range zoom of positive-negative-positive-positive power distribution. Groups I, II, and III constitute the varifocal subsystem; Group IV is a fixed relay lens. The prescription has 14 spherical glass elements in 11 air-separated groups and no aspherical surfaces. At the long end the vertex-to-vertex track divided by EFL is about 0.754, so the tele position is a true telephoto configuration; at the short end the lens is better described as a telephoto-range zoom rather than a strict telephoto ratio.
+
+Group I has positive refractive power and is the focusing group. It contains a cemented doublet followed by a positive singlet. In the infinity-focus zoom table, the gap after Group I, D1, increases from 2.128 mm at the wide position to 37.471 mm at the tele position.
+
+Group II is the negative variator. It contains a negative cemented doublet, an air-spaced negative singlet, and a positive singlet. The gap after Group II, D2, decreases from 36.355 mm to 0.976 mm as focal length increases, giving the principal zoom magnification change.
+
+Group III is the positive compensator. It is a cemented achromatic doublet. Its following gap, D3, is non-monotonic: 10.982 mm at wide, 1.800 mm at the intermediate position, and 11.017 mm at tele. This reversal is characteristic of cam-compensated zooms where a compensator group corrects focus shift introduced by the variator.
+
+Group IV is the fixed relay lens and contains the stop at its front. It is divided into four components: IVa, an air-spaced positive-negative pair that is positive as a whole; IVb, a positive singlet; IVc, a negative meniscus convex toward the image side; and IVd, a final positive singlet. The patent's central contribution is this relay topology. IVb reduces ray height at the negative meniscus IVc to suppress coma, while IVd is placed behind IVc to reduce positive distortion at the long-focal-length end.
+
+The zoom is constant in axial track at infinity focus. The sum D1 + D2 + D3 is 49.465 mm at all three zoom positions, within the patent's rounding. The vertex-to-vertex optical length is 146.324 mm, and the computed back focal distance is effectively constant at 43.656-43.658 mm.
+
+## Element-by-Element Analysis
+
+### L1 - Negative Meniscus, convex to object
+
+nd = 1.78472, νd = 25.68. Glass: S-TIH11 (OHARA; N-SF11 class). f = -142.2 mm.
+
+L1 is the dense-flint front element of the Group I cemented doublet. Its high refractive index and low Abbe number provide the negative dispersive power needed to achromatize the positive barium-crown element L2. In standalone in-air terms it is a negative meniscus, but in the cemented pair its effect must be read through the L1-L2 interface rather than as an isolated thin element.
+
+### L2 - Plano-Convex Positive, cemented to L1
+
+nd = 1.62299, νd = 58.14. Glass: S-BSM15 (OHARA). f = +93.8 mm.
+
+L2 supplies the main positive power of the front cemented pair. Its flat rear surface simplifies the transition to the short 0.150 mm air gap before L3. The L1-L2 doublet is only weakly positive as a standalone group, with f = +283.0 mm, so the doublet functions more as a chromatic and aberration-corrected collector than as the entire focusing-group power.
+
+### L3 - Plano-Convex Positive
+
+nd = 1.62299, νd = 58.14. Glass: S-BSM15 (OHARA). f = +141.3 mm.
+
+L3 is the rear positive singlet of Group I. It uses the same barium-crown glass as L2 and brings Group I as a whole to f = +95.8 mm. The repeated S-BSM15 choice keeps the front group conventional and avoids unnecessary glass diversity in a moving focusing group.
+
+### L4 - Biconcave Negative, cemented to L5
+
+nd = 1.74320, νd = 49.31. Glass: S-LAM60 (OHARA; patent νd = 49.31). f = -29.0 mm.
+
+L4 is the strongly negative leading element of the variator. Its biconcave geometry provides most of the divergent power in the front half of Group II. The glass sits in dense lanthanum-flint territory by Abbe number, despite the moderate dispersion compared with S-TIH11.
+
+### L5 - Positive Meniscus, cemented to L4
+
+nd = 1.78472, νd = 25.68. Glass: S-TIH11 (OHARA; N-SF11 class). f = +83.9 mm.
+
+L5 is a dense-flint positive meniscus cemented to L4. The L4-L5 cemented pair has f = -41.8 mm, so the pair remains strongly negative. Its glass contrast is smaller than a conventional crown-flint achromat, but the large Abbe-number difference between S-LAM60 and S-TIH11 still contributes chromatic correction within the variator.
+
+### L6 - Biconcave Negative
+
+nd = 1.77250, νd = 49.66. Glass: S-LAH66 class (OHARA; patent νd = 49.66). f = -44.0 mm.
+
+L6 is an air-spaced negative singlet in Group II. It supplements the divergent power of the cemented doublet and helps establish the large magnification swing of the zoom. Current OHARA S-LAH66-family data give nd = 1.77250 with a slightly different catalog Abbe value, so the patent value is treated as an older melt or rounding variant of the S-LAH66 class rather than a distinct modern catalog glass. In the data file, the L6 clear aperture is limited by the very short 0.640 mm airspace before L7; its semi-diameter is therefore set by signed sagittal-clearance constraints, not by a published patent aperture.
+
+### L7 - Biconvex Positive
+
+nd = 1.78472, νd = 25.68. Glass: S-TIH11 (OHARA; N-SF11 class). f = +67.7 mm.
+
+L7 is the positive rear element of Group II. It partly cancels the divergence introduced by L4-L6, moderating the exit ray angle before Group III. This positive dense-flint element also limits the Petzval contribution that a lower-index positive element would have added at the rear of the variator.
+
+### L8 - Biconvex Positive, cemented to L9
+
+nd = 1.51112, νd = 60.48. Glass: 511605 crown class (CDGM H-K6 / legacy NSL7 class). f = +48.3 mm.
+
+L8 is the crown element of the Group III compensator doublet. Its low index and relatively high Abbe number pair with the dense-flint L9 to form an independently corrected positive achromat. The stored nd/νd pair matches the 511605 crown family closely; it is best treated as a class/equivalent identification rather than a unique modern OHARA catalog glass.
+
+### L9 - Negative Meniscus, convex to image, cemented to L8
+
+nd = 1.78472, νd = 25.68. Glass: S-TIH11 (OHARA; N-SF11 class). f = -97.4 mm.
+
+L9 is the dense-flint correcting element of Group III. The L8-L9 doublet has f = +97.3 mm and acts as the compensator group. The strong index and dispersion contrast between L8 and L9 gives this group a more conventional crown-flint achromatic structure than the flint-flint variator doublet.
+
+### L10 - Plano-Convex Positive, relay component IVa front element
+
+nd = 1.50048, νd = 65.99. Glass: 500660 crown class (CDGM H-K2 / legacy BSL4 class). f = +52.9 mm.
+
+L10 sits immediately behind the aperture stop and supplies the strongest positive power in the relay. It begins the positive-negative IVa component that the patent requires to remain positive as a whole. Its low index and high Abbe number keep the front relay element chromatically mild despite its strong curvature.
+
+### L11 - Biconcave Negative, relay component IVa rear element
+
+nd = 1.80610, νd = 40.95. Glass: S-LAH53 class (OHARA; patent νd = 40.95). f = -96.5 mm.
+
+L11 is the negative member of the air-spaced IVa component. It is high-index lanthanum flint and balances the strong convergence from L10. The stored nd/νd pair is best described as S-LAH53 class: current S-LAH53 and S-LAH53V catalog entries sit very close to the patent value, while the patent itself gives only numerical nd/νd and no vendor glass name.
+
+### L12 - Biconvex Positive, relay component IVb
+
+nd = 1.51742, νd = 52.41. Glass: S-NSL36 (OHARA; patent νd = 52.41). f = +75.8 mm.
+
+L12 is the positive singlet that distinguishes the relay from the simpler prior art discussed in the patent. Its role is not merely to add positive power; by converging the beam before L13, it lowers ray height at the strong negative meniscus and reduces coma.
+
+### L13 - Negative Meniscus, convex to image, relay component IVc
+
+nd = 1.77250, νd = 49.66. Glass: S-LAH66 class (OHARA; patent νd = 49.66). f = -33.9 mm.
+
+L13 is the negative meniscus component IVc and is the surface-shape element governed by condition (3). Its shape factor is 1.6308 for Embodiment 4, inside the required 1.0-3.0 interval. The patent identifies this shape as important for balancing curvature of field between the short and long focal-length ends.
+
+### L14 - Biconvex Positive, relay component IVd
+
+nd = 1.51112, νd = 60.48. Glass: 511605 crown class (CDGM H-K6 / legacy NSL7 class). f = +120.1 mm.
+
+L14 is the final positive element of the relay lens. The patent places it behind IVc to counter the positive distortion that would otherwise remain at the telephoto end. The 8.5646 mm air gap between L13 and L14 is the distance D used in condition (4).
+
+## Glass Identification and Selection
+
+The prescription uses eight glass families across fourteen elements. Several identifications are exact or near-exact matches to current OHARA entries, while the two low-index crown glasses are better treated as class/equivalent matches because the patent gives only nd/νd values and no manufacturer glass names.
+
+| Glass / class | nd | νd | Elements | Identification note |
+|---|---:|---:|---|---|
+| S-TIH11 (OHARA; N-SF11 class) | 1.78472 | 25.68 | L1, L5, L7, L9 | Exact current OHARA nd/νd match; dense flint |
+| S-BSM15 (OHARA) | 1.62299 | 58.14 | L2, L3 | Current OHARA S-BSM15 has the same nd with catalog νd close to the patent value |
+| S-LAM60 (OHARA) | 1.74320 | 49.31 | L4 | Current catalog value is close; patent value treated as legacy/rounding variant |
+| S-LAH66 class (OHARA) | 1.77250 | 49.66 | L6, L13 | Same nd as the modern S-LAH66 family; patent νd is slightly higher than current catalog values |
+| 511605 crown class | 1.51112 | 60.48 | L8, L14 | CDGM H-K6 / legacy NSL7 / Schott K7 class |
+| 500660 crown class | 1.50048 | 65.99 | L10 | CDGM H-K2 / legacy BSL4 / Schott BK4 class |
+| S-LAH53 class (OHARA) | 1.80610 | 40.95 | L11 | S-LAH53-family lanthanum flint; patent value is numerical, not vendor-named |
+| S-NSL36 (OHARA) | 1.51742 | 52.41 | L12 | Same nd as current OHARA S-NSL36; patent νd is a close legacy value |
+
+The chromatic structure is conventional for a pre-ED telephoto zoom. The principal achromatic pairs are L1-L2 in the focusing group and L8-L9 in the compensator group. The variator doublet L4-L5 is less conventional because both elements fall on the flint side of the usual νd = 50 boundary, but the Abbe contrast remains large enough to contribute useful correction. No ED, fluorite, anomalous-partial-dispersion, or aspherical element is indicated by the patent table.
+
+## Focus Mechanism
+
+The patent identifies Group I as the focusing group and assigns it positive refractive power. The production lens is a manual-focus OM telephoto zoom; the optical prescription in US 4,568,150 publishes only infinity-focus zoom spacings and does not give a close-focus compensation table.
+
+Accordingly, the data file models the infinity-focus zoom only. The `var` table repeats each zoom spacing as identical infinity/close pairs so that D1, D2, and D3 interpolate correctly through the zoom range without inventing unsupported close-focus group travel. The production close-focus distance is recorded as metadata, but the rendered prescription should not be read as a close-focus optical model.
+
+| Gap | Surface | Wide | Mid | Tele | Motion |
+|---|---:|---:|---:|---:|---|
+| D1 | d5 | 2.128 | 24.404 | 37.471 | Increases toward tele |
+| D2 | d12 | 36.355 | 23.260 | 0.976 | Decreases toward tele |
+| D3 | d15 | 10.982 | 1.800 | 11.017 | Reverses after mid |
+
+## Conditional Expressions
+
+The patent defines four relay-lens conditions. Embodiment 4 satisfies all four.
+
+**Condition (1):** $0.3 < f_{4a} / f_4 < 3.0$
+
+$$f_{4a} / f_4 = 102.258 / 117.565 = 0.8698$$
+
+This keeps relay component IVa strong enough for compactness without making spherical aberration excessive.
+
+**Condition (2):** $0.03 < |f_{4c} / f_{4bcd}| < 0.3$
+
+$$f_{4c} / f_{4bcd} = -33.862 / -271.117 = 0.1249$$
+
+This constrains the negative IVc component relative to the IVb-IVc-IVd subsystem. The value remains well inside the patent's interval.
+
+**Condition (3):** $1.0 < \left| (r_{4c1} + r_{4c2}) / (r_{4c1} - r_{4c2}) \right| < 3.0$
+
+$$\left|\frac{-19.6359 + (-81.8964)}{-19.6359 - (-81.8964)}\right| = 1.6308$$
+
+This is the meniscus shape factor of L13. The patent links this condition to field-curvature control.
+
+**Condition (4):** $0.01 < D / f_W < 0.3$
+
+$$D / f_W = 8.5646 / 66.923 = 0.1280$$
+
+This distance is the airspace between IVc and IVd. Larger spacing improves distortion correction but increases the final positive element diameter.
+
+## Verification Summary
+
+The prescription was re-transcribed directly from claim 7 and verified by an independent paraxial y-ν ray trace. Surface powers were computed as $(n' - n) / R$, ray angles were propagated as reduced angles, and Petzval curvature was computed surface-by-surface as $\Phi/(n n')$.
+
+| Zoom position | Patent f (mm) | Computed EFL (mm) | Residual |
+|---|---:|---:|---:|
+| Wide | 66.923 | 66.9219 | -0.0011 mm |
+| Mid | 113.941 | 113.9409 | -0.0001 mm |
+| Tele | 194.149 | 194.1451 | -0.0039 mm |
+
+Computed group and component focal lengths also reproduce the patent values to the expected rounding precision: Group IV f = +117.564 mm, IVa f = +102.258 mm, IVc f = -33.862 mm, and IVbcd f = -271.121 mm. The computed back focal distance is 43.656-43.658 mm across the three zoom positions.
+
+The stop semi-diameter used in the data file is 13.724 mm. With the front zoom groups' pupil magnification, this yields an inferred design aperture of approximately F/4.24 at all three zoom positions. The marketed f/4 aperture is stored separately as the nominal f-number.
+
+The Petzval sum is +0.0008982 mm^-1, corresponding to a Petzval radius of approximately 1113 mm. This is a mildly positive Petzval sum for a conventional all-spherical telephoto zoom. The semi-diameters in the data file are estimated because the patent does not publish clear apertures; they were checked against edge thickness, surface-slope, element-ratio, and cross-gap sag constraints rather than asserted as measured production clear apertures. The limiting inferred-aperture case is the L6-to-L7 airspace: the rear L6 semi-diameter is constrained by the 0.640 mm d10 gap so that signed sag intrusion remains below 90% of the gap.
+
+## Design Heritage and Context
+
+The patent distinguishes the design from earlier four-group zooms with simpler relay lenses. One cited prior arrangement used a positive-negative component, a widely spaced biconvex lens, and a rear negative meniscus; the patent argues that this left positive distortion insufficiently corrected at the long end. Another used a positive-negative component, a negative meniscus, and a positive lens; the patent argues that the insufficient converging action before the negative meniscus produced excessive coma.
+
+US 4,568,150 addresses those problems by placing a positive IVb element before the negative IVc meniscus and a positive IVd element after it. The resulting relay remains simple by modern standards, but the additional positive singlet before IVc is analytically important: it lowers ray height at the high-power negative meniscus rather than relying solely on glass choice or final-element correction.
+
+## Sources
+
+- US 4,568,150, "Zoom Lens System," Kazuo Ikari and Tooru Fujii, Olympus Optical Co., Ltd.; filed March 28, 1984; granted February 4, 1986.
+- Olympus OM-System product literature for the Zuiko Auto-Zoom 65-200 mm f/4 production specifications.
+- OHARA optical glass catalog and datasheets for S-TIH11, S-BSM15, S-LAM60, S-LAH53, S-LAH66, and S-NSL36.
+- CDGM catalog data for H-K2 and H-K6, used as class/equivalent references for the two low-index crown glasses.
+- Schott and HOYA cross-reference tables, used only as class references where the patent gives nd/νd values but not a glass manufacturer name.

--- a/src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts
+++ b/src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts
@@ -1,0 +1,304 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════════════╗
+ * ║   LENS DATA — OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4              ║
+ * ╠══════════════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,568,150, Embodiment 4 / claim 7, Olympus Optical.       ║
+ * ║  Four-group positive-negative-positive-positive telephoto zoom.             ║
+ * ║  14 elements / 11 air-separated groups, all spherical.                     ║
+ * ║  Focus: patent identifies Group I as the focusing group; the patent table   ║
+ * ║  publishes only infinity-focus zoom spacings, so close-focus travel is not  ║
+ * ║  modeled here.                                                             ║
+ * ║                                                                            ║
+ * ║  Zoom variable gaps: D1 at surface 5, D2 at surface 12, D3 at surface 15.   ║
+ * ║  Reversing group: D3 decreases from wide to mid, then increases toward tele.║
+ * ║  Variable-gap sum D1 + D2 + D3 = 49.465 mm, preserving constant track.      ║
+ * ║                                                                            ║
+ * ║  NOTE ON SCALING:                                                          ║
+ * ║  No scale factor is applied. The prescription is transcribed at patent      ║
+ * ║  scale: f = 66.923, 113.941, 194.149 mm.                                   ║
+ * ║                                                                            ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                                   ║
+ * ║  The patent does not publish clear apertures. Semi-diameters are estimated  ║
+ * ║  from paraxial marginal/chief-ray requirements, a 55 mm filter-thread       ║
+ * ║  front-group constraint, and renderer safety checks: sd/|R| < 0.90, element ║
+ * ║  SD ratio <= 1.25, positive edge thickness, and cross-gap sag intrusion     ║
+ * ║  <= 90% of the relevant air gap at every zoom position. These SDs describe  ║
+ * ║  a physically plausible rendered prescription, not a no-vignetting aperture ║
+ * ║  audit of the production lens.                                              ║
+ * ╚══════════════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "olympus-zuiko-auto-zoom-65-200mm-f4",
+  maker: "Olympus",
+  name: "OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4",
+  subtitle: "US 4,568,150 Embodiment 4 — Olympus Optical / Ikari & Fujii",
+  specs: [
+    "14 elements / 11 groups",
+    "f = 66.923-194.149 mm design",
+    "Computed F/4.24 design aperture; f/4 marketed",
+    "35 mm full-frame format",
+    "All-spherical",
+  ],
+
+  focalLengthMarketing: [65, 200],
+  focalLengthDesign: [66.923, 194.149],
+  apertureMarketing: 4,
+  apertureDesign: 4.24,
+  lensMounts: ["olympus-om"],
+  imageFormat: "135-full-frame",
+  patentYear: 1986,
+  elementCount: 14,
+  groupCount: 11,
+  apertureBlades: 8,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.78472,
+      vd: 25.68,
+      fl: -142.2,
+      glass: "S-TIH11 (OHARA; N-SF11 class)",
+      cemented: "I",
+      role: "Dense-flint front element of the focusing-group achromat.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Plano-Convex Positive",
+      nd: 1.62299,
+      vd: 58.14,
+      fl: 93.8,
+      glass: "S-BSM15 (OHARA)",
+      cemented: "I",
+      role: "Barium-crown positive element cemented to L1.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Plano-Convex Positive",
+      nd: 1.62299,
+      vd: 58.14,
+      fl: 141.3,
+      glass: "S-BSM15 (OHARA)",
+      role: "Standalone positive element completing Group I.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.7432,
+      vd: 49.31,
+      fl: -29.0,
+      glass: "S-LAM60 (OHARA; patent vd = 49.31)",
+      cemented: "II",
+      role: "Strong negative front element of the variator cemented doublet.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Positive Meniscus",
+      nd: 1.78472,
+      vd: 25.68,
+      fl: 83.9,
+      glass: "S-TIH11 (OHARA; N-SF11 class)",
+      cemented: "II",
+      role: "Positive dense-flint partner in the Group II cemented doublet.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.7725,
+      vd: 49.66,
+      fl: -44.0,
+      glass: "S-LAH66 (OHARA; patent vd = 49.66)",
+      role: "Air-spaced negative variator singlet.",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.78472,
+      vd: 25.68,
+      fl: 67.7,
+      glass: "S-TIH11 (OHARA; N-SF11 class)",
+      role: "Positive rear element of the variator group.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.51112,
+      vd: 60.48,
+      fl: 48.3,
+      glass: "511605 crown class (CDGM H-K6 / legacy OHARA NSL7)",
+      cemented: "III",
+      role: "Crown positive element of the compensator achromat.",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Negative Meniscus",
+      nd: 1.78472,
+      vd: 25.68,
+      fl: -97.4,
+      glass: "S-TIH11 (OHARA; N-SF11 class)",
+      cemented: "III",
+      role: "Dense-flint corrector cemented to L8.",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Plano-Convex Positive",
+      nd: 1.50048,
+      vd: 65.99,
+      fl: 52.9,
+      glass: "500660 crown class (CDGM H-K2 / OHARA BSL4)",
+      role: "Strong positive element at the front of relay component IVa.",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Biconcave Negative",
+      nd: 1.8061,
+      vd: 40.95,
+      fl: -96.5,
+      glass: "S-LAH53 (OHARA; patent vd = 40.95)",
+      role: "High-index negative element completing air-spaced relay component IVa.",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Biconvex Positive",
+      nd: 1.51742,
+      vd: 52.41,
+      fl: 75.8,
+      glass: "S-NSL36 (OHARA; patent vd = 52.41)",
+      role: "Positive relay component IVb, reducing ray height at IVc.",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Negative Meniscus",
+      nd: 1.7725,
+      vd: 49.66,
+      fl: -33.9,
+      glass: "S-LAH66 (OHARA; patent vd = 49.66)",
+      role: "Strong negative meniscus relay component IVc.",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Biconvex Positive",
+      nd: 1.51112,
+      vd: 60.48,
+      fl: 120.1,
+      glass: "511605 crown class (CDGM H-K6 / legacy OHARA NSL7)",
+      role: "Final positive relay component IVd.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 125.0059, d: 2.6, nd: 1.78472, elemId: 1, sd: 26.4 },
+    { label: "2", R: 58.416, d: 6.8, nd: 1.62299, elemId: 2, sd: 26.4 },
+    { label: "3", R: 1e15, d: 0.15, nd: 1.0, elemId: 0, sd: 26.2 },
+    { label: "4", R: 88.051, d: 4.6, nd: 1.62299, elemId: 3, sd: 26.2 },
+    { label: "5", R: 1e15, d: 2.128, nd: 1.0, elemId: 0, sd: 25.8 },
+
+    { label: "6", R: -212.454, d: 1.7, nd: 1.7432, elemId: 4, sd: 12.4 },
+    { label: "7", R: 24.101, d: 3.4, nd: 1.78472, elemId: 5, sd: 12.4 },
+    { label: "8", R: 35.649, d: 4.0, nd: 1.0, elemId: 0, sd: 12.4 },
+    { label: "9", R: -53.172, d: 1.6, nd: 1.7725, elemId: 6, sd: 12.2 },
+    { label: "10", R: 95.653, d: 0.64, nd: 1.0, elemId: 0, sd: 12.2 },
+    { label: "11", R: 68.31, d: 3.2, nd: 1.78472, elemId: 7, sd: 16.4 },
+    { label: "12", R: -233.9318, d: 36.355, nd: 1.0, elemId: 0, sd: 16.4 },
+
+    { label: "13", R: 117.339, d: 5.8, nd: 1.51112, elemId: 8, sd: 15.5 },
+    { label: "14", R: -30.722, d: 2.0, nd: 1.78472, elemId: 9, sd: 15.5 },
+    { label: "15", R: -52.837, d: 10.982, nd: 1.0, elemId: 0, sd: 15.5 },
+
+    { label: "STO", R: 1e15, d: 1.7, nd: 1.0, elemId: 0, sd: 13.724 },
+    { label: "17", R: 26.4827, d: 5.6, nd: 1.50048, elemId: 10, sd: 15.2 },
+    { label: "18", R: 1e15, d: 2.2, nd: 1.0, elemId: 0, sd: 15.2 },
+    { label: "19", R: -128.0029, d: 2.0, nd: 1.8061, elemId: 11, sd: 14.8 },
+    { label: "20", R: 199.5243, d: 19.9834, nd: 1.0, elemId: 0, sd: 14.8 },
+    { label: "21", R: 100.7291, d: 3.6, nd: 1.51742, elemId: 12, sd: 15.4 },
+    { label: "22", R: -63.4132, d: 10.9209, nd: 1.0, elemId: 0, sd: 15.4 },
+    { label: "23", R: -19.6359, d: 1.8, nd: 1.7725, elemId: 13, sd: 14.5 },
+    { label: "24", R: -81.8964, d: 8.5646, nd: 1.0, elemId: 0, sd: 14.5 },
+    { label: "25", R: 113.1923, d: 4.0, nd: 1.51112, elemId: 14, sd: 16.8 },
+    { label: "26", R: -132.6134, d: 43.657, nd: 1.0, elemId: 0, sd: 16.8 },
+  ],
+
+  asph: {},
+
+  zoomPositions: [66.923, 113.941, 194.149],
+  zoomStep: 0.004,
+  zoomLabels: ["Wide", "Tele"],
+  var: {
+    "5": [
+      [2.128, 2.128],
+      [24.404, 24.404],
+      [37.471, 37.471],
+    ],
+    "12": [
+      [36.355, 36.355],
+      [23.26, 23.26],
+      [0.976, 0.976],
+    ],
+    "15": [
+      [10.982, 10.982],
+      [1.8, 1.8],
+      [11.017, 11.017],
+    ],
+  },
+  varLabels: [
+    ["5", "D1"],
+    ["12", "D2"],
+    ["15", "D3"],
+  ],
+
+  groups: [
+    { text: "I focus", fromSurface: "1", toSurface: "5" },
+    { text: "II variator", fromSurface: "6", toSurface: "12" },
+    { text: "III compensator", fromSurface: "13", toSurface: "15" },
+    { text: "IV relay", fromSurface: "STO", toSurface: "26" },
+  ],
+  doublets: [
+    { text: "I", fromSurface: "1", toSurface: "3" },
+    { text: "II", fromSurface: "6", toSurface: "8" },
+    { text: "III", fromSurface: "13", toSurface: "15" },
+  ],
+
+  closeFocusM: 0.85,
+  focusDescription:
+    "Front-group manual focus in production; patent US 4,568,150 publishes only infinity-focus zoom spacings, so close-focus travel is intentionally not modeled.",
+  nominalFno: 4,
+  fstopSeries: [4, 5.6, 8, 11, 16, 22, 32],
+  maxFstop: 32,
+  scFill: 0.72,
+  yScFill: 0.62,
+  rayLeadFrac: 0.2,
+  offAxisFieldFrac: 0.5,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.analysis.md
+++ b/src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.analysis.md
@@ -1,0 +1,233 @@
+# Olympus Zuiko Auto-Zoom 85-250 mm f/5
+
+## Patent Reference and Design Identification
+
+**Patent:** US 4,025,167  
+**Filed:** January 30, 1975  
+**Granted:** May 24, 1977  
+**Priority:** February 4, 1974 (Japan 49-14290)  
+**Inventor:** Yoshitsugi Ikeda  
+**Assignee:** Olympus Optical Co., Ltd., Tokyo, Japan  
+**Title:** Telephoto-Type Zoom Lens System  
+**Embodiment analyzed:** Embodiment 2 / Claim 3 numerical data
+
+The transcribed prescription is Embodiment 2 of US 4,025,167. The patent identifies the invention as a telephoto-type zoom lens system with a first focusing group, second variator group, third compensator group, and fourth relay group. The numerical Embodiment 2 table gives $f = 85.0$-$250.0$ mm, $F = 1:5$, overall length $l = 238.36$ mm, and telephoto ratio $p = 0.95$ at the 250 mm end.
+
+The production identification rests on four converging points. First, Embodiment 2 is the only example with the exact 85.0 mm wide-end focal length; Embodiments 1 and 3 start at 86.5 mm and 87.0 mm. Second, all examples are constant F/5, matching the marketed lens. Third, Embodiment 2 has 15 glass elements in 11 air-separated components when the L11-L12 relay pair is treated as cemented; this matches the published production specification for the Olympus OM Zuiko 85-250 mm f/5. Fourth, the patent's sub-unity telephoto ratio at the 250 mm end is consistent with the compact telephoto-zoom objective stated in the specification.
+
+A numerical correction is required in the patent table. The specification-side Embodiment 2 table prints surface $r_{20}$ as 8.663, but Claim 3 prints the same surface as 28.663. The latter value is consistent with the neighboring embodiments and is required for the paraxial trace to reproduce the patent focal lengths and relay data. The corrected analysis and data file therefore use $r_{20}=28.663$ mm.
+
+## Optical Architecture
+
+The design is a four-group, all-spherical telephoto zoom. Its group power sequence is positive-negative-positive-positive:
+
+- Group I: positive focusing group, 3 elements in 2 components.
+- Group II: negative variator group, 4 elements in 3 components.
+- Group III: positive compensator group, 2 elements in 1 cemented component.
+- Group IV: fixed positive relay group, 6 elements in 5 components.
+
+The first three groups form a varifocal afocal front system. Group II changes magnification during zooming, while Group III follows a compensating cam path to keep the image plane approximately fixed. Group IV is the fixed relay that images the afocal output onto the 35 mm film plane. Group I moves for focusing, rather than moving the entire lens or using a floating internal group.
+
+The patent's numerical table does not assign an aperture-stop surface. In the data file, the stop is inserted in the Group II-Group III air gap, 0.75 mm ahead of Group III, following the position shown schematically in the patent figure. With a stop semi-diameter of 13.42 mm, the paraxial entrance-pupil calculation gives F/5 within 0.04% at all three tabulated zoom positions. This stop position is a rendering and ray-trace implementation choice, not an additional patent-listed optical surface.
+
+The relay group is unusually important in this design. The patent explicitly gives Group IV a large positive Petzval contribution so that it offsets the negative Petzval contribution of the very short negative variator. This is one of the design's key compactness mechanisms: Group II is made strong and short, and Group IV is shaped to recover field curvature and image-plane stability.
+
+## Element-by-Element Analysis
+
+### L1 - Biconvex Positive
+
+nd = 1.48749, νd = 70.2. Glass: S-FSL5 (OHARA) / FK5 class. f = +206.3 mm.
+
+L1 is the first lens of the focusing group. It is a weak, low-index, high-Abbe biconvex element with $R_1=+152.515$ mm and $R_2=-291.307$ mm. Its role is not simply to add power; its bending is constrained by the patent's first two inequalities so that moving Group I for close focus does not create excessive spherical aberration or astigmatism at the telephoto end.
+
+### L2-L3 - Cemented Front-Group Achromat
+
+L2: nd = 1.62041, νd = 60.3. Glass: S-BSM16 (OHARA) / N-SK16 class. f = +127.6 mm.  
+L3: nd = 1.78472, νd = 25.7. Glass: S-TIH11 (OHARA) / SF11 class. f = -204.8 mm.  
+Cemented net focal length: +326.8 mm.
+
+The L2-L3 doublet supplies the remaining positive power in Group I while reducing the color introduced by a moving front group. L2 is a strong biconvex crown element; L3 is a weaker biconcave flint element cemented behind it. The large Abbe separation between the two glasses gives the group conventional primary axial-color correction without adding another airspace.
+
+The patent's third and fourth conditional expressions act on $r_3$ and $r_5$, the outer surfaces of this cemented component. Their purpose is to keep the aberration change during front-group focusing inside the range that Groups II-IV can correct.
+
+### L4 - Biconcave Negative
+
+nd = 1.56873, νd = 63.2. Glass: 569632 dense crown patent-code fallback. f = -127.7 mm.
+
+L4 opens the variator group. It is a biconcave negative element, with a very weak front radius and a stronger rear radius. The glass is not safely assignable to a single current manufacturer catalog entry from nd and νd alone. It is best treated as a 569632 dense crown or phosphate-crown-family glass-code fallback rather than as a named catalog glass.
+
+Its high Abbe number is notable for a negative variator element. The design uses negative power here without introducing the strong chromatic effect that would follow from a low-Abbe dense flint in the same position.
+
+### L5-L6 - Reversed Negative Variator Doublet
+
+L5: nd = 1.76182, νd = 26.6. Glass: FD140 (HOYA) / PBH14 (OHARA) class. f = +68.8 mm.  
+L6: nd = 1.61800, νd = 63.4. Glass: PSK53A / K-PSKn2 class. f = -48.0 mm.  
+Cemented net focal length: -161.8 mm.
+
+This is a reversed chromatic pairing: a positive dense-flint element is cemented to a negative high-Abbe crown element. In isolation, L5 is positive and L6 is stronger negative; together they form a net negative component in the variator group.
+
+The flat front surface of L5 simplifies the element shape, while the strong cemented interface and rear surface provide the actual negative power. This doublet helps the variator change angular magnification while keeping the chromatic behavior of Group II more moderate than a simple negative flint component would permit.
+
+### L7 - Negative Meniscus
+
+nd = 1.56873, νd = 63.2. Glass: 569632 dense crown patent-code fallback. f = -102.7 mm.
+
+L7 closes the negative variator group. Its front surface is strongly concave to the object, and its rear surface is much weaker. The element continues the high-Abbe negative-power strategy established by L4 and helps prepare the ray bundle for the compensator group.
+
+### L8-L9 - Cemented Positive Compensator
+
+L8: nd = 1.62012, νd = 49.7. Glass: K-SSK9 (Sumita) / dense barium-crown class. f = +47.2 mm.  
+L9: nd = 1.72151, νd = 29.2. Glass: S-TIH18 (OHARA) / FD18 class. f = -79.7 mm.  
+Cemented net focal length: +115.5 mm.
+
+Group III is a single cemented positive doublet. It moves during zooming as the compensator, keeping the image plane nearly fixed as Group II changes magnification. The doublet form is a compact way to give the compensator both positive power and chromatic correction.
+
+The computed cemented focal length is +115.546 mm, matching the patent's $f_3 = 115.55$ mm. Because this group reverses direction in spacing relative to Group IV over the zoom range, its cam path is central to the lens's mechanical compensation.
+
+### L10 - Biconvex Positive
+
+nd = 1.49831, νd = 65.0. Glass: 498650 borosilicate crown patent-code fallback. f = +75.1 mm.
+
+L10 is the first element of the fixed relay group. The nd/νd pair is a low-index crown-family glass, but no current public catalog match should be asserted as exact. It begins the relay's reconverging action after the moving afocal portion of the zoom.
+
+### L11-L12 - Cemented Negative Relay Component
+
+L11: nd = 1.54739, νd = 53.6. Glass: N-BALF5 / BAL5 class. f = +51.8 mm.  
+L12: nd = 1.80610, νd = 40.9. Glass: S-LAH53 (OHARA). f = -27.9 mm.  
+Cemented net focal length: -82.0 mm.
+
+This cemented pair is the clearest structural difference between Embodiment 2 and the other two examples. In Embodiment 2, L11 and L12 are cemented, producing the 15-element / 11-component count associated with the production lens. In Embodiments 1 and 3, the analogous pair is air-spaced.
+
+The component has net negative power even though the front element is positive. L11 is a barium light flint / BALF-class positive element, not a high-Abbe barium crown. L12 is a high-index lanthanum flint; its νd = 40.9 places it firmly in flint territory. This pair sits immediately before the long 39.0 mm relay airspace and is a major contributor to the relay's aberration balancing.
+
+### L13 - Biconvex Positive
+
+nd = 1.59551, νd = 39.2. Glass: F8 class (Hikari / HOYA). f = +52.1 mm.
+
+L13 is the strong positive element after the long relay air gap. Its low Abbe number is deliberate in context: it is a positive flint-class element, used not for low dispersion but for balancing the chromatic and Petzval behavior of the relay. Its placement after the 39.0 mm airspace gives it strong leverage over the converging relay beam.
+
+### L14 - Biconcave Negative
+
+nd = 1.72000, νd = 43.7. Glass: J-LAF02 class (Hikari; patent 720/437). f = -37.6 mm.
+
+L14 is a compact biconcave negative element near the rear of the relay. Its high index and medium-low Abbe number mark it as a lanthanum flint / LAF-family glass rather than a crown. It corrects relay residuals close to the image side, especially field curvature and astigmatism left by the strong positive elements around it.
+
+### L15 - Biconvex Positive
+
+nd = 1.56384, νd = 60.8. Glass: N-SK11 (SCHOTT) / BACD11 (HOYA) class. f = +101.2 mm.
+
+L15 is the final positive element before the image plane. Its moderate crown glass and positive power close the relay group and help maintain the near-constant back focal distance across the zoom range. Its position near the image plane gives it useful influence on residual field behavior without requiring extreme curvature.
+
+## Glass Identification and Selection
+
+The patent gives nd and νd values but does not name glass vendors. Catalog names below are therefore modern identifications or equivalence classes. Exact vendor attribution is not asserted unless the nd/νd pair matches a public catalog glass closely enough to support it.
+
+| Element | nd | νd | Patent code | Catalog status | Optical role |
+|---|---:|---:|---:|---|---|
+| L1 | 1.48749 | 70.2 | 487/702 | S-FSL5 / FK5 class | Low-index front crown |
+| L2 | 1.62041 | 60.3 | 620/603 | S-BSM16 / N-SK16 class | Positive crown in Group I achromat |
+| L3 | 1.78472 | 25.7 | 785/257 | S-TIH11 / SF11 class | Negative flint in Group I achromat |
+| L4, L7 | 1.56873 | 63.2 | 569632 | Dense crown code fallback | High-Abbe negative variator elements |
+| L5 | 1.76182 | 26.6 | 762/266 | FD140 / PBH14 class | Positive dense flint in reversed variator doublet |
+| L6 | 1.61800 | 63.4 | 618/634 | PSK53A / K-PSKn2 class | Negative high-Abbe partner in variator doublet |
+| L8 | 1.62012 | 49.7 | 620/497 | K-SSK9 / dense barium crown class | Positive compensator glass |
+| L9 | 1.72151 | 29.2 | 722/292 | S-TIH18 / FD18 class | Negative compensator flint |
+| L10 | 1.49831 | 65.0 | 498650 | Borosilicate crown code fallback | First relay positive element |
+| L11 | 1.54739 | 53.6 | 547/536 | N-BALF5 / BAL5 class | Positive barium light flint in relay doublet |
+| L12 | 1.80610 | 40.9 | 806/409 | S-LAH53 class | High-index negative lanthanum flint |
+| L13 | 1.59551 | 39.2 | 596/392 | F8 class | Positive flint relay element |
+| L14 | 1.72000 | 43.7 | 720/437 | J-LAF02 class | Negative lanthanum-flint relay element |
+| L15 | 1.56384 | 60.8 | 564/608 | N-SK11 / BACD11 class | Final positive crown relay element |
+
+No ED or fluorite element is present. The system should not be described as apochromatic. Several glasses have useful partial-dispersion behavior by family, but the patent does not publish line indices or partial-dispersion data, so the data file records nd/νd and catalog-class annotations rather than structured APO fields.
+
+## Focus and Zoom Mechanism
+
+The patent describes front-group focusing: Group I moves along the optical axis for focusing, while Groups II and III perform zooming and Group IV remains fixed. This is consistent with the problem statement in the patent, which is specifically concerned with limiting aberration change when the first lens group is advanced for close-distance photography.
+
+The zoom spacing table is:
+
+| f (mm) | D1: Group I-II | D2: Group II-III | D3: Group III-IV | D1+D2+D3 |
+|---:|---:|---:|---:|---:|
+| 85.0 | 1.03 | 45.00 | 16.71 | 62.74 |
+| 151.4 | 32.28 | 27.54 | 3.00 | 62.82 |
+| 250.0 | 48.06 | 1.49 | 13.27 | 62.82 |
+
+The 0.08 mm discrepancy at the wide end is patent table rounding. In the data file, the BFD is set per zoom position to the independently computed paraxial value so that each tabulated position images at the correct plane.
+
+The production specification lists a distance scale from 2.0 m to infinity, but the patent gives no close-focus spacing table. The data file therefore implements close focus by solving a paraxial 2.0 m front-group focus condition, measured from the film plane, with Groups II-IV and the image plane fixed. The inferred Group I motion is nearly constant across zoom positions:
+
+| f (mm) | D1 at infinity | D1 at 2.0 m | Group I advance represented in D1 |
+|---:|---:|---:|---:|
+| 85.0 | 1.03 | 10.874 | +9.844 |
+| 151.4 | 32.28 | 42.124 | +9.844 |
+| 250.0 | 48.06 | 57.904 | +9.844 |
+
+Because the patent does not list the production close-focus data, these close-focus spacings should be treated as paraxial implementation values, not as a recovered Olympus service-table prescription.
+
+## Conditional Expressions
+
+The patent defines four conditions on Group I. The specification gives broad ranges, and Claim 1 narrows them. Embodiment 2 satisfies the narrowed claim ranges.
+
+| Expression | Specification range | Claim 1 range | Embodiment 2 value |
+|---|---:|---:|---:|
+| $(n_1-1)f_1/r_1$ | 0.30-0.58 | 0.36-0.45 | 0.4045 |
+| $-r_1/r_2$ | 0.35-0.65 | 0.45-0.60 | 0.5236 |
+| $(n_2-1)f_1/r_3$ | 0.57-0.75 | 0.64-0.66 | 0.6453 |
+| $(n_3-1)f_1/r_5$ | 0.10-0.24 | 0.15-0.20 | 0.1703 |
+
+The conditions are not generic zoom design constraints; they are specifically aimed at Group I, where front-group focusing would otherwise cause excessive aberration variation, particularly at the telephoto end.
+
+## Verification Summary
+
+Independent paraxial verification was performed from the full prescription using reduced-angle ABCD ray tracing in $(y, n u)$ coordinates. Surface powers were traced surface by surface; Petzval sum was computed from $\phi/(n n')$, not from thin-element approximations.
+
+| Zoom position | Computed EFL | Patent f | Residual |
+|---:|---:|---:|---:|
+| 85.0 mm | 85.1196 mm | 85.0 mm | +0.14% |
+| 151.4 mm | 151.4004 mm | 151.4 mm | <0.01% |
+| 250.0 mm | 250.0038 mm | 250.0 mm | <0.01% |
+
+| Group | Computed focal length | Patent focal length |
+|---|---:|---:|
+| Group I | +126.546 mm | +126.55 mm |
+| Group II | -40.000 mm | -40.00 mm |
+| Group III | +115.546 mm | +115.55 mm |
+| Group IV | +138.249 mm | +138.25 mm |
+
+| Zoom position | Total track to image | Telephoto ratio |
+|---:|---:|---:|
+| 85.0 mm | 238.397 mm | 2.801 |
+| 151.4 mm | 238.360 mm | 1.574 |
+| 250.0 mm | 238.352 mm | 0.953 |
+
+| Quantity | Computed | Patent |
+|---|---:|---:|
+| Group IV length, r16 to image | 138.029 mm | 138.03 mm |
+| Group IV focal length | 138.249 mm | 138.25 mm |
+| Group IV Petzval sum × f4 | 0.7338 | 0.734 |
+| Full-system Petzval sum | 0.000789 mm^-1 | not tabulated |
+
+| Zoom position | Computed BFD |
+|---:|---:|
+| 85.0 mm | 54.037 mm |
+| 151.4 mm | 53.920 mm |
+| 250.0 mm | 53.912 mm |
+
+The near-constant BFD confirms the intended mechanical compensation. The remaining differences are consistent with patent table rounding and the corrected $r_{20}=28.663$ mm value.
+
+## Design Heritage and Context
+
+The design is a mid-1970s all-spherical telephoto zoom for the Olympus OM system. Its optical architecture follows the established four-group zoom pattern: a compact varifocal afocal front section followed by a fixed relay. The patent contribution is more specific than the basic zoom layout. Ikeda's claims focus on front-group focusing in a telephoto zoom and on shaping the first group so that close-distance aberration change remains manageable without a more complex floating or whole-lens focusing system.
+
+The design is not a retrofocus lens, because its back focal distance is far shorter than its long-end focal length. It is properly a telephoto zoom at the long end: the verified track-to-EFL ratio is 0.953 at 250 mm. At the wide and middle zoom positions the ratio is greater than 1, so the telephoto designation applies to the long-end compactness target rather than to every focal-length state.
+
+## Sources
+
+1. US 4,025,167, Yoshitsugi Ikeda, "Telephoto-Type Zoom Lens System," Olympus Optical Co., Ltd., granted May 24, 1977.
+2. Olympus OM Zuiko 85-250 mm f/5 production specification as reproduced in MIR / eSIF OM-System lens data.
+3. OHARA optical glass catalog and low-Tg/preform catalog references for S-FSL, S-BSM, S-TIH, S-LAH, and PBH-class glass matches.
+4. SCHOTT optical glass data sheets for N-BALF5 and N-SK11 class references.
+5. HOYA optical glass cross-reference material for FD/BACD class comparisons.
+6. Sumita optical glass catalog for K-SSK9 and K-PSKn family comparisons.
+7. Hikari optical glass references for J-F8 and J-LAF02 class comparisons.

--- a/src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts
+++ b/src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts
@@ -1,0 +1,315 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5
+ *
+ * Data source: US 4,025,167, Embodiment 2, Yoshitsugi Ikeda / Olympus Optical Co., Ltd.
+ * Patent prescription: f = 85.0-250.0 mm, F/5, 15 elements in 11 air-separated components.
+ *
+ * Optical layout: four zoom groups. Group I is the front focusing group; Group II is the negative variator;
+ * Group III is the positive compensator; Group IV is a fixed positive relay. The patent does not specify an
+ * aperture-stop surface in the numerical table. The stop is inserted here in the D2 air gap, 0.75 mm ahead of
+ * Group III, as inferred from Fig. 2 and fitted so the paraxial entrance pupil gives approximately F/5 at all
+ * three tabulated zoom positions.
+ *
+ * Patent erratum: the Embodiment 2 table prints r20 as 8.663 in the specification text. Claim 3 prints the
+ * same surface as 28.663, which is consistent with adjacent embodiments and with the verified EFL/BFD trace.
+ * This file uses r20 = 28.663.
+ *
+ * Zoom variables:
+ *   - surface 5: D1, Group I to Group II. This also carries the front-group focus motion.
+ *   - surface 12: first part of D2, Group II to the inserted stop. STO.d = 0.75 completes D2.
+ *   - surface 15: D3, Group III to Group IV.
+ *   - surface 26: paraxial BFD, set separately per zoom position to absorb patent table rounding.
+ *
+ * Close focus: production close focus is 2.0 m. The patent publishes aberration curves at 3 m but does not
+ * provide close-focus variable spacings. The close-focus state is therefore paraxially inferred by advancing
+ * Group I for a 2.0 m object distance measured from the film plane, with Groups II-IV and the image plane fixed.
+ *
+ * Semi-diameters: the patent omits clear apertures. Semi-diameters are estimated from on-axis marginal-ray and
+ * full-frame chief-ray envelopes, then constrained by a 55 mm filter size, edge thickness, element SD ratios,
+ * sd/|R| < 0.90, and cross-gap sag intrusion checks. They are clear-aperture estimates for rendering and
+ * paraxial clipping, not a manufacturer's mechanical aperture drawing.
+ */
+const LENS_DATA = {
+  key: "olympus-zuiko-auto-zoom-85-250mm-f5",
+  maker: "Olympus",
+  name: "OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5",
+  subtitle: "US 4,025,167 Embodiment 2 — Olympus / Ikeda",
+  specs: ["15 elements / 11 groups", "85-250mm", "f/5 constant aperture", "2ω ≈ 29°-10°", "All-spherical"],
+
+  focalLengthMarketing: [85, 250],
+  focalLengthDesign: [85.1196, 250.0038],
+  apertureMarketing: 5,
+  apertureDesign: 5,
+  lensMounts: ["olympus-om"],
+  imageFormat: "135-full-frame",
+  patentYear: 1977,
+  elementCount: 15,
+  groupCount: 11,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.48749,
+      vd: 70.2,
+      fl: 206.3,
+      glass: "S-FSL5 (OHARA) / FK5 class",
+      role: "Weak front positive lens in the focusing group; controls front-group spherical aberration variation.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconvex Positive",
+      nd: 1.62041,
+      vd: 60.3,
+      fl: 127.6,
+      glass: "S-BSM16 (OHARA) / N-SK16 class",
+      role: "Positive crown half of the front-group achromat.",
+      cemented: "C1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconcave Negative",
+      nd: 1.78472,
+      vd: 25.7,
+      fl: -204.8,
+      glass: "S-TIH11 (OHARA) / SF11 class",
+      role: "Negative flint half of the front-group achromat.",
+      cemented: "C1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.56873,
+      vd: 63.2,
+      fl: -127.7,
+      glass: "569632 — dense crown (patent glass code)",
+      role: "First negative variator element.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Plano-Convex Positive",
+      nd: 1.76182,
+      vd: 26.6,
+      fl: 68.8,
+      glass: "FD140 (HOYA) / PBH14 (OHARA) class",
+      role: "Positive flint half of the reversed negative variator doublet.",
+      cemented: "C2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconcave Negative",
+      nd: 1.618,
+      vd: 63.4,
+      fl: -48.0,
+      glass: "PSK53A / K-PSKn2 class",
+      role: "Negative high-Abbe half of the reversed negative variator doublet.",
+      cemented: "C2",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.56873,
+      vd: 63.2,
+      fl: -102.7,
+      glass: "569632 — dense crown (patent glass code)",
+      role: "Rear negative meniscus of the variator group.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Biconvex Positive",
+      nd: 1.62012,
+      vd: 49.7,
+      fl: 47.2,
+      glass: "K-SSK9 (Sumita) / BSM28 class",
+      role: "Positive half of the compensator doublet.",
+      cemented: "C3",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Negative Meniscus",
+      nd: 1.72151,
+      vd: 29.2,
+      fl: -79.7,
+      glass: "S-TIH18 (OHARA) / FD18 class",
+      role: "Negative flint half of the compensator doublet.",
+      cemented: "C3",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.49831,
+      vd: 65.0,
+      fl: 75.1,
+      glass: "498650 — borosilicate crown (patent glass code)",
+      role: "First positive element of the fixed relay group.",
+    },
+    {
+      id: 11,
+      name: "L11",
+      label: "Element 11",
+      type: "Biconvex Positive",
+      nd: 1.54739,
+      vd: 53.6,
+      fl: 51.8,
+      glass: "N-BALF5 / BAL5 class",
+      role: "Positive half of the relay negative-power cemented component.",
+      cemented: "C4",
+    },
+    {
+      id: 12,
+      name: "L12",
+      label: "Element 12",
+      type: "Biconcave Negative",
+      nd: 1.8061,
+      vd: 40.9,
+      fl: -27.9,
+      glass: "S-LAH53 (OHARA)",
+      role: "High-index lanthanum-flint half of the relay negative-power cemented component.",
+      cemented: "C4",
+    },
+    {
+      id: 13,
+      name: "L13",
+      label: "Element 13",
+      type: "Biconvex Positive",
+      nd: 1.59551,
+      vd: 39.2,
+      fl: 52.1,
+      glass: "F8 class (Hikari / HOYA)",
+      role: "Strong positive relay element after the long relay air gap.",
+    },
+    {
+      id: 14,
+      name: "L14",
+      label: "Element 14",
+      type: "Biconcave Negative",
+      nd: 1.72,
+      vd: 43.7,
+      fl: -37.6,
+      glass: "J-LAF02 class (Hikari; patent 720/437)",
+      role: "Rear relay negative element for field and astigmatism correction.",
+    },
+    {
+      id: 15,
+      name: "L15",
+      label: "Element 15",
+      type: "Biconvex Positive",
+      nd: 1.56384,
+      vd: 60.8,
+      fl: 101.2,
+      glass: "N-SK11 (SCHOTT) / BACD11 (HOYA) class",
+      role: "Final positive relay element near the image plane.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 152.515, d: 6.27, nd: 1.48749, elemId: 1, sd: 27.3 },
+    { label: "2", R: -291.307, d: 0.59, nd: 1.0, elemId: 0, sd: 27.0 },
+    { label: "3", R: 121.674, d: 5.8, nd: 1.62041, elemId: 2, sd: 26.8 },
+    { label: "4", R: -222.315, d: 2.41, nd: 1.78472, elemId: 3, sd: 26.2 },
+    { label: "5", R: 583.052, d: 1.03, nd: 1.0, elemId: 0, sd: 25.8 },
+    { label: "6", R: -569.43, d: 1.7, nd: 1.56873, elemId: 4, sd: 15.0 },
+    { label: "7", R: 83.352, d: 2.0, nd: 1.0, elemId: 0, sd: 14.8 },
+    { label: "8", R: 1e15, d: 4.0, nd: 1.76182, elemId: 5, sd: 14.7 },
+    { label: "9", R: -52.45, d: 1.5, nd: 1.618, elemId: 6, sd: 14.5 },
+    { label: "10", R: 69.088, d: 4.51, nd: 1.0, elemId: 0, sd: 14.3 },
+    { label: "11", R: -47.831, d: 1.7, nd: 1.56873, elemId: 7, sd: 14.1 },
+    { label: "12", R: -267.438, d: 44.25, nd: 1.0, elemId: 0, sd: 14.1 },
+    { label: "STO", R: 1e15, d: 0.75, nd: 1.0, elemId: 0, sd: 13.42 },
+    { label: "13", R: 158.234, d: 5.52, nd: 1.62012, elemId: 8, sd: 15.1 },
+    { label: "14", R: -35.438, d: 1.51, nd: 1.72151, elemId: 9, sd: 15.4 },
+    { label: "15", R: -94.092, d: 16.71, nd: 1.0, elemId: 0, sd: 15.6 },
+    { label: "16", R: 42.042, d: 5.67, nd: 1.49831, elemId: 10, sd: 18.2 },
+    { label: "17", R: -325.217, d: 0.6, nd: 1.0, elemId: 0, sd: 18.0 },
+    { label: "18", R: 37.123, d: 10.6, nd: 1.54739, elemId: 11, sd: 18.0 },
+    { label: "19", R: -107.794, d: 2.52, nd: 1.8061, elemId: 12, sd: 16.3 },
+    { label: "20", R: 28.663, d: 39.0, nd: 1.0, elemId: 0, sd: 15.8 },
+    { label: "21", R: 100.383, d: 7.17, nd: 1.59551, elemId: 13, sd: 19.4 },
+    { label: "22", R: -43.65, d: 3.0, nd: 1.0, elemId: 0, sd: 19.4 },
+    { label: "23", R: -38.74, d: 2.05, nd: 1.72, elemId: 14, sd: 19.5 },
+    { label: "24", R: 91.922, d: 7.5, nd: 1.0, elemId: 0, sd: 19.5 },
+    { label: "25", R: 78.964, d: 6.0, nd: 1.56384, elemId: 15, sd: 21.5 },
+    { label: "26", R: -200.325, d: 54.0374319328, nd: 1.0, elemId: 0, sd: 21.8 },
+  ],
+
+  asph: {},
+
+  zoomPositions: [85, 151.4, 250],
+  zoomStep: 0.004,
+  zoomLabels: ["85mm", "250mm"],
+
+  var: {
+    "5": [
+      [1.03, 10.8738108715],
+      [32.28, 42.1235841244],
+      [48.06, 57.9035329394],
+    ],
+    "12": [
+      [44.25, 44.25],
+      [26.79, 26.79],
+      [0.74, 0.74],
+    ],
+    "15": [
+      [16.71, 16.71],
+      [3.0, 3.0],
+      [13.27, 13.27],
+    ],
+    "26": [
+      [54.0374319328, 54.0374319328],
+      [53.9201853657, 53.9201853657],
+      [53.9117772352, 53.9117772352],
+    ],
+  },
+  varLabels: [
+    ["5", "D1 / Focus"],
+    ["12", "D2a"],
+    ["15", "D3"],
+    ["26", "BF"],
+  ],
+
+  groups: [
+    { text: "G1 Focus", fromSurface: "1", toSurface: "5" },
+    { text: "G2 Variator", fromSurface: "6", toSurface: "12" },
+    { text: "G3 Compensator", fromSurface: "13", toSurface: "15" },
+    { text: "G4 Relay", fromSurface: "16", toSurface: "26" },
+  ],
+  doublets: [
+    { text: "C1 L2-L3", fromSurface: "3", toSurface: "5" },
+    { text: "C2 L5-L6", fromSurface: "8", toSurface: "10" },
+    { text: "C3 L8-L9", fromSurface: "13", toSurface: "15" },
+    { text: "C4 L11-L12", fromSurface: "18", toSurface: "20" },
+  ],
+
+  closeFocusM: 2.0,
+  focusDescription:
+    "Front-group focusing. Group I advances for close focus; close-focus D1 values are paraxially inferred for 2.0 m because the patent gives 3 m aberration curves but no close-focus spacing table.",
+  nominalFno: 5,
+  fstopSeries: [5, 5.6, 8, 11, 16, 22, 32],
+  maxFstop: 32,
+  scFill: 0.82,
+  yScFill: 0.48,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -19,6 +19,12 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-06-21 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-06-21",
+    type: "lens",
+    summary: "Added three Olympus OM telephoto and zoom lenses",
+  },
   // ── 2026-06-20 ──────────────────────────────────────────────────────────
   {
     date: "2026-06-20",


### PR DESCRIPTION
## Summary
- Add Olympus F.Zuiko Auto-T 200mm f/5, Zuiko Auto-Zoom 65-200mm f/4, and Zuiko Auto-Zoom 85-250mm f/5 lens data
- Add companion patent-analysis notes and a lens-only changelog entry
- Refresh README lens count and generated glass reports

## Verification
- npm run typecheck
- npm run format:check
- npm run lint
- npm run test
- npm run generate:glass-reports