### PR TITLE
Fix ray ghost rendering after clips and misses

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart TD
 
 ## Current Scope
 
-- `352` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
+- `355` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Canon, Carl Zeiss Jena, Carl Zeiss Oberkochen, Fujifilm,
   Hasselblad, Laowa, Leica, Minolta, Nikon, Olympus, Panasonic, Pentax, Ricoh, Schneider-Kreuznach, Sigma, Sony,
   Vivitar, and Voigtländer

--- a/TRACE_MODEL_IMPROVEMENT_PLAN.md
+++ b/TRACE_MODEL_IMPROVEMENT_PLAN.md
@@ -4,7 +4,7 @@
 > described here has shipped into `src/optics/`. Use `agent_docs/architecture/optics-engine.md` for current engine
 > boundaries; keep this file for the rationale behind fisheye/vector launch behavior.
 
-Status: revised after the PR 8 follow-ups and PR #506 landed, 2026-05-21.
+Status: revised after the PR 8 follow-ups, PR #506, and the ray ghost/miss rendering fix landed, 2026-06-22.
 
 The current branch state: every analysis module's field-launch slope routes through the shared projection helper;
 the Distortion tab's field grid samples in angular space for fisheyes; equisolid-angle projection is a recognized
@@ -539,8 +539,10 @@ Shipped in the same commit as PR 7's follow-up:
 ### PR 8 — Tracer surgery (landed)
 
 Originally seven numbered steps. Six landed across the commits below; **Step 5 (visual smoke on the Nikon
-6mm at 110° in the running app)** still requires browser access. **Step 2c (`fallbackSurfacePoint` for
-ghost-mode visualization)** is deferred — see note under step 2.
+6mm at 110° in the running app)** still requires browser access. The former **Step 2c
+(`fallbackSurfacePoint` for ghost-mode visualization)** is superseded for the active RuntimeLens diagram path:
+prepared-state sequential/generalized traces now terminate on missed surfaces, preserve preceding solved hits,
+and do not fabricate fallback hit geometry after a miss.
 
 ```
 beb040e  Lift exact-tracer forward-cone gates for bounding-sphere launches  (Steps 1, 2a, 2b)
@@ -571,16 +573,16 @@ c707fe9  Restrict tracingHalfField safety margin to fisheyes only           (rec
   on the Nokton 50/1 and θ = 5° on the Nikon 6mm confirm bit-identical results between launch surfaces
   (~1e-12 mm at z=0).
 - Validator `projection.maxTraceFieldDeg` cap raised from 90° to 180° (`6ce2906`).
+- Ghost-mode diagram traces no longer extend through missed surfaces on the active prepared-state engine path.
+  A miss terminates tracing with the prior hit history intact, while aperture/semi-diameter clips can still
+  produce real clipped hit points. The display layer draws clipped ghost rays only from the last solid point
+  to the first clipped point, avoiding unbounded SVG paths during zoom/pan.
 
 **What's still partial:**
 
 - **Step 5 — visual smoke.** Cannot be automated. Open the running app on the Nikon 6mm, click through
   diagram + distortion + vignette + pupil-aberration + off-axis tabs, confirm no NaN gaps, console
   warnings, or visually nonsense rays. Easiest after the next dev-server start.
-- **Step 2c — ghost-mode fallback.** `fallbackSurfacePoint()` in
-  [exactSurfaceTrace.ts](src/optics/internal/exactSurfaceTrace.ts) still rejects rays with
-  `|direction[2]| <= 1e-12`. Only reached via `ghost: true` visualization (not used by chief-ray
-  solving); it remains a polish task for diagnostic/ghost visualization edge cases.
 - **Vector-launch policy is still module-specific.** Bokeh, vignetting, pupil-aberration, distortion-grid, image-height,
   visible off-axis, and chromatic off-axis paths all consume vector launches where needed, but there is no shared
   `buildRayBundleForField()` abstraction yet. Keep that deferred until duplication becomes painful.
@@ -590,9 +592,9 @@ c707fe9  Restrict tracingHalfField safety margin to fisheyes only           (rec
   most Nikon 6mm angles, which produces `console.warn`s in dev mode; might be worth promoting the
   diagnostics aggregator to a CI gate.
 
-**Realistic effort for the remaining work:** Step 5 is 30 minutes with browser access. Step 2c and the catalog
-audit are opportunistic. A shared bundle builder is only worth a dedicated pass if future fisheye work starts
-copying vector launch policy across modules again.
+**Realistic effort for the remaining work:** Step 5 is 30 minutes with browser access. The catalog audit is
+opportunistic. A shared bundle builder is only worth a dedicated pass if future fisheye work starts copying
+vector launch policy across modules again.
 
 #### Step 1 — Lift the forward-cone gate in `surfaceIntersectionMaxT()`
 
@@ -669,18 +671,13 @@ The bracket midpoint is a worse starting guess for steep rays but a perfectly go
 bracket finder at [surfaceIntersection.ts:118](src/optics/internal/surfaceIntersection.ts#L118) already
 guarantees `lo < hi` brackets a sign change.
 
-**2c. Same fix in `fallbackSurfacePoint()`** at [exactSurfaceTrace.ts:340](src/optics/internal/exactSurfaceTrace.ts#L340).
-Currently `if (Math.abs(direction[2]) <= 1e-12) return null;`. The fallback's job is to give the *ghost-mode*
-visualizer something to draw when the real intersection fails. For grazing rays, project to the bounding-sphere
-intersection with the vertex plane via the `(lo, hi)` midpoint instead of dividing by `direction[2]`. If even
-that fails (e.g., the ray completely misses the sphere), return `null` is correct.
-
-**Deferred from steps 1–2** (commit `<commit-pending>`): Step 2c was not implemented in the steps-1+2 commit
-because `fallbackSurfacePoint` is only called from the `ghost: true` visualization branch in
-[exactSurfaceTrace.ts:195](src/optics/internal/exactSurfaceTrace.ts#L195), and no chief-ray-solving or analysis
-path enables ghost mode. With ghost mode off (today's default everywhere), failed intersections just break out
-of the trace loop. Step 2c becomes necessary only when the diagram panel (which does use ghost-mode rays) is
-asked to render a bounding-sphere launch — i.e., as part of step 6's catalog promotion. Wire it then.
+**2c. Superseded for active diagram rendering.** The original note targeted
+`fallbackSurfacePoint()` in [exactSurfaceTrace.ts](src/optics/internal/exactSurfaceTrace.ts), which could
+invent ghost-mode geometry after a failed intersection. The active RuntimeLens diagram path now uses the
+prepared-state trace adapters in [rayAdapters.ts](src/optics/trace/rayAdapters.ts). In that path, sequential
+and generalized traces stop immediately on a surface-intersection miss, keep preceding solved hits for display,
+and emit no fallback ghost point. The internal exact-trace fallback remains only for lower-level internal callers;
+do not reintroduce it into the diagram path as a post-miss visualization extension.
 
 **Risk assessment for steps 1–2.** This is the genuine numerics work. The intersection algorithm has been stable
 for forward-cone rays for many lens generations; opening it up to sideways and backward rays creates new failure
@@ -861,7 +858,7 @@ This is the bookkeeping step that completes PR 8.
 | Step | Files |
 |------|-------|
 | 1    | [src/optics/internal/exactSurfaceTrace.ts](src/optics/internal/exactSurfaceTrace.ts) (`surfaceIntersectionMaxT` + `traceExactSurfaceStackVector` options) |
-| 2    | [src/optics/internal/surfaceIntersection.ts](src/optics/internal/surfaceIntersection.ts) (gate + Newton seed), [src/optics/internal/exactSurfaceTrace.ts](src/optics/internal/exactSurfaceTrace.ts) (`fallbackSurfacePoint`) |
+| 2    | [src/optics/internal/surfaceIntersection.ts](src/optics/internal/surfaceIntersection.ts) (gate + Newton seed); the original [src/optics/internal/exactSurfaceTrace.ts](src/optics/internal/exactSurfaceTrace.ts) `fallbackSurfacePoint` follow-up is superseded for the active diagram path by miss termination in [src/optics/trace/sequentialTrace.ts](src/optics/trace/sequentialTrace.ts) and [src/optics/trace/generalizedTrace.ts](src/optics/trace/generalizedTrace.ts) |
 | 3    | [src/optics/fieldGeometry.ts](src/optics/fieldGeometry.ts) (`solveChiefRayBoundingSphere`), [src/optics/buildLens.ts](src/optics/buildLens.ts) (cache launch radius if useful) |
 | 4    | new `__tests__/src/optics/boundingSphereParity.test.ts` |
 | 5    | none in code (visual verification only) |

--- a/__tests__/src/components/hooks/raySegmentUtils.test.ts
+++ b/__tests__/src/components/hooks/raySegmentUtils.test.ts
@@ -62,7 +62,7 @@ describe("compileRaySegment", () => {
   });
 
   describe("clipped rays (clipped = true)", () => {
-    it("builds ghost polyline from last solid + ghost pts + endpoint", () => {
+    it("builds ghost polyline only from last solid to the first clipped point", () => {
       const pts = [
         [0, 1],
         [10, 2],
@@ -77,21 +77,25 @@ describe("compileRaySegment", () => {
         [0, 1],
         [10, 2],
       ]);
-      // ghost polyline: last solid + ghost pts + clampedRayEnd from last ghost
+      // ghost polyline: last solid + first clipped point only
       expect(seg.gp).toEqual([
         [10, 2],
         [20, 3],
-        [30, 4],
-        [100, 0],
       ]);
     });
 
-    it("uses endOverride for ghost endpoint when provided", () => {
+    it("ignores later ghost points and endOverride for clipped rays", () => {
       const pts = [[0, 0]];
-      const ghostPts = [[10, 5]];
+      const ghostPts = [
+        [10, 5],
+        [20, 8],
+      ];
       const override = [42, 24];
       const seg = compileRaySegment(pts, ghostPts, 0, true, identity, identity, clampedRayEnd, 50, override);
-      expect(seg.gp[seg.gp.length - 1]).toEqual([42, 24]);
+      expect(seg.gp).toEqual([
+        [0, 0],
+        [10, 5],
+      ]);
     });
 
     it("produces empty ghost when ghostPts is empty", () => {
@@ -108,12 +112,12 @@ describe("compileRaySegment", () => {
       ]);
     });
 
-    it("calls clampedRayEnd with last ghost point and exit slope", () => {
+    it("does not call clampedRayEnd for clipped rays", () => {
       const clamped = vi.fn((): [number, number] => [200, 50]);
       const pts = [[0, 0]];
       const ghostPts = [[30, 7]];
       compileRaySegment(pts, ghostPts, 0.15, true, identity, identity, clamped, 80);
-      expect(clamped).toHaveBeenCalledWith(30, 7, 0.15, 80);
+      expect(clamped).not.toHaveBeenCalled();
     });
 
     it("applies coordinate transforms to ghost points", () => {

--- a/__tests__/src/optics/optics.test.ts
+++ b/__tests__/src/optics/optics.test.ts
@@ -27,6 +27,7 @@ import {
   buildChromaticPositiveElementLens,
   buildGhostClippingLens,
   buildLayoutLens,
+  buildMissAfterFirstHitLens,
   buildSimplePositiveElementLens,
   buildTirLens,
   buildVariableStopGapLens,
@@ -615,12 +616,23 @@ describe("traceRay — Sonnar 50 f/1.5 production lens", () => {
   });
 
   it("ghost mode returns rendering points even when clipped", () => {
-    // Use a very large ray that will definitely clip
-    const h = 2.0 * L.EP.epSD;
+    // Use a marginal ray that hits several surfaces before missing a later one.
+    const h = 0.7 * L.EP.epSD;
     const { clipped, pts, ghostPts } = traceRay(h, 0, zPos, 0, 0, L.stopPhysSD, true, L);
     expect(clipped).toBe(true);
-    // Should still have some rendering points (pts from before clip + ghostPts after)
+    // Preceding valid hits still render even though tracing stops at the miss.
     expect(pts.length + ghostPts.length).toBeGreaterThan(1);
+  });
+
+  it("ghost mode stops after a missed surface while preserving preceding hits", () => {
+    const missLens = buildMissAfterFirstHitLens();
+    const { z: missZPos } = doLayout(0, 0, missLens);
+    const result = traceRay(20, 0, missZPos, 0, 0, 100, true, missLens);
+
+    expect(result.clipped).toBe(true);
+    expect(result.pts).toHaveLength(2);
+    expect(result.pts[1]).toEqual([missZPos[0], 20]);
+    expect(result.ghostPts).toHaveLength(0);
   });
 });
 

--- a/__tests__/src/optics/testLensFixtures.ts
+++ b/__tests__/src/optics/testLensFixtures.ts
@@ -93,3 +93,15 @@ export function buildGhostClippingLens(key = "test-ghost-clipping-lens"): Runtim
     ],
   });
 }
+
+export function buildMissAfterFirstHitLens(key = "test-miss-after-first-hit-lens"): RuntimeLens {
+  return buildFixture({
+    key,
+    nominalFno: 4,
+    surfaces: [
+      { label: "STO", R: 1e15, nd: 1.0, sd: 100, d: 10, elemId: 0 },
+      { label: "1", R: 20, nd: 1.5, sd: 10, d: 8, elemId: 1 },
+      { label: "2", R: -20, nd: 1.0, sd: 10, d: 50, elemId: 1 },
+    ],
+  });
+}

--- a/agent_docs/architecture/optics-engine.md
+++ b/agent_docs/architecture/optics-engine.md
@@ -123,6 +123,13 @@ Exact tracing is the only trace path. `traceRay()`, `traceRayChromatic()`, `trac
 have no mode/options surface — every call resolves to the exact path. The legacy vertex-plane tracer has
 been removed; do not reintroduce a `RayTraceOptions` parameter or a `traceMode` flag.
 
+The public RuntimeLens trace adapters route through the prepared-state sequential/generalized engine in
+`src/optics/trace/`. Surface-intersection misses are terminal in both paths, including ghost-mode diagram
+traces: the result preserves already solved hits for display and diagnostics, but does not fabricate fallback
+surface points after a miss. Aperture/semi-diameter clips remain distinct from misses; ghost mode can retain
+real clipped hit points, and the diagram display layer renders only the first clipped span so zoomed SVG
+bounds stay finite.
+
 The exact tracer in `internal/exactSurfaceTrace.ts` exposes two entry points:
 
 - `traceExactSurfaceStack({ x0, y0, ux0, uy0 }, options)` — slope launch, normalizes

--- a/agent_docs/architecture/viewer-and-diagram.md
+++ b/agent_docs/architecture/viewer-and-diagram.md
@@ -54,7 +54,7 @@ Key responsibilities:
 | Hook | Purpose |
 | --- | --- |
 | `useLensComputation.ts` | Lens building/reuse, layout, transforms, element shapes, aperture, current-state field geometry, and optional perspective-control movement. It imports stable optics modules directly; there is no old-vs-new selector. Stabilizes `zPos` by element-wise comparison. |
-| `useRayTracing.ts` | Orchestrates on-axis, off-axis, and chromatic ray hooks, applies ray density and optional movement transforms, and reports the first ray error. Folded systems receive generalized trace results terminating on `L.imagePlane`. |
+| `useRayTracing.ts` | Orchestrates on-axis, off-axis, and chromatic ray hooks, applies ray density and optional movement transforms, and reports the first ray error. Folded systems receive generalized trace results terminating on `L.imagePlane`; missed surfaces stop tracing while preserving preceding display hits. |
 | `useOnAxisRays.ts` | Computes density-derived on-axis ray fan segments, using obstruction-aware sampling for folded mirror systems. |
 | `useOffAxisRays.ts` | Computes density-derived visible off-axis rays using state-aware field geometry and folded image-plane termination where applicable. |
 | `offAxisRayUtils.ts` | Shared off-axis tracing geometry and optional edge-projection endpoint logic for monochrome and chromatic fans. |
@@ -87,7 +87,7 @@ Key responsibilities:
 | `DiagramGridAxisLayer.tsx` | Grid, axis, and image-plane reference elements, including explicit folded-system image planes that may be in front of, behind, or above the axial layout. |
 | `DiagramElementLayer.tsx` | Lens element paths, aspheric overlays, and surface accents. Annular elements use even-odd fill, tilted flat mirrors render from `interaction.normal`, and second-surface mirror coatings render as dashed substrate accents. |
 | `DiagramRayLayers.tsx` | On-axis, off-axis, and chromatic ray layers. When chromatic mode is active, it hides monochrome layers and lets ON-AXIS/OFF-AXIS gate the chromatic axial/off-axis groups. Folded ray polylines follow the generalized tracer rather than surface-list order. |
-| `RayPolylines.tsx` | Consolidated ray segment polyline rendering. |
+| `RayPolylines.tsx` | Consolidated ray segment polyline rendering. Ray segment compilation displays clipped ghost rays only from the last solid point to the first clipped point, keeping zoomed SVG bounds finite. |
 | `ApertureStop.tsx` | Aperture stop blades and STO label. |
 | `CardinalElementsOverlay.tsx` | Feature-flagged F/F′, H/H′, N/N′ and axial span overlay. |
 | `ElementAnnotations.tsx` | Element numbers, Abbe badges, group/doublet labels. |

--- a/agent_docs/generated/catalog-mismatches.generated.md
+++ b/agent_docs/generated/catalog-mismatches.generated.md
@@ -13,10 +13,10 @@ with words like "probable" or "approx").
 
 ## Summary
 
-- **360** lenses scanned
-- **4068** glass surfaces examined
-- **4062** surfaces with non-empty `glass` strings
-- **3277** of those resolved to a catalog entry
+- **363** lenses scanned
+- **4090** glass surfaces examined
+- **4084** surfaces with non-empty `glass` strings
+- **3297** of those resolved to a catalog entry
 - **0** mismatches found (0.0% of resolved surfaces)
 - **0** distinct lens files affected
 

--- a/agent_docs/generated/glass-coverage-opportunities.generated.md
+++ b/agent_docs/generated/glass-coverage-opportunities.generated.md
@@ -9,13 +9,13 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **360** lenses scanned (**352** visible)
-- **3277 / 4068** non-air surfaces use strict catalog Sellmeier data (80.6%)
-- **3301 / 4068** non-air surfaces use trusted chromatic data (Sellmeier or measured line indices, 81.1%)
+- **363** lenses scanned (**355** visible)
+- **3297 / 4090** non-air surfaces use strict catalog Sellmeier data (80.6%)
+- **3321 / 4090** non-air surfaces use trusted chromatic data (Sellmeier or measured line indices, 81.2%)
 - **0** mismatch surfaces in Sweep 1 across **0** lens files
 - **0** Sweep 1 surfaces have a matching untracked local patent PDF
 - **206** code-only missing-Sellmeier elements in Sweep 2
-- **132** unresolved named-token elements in Sweep 2B
+- **134** unresolved named-token elements in Sweep 2B
 - **0** Tier A proprietary backfill rows in Sweep 3
 
 ## Sweep 1 - Relabel Mismatches
@@ -78,6 +78,7 @@ These are efficient follow-up targets after mismatch blockers because one or two
 | [CANON RF 24-240mm f/4-6.3 IS USM](../../src/lens-data/canon/CanonRF24240mmf463.data.ts) | 90.5% (19/21) | 90.5% (19/21) | 2 | abbe: 2 |
 | [NIKON AF-S NIKKOR 24-70mm f/2.8 E ED VR](../../src/lens-data/nikon/NikonNikkorAFS2470mmf28E.data.ts) | 90.5% (19/21) | 90.5% (19/21) | 2 | abbe: 2 |
 | [NIKON NIKKOR Z DX 16-50mm f/3.5-6.3 VR](../../src/lens-data/nikon/NikonZDX1650mmf3563VR.data.ts) | 90.0% (9/10) | 90.0% (9/10) | 1 | abbe: 1 |
+| [PENTAX SMC PENTAX-A★ 200mm f/4 MACRO ED](../../src/lens-data/pentax/PentaxA200mmf4MacroED.data.ts) | 90.0% (9/10) | 90.0% (9/10) | 1 | abbe: 1 |
 | [VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) | 90.0% (9/10) | 90.0% (9/10) | 1 | abbe: 1 |
 | [VOIGTLÄNDER NOKTON 35mm f/1.2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderNokton35mmf12.data.ts) | 90.0% (9/10) | 90.0% (9/10) | 1 | abbe: 1 |
 | [SONY FE 24-70mm f/2.8 GM II](../../src/lens-data/sony/SonyFE2470mmf28GMII.data.ts) | 90.0% (18/20) | 90.0% (18/20) | 2 | abbe: 2 |
@@ -109,6 +110,7 @@ These are efficient follow-up targets after mismatch blockers because one or two
 | [MINOLTA MD ROKKOR 50mm f/1.4](../../src/lens-data/minolta/MinoltaRokkor50mmf14MD.data.ts) | 85.7% (6/7) | 85.7% (6/7) | 1 | abbe: 1 |
 | [OLYMPUS G.ZUIKO AUTO-W 21mm f/3.5](../../src/lens-data/olympus/OlympusGZuikoAutoW21mmf35.data.ts) | 85.7% (6/7) | 85.7% (6/7) | 1 | abbe: 1 |
 | [OLYMPUS ZUIKO AUTO-S 50mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS50mmf12.data.ts) | 85.7% (6/7) | 85.7% (6/7) | 1 | abbe: 1 |
+| [PENTAX SMC PENTAX-A★ 135mm f/1.8](../../src/lens-data/pentax/PentaxA135mmf18.data.ts) | 85.7% (6/7) | 85.7% (6/7) | 1 | abbe: 1 |
 | [RICOH GR LENS 28mm f/2.8 (Ricoh GR1)](../../src/lens-data/ricoh/RicohGR28f28.data.ts) | 85.7% (6/7) | 85.7% (6/7) | 1 | abbe: 1 |
 | [RICOH GR LENS 26.1mm f/2.8 (Ricoh GR IIIx)](../../src/lens-data/ricoh/RicohGR3x.data.ts) | 85.7% (6/7) | 85.7% (6/7) | 1 | abbe: 1 |
 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR IV)](../../src/lens-data/ricoh/RicohGR428f28.data.ts) | 85.7% (6/7) | 85.7% (6/7) | 1 | abbe: 1 |

--- a/agent_docs/generated/sellmeier-coverage.generated.md
+++ b/agent_docs/generated/sellmeier-coverage.generated.md
@@ -10,18 +10,18 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **360** lenses scanned
-- **352** visible lenses scanned
-- **105** lenses fully covered by trusted chromatic data
-- **105** visible lenses fully covered by trusted chromatic data
-- **99** lenses fully covered by strict Sellmeier data
-- **99** visible lenses fully covered by strict Sellmeier data
+- **363** lenses scanned
+- **355** visible lenses scanned
+- **106** lenses fully covered by trusted chromatic data
+- **106** visible lenses fully covered by trusted chromatic data
+- **100** lenses fully covered by strict Sellmeier data
+- **100** visible lenses fully covered by strict Sellmeier data
 - **6** lenses fully covered only after measured line-index data
 - **6** visible lenses fully covered only after measured line-index data
-- **3277 / 4068** non-air surfaces use strict catalog Sellmeier data
+- **3297 / 4090** non-air surfaces use strict catalog Sellmeier data
 - **80.6%** strict Sellmeier surface coverage overall
-- **3301 / 4068** non-air surfaces use trusted chromatic data
-- **81.1%** trusted chromatic coverage overall
+- **3321 / 4090** non-air surfaces use trusted chromatic data
+- **81.2%** trusted chromatic coverage overall
 
 ## Fully Strict Sellmeier Lenses
 
@@ -121,6 +121,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 | [NIKON REFLEX-NIKKOR 1000mm f/11](../../src/lens-data/nikon/NikonReflexNikkor1000mmf11.data.ts) | 5/5 | 5 | 5/5 |
 | [OLYMPUS ZUIKO AUTO-T 85mm f/2](../../src/lens-data/olympus/OlympusZuiko85mmf2.data.ts) | 5/5 | 5 | 5/5 |
 | [PENTAX 110 50mm f/2.8](../../src/lens-data/pentax/Pentax11050mmf28.data.ts) | 5/5 | 5 | 5/5 |
+| [PENTAX SMC PENTAX-FA 28mm f/2.8 Soft](../../src/lens-data/pentax/PentaxFA28mmf28Soft.data.ts) | 5/5 | 5 | 5/5 |
 | [CARL ZEISS OLYMPIA-SONNAR 180mm f/2.8](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissOlympiaSonnar180mmf28.data.ts) | 4/4 | 4 | 4/4 |
 | [NIKON AI NIKKOR 45mm f/2.8 P](../../src/lens-data/nikon/NikonAINikkor45mmf28.data.ts) | 4/4 | 4 | 4/4 |
 | [NIKON SERIES E 100mm f/2.8](../../src/lens-data/nikon/NikonSeriesE100mmf28.data.ts) | 4/4 | 4 | 4/4 |
@@ -195,225 +196,227 @@ Fully strict and line-index-complete trusted lenses are listed above; this table
 | 45 | [CANON RF 24-240mm f/4-6.3 IS USM](../../src/lens-data/canon/CanonRF24240mmf463.data.ts) | 90.5% | 90.5% | 19/21 | 19/21 | 2 | abbe: 2 |
 | 46 | [NIKON AF-S NIKKOR 24-70mm f/2.8 E ED VR](../../src/lens-data/nikon/NikonNikkorAFS2470mmf28E.data.ts) | 90.5% | 90.5% | 19/21 | 19/21 | 2 | abbe: 2 |
 | 47 | [NIKON NIKKOR Z DX 16-50mm f/3.5-6.3 VR](../../src/lens-data/nikon/NikonZDX1650mmf3563VR.data.ts) | 90.0% | 90.0% | 9/10 | 9/10 | 1 | abbe: 1 |
-| 48 | [VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) | 90.0% | 90.0% | 9/10 | 9/10 | 1 | abbe: 1 |
-| 49 | [VOIGTLÄNDER NOKTON 35mm f/1.2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderNokton35mmf12.data.ts) | 90.0% | 90.0% | 9/10 | 9/10 | 1 | abbe: 1 |
-| 50 | [SONY FE 24-70mm f/2.8 GM II](../../src/lens-data/sony/SonyFE2470mmf28GMII.data.ts) | 90.0% | 90.0% | 18/20 | 18/20 | 2 | abbe: 2 |
+| 48 | [PENTAX SMC PENTAX-A★ 200mm f/4 MACRO ED](../../src/lens-data/pentax/PentaxA200mmf4MacroED.data.ts) | 90.0% | 90.0% | 9/10 | 9/10 | 1 | abbe: 1 |
+| 49 | [VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) | 90.0% | 90.0% | 9/10 | 9/10 | 1 | abbe: 1 |
+| 50 | [VOIGTLÄNDER NOKTON 35mm f/1.2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderNokton35mmf12.data.ts) | 90.0% | 90.0% | 9/10 | 9/10 | 1 | abbe: 1 |
+| 51 | [SONY FE 24-70mm f/2.8 GM II](../../src/lens-data/sony/SonyFE2470mmf28GMII.data.ts) | 90.0% | 90.0% | 18/20 | 18/20 | 2 | abbe: 2 |
 |  | **85-89.9% coverage** |  |  |  |  |  |  |
-| 51 | [NIKON NIKKOR Z 24-200mm f/4-6.3 VR](../../src/lens-data/nikon/NikonNikkorZ24200mmf463VR.data.ts) | 89.5% | 89.5% | 17/19 | 17/19 | 2 | abbe: 2 |
-| 52 | [NIKON NIKKOR Z DX 18-140mm f/3.5-6.3 VR](../../src/lens-data/nikon/NikonZDX18140mmf3563VR.data.ts) | 89.5% | 89.5% | 17/19 | 17/19 | 2 | abbe: 2 |
-| 53 | [NIKON 1 NIKKOR 32mm f/1.2](../../src/lens-data/nikon/Nikon1Nikkor32mmf12.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 54 | [NIKON FISHEYE-NIKKOR 6mm f/5.6](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf56.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 55 | [NIKON NIKKOR Z 26mm f/2.8](../../src/lens-data/nikon/NikonZ26f28.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 56 | [NIKON NIKKOR-N 5cm f/1.1](../../src/lens-data/nikon/NikonN5cmf11.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 57 | [PENTAX DA 21mm f/3.2 AL Limited](../../src/lens-data/pentax/PentaxDA21mmf32Limited.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 58 | [SIGMA 30mm f/1.4 DC HSM | Art](../../src/lens-data/sigma/Sigma30mmf14DCHSMA.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 59 | [SONY E 35mm f/1.8 OSS](../../src/lens-data/sony/SonyE35mmf18.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 60 | [SONY FE 28mm f/2](../../src/lens-data/sony/SonyFE28mmf2.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 61 | [VOIGTLÄNDER NOKTON 50mm f/1.2 X-Mount](../../src/lens-data/voigtlander/VoigtlanderNoktonX50mmf12.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
-| 62 | [FUJIFILM FUJINON GF 45-100mm f/4 R LM OIS WR](../../src/lens-data/fujifilm/FujifilmGF45100mmf4.data.ts) | 88.2% | 88.2% | 15/17 | 15/17 | 2 | abbe: 2 |
-| 63 | [NIKON NIKKOR Z 50mm f/1.2 S](../../src/lens-data/nikon/NikonNikkorZ50f12.data.ts) | 88.2% | 88.2% | 15/17 | 15/17 | 2 | abbe: 2 |
-| 64 | [FUJIFILM FUJINON XF 23mm f/2.8 R WR](../../src/lens-data/fujifilm/FujifilmXF23mmf28RWR.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
-| 65 | [FUJIFILM FUJINON XF 35mm f/1.4 R](../../src/lens-data/fujifilm/FujifilmXF35mmf14R.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
-| 66 | [MINOLTA AF 100mm f/2.8 Macro](../../src/lens-data/minolta/MinoltaAF100mmf28Macro.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
-| 67 | [RICOH GR LENS A12 28mm f/2.5 (Ricoh GXR A12)](../../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
-| 68 | [SIGMA 60mm f/2.8 DN | Art](../../src/lens-data/sigma/Sigma60mmf28DN.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
-| 69 | [SONY SONNAR T* E 24mm f/1.8 ZA](../../src/lens-data/sony/SonyFE24mmf18ZA.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
-| 70 | [NIKON AF-S NIKKOR 24-70mm f/2.8 G ED](../../src/lens-data/nikon/NikonAFS2470mmf28G.data.ts) | 87.5% | 87.5% | 14/16 | 14/16 | 2 | abbe: 2 |
-| 71 | [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) | 87.5% | 87.5% | 14/16 | 14/16 | 2 | abbe: 2 |
-| 72 | [SIGMA 40mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/SigmaArt40mmf14.data.ts) | 87.5% | 87.5% | 14/16 | 14/16 | 2 | abbe: 2 |
-| 73 | [FUJIFILM FUJINON GF 32-64mm f/4 R LM WR](../../src/lens-data/fujifilm/FujifilmGF3264mmf4.data.ts) | 86.7% | 86.7% | 13/15 | 13/15 | 2 | abbe: 2 |
-| 74 | [NIKON AF-S NIKKOR 28mm f/1.4 E ED](../../src/lens-data/nikon/NikonAFS28f14E.data.ts) | 86.7% | 86.7% | 13/15 | 13/15 | 2 | abbe: 2 |
-| 75 | [NIKON PC-E NIKKOR 24mm f/3.5 D ED](../../src/lens-data/nikon/NikonPCENikkor24mmf35DED.data.ts) | 86.7% | 86.7% | 13/15 | 13/15 | 2 | abbe: 2 |
-| 76 | [MINOLTA MD ROKKOR 50mm f/1.4](../../src/lens-data/minolta/MinoltaRokkor50mmf14MD.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
-| 77 | [OLYMPUS G.ZUIKO AUTO-W 21mm f/3.5](../../src/lens-data/olympus/OlympusGZuikoAutoW21mmf35.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
-| 78 | [OLYMPUS ZUIKO AUTO-S 50mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS50mmf12.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
-| 79 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR IV)](../../src/lens-data/ricoh/RicohGR428f28.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
-| 80 | [RICOH GR LENS 26.1mm f/2.8 (Ricoh GR IIIx)](../../src/lens-data/ricoh/RicohGR3x.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
-| 81 | [RICOH GR LENS 28mm f/2.8 (Ricoh GR1)](../../src/lens-data/ricoh/RicohGR28f28.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
-| 82 | [SONY SONNAR T* FE 55mm f/1.8 ZA](../../src/lens-data/sony/SonyFE55mmf18ZA.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
-| 83 | [CANON EF-S 10-22mm f/3.5-4.5 USM](../../src/lens-data/canon/CanonEFS1022mmf3545.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
-| 84 | [FUJIFILM FUJINON GF 20-35mm f/4 R WR](../../src/lens-data/fujifilm/FujifilmGF2035mmf4.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
-| 85 | [FUJIFILM FUJINON GF 55mm f/1.7 R WR](../../src/lens-data/fujifilm/FujifilmGF55mmf17.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
-| 86 | [NIKON AF-S NIKKOR 105mm f/1.4 E ED](../../src/lens-data/nikon/NikonNikkor105f14E.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
-| 87 | [Nikon AF-S NIKKOR 24mm f/1.8G ED](../../src/lens-data/nikon/NikonAFSNikkor24mmf18GED.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
-| 88 | [NIKON AF-S VR MICRO-NIKKOR 105mm f/2.8 G IF-ED](../../src/lens-data/nikon/NikonAFS105f28G.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
-| 89 | [NIKON NIKKOR Z 24-70mm f/4 S](../../src/lens-data/nikon/NikonNikkorZ2470mmf4S.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
-| 90 | [NIKON NIKKOR Z 50mm f/1.8 S](../../src/lens-data/nikon/NikonNikkorZ50f18S.data.ts) | 85.7% | 85.7% | 12/12 | 12/12 | 2 | constant: 2 |
-| 91 | [LAOWA 24mm f/14 2× Macro Probe](../../src/lens-data/laowa/Laowa24mmf14Probe.data.ts) | 85.2% | 85.2% | 23/27 | 23/27 | 4 | abbe: 4 |
+| 52 | [NIKON NIKKOR Z 24-200mm f/4-6.3 VR](../../src/lens-data/nikon/NikonNikkorZ24200mmf463VR.data.ts) | 89.5% | 89.5% | 17/19 | 17/19 | 2 | abbe: 2 |
+| 53 | [NIKON NIKKOR Z DX 18-140mm f/3.5-6.3 VR](../../src/lens-data/nikon/NikonZDX18140mmf3563VR.data.ts) | 89.5% | 89.5% | 17/19 | 17/19 | 2 | abbe: 2 |
+| 54 | [NIKON 1 NIKKOR 32mm f/1.2](../../src/lens-data/nikon/Nikon1Nikkor32mmf12.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 55 | [NIKON FISHEYE-NIKKOR 6mm f/5.6](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf56.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 56 | [NIKON NIKKOR Z 26mm f/2.8](../../src/lens-data/nikon/NikonZ26f28.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 57 | [NIKON NIKKOR-N 5cm f/1.1](../../src/lens-data/nikon/NikonN5cmf11.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 58 | [PENTAX DA 21mm f/3.2 AL Limited](../../src/lens-data/pentax/PentaxDA21mmf32Limited.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 59 | [SIGMA 30mm f/1.4 DC HSM | Art](../../src/lens-data/sigma/Sigma30mmf14DCHSMA.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 60 | [SONY E 35mm f/1.8 OSS](../../src/lens-data/sony/SonyE35mmf18.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 61 | [SONY FE 28mm f/2](../../src/lens-data/sony/SonyFE28mmf2.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 62 | [VOIGTLÄNDER NOKTON 50mm f/1.2 X-Mount](../../src/lens-data/voigtlander/VoigtlanderNoktonX50mmf12.data.ts) | 88.9% | 88.9% | 8/9 | 8/9 | 1 | abbe: 1 |
+| 63 | [FUJIFILM FUJINON GF 45-100mm f/4 R LM OIS WR](../../src/lens-data/fujifilm/FujifilmGF45100mmf4.data.ts) | 88.2% | 88.2% | 15/17 | 15/17 | 2 | abbe: 2 |
+| 64 | [NIKON NIKKOR Z 50mm f/1.2 S](../../src/lens-data/nikon/NikonNikkorZ50f12.data.ts) | 88.2% | 88.2% | 15/17 | 15/17 | 2 | abbe: 2 |
+| 65 | [FUJIFILM FUJINON XF 23mm f/2.8 R WR](../../src/lens-data/fujifilm/FujifilmXF23mmf28RWR.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
+| 66 | [FUJIFILM FUJINON XF 35mm f/1.4 R](../../src/lens-data/fujifilm/FujifilmXF35mmf14R.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
+| 67 | [MINOLTA AF 100mm f/2.8 Macro](../../src/lens-data/minolta/MinoltaAF100mmf28Macro.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
+| 68 | [RICOH GR LENS A12 28mm f/2.5 (Ricoh GXR A12)](../../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
+| 69 | [SIGMA 60mm f/2.8 DN | Art](../../src/lens-data/sigma/Sigma60mmf28DN.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
+| 70 | [SONY SONNAR T* E 24mm f/1.8 ZA](../../src/lens-data/sony/SonyFE24mmf18ZA.data.ts) | 87.5% | 87.5% | 7/8 | 7/8 | 1 | abbe: 1 |
+| 71 | [NIKON AF-S NIKKOR 24-70mm f/2.8 G ED](../../src/lens-data/nikon/NikonAFS2470mmf28G.data.ts) | 87.5% | 87.5% | 14/16 | 14/16 | 2 | abbe: 2 |
+| 72 | [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) | 87.5% | 87.5% | 14/16 | 14/16 | 2 | abbe: 2 |
+| 73 | [SIGMA 40mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/SigmaArt40mmf14.data.ts) | 87.5% | 87.5% | 14/16 | 14/16 | 2 | abbe: 2 |
+| 74 | [FUJIFILM FUJINON GF 32-64mm f/4 R LM WR](../../src/lens-data/fujifilm/FujifilmGF3264mmf4.data.ts) | 86.7% | 86.7% | 13/15 | 13/15 | 2 | abbe: 2 |
+| 75 | [NIKON AF-S NIKKOR 28mm f/1.4 E ED](../../src/lens-data/nikon/NikonAFS28f14E.data.ts) | 86.7% | 86.7% | 13/15 | 13/15 | 2 | abbe: 2 |
+| 76 | [NIKON PC-E NIKKOR 24mm f/3.5 D ED](../../src/lens-data/nikon/NikonPCENikkor24mmf35DED.data.ts) | 86.7% | 86.7% | 13/15 | 13/15 | 2 | abbe: 2 |
+| 77 | [MINOLTA MD ROKKOR 50mm f/1.4](../../src/lens-data/minolta/MinoltaRokkor50mmf14MD.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 78 | [OLYMPUS G.ZUIKO AUTO-W 21mm f/3.5](../../src/lens-data/olympus/OlympusGZuikoAutoW21mmf35.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 79 | [OLYMPUS ZUIKO AUTO-S 50mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS50mmf12.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 80 | [PENTAX SMC PENTAX-A★ 135mm f/1.8](../../src/lens-data/pentax/PentaxA135mmf18.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 81 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR IV)](../../src/lens-data/ricoh/RicohGR428f28.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 82 | [RICOH GR LENS 26.1mm f/2.8 (Ricoh GR IIIx)](../../src/lens-data/ricoh/RicohGR3x.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 83 | [RICOH GR LENS 28mm f/2.8 (Ricoh GR1)](../../src/lens-data/ricoh/RicohGR28f28.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 84 | [SONY SONNAR T* FE 55mm f/1.8 ZA](../../src/lens-data/sony/SonyFE55mmf18ZA.data.ts) | 85.7% | 85.7% | 6/7 | 6/7 | 1 | abbe: 1 |
+| 85 | [CANON EF-S 10-22mm f/3.5-4.5 USM](../../src/lens-data/canon/CanonEFS1022mmf3545.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
+| 86 | [FUJIFILM FUJINON GF 20-35mm f/4 R WR](../../src/lens-data/fujifilm/FujifilmGF2035mmf4.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
+| 87 | [FUJIFILM FUJINON GF 55mm f/1.7 R WR](../../src/lens-data/fujifilm/FujifilmGF55mmf17.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
+| 88 | [NIKON AF-S NIKKOR 105mm f/1.4 E ED](../../src/lens-data/nikon/NikonNikkor105f14E.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
+| 89 | [Nikon AF-S NIKKOR 24mm f/1.8G ED](../../src/lens-data/nikon/NikonAFSNikkor24mmf18GED.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
+| 90 | [NIKON AF-S VR MICRO-NIKKOR 105mm f/2.8 G IF-ED](../../src/lens-data/nikon/NikonAFS105f28G.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
+| 91 | [NIKON NIKKOR Z 24-70mm f/4 S](../../src/lens-data/nikon/NikonNikkorZ2470mmf4S.data.ts) | 85.7% | 85.7% | 12/14 | 12/14 | 2 | abbe: 2 |
+| 92 | [NIKON NIKKOR Z 50mm f/1.8 S](../../src/lens-data/nikon/NikonNikkorZ50f18S.data.ts) | 85.7% | 85.7% | 12/12 | 12/12 | 2 | constant: 2 |
+| 93 | [LAOWA 24mm f/14 2× Macro Probe](../../src/lens-data/laowa/Laowa24mmf14Probe.data.ts) | 85.2% | 85.2% | 23/27 | 23/27 | 4 | abbe: 4 |
 |  | **80-84.9% coverage** |  |  |  |  |  |  |
-| 92 | [NIKON AF-P DX NIKKOR 18-55mm f/3.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1855mmf3556G.data.ts) | 84.6% | 84.6% | 11/13 | 11/13 | 2 | abbe: 2 |
-| 93 | [SIGMA 35mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma35mmf14DGHSMA.data.ts) | 84.6% | 84.6% | 11/13 | 11/13 | 2 | abbe: 2 |
-| 94 | [Nikon AF Nikkor 28mm f/2.8D](../../src/lens-data/nikon/NikonAFNikkor28mmf28D.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 95 | [NIKON REFLEX-NIKKOR 500mm f/8 (New)](../../src/lens-data/nikon/NikonReflexNikkor500mmf8New.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 96 | [OLYMPUS F.ZUIKO AUTO-T 200mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoT200mmf5.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 97 | [PENTAX 110 24mm f/2.8](../../src/lens-data/pentax/Pentax11024mmf28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 98 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR III)](../../src/lens-data/ricoh/RicohGR328f28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
-| 99 | [NIKON NIKKOR Z 24-70mm f/2.8 S](../../src/lens-data/nikon/NikonZ2470f28.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
-| 100 | [NIKON NIKKOR Z 35mm f/1.2 S](../../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
-| 101 | [LEICA SUMMILUX 28mm f/1.7 ASPH. (Leica Q, Q2, Q3)](../../src/lens-data/leica/Leica28mmf17.data.ts) | 81.8% | 81.8% | 9/11 | 9/11 | 2 | abbe: 2 |
-| 102 | [NIKON AF-S NIKKOR 20mm f/1.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS20mmf18G.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 103 | [Nikon AI Zoom-Nikkor 35–105mm f/3.5–4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35105mmf3545.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 104 | [NIKON NIKKOR Z 24-120mm f/4 S](../../src/lens-data/nikon/NikonNikkorZ24120mmf4S.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 105 | [PENTAX DA* 16-50mm f/2.8 ED AL[IF] SDM](../../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
-| 106 | [CANON SERENAR 100mm f/3.5 I](../../src/lens-data/canon/CanonSerenar100mmf35.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
-| 107 | [NIKON 35mm f/2.8 (Nikon L35AF)](../../src/lens-data/nikon/NikonL35AF35mmf28.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
-| 108 | [FUJIFILM FUJINON 35mm f/4 (Fujifilm GFX100RF)](../../src/lens-data/fujifilm/FujifilmGFX100RF35mmf4.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 109 | [FUJIFILM FUJINON XF 23mm f/2 R WR](../../src/lens-data/fujifilm/FujifilmXF23mmf2RWR.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 110 | [LEICA ELMARIT-TL 18mm f/2.8 ASPH.](../../src/lens-data/leica/LeicaElmaritTL18mmf28.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 111 | [OLYMPUS OM J. ZUIKO AUTO-W 24mm f/2](../../src/lens-data/olympus/OlympusZuiko24mmf2J.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 112 | [OLYMPUS OM ZUIKO 16mm f/3.5 Fisheye](../../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 113 | [VOIGTLÄNDER ULTRON Vintage Line 28mm f/2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
-| 114 | [NIKON AF-S NIKKOR 14-24mm f/2.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.ts) | 80.0% | 80.0% | 12/15 | 12/15 | 3 | abbe: 3 |
-| 115 | [MINOLTA AF 28-75mm f/2.8 (D)](../../src/lens-data/minolta/MinoltaAF2875mmf28D.data.ts) | 80.0% | 80.0% | 16/20 | 16/20 | 4 | abbe: 4 |
+| 94 | [NIKON AF-P DX NIKKOR 18-55mm f/3.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1855mmf3556G.data.ts) | 84.6% | 84.6% | 11/13 | 11/13 | 2 | abbe: 2 |
+| 95 | [SIGMA 35mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma35mmf14DGHSMA.data.ts) | 84.6% | 84.6% | 11/13 | 11/13 | 2 | abbe: 2 |
+| 96 | [Nikon AF Nikkor 28mm f/2.8D](../../src/lens-data/nikon/NikonAFNikkor28mmf28D.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 97 | [NIKON REFLEX-NIKKOR 500mm f/8 (New)](../../src/lens-data/nikon/NikonReflexNikkor500mmf8New.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 98 | [OLYMPUS F.ZUIKO AUTO-T 200mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoT200mmf5.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 99 | [PENTAX 110 24mm f/2.8](../../src/lens-data/pentax/Pentax11024mmf28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 100 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR III)](../../src/lens-data/ricoh/RicohGR328f28.data.ts) | 83.3% | 83.3% | 5/6 | 5/6 | 1 | abbe: 1 |
+| 101 | [NIKON NIKKOR Z 24-70mm f/2.8 S](../../src/lens-data/nikon/NikonZ2470f28.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
+| 102 | [NIKON NIKKOR Z 35mm f/1.2 S](../../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) | 82.4% | 82.4% | 14/17 | 14/17 | 3 | abbe: 3 |
+| 103 | [LEICA SUMMILUX 28mm f/1.7 ASPH. (Leica Q, Q2, Q3)](../../src/lens-data/leica/Leica28mmf17.data.ts) | 81.8% | 81.8% | 9/11 | 9/11 | 2 | abbe: 2 |
+| 104 | [NIKON AF-S NIKKOR 20mm f/1.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS20mmf18G.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 105 | [Nikon AI Zoom-Nikkor 35–105mm f/3.5–4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35105mmf3545.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 106 | [NIKON NIKKOR Z 24-120mm f/4 S](../../src/lens-data/nikon/NikonNikkorZ24120mmf4S.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 107 | [PENTAX DA* 16-50mm f/2.8 ED AL[IF] SDM](../../src/lens-data/pentax/PentaxDA1650mmf28.data.ts) | 81.3% | 81.3% | 13/16 | 13/16 | 3 | abbe: 3 |
+| 108 | [CANON SERENAR 100mm f/3.5 I](../../src/lens-data/canon/CanonSerenar100mmf35.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
+| 109 | [NIKON 35mm f/2.8 (Nikon L35AF)](../../src/lens-data/nikon/NikonL35AF35mmf28.data.ts) | 80.0% | 80.0% | 4/5 | 4/5 | 1 | abbe: 1 |
+| 110 | [FUJIFILM FUJINON 35mm f/4 (Fujifilm GFX100RF)](../../src/lens-data/fujifilm/FujifilmGFX100RF35mmf4.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 111 | [FUJIFILM FUJINON XF 23mm f/2 R WR](../../src/lens-data/fujifilm/FujifilmXF23mmf2RWR.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 112 | [LEICA ELMARIT-TL 18mm f/2.8 ASPH.](../../src/lens-data/leica/LeicaElmaritTL18mmf28.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 113 | [OLYMPUS OM J. ZUIKO AUTO-W 24mm f/2](../../src/lens-data/olympus/OlympusZuiko24mmf2J.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 114 | [OLYMPUS OM ZUIKO 16mm f/3.5 Fisheye](../../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 115 | [VOIGTLÄNDER ULTRON Vintage Line 28mm f/2 Aspherical](../../src/lens-data/voigtlander/VoigtlanderUltron28f2.data.ts) | 80.0% | 80.0% | 8/10 | 8/10 | 2 | abbe: 2 |
+| 116 | [NIKON AF-S NIKKOR 14-24mm f/2.8 G ED](../../src/lens-data/nikon/NikonNikkorAFS1424mmf28.data.ts) | 80.0% | 80.0% | 12/15 | 12/15 | 3 | abbe: 3 |
+| 117 | [MINOLTA AF 28-75mm f/2.8 (D)](../../src/lens-data/minolta/MinoltaAF2875mmf28D.data.ts) | 80.0% | 80.0% | 16/20 | 16/20 | 4 | abbe: 4 |
 |  | **75-79.9% coverage** |  |  |  |  |  |  |
-| 116 | [NIKON AF-S NIKKOR 24mm f/1.4 G ED](../../src/lens-data/nikon/NikonNikkorAFS24mmf14G.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
-| 117 | [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
-| 118 | [SIGMA 85mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma85mmf14Art.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
-| 119 | [CARL ZEISS DISTAGON T* 35mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf14.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 120 | [HASSELBLAD HC 150mm f/3.2](../../src/lens-data/hasselblad/HasselbladHC150mmf32.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 121 | [NIKON NIKKOR-N AUTO 28mm f/2](../../src/lens-data/nikon/NikonNikkorN28mmf2.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 122 | [PENTAX FA 31mm f/1.8 AL Limited](../../src/lens-data/pentax/PentaxFA31mmf18ALLtd.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 123 | [SONY E 30mm f/3.5 Macro](../../src/lens-data/sony/SonySEL30mmf35.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
-| 124 | [SIGMA 50mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma50mmf14DGHSMA.data.ts) | 76.9% | 76.9% | 10/13 | 10/13 | 3 | abbe: 3 |
-| 125 | [NIKON NIKKOR Z 100-400mm f/4.5-5.6 VR S](../../src/lens-data/nikon/NikonNikkorZ100400f4556.data.ts) | 76.9% | 76.9% | 20/26 | 20/26 | 6 | abbe: 6 |
-| 126 | [CANON RF 24-50mm f/4.5-6.3 IS STM](../../src/lens-data/canon/CanonRF2450mmf463.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
-| 127 | [OLYMPUS M.ZUIKO DIGITAL 14-42mm f/3.5-5.6 II R](../../src/lens-data/olympus/OlympusMZuiko1442mmf3556II.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
-| 128 | [SIGMA 45mm f/2.8 DG DN | Contemporary](../../src/lens-data/sigma/Sigma45mmf28DGDN.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
-| 129 | [NIKON FISHEYE-NIKKOR 6mm f/2.8](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
-| 130 | [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
-| 131 | [LAOWA 12mm f/2.8 Zero-D](../../src/lens-data/laowa/Laowa12mmf28ZeroD.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
-| 132 | [Nikon AI Zoom-Nikkor 50-135mm f/3.5S](../../src/lens-data/nikon/NikonAIZoomNikko50135mmf35S.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 118 | [NIKON AF-S NIKKOR 24mm f/1.4 G ED](../../src/lens-data/nikon/NikonNikkorAFS24mmf14G.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
+| 119 | [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
+| 120 | [SIGMA 85mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma85mmf14Art.data.ts) | 78.6% | 78.6% | 11/14 | 11/14 | 3 | abbe: 3 |
+| 121 | [CARL ZEISS DISTAGON T* 35mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf14.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 122 | [HASSELBLAD HC 150mm f/3.2](../../src/lens-data/hasselblad/HasselbladHC150mmf32.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 123 | [NIKON NIKKOR-N AUTO 28mm f/2](../../src/lens-data/nikon/NikonNikkorN28mmf2.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 124 | [PENTAX FA 31mm f/1.8 AL Limited](../../src/lens-data/pentax/PentaxFA31mmf18ALLtd.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 125 | [SONY E 30mm f/3.5 Macro](../../src/lens-data/sony/SonySEL30mmf35.data.ts) | 77.8% | 77.8% | 7/9 | 7/9 | 2 | abbe: 2 |
+| 126 | [SIGMA 50mm f/1.4 DG HSM | Art](../../src/lens-data/sigma/Sigma50mmf14DGHSMA.data.ts) | 76.9% | 76.9% | 10/13 | 10/13 | 3 | abbe: 3 |
+| 127 | [NIKON NIKKOR Z 100-400mm f/4.5-5.6 VR S](../../src/lens-data/nikon/NikonNikkorZ100400f4556.data.ts) | 76.9% | 76.9% | 20/26 | 20/26 | 6 | abbe: 6 |
+| 128 | [CANON RF 24-50mm f/4.5-6.3 IS STM](../../src/lens-data/canon/CanonRF2450mmf463.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
+| 129 | [OLYMPUS M.ZUIKO DIGITAL 14-42mm f/3.5-5.6 II R](../../src/lens-data/olympus/OlympusMZuiko1442mmf3556II.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
+| 130 | [SIGMA 45mm f/2.8 DG DN | Contemporary](../../src/lens-data/sigma/Sigma45mmf28DGDN.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
+| 131 | [NIKON FISHEYE-NIKKOR 6mm f/2.8](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
+| 132 | [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 133 | [LAOWA 12mm f/2.8 Zero-D](../../src/lens-data/laowa/Laowa12mmf28ZeroD.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 134 | [Nikon AI Zoom-Nikkor 50-135mm f/3.5S](../../src/lens-data/nikon/NikonAIZoomNikko50135mmf35S.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
 |  | **70-74.9% coverage** |  |  |  |  |  |  |
-| 133 | [CANON RF 50mm f/1.2 L USM](../../src/lens-data/canon/CanonRF50mmf12L.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
-| 134 | [SIGMA 35mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
-| 135 | [PANASONIC LUMIX S 20-60mm f/3.5-5.6](../../src/lens-data/panasonic/PanasonicLumixS2060mmf3556.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
-| 136 | [PANASONIC LUMIX S 35mm f/1.8](../../src/lens-data/panasonic/PanasonicS35mmf18.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
-| 137 | [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) | 72.2% | 72.2% | 13/18 | 13/18 | 5 | abbe: 5 |
-| 138 | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 139 | [CANON New FD 50mm f/1.2](../../src/lens-data/canon/CanonFDn50f12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 140 | [CANON SERENAR 85mm f/1.5](../../src/lens-data/canon/CanonSerenar85mmf15.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 141 | [FUJIFILM FUJINON 18.5mm f/2.8 (Fujifilm X70)](../../src/lens-data/fujifilm/FujifilmX7018mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 142 | [NIKON AI-S NIKKOR 50mm f/1.2](../../src/lens-data/nikon/NikonAISNikkor50mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 143 | [OLYMPUS G.ZUIKO AUTO-S 55mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS55mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 144 | [PANASONIC LUMIX G 14mm f/2.5 II ASPH](../../src/lens-data/panasonic/PanasonicG14mmf25II.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 145 | [SIGMA 24mm f/2.8 (Sigma DP2x)](../../src/lens-data/sigma/SigmaDP2X24mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 146 | [LAOWA 65mm f/2.8 2× Ultra Macro APO](../../src/lens-data/laowa/Laowa65mmf28MacroAPO.data.ts) | 71.4% | 71.4% | 10/14 | 10/14 | 4 | abbe: 4 |
-| 147 | [FUJIFILM FUJINON XF 60mm f/2.4 R Macro](../../src/lens-data/fujifilm/FujifilmXF60mmf24R.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 148 | [Nikon AI Micro-Nikkor 105mm f/2.8S](../../src/lens-data/nikon/NikonAIMicroNikkor105mmf28S.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 149 | [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 150 | [SIGMA 50mm f/2.8 (Sigma DP3 Merrill)](../../src/lens-data/sigma/SigmaDP3M50mmf28.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 151 | [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) | 70.0% | 70.0% | 14/20 | 14/20 | 6 | abbe: 6 |
+| 135 | [CANON RF 50mm f/1.2 L USM](../../src/lens-data/canon/CanonRF50mmf12L.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
+| 136 | [SIGMA 35mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
+| 137 | [PANASONIC LUMIX S 20-60mm f/3.5-5.6](../../src/lens-data/panasonic/PanasonicLumixS2060mmf3556.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
+| 138 | [PANASONIC LUMIX S 35mm f/1.8](../../src/lens-data/panasonic/PanasonicS35mmf18.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
+| 139 | [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) | 72.2% | 72.2% | 13/18 | 13/18 | 5 | abbe: 5 |
+| 140 | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 141 | [CANON New FD 50mm f/1.2](../../src/lens-data/canon/CanonFDn50f12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 142 | [CANON SERENAR 85mm f/1.5](../../src/lens-data/canon/CanonSerenar85mmf15.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 143 | [FUJIFILM FUJINON 18.5mm f/2.8 (Fujifilm X70)](../../src/lens-data/fujifilm/FujifilmX7018mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 144 | [NIKON AI-S NIKKOR 50mm f/1.2](../../src/lens-data/nikon/NikonAISNikkor50mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 145 | [OLYMPUS G.ZUIKO AUTO-S 55mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS55mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 146 | [PANASONIC LUMIX G 14mm f/2.5 II ASPH](../../src/lens-data/panasonic/PanasonicG14mmf25II.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 147 | [SIGMA 24mm f/2.8 (Sigma DP2x)](../../src/lens-data/sigma/SigmaDP2X24mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 148 | [LAOWA 65mm f/2.8 2× Ultra Macro APO](../../src/lens-data/laowa/Laowa65mmf28MacroAPO.data.ts) | 71.4% | 71.4% | 10/14 | 10/14 | 4 | abbe: 4 |
+| 149 | [FUJIFILM FUJINON XF 60mm f/2.4 R Macro](../../src/lens-data/fujifilm/FujifilmXF60mmf24R.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 150 | [Nikon AI Micro-Nikkor 105mm f/2.8S](../../src/lens-data/nikon/NikonAIMicroNikkor105mmf28S.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 151 | [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 152 | [SIGMA 50mm f/2.8 (Sigma DP3 Merrill)](../../src/lens-data/sigma/SigmaDP3M50mmf28.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 153 | [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) | 70.0% | 70.0% | 14/20 | 14/20 | 6 | abbe: 6 |
 |  | **65-69.9% coverage** |  |  |  |  |  |  |
-| 152 | [SIGMA 10-18mm f/2.8 DC DN | Contemporary](../../src/lens-data/sigma/Sigma1018mmf28DCDN.data.ts) | 69.2% | 69.2% | 9/13 | 9/13 | 4 | abbe: 4 |
-| 153 | [NIKON Gyogyotto 20mm f/8](../../src/lens-data/nikon/NikonGyogyotto20mmf8.data.ts) | 66.7% | 66.7% | 2/3 | 2/3 | 1 | abbe: 1 |
-| 154 | [CANON SERENAR 28mm f/3.5](../../src/lens-data/canon/CanonSerenar28mmf35.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 155 | [LEICA MACRO-ELMARIT-R 60mm f/2.8](../../src/lens-data/leica/LeicaMacroElmaritR60mmf28.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 156 | [NIKON AI NIKKOR 135mm f/2](../../src/lens-data/nikon/NikonAI135mmf2.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 157 | [NIKON REFLEX-NIKKOR·C 500mm f/8](../../src/lens-data/nikon/NikonReflexNikkorC500mmf8.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 158 | [SCHNEIDER-KREUZNACH APO-SYMMAR 100mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 159 | [SCHNEIDER-KREUZNACH SUPER-SYMMAR XL 110mm f/5.6 ASPHERIC](../../src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 160 | [CANON FD 35mm f/2 S.S.C. (I)](../../src/lens-data/canon/CanonFD35mmf2.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 161 | [HASSELBLAD HC Macro 120mm f/4](../../src/lens-data/hasselblad/HasselbladHC120mmf4Macro.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 162 | [NIKON AF-S NIKKOR 58mm f/1.4 G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 163 | [HASSELBLAD XCD 90mm f/2.5 V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 66.7% | 66.7% | 8/9 | 8/9 | 4 | constant: 3, abbe: 1 |
-| 164 | [VIVITAR SERIES 1 35-85mm f/2.8 VMC](../../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) | 66.7% | 66.7% | 8/12 | 8/12 | 4 | abbe: 4 |
+| 154 | [SIGMA 10-18mm f/2.8 DC DN | Contemporary](../../src/lens-data/sigma/Sigma1018mmf28DCDN.data.ts) | 69.2% | 69.2% | 9/13 | 9/13 | 4 | abbe: 4 |
+| 155 | [NIKON Gyogyotto 20mm f/8](../../src/lens-data/nikon/NikonGyogyotto20mmf8.data.ts) | 66.7% | 66.7% | 2/3 | 2/3 | 1 | abbe: 1 |
+| 156 | [CANON SERENAR 28mm f/3.5](../../src/lens-data/canon/CanonSerenar28mmf35.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 157 | [LEICA MACRO-ELMARIT-R 60mm f/2.8](../../src/lens-data/leica/LeicaMacroElmaritR60mmf28.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 158 | [NIKON AI NIKKOR 135mm f/2](../../src/lens-data/nikon/NikonAI135mmf2.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 159 | [NIKON REFLEX-NIKKOR·C 500mm f/8](../../src/lens-data/nikon/NikonReflexNikkorC500mmf8.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 160 | [SCHNEIDER-KREUZNACH APO-SYMMAR 100mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 161 | [SCHNEIDER-KREUZNACH SUPER-SYMMAR XL 110mm f/5.6 ASPHERIC](../../src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 162 | [CANON FD 35mm f/2 S.S.C. (I)](../../src/lens-data/canon/CanonFD35mmf2.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 163 | [HASSELBLAD HC Macro 120mm f/4](../../src/lens-data/hasselblad/HasselbladHC120mmf4Macro.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 164 | [NIKON AF-S NIKKOR 58mm f/1.4 G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 165 | [HASSELBLAD XCD 90mm f/2.5 V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 66.7% | 66.7% | 8/9 | 8/9 | 4 | constant: 3, abbe: 1 |
+| 166 | [VIVITAR SERIES 1 35-85mm f/2.8 VMC](../../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) | 66.7% | 66.7% | 8/12 | 8/12 | 4 | abbe: 4 |
 |  | **60-64.9% coverage** |  |  |  |  |  |  |
-| 165 | [NIKON AF NIKKOR 28mm f/1.4 D](../../src/lens-data/nikon/NikonAF28f14D.data.ts) | 63.6% | 63.6% | 7/11 | 7/11 | 4 | abbe: 4 |
-| 166 | [FUJIFILM FUJINON 23mm f/2 (Fujifilm X100V)](../../src/lens-data/fujifilm/FujifilmX100V23mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 167 | [LEICA ELMARIT-R 28mm f/2.8](../../src/lens-data/leica/LeicaElmarit28mmf28.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 168 | [NIKON AI NIKKOR 35mm f/2](../../src/lens-data/nikon/NikonAINikkor35mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 169 | [NIKON NIKKOR Z 40mm f/2](../../src/lens-data/nikon/NikonNikkorZ40mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 170 | [SONY PLANAR T* 50mm f/1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 171 | [NIKON AF ZOOM-MICRO NIKKOR ED 70-180mm f/4.5-5.6D](../../src/lens-data/nikon/NikonAFZoomMicro70180mmf4556D.data.ts) | 61.1% | 61.1% | 11/18 | 11/18 | 7 | abbe: 7 |
-| 172 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 61.1% | 61.1% | 11/17 | 11/17 | 7 | abbe: 6, constant: 1 |
-| 173 | [OLYMPUS E.ZUIKO AUTO-T 135mm f/3.5](../../src/lens-data/olympus/OlympusZuiko135mmf35.data.ts) | 60.0% | 60.0% | 3/5 | 3/5 | 2 | abbe: 2 |
-| 174 | [MINOLTA AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
-| 175 | [OLYMPUS ZUIKO AUTO-FISHEYE 8mm f/2.8](../../src/lens-data/olympus/OlympusZuikoAutoFisheye8mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
-| 176 | [NIKON AF-S NIKKOR 28-300mm f/3.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS28300mmf3556G.data.ts) | 60.0% | 60.0% | 12/20 | 12/20 | 8 | abbe: 8 |
+| 167 | [NIKON AF NIKKOR 28mm f/1.4 D](../../src/lens-data/nikon/NikonAF28f14D.data.ts) | 63.6% | 63.6% | 7/11 | 7/11 | 4 | abbe: 4 |
+| 168 | [FUJIFILM FUJINON 23mm f/2 (Fujifilm X100V)](../../src/lens-data/fujifilm/FujifilmX100V23mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 169 | [LEICA ELMARIT-R 28mm f/2.8](../../src/lens-data/leica/LeicaElmarit28mmf28.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 170 | [NIKON AI NIKKOR 35mm f/2](../../src/lens-data/nikon/NikonAINikkor35mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 171 | [NIKON NIKKOR Z 40mm f/2](../../src/lens-data/nikon/NikonNikkorZ40mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 172 | [SONY PLANAR T* 50mm f/1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 173 | [NIKON AF ZOOM-MICRO NIKKOR ED 70-180mm f/4.5-5.6D](../../src/lens-data/nikon/NikonAFZoomMicro70180mmf4556D.data.ts) | 61.1% | 61.1% | 11/18 | 11/18 | 7 | abbe: 7 |
+| 174 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 61.1% | 61.1% | 11/17 | 11/17 | 7 | abbe: 6, constant: 1 |
+| 175 | [OLYMPUS E.ZUIKO AUTO-T 135mm f/3.5](../../src/lens-data/olympus/OlympusZuiko135mmf35.data.ts) | 60.0% | 60.0% | 3/5 | 3/5 | 2 | abbe: 2 |
+| 176 | [MINOLTA AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
+| 177 | [OLYMPUS ZUIKO AUTO-FISHEYE 8mm f/2.8](../../src/lens-data/olympus/OlympusZuikoAutoFisheye8mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
+| 178 | [NIKON AF-S NIKKOR 28-300mm f/3.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS28300mmf3556G.data.ts) | 60.0% | 60.0% | 12/20 | 12/20 | 8 | abbe: 8 |
 |  | **55-59.9% coverage** |  |  |  |  |  |  |
-| 177 | [CARL ZEISS B-DISTAGON 35mm f/4 (Contarex)](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf4.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 178 | [CARL ZEISS CONTAREX PLANAR 55mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissContarexPlanar55mmf14.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 179 | [MINOLTA AF Reflex 500mm f/8](../../src/lens-data/minolta/MinoltaAFReflex500mmf8.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 180 | [NIKON NIKKOR 28mm f/2.8 (Nikon 28Ti)](../../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 181 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR / GR II)](../../src/lens-data/ricoh/RicohGR218mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 182 | [SONY FE 14mm f/1.8 GM](../../src/lens-data/sony/SonyFE14mmf18GM.data.ts) | 57.1% | 57.1% | 8/14 | 8/14 | 6 | abbe: 6 |
-| 183 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 56.3% | 56.3% | 9/16 | 9/16 | 7 | abbe: 7 |
-| 184 | [OLYMPUS ZUIKO AUTO-MACRO 50mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro50mmf2.data.ts) | 55.6% | 55.6% | 5/9 | 5/9 | 4 | abbe: 4 |
+| 179 | [CARL ZEISS B-DISTAGON 35mm f/4 (Contarex)](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf4.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 180 | [CARL ZEISS CONTAREX PLANAR 55mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissContarexPlanar55mmf14.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 181 | [MINOLTA AF Reflex 500mm f/8](../../src/lens-data/minolta/MinoltaAFReflex500mmf8.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 182 | [NIKON NIKKOR 28mm f/2.8 (Nikon 28Ti)](../../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 183 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR / GR II)](../../src/lens-data/ricoh/RicohGR218mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 184 | [SONY FE 14mm f/1.8 GM](../../src/lens-data/sony/SonyFE14mmf18GM.data.ts) | 57.1% | 57.1% | 8/14 | 8/14 | 6 | abbe: 6 |
+| 185 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 56.3% | 56.3% | 9/16 | 9/16 | 7 | abbe: 7 |
+| 186 | [OLYMPUS ZUIKO AUTO-MACRO 50mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro50mmf2.data.ts) | 55.6% | 55.6% | 5/9 | 5/9 | 4 | abbe: 4 |
 |  | **50-54.9% coverage** |  |  |  |  |  |  |
-| 185 | [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
-| 186 | [PENTAX HD D FA* 50mm f/1.4 SDM AW](../../src/lens-data/pentax/PentaxDFA50mmf14SDM.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
-| 187 | [Nikon AI Zoom-Nikkor 35-200mm f/3.5-4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35200mmf3545S.data.ts) | 52.9% | 52.9% | 9/17 | 9/17 | 8 | abbe: 8 |
-| 188 | [MINOLTA AF 70-200mm f/2.8 APO G (D) SSM](../../src/lens-data/minolta/MinoltaAF70200mmf28APO.data.ts) | 52.6% | 52.6% | 10/19 | 10/19 | 9 | abbe: 9 |
-| 189 | [CARL ZEISS HOLOGON 15mm f/8 (Contarex Hologon / Leica M)](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) | 50.0% | 50.0% | 2/3 | 2/3 | 2 | abbe: 2 |
-| 190 | [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 191 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 192 | [NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 193 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
-| 194 | [VIVITAR SERIES 1 200mm f/3.0 VMC](../../src/lens-data/vivitar/VivitarSeries1200mmf3.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
-| 195 | [MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
-| 196 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 50.0% | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
-| 197 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 198 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 199 | [NIKON AF-P DX NIKKOR 10-20mm f/4.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
+| 187 | [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
+| 188 | [PENTAX HD D FA* 50mm f/1.4 SDM AW](../../src/lens-data/pentax/PentaxDFA50mmf14SDM.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
+| 189 | [Nikon AI Zoom-Nikkor 35-200mm f/3.5-4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35200mmf3545S.data.ts) | 52.9% | 52.9% | 9/17 | 9/17 | 8 | abbe: 8 |
+| 190 | [MINOLTA AF 70-200mm f/2.8 APO G (D) SSM](../../src/lens-data/minolta/MinoltaAF70200mmf28APO.data.ts) | 52.6% | 52.6% | 10/19 | 10/19 | 9 | abbe: 9 |
+| 191 | [CARL ZEISS HOLOGON 15mm f/8 (Contarex Hologon / Leica M)](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) | 50.0% | 50.0% | 2/3 | 2/3 | 2 | abbe: 2 |
+| 192 | [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 193 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 194 | [NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 195 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
+| 196 | [VIVITAR SERIES 1 200mm f/3.0 VMC](../../src/lens-data/vivitar/VivitarSeries1200mmf3.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
+| 197 | [MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
+| 198 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 50.0% | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
+| 199 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 200 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 201 | [NIKON AF-P DX NIKKOR 10-20mm f/4.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
 |  | **45-49.9% coverage** |  |  |  |  |  |  |
-| 200 | [SIGMA 17-40mm f/1.8 DC | Art](../../src/lens-data/sigma/Sigma1740mmf18DCA.data.ts) | 47.1% | 47.1% | 8/17 | 8/17 | 9 | abbe: 9 |
-| 201 | [Nikon AI Zoom-Nikkor 25-50mm f/4](../../src/lens-data/nikon/NikonAIZoomNikkor2550mmf4.data.ts) | 45.5% | 45.5% | 5/11 | 5/11 | 6 | abbe: 6 |
-| 202 | [Nikon AI Zoom-Nikkor 360-1200mm f/11 ED](../../src/lens-data/nikon/NikonAIZoomNikkor3601200mmf11ED.data.ts) | 45.0% | 45.0% | 9/20 | 9/20 | 11 | abbe: 11 |
+| 202 | [SIGMA 17-40mm f/1.8 DC | Art](../../src/lens-data/sigma/Sigma1740mmf18DCA.data.ts) | 47.1% | 47.1% | 8/17 | 8/17 | 9 | abbe: 9 |
+| 203 | [Nikon AI Zoom-Nikkor 25-50mm f/4](../../src/lens-data/nikon/NikonAIZoomNikkor2550mmf4.data.ts) | 45.5% | 45.5% | 5/11 | 5/11 | 6 | abbe: 6 |
+| 204 | [Nikon AI Zoom-Nikkor 360-1200mm f/11 ED](../../src/lens-data/nikon/NikonAIZoomNikkor3601200mmf11ED.data.ts) | 45.0% | 45.0% | 9/20 | 9/20 | 11 | abbe: 11 |
 |  | **40-44.9% coverage** |  |  |  |  |  |  |
-| 203 | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 204 | [MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 205 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 206 | [CARL ZEISS JENA BIOGON 35mm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 207 | [MINOLTA AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 208 | [SONY SONNAR T* FE 35mm f/2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 209 | [LAOWA 58mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
-| 210 | [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 211 | [NIKON AI NIKKOR 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 212 | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 213 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 205 | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 206 | [MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 207 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 208 | [CARL ZEISS JENA BIOGON 35mm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 209 | [MINOLTA AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 210 | [SONY SONNAR T* FE 35mm f/2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 211 | [LAOWA 58mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
+| 212 | [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 213 | [NIKON AI NIKKOR 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 214 | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 215 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
 |  | **35-39.9% coverage** |  |  |  |  |  |  |
-| 214 | [NIKON AF-P NIKKOR 70-300mm f/4.5-5.6 E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
-| 215 | [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
-| 216 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
-| 217 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
-| 218 | [NIKON NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
-| 219 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
-| 220 | [SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
+| 216 | [NIKON AF-P NIKKOR 70-300mm f/4.5-5.6 E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
+| 217 | [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
+| 218 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
+| 219 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
+| 220 | [NIKON NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
+| 221 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
+| 222 | [SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
 |  | **30-34.9% coverage** |  |  |  |  |  |  |
-| 221 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 222 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 223 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 224 | [NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 225 | [PENTAX DA 70mm f/2.4 Limited](../../src/lens-data/pentax/PentaxDA70mmf24Limited.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 226 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 227 | [SIGMA 85mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
-| 228 | [NIKON AF-S DX NIKKOR 55-200mm f/4-5.6 G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
-| 229 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
+| 223 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 224 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 225 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 226 | [NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 227 | [PENTAX DA 70mm f/2.4 Limited](../../src/lens-data/pentax/PentaxDA70mmf24Limited.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 228 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 229 | [SIGMA 85mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
+| 230 | [NIKON AF-S DX NIKKOR 55-200mm f/4-5.6 G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
+| 231 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
 |  | **25-29.9% coverage** |  |  |  |  |  |  |
-| 230 | [LEICA ELMARIT-R 35mm f/2.8](../../src/lens-data/leica/LeicaElmaritR35mmf28.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
-| 231 | [NIKON W-NIKKOR 35mm f/1.8](../../src/lens-data/nikon/NikonWNikkor35mmf18.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
+| 232 | [LEICA ELMARIT-R 35mm f/2.8](../../src/lens-data/leica/LeicaElmaritR35mmf28.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
+| 233 | [NIKON W-NIKKOR 35mm f/1.8](../../src/lens-data/nikon/NikonWNikkor35mmf18.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
 |  | **20-24.9% coverage** |  |  |  |  |  |  |
-| 232 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
+| 234 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
 |  | **15-19.9% coverage** |  |  |  |  |  |  |
-| 233 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
-| 234 | [SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
+| 235 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
+| 236 | [SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
 |  | **10-14.9% coverage** |  |  |  |  |  |  |
-| 235 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
-| 236 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 237 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 238 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
 |  | **0-4.9% coverage** |  |  |  |  |  |  |
-| 237 | [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) *(hidden)* | 0.0% | 0.0% | 0/3 | 0/3 | 1 | abbe: 1 |
-| 238 | [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) *(hidden)* | 0.0% | 0.0% | 0/1 | 0/1 | 1 | abbe: 1 |
-| 239 | [CARL ZEISS JENA TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 240 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 241 | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) | 0.0% | 0.0% | 0/5 | 0/5 | 5 | abbe: 5 |
-| 242 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 243 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 244 | [LEICA SUMMICRON-R 50mm f/2](../../src/lens-data/leica/LeicaSummicronR50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 245 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 246 | [NIKON AI NIKKOR 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 247 | [CARL ZEISS JENA SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 248 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 249 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
+| 239 | [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) *(hidden)* | 0.0% | 0.0% | 0/3 | 0/3 | 1 | abbe: 1 |
+| 240 | [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) *(hidden)* | 0.0% | 0.0% | 0/1 | 0/1 | 1 | abbe: 1 |
+| 241 | [CARL ZEISS JENA TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 242 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 243 | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) | 0.0% | 0.0% | 0/5 | 0/5 | 5 | abbe: 5 |
+| 244 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 245 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 246 | [LEICA SUMMICRON-R 50mm f/2](../../src/lens-data/leica/LeicaSummicronR50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 247 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 248 | [NIKON AI NIKKOR 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 249 | [CARL ZEISS JENA SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 250 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 251 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
 
 ## Missing Surface Details
 
@@ -704,6 +707,12 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 |---|---|---|---|---|
 | 2 | Element 1r (resin layer) | abbe | `UV-curable optical resin` | No catalog match |
 
+### [PENTAX SMC PENTAX-A★ 200mm f/4 MACRO ED](../../src/lens-data/pentax/PentaxA200mmf4MacroED.data.ts) - 90.0% trusted (9/10); 90.0% Sellmeier (9/10) - US 4,666,260
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 7 | Element 4 | abbe | `BPM4 (OHARA legacy, 613/438 short flint)` | No catalog match |
+
 ### [VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) - 90.0% trusted (9/10); 90.0% Sellmeier (9/10) - JP 2002-090622 A
 
 | Surface | Element | Runtime quality | Glass annotation | Reason |
@@ -900,6 +909,12 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 | Surface | Element | Runtime quality | Glass annotation | Reason |
 |---|---|---|---|---|
 | 5 | Element 3 | abbe | `S-TIF8 (OHARA) / TIF6 (HOYA)` | No catalog match |
+
+### [PENTAX SMC PENTAX-A★ 135mm f/1.8](../../src/lens-data/pentax/PentaxA135mmf18.data.ts) - 85.7% trusted (6/7); 85.7% Sellmeier (6/7) - US4447137
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 10 | Element 6 | abbe | `K-LaFn11 (Sumita) / H-LaF72 class` | No catalog match |
 
 ### [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR IV)](../../src/lens-data/ricoh/RicohGR428f28.data.ts) - 85.7% trusted (6/7); 85.7% Sellmeier (6/7) - JP2025-069516A
 

--- a/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
@@ -9,7 +9,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **360** lenses scanned
+- **363** lenses scanned
 - **306** total code-only elements found
 - **206** elements in this report
 - **83** distinct lens files affected

--- a/agent_docs/generated/six-digit-glass-codes.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes.generated.md
@@ -9,7 +9,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **360** lenses scanned
+- **363** lenses scanned
 - **306** total code-only elements found
 - **306** elements in this report
 - **108** distinct lens files affected

--- a/agent_docs/generated/unresolved-glass.generated.md
+++ b/agent_docs/generated/unresolved-glass.generated.md
@@ -8,11 +8,11 @@ or per-lens patent backfills.
 
 ## Summary
 
-- **360** lenses scanned
-- **4068** non-air surfaces examined
-- **4072** element glass declarations examined
-- **632** non-explicit-unmatched annotations did not resolve
-- **221** distinct unresolved glass-like tokens found
+- **363** lenses scanned
+- **4090** non-air surfaces examined
+- **4094** element glass declarations examined
+- **634** non-explicit-unmatched annotations did not resolve
+- **223** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency
 
@@ -172,6 +172,7 @@ or per-lens patent backfills.
 | H-LAF51 | 1 | 1 | |
 | H-LAF53 | 1 | 1 | |
 | H-LAF6L | 1 | 1 | |
+| H-LAF72 | 1 | 1 | |
 | H-LAK3 | 1 | 1 | |
 | H-LAK53A | 1 | 1 | |
 | H-LAK5A | 1 | 1 | |
@@ -188,6 +189,7 @@ or per-lens patent backfills.
 | H-ZLAF75B | 1 | 1 | |
 | H-ZLAF92 | 1 | 1 | |
 | K-BASF5 | 1 | 1 | |
+| K-LAFN11 | 1 | 1 | |
 | K-PSKN2 | 1 | 1 | |
 | K-SFS5 | 1 | 1 | |
 | K-SSK9 | 1 | 1 | |
@@ -915,6 +917,10 @@ or per-lens patent backfills.
 
 - [FUJIFILM FUJINON GF 20-35mm f/4 R WR](../../src/lens-data/fujifilm/FujifilmGF2035mmf4.data.ts) 14: `H-LaF6L / lanthanum flint class (757/477)`
 
+### H-LAF72 — 1 occurrence
+
+- [PENTAX SMC PENTAX-A★ 135mm f/1.8](../../src/lens-data/pentax/PentaxA135mmf18.data.ts) 10: `K-LaFn11 (Sumita) / H-LaF72 class`
+
 ### H-LAK3 — 1 occurrence
 
 - [NIKON NIKKOR Z 35mm f/1.2 S](../../src/lens-data/nikon/NikonNikkorZ35mmf12S.data.ts) 1: `LaK family (640601, CDGM H-LAK3)`
@@ -978,6 +984,10 @@ or per-lens patent backfills.
 ### K-BASF5 — 1 occurrence
 
 - [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) 1: `603/425 barium flint; Sumita K-BaSF5-equivalent`
+
+### K-LAFN11 — 1 occurrence
+
+- [PENTAX SMC PENTAX-A★ 135mm f/1.8](../../src/lens-data/pentax/PentaxA135mmf18.data.ts) 10: `K-LaFn11 (Sumita) / H-LaF72 class`
 
 ### K-PSKN2 — 1 occurrence
 

--- a/agent_docs/records/ray-ghost-miss-rendering-fix.md
+++ b/agent_docs/records/ray-ghost-miss-rendering-fix.md
@@ -1,0 +1,24 @@
+# Ray Ghost And Miss Rendering Fix
+
+## Summary
+
+- Fixed slow zoom/pan rendering caused by pathological ghost-ray geometry after clips and missed surfaces.
+
+## Changes
+
+- Display ray compilation now draws clipped ghost rays only from the last solid point to the first clipped point.
+- Prepared-state sequential and generalized traces now stop immediately after a missed surface intersection, preserving preceding solved hits and emitting no fallback ghost hit.
+- Removed the unused prepared-state fallback surface-point helper so active trace comments match behavior.
+- Added regression coverage for clipped ghost display bounds and post-hit surface misses.
+- Updated architecture docs, trace-plan notes, changelog, and inline trace comments.
+
+## Verification
+
+- `npm run typecheck` — passed
+- `npm run format:check` — passed
+- `npm run lint` — passed
+- `npm run test` — passed
+
+## Follow-ups
+
+- None known.

--- a/src/components/hooks/raySegmentUtils.ts
+++ b/src/components/hooks/raySegmentUtils.ts
@@ -12,7 +12,7 @@ import type { ChromaticChannel } from "../../types/optics.js";
  * Compile traced ray points into a RaySegment with solid (sp) and ghost (gp) polylines.
  *
  * @param pts           — traced surface intersection points [[z, y], ...]
- * @param ghostPts      — extrapolated points beyond the clipping surface
+ * @param ghostPts      — clipped trace points; display uses only the first clip point
  * @param u             — exit slope of the ray
  * @param clipped       — true if the ray was clipped by the aperture stop
  * @param sx            — z → SVG-x coordinate transform
@@ -39,11 +39,10 @@ export function compileRaySegment(
 
   if (clipped && ghostPts.length > 0) {
     const lastSolid = pts[pts.length - 1];
-    if (lastSolid) gp.push([sx(lastSolid[0]), sy(lastSolid[1])]);
-    gp = gp.concat(ghostPts.map(([z, yy]) => [sx(z), sy(yy)]));
-    const lastGhost = ghostPts[ghostPts.length - 1];
-    if (lastGhost) {
-      gp.push(endOverride ?? clampedRayEnd(lastGhost[0], lastGhost[1], u, IMG_MM));
+    const firstGhost = ghostPts[0];
+    if (lastSolid && firstGhost) {
+      gp.push([sx(lastSolid[0]), sy(lastSolid[1])]);
+      gp.push([sx(firstGhost[0]), sy(firstGhost[1])]);
     }
   }
   if (!clipped && !reachedImagePlane) {

--- a/src/components/hooks/raySegmentUtils.ts
+++ b/src/components/hooks/raySegmentUtils.ts
@@ -41,6 +41,8 @@ export function compileRaySegment(
     const lastSolid = pts[pts.length - 1];
     const firstGhost = ghostPts[0];
     if (lastSolid && firstGhost) {
+      // Later clipped diagnostics can be far outside the viewport; render only
+      // the first clipped span so zoomed SVG bounds stay finite.
       gp.push([sx(lastSolid[0]), sy(lastSolid[1])]);
       gp.push([sx(firstGhost[0]), sy(firstGhost[1])]);
     }

--- a/src/lens-data/pentax/PentaxA135mmf18.analysis.md
+++ b/src/lens-data/pentax/PentaxA135mmf18.analysis.md
@@ -1,0 +1,162 @@
+# smc PENTAX-A★ 135mm F1.8 — Optical Analysis
+
+## Patent Reference and Design Identification
+
+**Patent:** US 4,447,137 — "Large-Aperture Telephoto Lens"  
+**Application Number:** 420,683  
+**Filed:** September 21, 1982  
+**Granted:** May 8, 1984  
+**Priority:** January 23, 1982 (Japan, 57-9214)  
+**Inventor:** Yasunori Arai  
+**Assignee:** Asahi Kogaku Kogyo Kabushiki Kaisha  
+**Embodiment analyzed:** Example 2 — f = 135 mm, FNO 1:1.8, 2ω = 18°
+
+The transcribed prescription is Example 2 of US 4,447,137. The patent describes a large-aperture Ernostar-type telephoto objective with seven elements in six components, a cemented second component, and a fixed sixth component during focusing. Example 2 is the f/1.8 version of the two disclosed examples; Example 1 is the same design family at f/2.0.
+
+The production identification is the smc PENTAX-A★ 135mm F1.8. The match rests on the full convergence of focal length, f-number, format, optical layout, focus scheme, and patent timing. Example 2 gives f = 135 mm, FNO 1:1.8, and 2ω = 18°. The element count is seven elements in six groups/components, with the second component cemented. The patent's focusing claim fixes the sixth component, L7, while the first through fifth components move. The production lens is the corresponding K-mount, 135-format, 7-element/6-group Pentax A★ 135 mm f/1.8 design.
+
+Where a hard product specification is needed, the production specification governs. The patent evaluates aberrations at β = −1/10, with d11 = 20.42 mm for Example 2; that is an internal patent evaluation point, not necessarily the mechanical end of the production focusing helix. The production close-focus distance used in the data file is 1.2 m.
+
+A transcription point is material. The Example 2 patent image reads d4 = 15.0 mm at the cemented L2-L3 interface after r4. Optical verification rejects d4 = 5.0 mm: that reading gives EFL ≈ 154.09 mm and f1,2,3 ≈ 0.505f, inconsistent with the patent's f = 135 mm and f1,2,3 = 0.476f. With d4 = 15.0 mm, the same prescription gives EFL = 134.9875 mm and f1,2,3 = 0.476f.
+
+## Optical Architecture
+
+The design is a large-aperture, long-focus objective in the Ernostar lineage rather than a strict short-track telephoto system. The patent itself frames the problem as an Ernostar-type telephoto lens whose spherical aberration, especially near the g-line, becomes overcorrected when the aperture is opened from the more ordinary f/2.8 region to f/1.8–f/2.0.
+
+The front-to-rear component order is:
+
+1. L1, a positive front collector.
+2. L2-L3, a cemented negative-positive meniscus doublet with a hyperchromatic buried interface at r4.
+3. L4, a strong negative meniscus with its concave side facing the image.
+4. L5, a very weak meniscus with its concave side facing the object.
+5. L6, a positive meniscus whose stronger curvature faces the object.
+6. L7, a weak positive rear element held fixed during focusing.
+
+The optical power distribution is a strong positive front collector/doublet pair, a strong negative L4, a large air space, and a positive rear relay/corrector section. The patent calls the lens telephoto, but the paraxial track is not sub-unity: EFL = 134.99 mm and the first-vertex-to-image distance is 143.46 mm, giving TL/EFL ≈ 1.063. The term is therefore best read in the historical photographic sense of a fast long-focus lens, not as a strict optical telephoto ratio.
+
+The large d7 air interval between L4 and L5 is the architectural hinge. It separates the high-power front objective from the rear correction section and gives L5 room to work as a weak near-concentric higher-order aberration corrector. The patent does not disclose any aspherical surfaces; the design is all-spherical.
+
+The patent does not tabulate the aperture stop as a numbered surface. Requirement (4) says the eighth surface r8 has a large radius of curvature concentric with the aperture, but applying that statement literally to the Example 2 vertex spacings places the r8 center 1.188 mm behind r6, inside L4. That is not a plausible physical iris plane. The data file therefore keeps STO in the d7 air interval, 8.50 mm behind r7, where the f/1.8 stop radius clears the rear-surface sag of L4. The d7 split is 8.50 mm before STO and 25.88 mm after it, preserving the patent total of 34.38 mm. STO semi-diameter is a paraxial f/1.8 entrance-pupil value; other clear apertures remain conservative visualization estimates.
+
+## Element-by-Element Analysis
+
+The focal lengths below are standalone thick-lens-in-air values calculated from the corrected Example 2 prescription. They are useful for element role and sign, but they are not substitutes for the in-situ powers of the assembled system.
+
+### L1 — Positive meniscus front collector
+
+nd = 1.62041, νd = 60.3. Glass: S-BSM16 / N-SK16 / BACD16 class dense barium crown. f ≈ +117.0 mm.
+
+L1 is the principal front collector. Both radii are positive, r1 = 71.398 mm and r2 = 4020.868 mm, so the element is formally a positive meniscus, though the rear surface is nearly flat in comparison with the front. L1 is one of the two positive front-component glasses used in the patent's achromatic and Petzval condition.
+
+### L2-L3 — Cemented doublet, hyperchromatic second component
+
+L2: nd = 1.72342, νd = 37.9. Glass: S-BAH28 / BAFD8 class dense barium flint. f ≈ −119.2 mm.  
+L3: nd = 1.69680, νd = 55.5. Glass: S-LAL14 / LAC14 class lanthanum crown. f ≈ +61.3 mm.
+
+The second component is the defining chromatic element of the design. L2 is a negative meniscus with its concave side facing the image; L3 is a stronger positive meniscus cemented behind it. The pair has a net positive component focal length of approximately +148.3 mm, but the more important function is chromatic. The cemented surface r4 has small monochromatic power because n2 and n3 are close, while the Abbe-number difference is large.
+
+For Example 2, |n2 − n3| = 0.02662 and ν3 − ν2 = 17.6. This satisfies the patent's hyperchromatic-surface requirement and gives the buried interface an independent chromatic correction role. The r4 radius is 31.309 mm, within the required interval 0.2f < r4 < 0.35f.
+
+### L4 — Negative meniscus, third component
+
+nd = 1.67270, νd = 32.1. Glass: S-TIM25 / N-SF5 / E-FD5 class dense flint. f ≈ −48.5 mm.
+
+L4 is the strong negative third component. Its front surface is weak, r6 = 461.054 mm, and its rear surface is steep, r7 = 30.267 mm, giving the element substantial negative power with the concave side facing the image.
+
+The patent's f1,2,3 condition refers to the composite focal length of the first three glass lenses, L1 through L3, not to L4. The corrected L1-L3 composite focal length is 64.206 mm, or 0.476f. L4 follows that front positive section and supplies the major negative power needed to complete the Ernostar-type front objective. If the L1-L3 composite is too short, the patent explains that the third component must carry excessive negative power and higher-order spherical aberration, coma, and distortion become difficult to correct.
+
+### L5 — Weak meniscus, fourth component
+
+nd = 1.70154, νd = 41.2. Glass: S-BAH27 / BAFD7 class dense barium flint. f ≈ +752 mm.
+
+L5 is a weak positive meniscus immediately after the large air gap. Both radii are negative and close in magnitude, r8 = −41.362 mm and r9 = −40.027 mm, so the element presents its concave side to the object and carries very little paraxial power.
+
+The patent assigns L5 to higher-order aberration correction rather than ordinary power distribution. The element satisfies |f5| > 4f, with |f5|/f ≈ 5.57, and its object-side radius satisfies 0.2f < −r8 < 0.4f. In this position, the near-concentric meniscus generates higher-order spherical aberration and coma of the sign needed to cancel residual errors left by the front objective.
+
+### L6 — Positive meniscus, fifth component
+
+nd = 1.72000, νd = 46.0. Glass: K-LaFn11 / H-LaF72 class lanthanum flint. f ≈ +195.7 mm.
+
+L6 is a positive meniscus whose stronger curvature faces the object, as required by the patent. The object-side radius r10 = 71.985 mm lies inside the stated interval 0.35f < r10 < f. The patent identifies this radius condition as the distortion-control condition after spherical aberration and coma have been substantially corrected by the preceding components.
+
+### L7 — Fixed positive rear element, sixth component
+
+nd = 1.70000, νd = 48.1. Glass: J-LAF01 / H-LaF51 class lanthanum flint. f ≈ +424.9 mm.
+
+L7 is the rearmost element and remains fixed relative to the image plane during focusing. Both surfaces have positive radii, r12 = 248.646 mm and r13 = 1506.638 mm, so it is a weak positive meniscus. Its power satisfies the patent's focusing condition, 0.25 < f/f7 < 0.45, with f/f7 ≈ 0.318. The weak positive rear element is not a large focusing group; its function is to stabilize aberration variation while the front five components extend forward.
+
+## Glass Identification and Selection
+
+The patent gives only nd and νd values, not catalog names. The glass labels below are therefore catalog-class identifications, matched against manufacturer-published catalog values where available and expressed conservatively when the exact historical supplier cannot be proved.
+
+| Element | nd | νd | Code | Catalog-class identification | Role |
+|---|---:|---:|---|---|---|
+| L1 | 1.62041 | 60.3 | 620/603 | S-BSM16 / N-SK16 / BACD16 dense barium crown class | Positive front collector |
+| L2 | 1.72342 | 37.9 | 723/379–380 | S-BAH28 / BAFD8 dense barium flint class | Negative doublet member |
+| L3 | 1.69680 | 55.5 | 697/555 | S-LAL14 / LAC14 lanthanum crown class | Positive doublet member |
+| L4 | 1.67270 | 32.1 | 673/321 | S-TIM25 / N-SF5 / E-FD5 dense flint class | Strong negative component |
+| L5 | 1.70154 | 41.2 | 702/412 | S-BAH27 / BAFD7 dense barium flint class | Weak higher-order corrector |
+| L6 | 1.72000 | 46.0 | 720/460 | K-LaFn11 / H-LaF72 lanthanum flint class | Distortion-control positive meniscus |
+| L7 | 1.70000 | 48.1 | 700/481 | J-LAF01 / H-LaF51 lanthanum flint class | Fixed rear positive element |
+
+The chromatic strategy does not depend on ED, fluorite, or aspherical surfaces. It depends instead on the L2-L3 cemented interface: nearly equal refractive indices suppress monochromatic interface power, while the large Abbe-number difference gives the buried surface useful chromatic leverage. This is the mechanism the patent calls a hyperchromatic surface.
+
+The surface-by-surface Petzval sum of the assembled corrected Example 2 prescription is approximately 8.40 × 10−4 mm−1, corresponding to a Petzval radius of about 1.19 m in magnitude. That is a favorable figure for a 135 mm f/1.8 all-spherical design.
+
+## Focus Mechanism
+
+The focus mechanism is fixed-rear-element extension. The sixth component, L7, remains fixed relative to the image plane, while L1 through L6 move forward together. In prescription terms, the only changing separation is d11, the air gap between L6 and L7.
+
+| State | d11 | Moving-group travel | Paraxial result |
+|---|---:|---:|---|
+| Infinity | 4.00 mm | 0.00 mm | EFL = 134.9875 mm, BFD = 40.7543 mm |
+| Patent β = −1/10 evaluation | 20.42 mm | 16.42 mm | object ≈ 1518 mm before first vertex; β ≈ −0.098; subject-to-film ≈ 1.678 m |
+| Production 1.2 m MFD representation in data file | 29.4035 mm | 25.4035 mm | β ≈ −0.152 at 1.2 m subject-to-film |
+
+The patent text and figures use the β = −1/10 state to compare the invention's fixed-rear focusing against a less-corrected alternative at the same magnification. The data file also includes the manufacturer's 1.2 m close-focus specification. That row is not a patent-published prescription row; it is a paraxial extension of the same fixed-L7 focus law so the viewer's close-focus endpoint matches the production lens.
+
+## Conditional Expressions
+
+The patent states six conditions. The corrected Example 2 prescription satisfies all of them.
+
+| # | Condition | Corrected Example 2 value | Status |
+|---|---|---:|---|
+| (1) | 1.60 < (n1+n3)/2; 50 < (ν1+ν3)/2 | 1.6586; 57.9 | satisfied |
+| (2) | \|n2−n3\| < 0.1; ν3−ν2 > 10; 0.2f < r4 < 0.35f | 0.02662; 17.6; r4 = 31.309 mm | satisfied |
+| (3) | 0.35f < f1,2,3 < 0.55f | 64.206 mm = 0.476f | satisfied |
+| (4) | \|f5\| > 4f; 0.2f < −r8 < 0.4f | 752.36 mm = 5.57f; −r8 = 41.362 mm | satisfied |
+| (5) | 0.35f < r10 < f | r10 = 71.985 mm | satisfied |
+| (6) | 0.25 < f/f7 < 0.45 | 0.318 | satisfied |
+
+The printed form of condition (1) is internally inconsistent in the patent: one displayed expression appears to use n2, while the accompanying explanation identifies the positive lenses in the front components, i.e. L1 and L3. The Abbe-number half of the same condition already uses ν1 and ν3. The physically consistent reading is therefore (n1+n3)/2. The literal (n1+n2)/2 reading would also satisfy the lower bound, so the conformance result does not depend on that typesetting ambiguity.
+
+## Design Heritage and Context
+
+The design is a late all-spherical fast telephoto formulation rather than an exotic-glass or aspherical solution. The patent addresses the f/1.8 problem with two structural devices: the hyperchromatic buried surface in the L2-L3 doublet for short-wavelength spherical-aberration control, and the near-concentric weak L5 corrector for higher-order spherical aberration and coma after the front objective.
+
+The fixed-rear-element focus scheme is equally central. Rather than moving the entire lens as a rigid unit, the prescription holds L7 fixed and advances L1 through L6. This keeps the rear weak positive element in a stable relationship with the image plane and reduces aberration variation at short distances.
+
+## Verification Summary
+
+The final prescription was re-run from the patent values with a paraxial y-nu matrix trace, standalone thick-lens calculations, Petzval summation, and finite-conjugate focusing checks.
+
+| Quantity | Patent / source value | Independently verified value |
+|---|---:|---:|
+| Effective focal length | 135 mm | 134.9875 mm |
+| Front-vertex-to-image track | not tabulated | 143.4643 mm |
+| Back focal distance from r13 | not tabulated | 40.7543 mm |
+| TL/EFL | not tabulated | 1.063 |
+| f1,2,3 | 0.476f | 64.206 mm = 0.476f |
+| f5 | 5.57f | 752.36 mm = 5.57f |
+| f/f7 | 0.318 | 0.318 |
+| Patent d11 at β = −1/10 | 20.42 mm | β ≈ −0.098 |
+| Production close focus | 1.2 m | d11 ≈ 29.4035 mm, β ≈ −0.152 |
+| Petzval sum | not tabulated | 8.40 × 10−4 mm−1 |
+
+The corrected d4 = 15.0 mm reading is required for consistency. A 5.0 mm reading returns the wrong focal length and the wrong f1,2,3 ratio, so it is not used. The aperture stop is not patent-published as a numbered surface; the data file places it in the d7 air interval with clearance from L4, and the remaining semi-diameters are conservative visualization estimates rather than claimed prescription data.
+
+## Sources and References
+
+- US Patent 4,447,137, "Large-Aperture Telephoto Lens," Yasunori Arai, Asahi Kogaku Kogyo Kabushiki Kaisha, granted May 8, 1984. Primary source for the optical prescription, conditional expressions, focusing claim, and aberration-comparison figures.
+- Pentax A-series and K-mount lens reference specifications for the smc PENTAX-A★ 135mm F1.8: 7 elements / 6 groups, K mount, 1.2 m minimum focus, 77 mm filter, 9 aperture blades, 865 g, 1984–1989 production range.
+- OHARA, HOYA, Schott, Sumita, CDGM, and Hikari optical-glass catalog data for nd/νd class matching. Catalog names in this analysis are class identifications unless the patent itself supplies the name; US 4,447,137 provides only nd and νd.

--- a/src/lens-data/pentax/PentaxA135mmf18.data.ts
+++ b/src/lens-data/pentax/PentaxA135mmf18.data.ts
@@ -1,0 +1,172 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — smc PENTAX-A★ 135mm F1.8                    ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,447,137, Example 2 (Asahi / Yasunori Arai).    ║
+ * ║  Large-aperture Ernostar-lineage long-focus lens for 135 format.  ║
+ * ║  7 elements / 6 groups, all spherical.                            ║
+ * ║  Focus: fixed rear element extension; L1-L6 move, L7 remains fixed.║
+ * ║                                                                    ║
+ * ║  NOTE ON TRANSCRIPTION:                                            ║
+ * ║    Example 2 surface r4 uses d4 = 15.0 mm. The patent OCR can read ║
+ * ║    this as 5.0 mm, but the patent image, the stated EFL, and       ║
+ * ║    f1,2,3 = 0.476 f require 15.0 mm.                              ║
+ * ║                                                                    ║
+ * ║  NOTE ON FOCUS:                                                    ║
+ * ║    The patent lists d11 = 20.42 mm at beta = -1/10. The production ║
+ * ║    lens is specified at 1.2 m minimum focus, so the close-focus    ║
+ * ║    slider extends d11 paraxially to 29.40349 mm to represent that  ║
+ * ║    manufacturer close-focus distance while preserving fixed L7.    ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP AND SEMI-DIAMETERS:                                  ║
+ * ║    The patent does not tabulate the aperture stop as a numbered      ║
+ * ║    surface. Its r8/aperture concentricity condition points inside    ║
+ * ║    L4, so it is not used as a literal iris plane. STO is placed in   ║
+ * ║    the d7 air interval, 8.50 mm behind r7, clearing the rear-surface ║
+ * ║    sag at the f/1.8 stop radius. Other semi-diameters are            ║
+ * ║    conservative visualization estimates, not patent values.         ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "pentax-a-star-135mm-f18",
+  maker: "Pentax",
+  name: "PENTAX SMC PENTAX-A★ 135mm f/1.8",
+  subtitle: "US4447137 Example 2 — Asahi / Yasunori Arai",
+  specs: ["7 elements / 6 groups", "f = 134.99 mm", "F/1.8", "2ω = 18°", "all-spherical", "fixed rear element focus"],
+
+  focalLengthMarketing: 135,
+  focalLengthDesign: 134.9875,
+  apertureMarketing: 1.8,
+  apertureDesign: 1.8,
+  lensMounts: ["pentax-k"],
+  imageFormat: "135-full-frame",
+  patentYear: 1984,
+  elementCount: 7,
+  groupCount: 6,
+  focusDescription: "Fixed rear element extension: L1-L6 move together while L7 remains fixed at the rear.",
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.62041,
+      vd: 60.3,
+      fl: 117.016,
+      glass: "S-BSM16 (OHARA) / N-SK16 / BACD16 class",
+      role: "Front positive collector; high-Abbe crown member of the front achromatic/Petzval pair.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.72342,
+      vd: 37.9,
+      fl: -119.214,
+      glass: "S-BAH28 (OHARA) / BAFD8 class",
+      role: "Negative flint member of the cemented second component; paired with L3 across the hyperchromatic r4 interface.",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.6968,
+      vd: 55.5,
+      fl: 61.307,
+      glass: "S-LAL14 (OHARA) / LAC14 class",
+      role: "Positive lanthanum-crown member of the cemented second component; forms the patent's front positive material pair with L1.",
+      cemented: "D1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.6727,
+      vd: 32.1,
+      fl: -48.525,
+      glass: "S-TIM25 (OHARA) / N-SF5 / E-FD5 class",
+      role: "Strong negative third component; balances the front positive components and controls higher-order aberrations with the following corrector.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Weak Positive Meniscus",
+      nd: 1.70154,
+      vd: 41.2,
+      fl: 752.357,
+      glass: "S-BAH27 (OHARA) / BAFD7 class",
+      role: "Very weak near-concentric fourth component; patent-defined higher-order spherical aberration and coma corrector.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Positive Meniscus",
+      nd: 1.72,
+      vd: 46.0,
+      fl: 195.68,
+      glass: "K-LaFn11 (Sumita) / H-LaF72 class",
+      role: "Positive fifth component with the larger curvature toward the object; patent-defined distortion-control element.",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Positive Meniscus",
+      nd: 1.7,
+      vd: 48.1,
+      fl: 424.86,
+      glass: "J-LAF01 (Hikari) / H-LaF51 class",
+      role: "Fixed weak positive rear element; governs aberration stability during front-group extension focusing.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 71.398, d: 12.9, nd: 1.62041, elemId: 1, sd: 38.0 },
+    { label: "2", R: 4020.868, d: 0.1, nd: 1.0, elemId: 0, sd: 35.5 },
+    { label: "3", R: 52.33, d: 4.82, nd: 1.72342, elemId: 2, sd: 30.5 },
+    { label: "4", R: 31.309, d: 15.0, nd: 1.6968, elemId: 3, sd: 28.0 },
+    { label: "5", R: 94.161, d: 4.05, nd: 1.0, elemId: 0, sd: 26.5 },
+    { label: "6", R: 461.054, d: 8.17, nd: 1.6727, elemId: 4, sd: 24.5 },
+    { label: "7", R: 30.267, d: 8.5, nd: 1.0, elemId: 0, sd: 21.5 },
+    { label: "STO", R: 1e15, d: 25.88, nd: 1.0, elemId: 0, sd: 18.99085983 },
+    { label: "8", R: -41.362, d: 4.37, nd: 1.70154, elemId: 5, sd: 25.0 },
+    { label: "9", R: -40.027, d: 6.87, nd: 1.0, elemId: 0, sd: 26.5 },
+    { label: "10", R: 71.985, d: 4.05, nd: 1.72, elemId: 6, sd: 27.0 },
+    { label: "11", R: 143.722, d: 4.0, nd: 1.0, elemId: 0, sd: 26.5 },
+    { label: "12", R: 248.646, d: 4.0, nd: 1.7, elemId: 7, sd: 26.5 },
+    { label: "13", R: 1506.638, d: 40.754258341, nd: 1.0, elemId: 0, sd: 26.0 },
+  ],
+
+  asph: {},
+  var: {
+    "11": [4.0, 29.4034898751],
+  },
+  varLabels: [["11", "D11"]],
+  groups: [
+    { text: "Moving group (L1-L6)", fromSurface: "1", toSurface: "11" },
+    { text: "Fixed rear (L7)", fromSurface: "12", toSurface: "13" },
+  ],
+  doublets: [{ text: "D1", fromSurface: "3", toSurface: "5" }],
+
+  closeFocusM: 1.2,
+  nominalFno: 1.8,
+  fstopSeries: [1.8, 2, 2.8, 4, 5.6, 8, 11, 16, 22],
+  maxFstop: 22,
+  apertureBlades: 9,
+
+  offAxisFieldFrac: 0.35,
+  scFill: 0.74,
+  yScFill: 0.72,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/pentax/PentaxA200mmf4MacroED.analysis.md
+++ b/src/lens-data/pentax/PentaxA200mmf4MacroED.analysis.md
@@ -1,0 +1,189 @@
+# smc Pentax-A★ 200mm F/4 Macro ED — Optical Analysis
+
+## Patent Reference and Design Identification
+
+**Patent:** US 4,666,260  
+**Application Number:** 06/801,992  
+**Filed:** November 25, 1985  
+**Priority:** November 30, 1984 — JP 59-254653  
+**Granted:** May 19, 1987  
+**Inventor:** Takayuki Itoh  
+**Assignee:** Asahi Kogaku Kogyo Kabushiki Kaisha  
+**Title:** Telephoto Macro Lens System  
+**Embodiment analyzed:** Example 1, also reproduced as claim 5
+
+The production lens identified for this prescription is the **smc Pentax-A★ 200mm F/4 Macro ED**. The match rests on convergent rather than single-factor evidence. The patent states a 200 mm f/4 telephoto macro for 35 mm still cameras, covering object distances from infinity to unity magnification. Example 1 is a ten-element, nine-group, all-spherical telephoto macro whose two lowest-dispersion positive elements are the nd = 1.49700, νd = 81.6 glasses in the front subgroup. Public lens references for the production A★ Macro likewise list 200 mm, f/4, ten elements in nine groups, ED glass, Pentax K mount, 1:1 macro capability, and a 0.55 m minimum focus distance.
+
+Example 1 is the rigid fixed-rear embodiment. In the patent's focusing description, the first lens group moves toward the object while the rear group and the image plane remain stationary. Pentax later defines FREE as “Fixed Rear Element Extension,” in which only the front group shifts during focusing while the rear group remains stationary. This does not prove that every production detail equals Example 1, but it strongly favors Example 1 over Examples 3 and 4, both of which move rear components. Example 2 is the remaining ambiguity: it is also fixed-rear but varies the spacing inside the front group. Because public production literature does not disclose whether the A★ Macro floats the 1a–1b gap, the present data file transcribes the patent's Example 1 / claim 5 prescription, the rigid front-group extension design shown in Fig. 1.
+
+The half-field angle in the patent is ω = 6.2°. For a 200 mm rectilinear lens, the 43.3 mm diagonal of the 135 still frame gives a computed half diagonal field of 6.17°, which is consistent with the patent field. At 1:1, the patent's front-vertex working distance is 302.2 mm. Adding the close-focus optical track of 244.09 mm gives a focal-plane-to-subject distance of 546.3 mm, which rounds to the commonly published 0.55 m production specification.
+
+The design is all-spherical. The patent tabulates no aspherical coefficients. Its “non-spherical aberration” plots are field-curvature astigmatism plots, not aspheric departures.
+
+## Optical Architecture
+
+The top-level form is a positive-negative telephoto macro: a positive first lens group, followed by a negative second lens group. The first group is divided into subgroup 1a and subgroup 1b; the rear group is divided into negative subgroup 2a and the positive unitary lens 2b. The patent's claim language describes the same partition: subgroup 1a is three positive lenses followed by a negative meniscus; subgroup 1b is a cemented negative-positive doublet followed by another positive lens; subgroup 2a is a positive lens followed by a negative biconcave lens; 2b is a single positive element.
+
+The verified paraxial group powers are:
+
+| Unit            | Surfaces | Verified focal length |
+| --------------- | -------: | --------------------: |
+| Subgroup 1a     |      1–8 |            +149.63 mm |
+| Subgroup 1b     |     9–13 |            +190.08 mm |
+| First group     |     1–13 |            +104.93 mm |
+| Subgroup 2a     |    14–17 |             −66.97 mm |
+| Rear group      |    14–19 |            −270.10 mm |
+| Unitary lens 2b |    18–19 |            +143.65 mm |
+
+The characteristic design choice is not merely the telephoto split. It is the constrained aberration balance over the full conjugate range. The patent states that ordinary telephoto lenses are corrected over only a limited range and degrade when extended to high magnification. This design uses a strong positive front group, a large negative rear subgroup, and a controlled divergent surface in subgroup 1b so that the residual aberrations of the front group are cancelled by the rear group from infinity to unity magnification.
+
+Focusing is by front-group extension. The first group moves object-ward; subgroup 2a, unitary lens 2b, and the image plane remain fixed. In the data file, the aperture stop is placed in the focusing gap just ahead of subgroup 2a, matching the Fig. 1 drawing. The patent does not tabulate the stop split, so the data file places STO 1.00 mm before surface 14 and varies the remaining part of the d13 spacing.
+
+## Element-by-Element Analysis
+
+Element focal lengths below are standalone thick-lens values in air at the d line. They should not be confused with the in-situ group powers above.
+
+### L1 — Positive Meniscus, convex to object
+
+nd = 1.48749, νd = 70.1. Glass: S-FSL5 / N-FK5 class fluor-crown. f = +383.9 mm.
+
+L1 is the weakest of the front positive lenses. It begins the low-dispersion front-cell correction while bending the incoming bundle gently. Its two positive radii give a convex-to-object positive meniscus form, consistent with the patent's subgroup 1a description.
+
+### L2 — Biconvex Positive ED element
+
+nd = 1.49700, νd = 81.6. Glass: S-FPL51 / FCD1 class ED fluorophosphate. f = +109.9 mm.
+
+L2 is the strongest single positive in subgroup 1a and one of the two ED elements. Most of its power is carried by the steep front surface because the rear surface is nearly flat at R = −2002.939 mm. This concentrates useful positive power while keeping the rear surface from adding unnecessary higher-order aberration.
+
+### L3 — Positive Meniscus ED element, convex to object
+
+nd = 1.49700, νd = 81.6. Glass: S-FPL51 / FCD1 class ED fluorophosphate. f = +143.7 mm.
+
+L3 is the second ED positive in subgroup 1a. Splitting the low-dispersion positive power between L2 and L3 spreads the chromatic correction and avoids relying on a single steep ED element. Together with L1, these three positives give an average νd of 77.77, satisfying the patent's requirement that the positive lenses in subgroup 1a have an average Abbe number greater than 70.
+
+### L4 — Negative Meniscus, convex to object
+
+nd = 1.61340, νd = 43.8. Glass: BPM4 legacy Ohara 613/438 short flint class. f = −61.7 mm.
+
+L4 closes subgroup 1a as the dispersing negative partner to the three preceding low-dispersion positives. Both radii are positive, so the element is a convex-to-object negative meniscus. The steep rear radius supplies most of the negative power and is the main front-cell counterweight to the ED positives.
+
+### L5 + L6 — Cemented negative-positive doublet
+
+Cemented net f = −306.8 mm.
+
+L5 is a negative meniscus: nd = 1.61293, νd = 37.0, glass S-TIM3 / E-F3 class flint, f = −114.0 mm. Its object-side surface R9 = −59.122 mm is the divergent surface singled out in condition 4. Using the patent's definition, f1b = r1b / (N1b − 1) = −96.46 mm, so F/f1b = −2.073.
+
+L6 is a positive meniscus: nd = 1.69680, νd = 55.5, glass S-LAL14 lanthanum crown, f = +189.0 mm. It is cemented directly to L5 at surface 10. The interface adds chromatic correction while leaving the doublet weakly negative overall. The doublet is therefore a correction unit more than a primary power unit.
+
+### L7 — Biconvex Positive
+
+nd = 1.73400, νd = 51.5. Glass: S-LAL59 lanthanum crown. f = +122.4 mm.
+
+L7 is the final positive of subgroup 1b and the last element of the moving first group. Its high index supplies useful positive power with moderate curvature. The air gap after L7 is the focus gap between the moving front group and the stationary rear group.
+
+### L8 — Positive Meniscus, concave to object
+
+nd = 1.80518, νd = 25.4. Glass: S-TIH6 dense flint. f = +178.0 mm.
+
+L8 begins subgroup 2a. It is a positive lens despite its concave-to-object meniscus form; the second, more strongly negative radius dominates the sign of the power. The very high index and strong dispersion are deliberate: L8 works against the following negative lanthanum-crown element to shape the rear-group chromatic and field behavior.
+
+### L9 — Biconcave Negative
+
+nd = 1.71300, νd = 53.8. Glass: S-LAL8 / N-LAK8 class lanthanum crown. f = −48.2 mm.
+
+L9 provides most of subgroup 2a's negative power. The use of a high-index, relatively high-Abbe negative element lets the design obtain the needed telephoto divergence without an excessive Petzval penalty. It is the main contributor to the negative rear subgroup focal length of −66.97 mm.
+
+### L10 — Biconvex Positive unitary lens 2b
+
+nd = 1.51633, νd = 64.1. Glass: S-BSL7 / N-BK7 class borosilicate crown. f = +143.7 mm.
+
+L10 is the positive unitary lens spaced behind subgroup 2a. The d17 separation of 39.83 mm is the l2a-2b term in condition 5. Its role is to re-converge the bundle toward the image plane while contributing to the field-curvature and distortion balance governed by the rear-group spacing.
+
+## Glass Identification and Selection
+
+The patent gives nd and νd, not manufacturer glass names. The corrected glass table therefore distinguishes exact catalog matches from class-equivalent identifications. Modern Ohara S-prefix entries are used where current Ohara data match the patent values; the older non-S names are retained where a current S-glass would be a misleading exact-name substitution.
+
+| Element | Patent nd | Patent νd | Catalog / class identification        | Basis                                                |
+| ------- | --------: | --------: | ------------------------------------- | ---------------------------------------------------- |
+| L1      |   1.48749 |      70.1 | S-FSL5 (OHARA) / N-FK5 class          | Current Ohara S-FSL5 is 1.48749, νd 70.23            |
+| L2      |   1.49700 |      81.6 | S-FPL51 (OHARA) / FCD1 class ED       | Current Ohara S-FPL51 is 1.49700, νd 81.54           |
+| L3      |   1.49700 |      81.6 | S-FPL51 (OHARA) / FCD1 class ED       | Same as L2                                           |
+| L4      |   1.61340 |      43.8 | BPM4 legacy Ohara 613/438 short flint | Better match than current S-NBM51-like substitutions |
+| L5      |   1.61293 |      37.0 | S-TIM3 / E-F3 class 613/370 flint     | Current/legacy catalog code 613370                   |
+| L6      |   1.69680 |      55.5 | S-LAL14 (OHARA)                       | Current Ohara 697555                                 |
+| L7      |   1.73400 |      51.5 | S-LAL59 (OHARA)                       | Current Ohara 734515                                 |
+| L8      |   1.80518 |      25.4 | S-TIH6 (OHARA)                        | Current Ohara 805254                                 |
+| L9      |   1.71300 |      53.8 | S-LAL8 (OHARA) / N-LAK8 class         | Current Ohara 713539; patent rounds νd to 53.8       |
+| L10     |   1.51633 |      64.1 | S-BSL7 (OHARA) / N-BK7 class          | Current Ohara 516641                                 |
+
+The older draft's glass table over-specified several partial-dispersion deviations and used some loose class names where exact catalog matches were available. Those claims have been softened. The patent supports the statement that the design uses very low-dispersion glass in the front positive subgroup; it does not publish partial-dispersion data sufficient to assert a measured apochromatic correction.
+
+## Focus Mechanism
+
+**Type:** fixed-rear extension by first-group motion.
+
+The focus variable is the air spacing after surface 13, between the moving first group and the fixed rear group. The patent's Example 1 table gives three d13 values:
+
+| Focus state | Patent d13 total | First-group advance from infinity |
+| ----------- | ---------------: | --------------------------------: |
+| Infinity    |          7.53 mm |                           0.00 mm |
+| 1:2         |         35.05 mm |                          27.52 mm |
+| 1:1         |         62.58 mm |                          55.05 mm |
+
+The data file splits this total gap into surface 13 to STO plus STO to surface 14. STO is fixed 1.00 mm ahead of surface 14, so the data file varies surface 13 from 6.53 mm at infinity to 61.58 mm at 1:1.
+
+A finite-conjugate paraxial trace verifies the focusing kinematics. With d13 = 62.58 mm and the object 302.2 mm in front of surface 1, the image falls 76.83 mm behind the last surface at magnification −0.9997. Solving the same system for the fixed 76.9 mm image plane gives WD = 302.13 mm and magnification −1.0001. At the intermediate d13 = 35.05 mm, the fixed-image solution gives WD = 502.11 mm and magnification −0.5001.
+
+The first-group travel also matches the patent's stated scaling. F/F1 = 1.906, so the movement needed for front-group focus is approximately the reciprocal square of that ratio: 1 / 1.906² = 0.275. Applied to 200 mm unit-magnification whole-lens extension, this predicts 55.0 mm of travel, matching the 55.05 mm d13 increase.
+
+## Chromatic Correction Strategy
+
+The chromatic correction is front-loaded. L1, L2, and L3 are all low-dispersion positives, and L2/L3 are ED fluorophosphate-class glasses. L4 then supplies a higher-dispersion negative component in subgroup 1a. That is the direct implementation of the patent's claim that higher performance is obtained by using super-low-dispersion glass in the positive elements on the object side of the first subgroup.
+
+Subgroup 1b and subgroup 2a then trim the residual color. L5/L6 form a flint-lanthanum crown cemented correction pair. L8/L9 form a dense-flint positive and lanthanum-crown negative pair inside the strongly negative rear subgroup. The result is not documented here as apochromatic in the strict three-line sense, because the patent does not publish the partial-dispersion or line-index data required to verify that claim. It is more precise to describe the design as a highly corrected ED telephoto macro with secondary-spectrum reduction inferred from the two ED positive elements.
+
+## Conditional Expressions
+
+The patent's five design conditions were recomputed from the corrected Example 1 prescription. The focal length F below is the patent's 200 mm normalization.
+
+| #   | Patent condition       | Re-derived value | Patent value | Result |
+| --- | ---------------------- | ---------------: | -----------: | ------ |
+| 1   | 1.0 < F/F1a < 1.8      |            1.337 |        1.336 | Pass   |
+| 2   | 1.5 < F/F1 < 2.3       |            1.906 |        1.906 | Pass   |
+| 3   | −3.7 < F/F2a < −2.5    |           −2.986 |       −2.986 | Pass   |
+| 4   | −2.5 < F/f1b < −0.8    |           −2.073 |       −2.073 | Pass   |
+| 5   | 0.15 < l2a-2b/F < 0.35 |            0.199 |        0.199 | Pass   |
+
+Here F1a is subgroup 1a, F1 is the whole first group, F2a is subgroup 2a, f1b is the single-surface focal length of R9 by the patent definition r1b/(N1b−1), and l2a-2b is d17 = 39.83 mm.
+
+## Verification Summary
+
+The prescription was rechecked against the patent page images and then traced independently. Two OCR-sensitive entries are load-bearing. Surface 8 is +31.143 mm, not +31.43 mm; using +31.43 mm lowers the computed system EFL to about 196.33 mm and the BFL to about 73.32 mm. The corrected +31.143 mm value returns the patent's 200 mm / 76.9 mm system. Surface 13 is −226.517 mm in the final trace.
+
+Verified paraxial results from the corrected prescription:
+
+| Quantity                                          |             Result |
+| ------------------------------------------------- | -----------------: |
+| Effective focal length                            |         199.980 mm |
+| Back focal distance                               |          76.866 mm |
+| Petzval sum Σφ/(n·n′)                             | 3.1299 × 10⁻⁴ mm⁻¹ |
+| Petzval radius                                    |         +3195.0 mm |
+| Close-focus image distance at WD = 302.2 mm       |           76.83 mm |
+| Close-focus magnification at WD = 302.2 mm        |            −0.9997 |
+| Close-focus focal-plane-to-subject reconstruction |           546.3 mm |
+
+The data file's semi-diameters are not patent data. They are physically constrained estimates for rendering and ray visualization. They were checked for rim slope, element front/rear semi-diameter ratio, element edge thickness, and cross-gap sag intrusion. The largest spherical height ratio is at surface 8, with sd/|R| ≈ 0.706, below the project limit. The closest practical clearance is the inferred STO-to-surface-14 split at the stop rim; the selected stop position and semi-diameter leave approximately 0.45 mm of axial clearance at the rim.
+
+## Design Heritage and Context
+
+The patent is explicitly a response to the limitations of ordinary telephoto lenses used at macro distances. The background section says conventional telephotos are normally corrected only to about 1/10 magnification, while unity magnification with accessory extension lies outside their intended correction range. Normal and semi-telephoto macros can reach 1:1, but with shorter working distance. This design solves the problem by combining a true telephoto power split with first-group extension and ED front-group correction, producing life-size coverage with roughly 0.3 m front-vertex working distance.
+
+## Sources
+
+- US Patent 4,666,260, “Telephoto Macro Lens System,” Takayuki Itoh, Asahi Kogaku Kogyo Kabushiki Kaisha, granted May 19, 1987. Primary source for prescription, conditions, focus method, and claims.
+- Ricoh/Pentax, _PENTAX K-mount Lens & Accessories_, definition of FREE as Fixed Rear Element Extension and general ED terminology.
+- The K-Mount Page, “A\* 200/4 Macro ED,” production lens dimensions and specifications.
+- Kamerastore, “Pentax 200mm f4 SMC ED Pentax-A\* Macro,” production element/group count, minimum focus distance, production period, and basic physical data.
+- Lens-DB, “smc Pentax-A\* 200mm F/4 ED Macro,” production focal length, aperture, lens construction, mount, and field angle.
+- OHARA Corporation product tables and datasheets for S-FSL5, S-FPL51, S-LAL14, S-LAL59, S-TIH6, S-LAL8, and S-BSL7.
+- OHARA legacy / optical-glass index data for BPM4 and S-TIM3 where the patent values predate direct modern S-prefix equivalents.

--- a/src/lens-data/pentax/PentaxA200mmf4MacroED.data.ts
+++ b/src/lens-data/pentax/PentaxA200mmf4MacroED.data.ts
@@ -1,0 +1,220 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║       LENS DATA — smc Pentax-A★ Macro 200mm F/4 ED                ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 4,666,260 Example 1 / claim 5, Asahi Kogaku.      ║
+ * ║  Positive-front / negative-rear telephoto macro, 10 elements /     ║
+ * ║  9 groups, all spherical, fixed-rear extension focus to 1:1.       ║
+ * ║                                                                    ║
+ * ║  OCR note: surface 8 is +31.143 mm from the patent page image,      ║
+ * ║  not +31.43 mm. The +31.43 reading gives EFL ≈196.34 mm and        ║
+ * ║  BFL ≈73.33 mm, so the EFL/BFL trace rejects it. Surface 13 is      ║
+ * ║  transcribed as -226.517 mm.                                       ║
+ * ║                                                                    ║
+ * ║  Aperture stop: patent Fig. 1 shows the iris in d13 just before     ║
+ * ║  subgroup 2a but the table does not give an axial stop split.       ║
+ * ║  STO is therefore placed 1.00 mm before surface 14. Surface 13 d    ║
+ * ║  plus STO.d equals the patent d13 value.                            ║
+ * ║                                                                    ║
+ * ║  Semi-diameters: patent does not publish clear apertures. Values    ║
+ * ║  were estimated from paraxial marginal/chief-ray envelopes, the     ║
+ * ║  production 58 mm filter / 71 mm maximum diameter envelope, and     ║
+ * ║  sag/edge-thickness checks. Full-field f/4 bundles vignette in      ║
+ * ║  the front group; off-axis visual tracing is limited accordingly.   ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "pentax-a-200mm-f4-macro-ed",
+  maker: "Pentax",
+  name: "PENTAX SMC PENTAX-A★ 200mm f/4 MACRO ED",
+  subtitle: "US 4,666,260 Example 1 — Asahi Kogaku / Takayuki Itoh",
+  specs: [
+    "10 elements / 9 groups",
+    "f = 199.98 mm design",
+    "F/4",
+    "2ω = 12.4° patent field",
+    "All-spherical",
+    "Fixed-rear extension macro focus",
+  ],
+
+  focalLengthMarketing: 200,
+  focalLengthDesign: 199.98,
+  apertureMarketing: 4,
+  apertureDesign: 4,
+  lensMounts: ["pentax-k"],
+  imageFormat: "135-full-frame",
+  patentYear: 1987,
+  elementCount: 10,
+  groupCount: 9,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.48749,
+      vd: 70.1,
+      fl: 383.9,
+      glass: "S-FSL5 (OHARA) / N-FK5 class",
+      role: "Weak front low-dispersion positive meniscus in subgroup 1a.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconvex Positive",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 109.9,
+      glass: "S-FPL51 (OHARA) / FCD1 class ED",
+      apd: "inferred",
+      apdNote: "ED fluorophosphate class; patent lists nd/vd only, not partial dispersion.",
+      role: "Primary front positive ED element in subgroup 1a.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.497,
+      vd: 81.6,
+      fl: 143.7,
+      glass: "S-FPL51 (OHARA) / FCD1 class ED",
+      apd: "inferred",
+      apdNote: "ED fluorophosphate class; patent lists nd/vd only, not partial dispersion.",
+      role: "Second ED positive in subgroup 1a; shares the super-low-dispersion burden with L2.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Negative Meniscus",
+      nd: 1.6134,
+      vd: 43.8,
+      fl: -61.7,
+      glass: "BPM4 (OHARA legacy, 613/438 short flint)",
+      role: "Negative meniscus closing subgroup 1a and providing the front-cell dispersing partner.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.61293,
+      vd: 37,
+      fl: -114,
+      glass: "S-TIM3 (OHARA, 613/370 flint)",
+      role: "Negative member of the cemented doublet; its concave object-side surface is the governed divergent surface.",
+      cemented: "D1",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Positive Meniscus",
+      nd: 1.6968,
+      vd: 55.5,
+      fl: 189,
+      glass: "S-LAL14 (OHARA)",
+      role: "Positive lanthanum crown cemented to L5; restores power and forms a chromatic correction junction.",
+      cemented: "D1",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Biconvex Positive",
+      nd: 1.734,
+      vd: 51.5,
+      fl: 122.4,
+      glass: "S-LAL59 (OHARA)",
+      role: "High-index positive power element terminating the moving first group.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Positive Meniscus",
+      nd: 1.80518,
+      vd: 25.4,
+      fl: 178,
+      glass: "S-TIH6 (OHARA)",
+      role: "Dense-flint positive at the front of negative rear subgroup 2a.",
+    },
+    {
+      id: 9,
+      name: "L9",
+      label: "Element 9",
+      type: "Biconcave Negative",
+      nd: 1.713,
+      vd: 53.8,
+      fl: -48.2,
+      glass: "S-LAL8 (OHARA) / N-LAK8 class",
+      role: "Strong negative lanthanum-crown element giving subgroup 2a its large negative power.",
+    },
+    {
+      id: 10,
+      name: "L10",
+      label: "Element 10",
+      type: "Biconvex Positive",
+      nd: 1.51633,
+      vd: 64.1,
+      fl: 143.7,
+      glass: "S-BSL7 (OHARA) / N-BK7 class",
+      role: "Unitary positive rear lens 2b, separated from subgroup 2a by the governed d17 gap.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 100.7, d: 4.5, nd: 1.48749, elemId: 1, sd: 29 },
+    { label: "2", R: 214.834, d: 0.5, nd: 1, elemId: 0, sd: 28.7 },
+    { label: "3", R: 56.079, d: 9.96, nd: 1.497, elemId: 2, sd: 31 },
+    { label: "4", R: -2002.939, d: 0.5, nd: 1, elemId: 0, sd: 29 },
+    { label: "5", R: 42.778, d: 7.32, nd: 1.497, elemId: 3, sd: 29 },
+    { label: "6", R: 100.598, d: 2.82, nd: 1, elemId: 0, sd: 25.5 },
+    { label: "7", R: 181.169, d: 2.8, nd: 1.6134, elemId: 4, sd: 23.5 },
+    { label: "8", R: 31.143, d: 12.41, nd: 1, elemId: 0, sd: 22 },
+    { label: "9", R: -59.122, d: 2.5, nd: 1.61293, elemId: 5, sd: 18.2 },
+    { label: "10", R: -389.821, d: 3.68, nd: 1.6968, elemId: 6, sd: 18 },
+    { label: "11", R: -98.827, d: 0.2, nd: 1, elemId: 0, sd: 17.8 },
+    { label: "12", R: 147.652, d: 4.59, nd: 1.734, elemId: 7, sd: 17.8 },
+    { label: "13", R: -226.517, d: 6.53, nd: 1, elemId: 0, sd: 17 },
+    { label: "STO", R: 1e15, d: 1, nd: 1, elemId: 0, sd: 13.54 },
+    { label: "14", R: -167.918, d: 2.5, nd: 1.80518, elemId: 8, sd: 14.5 },
+    { label: "15", R: -77.836, d: 0.7, nd: 1, elemId: 0, sd: 14.5 },
+    { label: "16", R: -95.674, d: 5.5, nd: 1.713, elemId: 9, sd: 14.4 },
+    { label: "17", R: 54.994, d: 39.83, nd: 1, elemId: 0, sd: 14.2 },
+    { label: "18", R: 95.94, d: 4.3, nd: 1.51633, elemId: 10, sd: 20.5 },
+    { label: "19", R: -321.938, d: 76.9, nd: 1, elemId: 0, sd: 20.5 },
+  ],
+
+  asph: {},
+  var: {
+    "13": [6.53, 61.58],
+  },
+  varLabels: [["13", "D13"]],
+  groups: [
+    { text: "1a", fromSurface: "1", toSurface: "8" },
+    { text: "1b", fromSurface: "9", toSurface: "13" },
+    { text: "2a", fromSurface: "14", toSurface: "17" },
+    { text: "2b", fromSurface: "18", toSurface: "19" },
+  ],
+  doublets: [{ text: "D1", fromSurface: "9", toSurface: "11" }],
+
+  closeFocusM: 0.55,
+  nominalFno: 4,
+  fstopSeries: [4, 5.6, 8, 11, 16, 22, 32],
+  maxFstop: 32,
+  rayLeadFrac: 0.28,
+  offAxisFieldFrac: 0.35,
+  scFill: 0.7,
+  yScFill: 0.56,
+  focusDescription:
+    "Fixed-rear extension: the first lens group moves toward the object. The data varies surface 13 so that D13 + STO.d equals the patent d13 spacing.",
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/pentax/PentaxFA28mmf28Soft.analysis.md
+++ b/src/lens-data/pentax/PentaxFA28mmf28Soft.analysis.md
@@ -1,0 +1,166 @@
+# smc Pentax-FA 28mm F2.8 Soft — Optical Analysis
+
+## Patent Reference and Design Identification
+
+**Patent:** US 5,822,132  
+**Application Number:** 08/772,251  
+**Filed:** December 23, 1996  
+**Priority:** Japanese Application HEI 07-351074, December 25, 1995  
+**Granted:** October 13, 1998  
+**Inventor:** Jun Hirakawa  
+**Assignee:** Asahi Kogaku Kogyo Kabushiki Kaisha (Pentax) — corrected by the Certificate of Correction; the printed cover sheet gives the shorter “Asahi Kogaku Kabushiki Kaisha” form.  
+**Title:** Soft Focus Lens  
+**Embodiment analyzed:** First Embodiment — TABLE 1, FIG. 1
+
+The patent describes four numerical embodiments of a wide-angle soft-focus lens built on a retrofocus chassis. The First Embodiment is transcribed here. The prescription is normalized to a whole-system focal length of $f = 100.00$; the production 28 mm representation uses a uniform scale factor of $0.28$ for radii, axial spacings, and inferred semi-diameters.
+
+The identification of this embodiment with the production **smc Pentax-FA 28mm F2.8 Soft** rests on convergent evidence rather than on a published production prescription. Example 1 is a five-element, five-group, all-spherical design, and Ricoh’s archived product specification also gives five elements in five groups. Example 1 is $F.No. = 1:2.9$, while the production lens is published as 28 mm F2.8. Example 1 gives a half angle of view of $37.9^\circ$; the production lens is published as a 75° diagonal-field full-frame lens. The aberration strategy also matches the product description: the soft effect is aperture-controlled, with softness decreasing as the lens is stopped down to F4.
+
+Examples 3 and 4 are slower and narrower ($F.No. = 1:3.6$, $\omega = 34.2^\circ$ / $34.0^\circ$), and Example 3 has only four elements. They are not plausible matches for the 28 mm F2.8 production lens. Example 2 remains a close sibling: it also has five elements, five groups, $F.No. = 1:2.9$, and $\omega = 37.9^\circ$, but differs in glass choices and in the tabulated $f/f_F$ and $SAU/f$. Public product literature does not disclose enough internal prescription data to distinguish Example 1 from Example 2 definitively. This file uses Example 1 and records Example 2 only as a near sibling.
+
+## Optical Architecture
+
+The design is a **retrofocus soft-focus prime**: a negative front group $G_F$ followed by a positive rear group $G_R$, with the diaphragm positioned inside the rear group. The patent states the same basic structure in the abstract and in the detailed description. The negative/positive group order gives the back focus needed for a 35 mm SLR wide-angle lens, while the rear group carries the intentionally retained spherical aberration that produces the soft-focus effect.
+
+The front group contains a very weak positive element followed by a strong negative meniscus. The rear group contains a strong positive biconvex element, the stop, a biconcave dense flint, and a rear positive element. In power sequence, the elements read as **(+ weak)(−)(+)(−)(+)**; in group terms, the design is **negative / positive**.
+
+The important architectural choice is the treatment of oblique aberrations. The patent explains that a negative meniscus in the front group, convex toward the object, can reduce coma and astigmatism when its centers of curvature are arranged toward the diaphragm. It also explains that the high-power convex surface on the positive element in front of the diaphragm generates the spherical aberration needed for the soft effect, while its near-concentric relationship to the stop suppresses other aberrations. The design therefore retains a large monochromatic aberration without letting off-axis aberrations dominate the wide field.
+
+The group boundary is the largest air space in the system. In Example 1 this is the 69.55 normalized gap after surface 4, scaled to 19.474 mm in the production-size data file.
+
+## Element-by-Element Analysis
+
+Focal lengths below are standalone thick-lens-in-air values. Scaled production-size values are given first; normalized patent values follow in parentheses.
+
+### E1 — Near-Plano Weak Positive
+
+nd = 1.58913, νd = 61.2. Glass: N-SK5 / SK5-class crown. f = +339.3 mm (+1212 normalized).
+
+The first element is a very weak biconvex positive lens. Both radii are extremely long compared with the system focal length, so it contributes little direct power. Its function is better read as an entrance refraction ahead of the negative meniscus than as a primary aberration-correcting element. The patent describes this kind of element as an optional low-positive-power lens placed object-side of the negative meniscus.
+
+### E2 — Negative Meniscus, Convex to Object
+
+nd = 1.62041, νd = 60.3. Glass: S-BSM16 / N-SK16-class dense barium crown. f = −29.34 mm (−104.8 normalized).
+
+The second element supplies most of the front group’s negative power. Both radii are positive, so the element is a negative meniscus with its convex face toward the object, exactly the form described in the patent’s front-group discussion and claim language. The high Abbe number keeps this large negative power from adding excessive lateral color.
+
+### E3 — Biconvex Positive Spherical-Aberration Generator
+
+nd = 1.77250, νd = 49.6. Glass: S-LAH66 / N-LAF34-class high-index lanthanum glass. f = +21.85 mm (+78.0 normalized).
+
+The first element of the rear group is a thick biconvex positive lens. Its object-side surface, surface 5, is the convex surface with the largest positive power on the object side of the diaphragm. Example 1 gives $r_m = 84.27$ normalized, so $r_m/f = 0.843$.
+
+This surface is the deliberate spherical-aberration generator. The high index allows substantial positive power at a manageable curvature, while the stop-side placement is part of the patent’s strategy for keeping coma, astigmatism, and field curvature controlled while spherical aberration remains large.
+
+### E4 — Biconcave Negative Dense Flint
+
+nd = 1.78470, νd = 26.2. Glass: J-SFS3 / SF56A-class dense short flint. f = −17.74 mm (−63.3 normalized).
+
+The fourth element is the only high-dispersion element in the prescription. It sits just behind the stop and provides the main chromatic counterweight to the lanthanum positive elements on either side. The patent describes the rear group generically as including a negative lens and a positive lens behind the diaphragm; the chromatic role follows from the glass selection.
+
+The patent’s $n_d = 1.78470$ and $ν_d = 26.2$ are closest to Hikari J-SFS3 among the catalog values checked; Schott SF56A is also a near-equivalent in the same dense-short-flint region. This is a class identification, not a claim that the original production melt was supplied by either vendor.
+
+### E5 — Near-Plano-Convex Positive
+
+nd = 1.77250, νd = 49.6. Glass: S-LAH66 / N-LAF34-class high-index lanthanum glass. f = +21.50 mm (+76.8 normalized).
+
+The rear element is nearly plano-convex, with a very weak front surface and a strong rear surface convex toward the image. It completes the rear group’s positive power and works with E4 as the post-stop negative/positive pair. Sharing the E3 lanthanum glass keeps the glass palette compact and leaves the dense flint as the main dispersion-balancing element.
+
+## Glass Identification and Selection
+
+The patent gives only $n_d$ and $ν_d$, not manufacturer glass names. The identifications below use catalog matches to those two numbers and are therefore class/equivalent labels rather than assertions about the actual factory glass.
+
+| Element | Patent $n_d$ / $ν_d$ | Catalog match or class | Role |
+|---|---:|---|---|
+| E1 | 1.58913 / 61.2 | N-SK5 / SK5-class crown | Weak positive entrance crown |
+| E2 | 1.62041 / 60.3 | S-BSM16 / N-SK16-class crown | Front negative-meniscus crown |
+| E3 | 1.77250 / 49.6 | S-LAH66 / N-LAF34-class lanthanum glass | High-index positive, SA generator |
+| E4 | 1.78470 / 26.2 | J-SFS3 / SF56A dense short-flint class | Chromatic balancing negative |
+| E5 | 1.77250 / 49.6 | S-LAH66 / N-LAF34-class lanthanum glass | Rear positive |
+
+No element is an ED, fluorite, or anomalous-partial-dispersion glass in the usual photographic sense. The correction scheme is ordinary achromatization by separated positive high-index elements and a single dense flint. That is consistent with the patent’s aim: preserve a controlled monochromatic spherical aberration while preventing color and off-axis aberrations from overwhelming the soft-focus image.
+
+## Focus Mechanism
+
+US 5,822,132 publishes only the infinity prescription. It gives no close-focus prescription, no variable air-spacing table, and no explicit moving group. The data file therefore models close focus as **inferred unit focus**, not as a patent-stated mechanism.
+
+Ricoh’s archived production specification gives a minimum focus distance of 0.25 m and a maximum magnification of 0.18×. Under a unit-focus model, the close-focus extension is approximately $m \cdot f = 0.18 \times 28 = 5.04$ mm. The data file implements that as a final back-focus gap change from 35.63 mm at infinity to 40.67 mm at close focus.
+
+The Ricoh archive discusses floating focus generally on the same page and explicitly attributes FREE rear-group separation to the FA Soft 85mm F2.8, but it does not make the same specific statement for the FA Soft 28mm F2.8. The 28 mm lens should therefore not be described as a documented floating-focus design from the available sources.
+
+## Spherical-Aberration / Soft-Focus Strategy
+
+The lens is defined by a retained aberration. The patent states:
+
+$$\frac{SAU}{f} < -0.10 \quad (1)$$
+
+For Example 1, TABLE 5 gives $SAU/f = -0.22$. The sign is the patent’s convention; the accompanying text states that the condition leaves positive spherical aberration, producing the soft-focus effect and natural background blur. The finite-ray spherical aberration value is taken from the patent and is not replaced by a paraxial calculation.
+
+The production control is aperture-based. Ricoh states that from full aperture to F4 the lens uses manual stop-down metering and the amount of softness decreases as the aperture is stopped down. From F4 onward it behaves like an ordinary lens with automatic aperture and open-aperture metering. F4 is therefore the transition point between the soft-control range and normal automatic-aperture operation.
+
+## Conditional Expressions
+
+The patent states six relevant design conditions. Example 1 satisfies all of them.
+
+| # | Published form | Computed or patent value for Example 1 | Patent TABLE 5 | Satisfied |
+|---|---|---:|---:|---|
+| (1) | $SAU/f < -0.10$ | finite-ray, patent-listed | −0.22 | yes |
+| (2) | $f/f_F < -0.5$ | −0.8636 | −0.864 | yes |
+| (3) | $-2.0 < f/f_F$ | −0.8636 | −0.864 | yes |
+| (4) | $0.50 < r_m/f < 10.00$ | 0.8427 | 0.84 | yes |
+| (5) | $FNO. < 4$ | 1:2.9 | 1:2.9 | yes |
+| (6) | $\omega > 30^\circ$ | 37.9° | 37.9° | yes |
+
+Conditions (2) and (3) set the front group’s negative power range. Too little negative power narrows the field; too much overcorrects field curvature. Condition (4) sets the strong object-side convex surface in the rear group within the range needed to generate the soft effect without making the rest of the correction unmanageable.
+
+## Verification Summary
+
+A separate paraxial y–ν trace of the transcribed TABLE 1 prescription reproduces the patent values. The computation used the patent’s radius sign convention, $n_d$ values, and normalized $f = 100$ scale.
+
+| Quantity | Independent computation | Patent | Agreement |
+|---|---:|---:|---|
+| System EFL, normalized | 100.002 | 100.00 | within 0.002 |
+| Back focus $f_B$, normalized | 127.225 | 127.25 | within 0.03 |
+| Front-group focal length $f_F$, normalized | −115.798 | −115.765 | within 0.04 |
+| Rear-group focal length, normalized | +93.147 | — | computed only |
+| $f/f_F$ | −0.8636 | −0.864 | within rounding |
+| $r_m/f$ | 0.8427 | 0.84 | within rounding |
+| Petzval sum $P \cdot f$ | +0.0934 | — | computed only |
+
+The scaled production-size computed EFL is 28.0006 mm. The final-surface back focal distance from the patent table is 35.63 mm after scaling; the paraxial trace computes 35.623 mm from the rounded prescription. The surface-by-surface Petzval calculation used $\sum \phi/(n n')$, not an element-level thin-lens approximation.
+
+## Data File Implementation Notes
+
+The patent does not publish semi-diameters. The data file therefore uses inferred clear apertures constrained by four checks: spherical rim height below $sd/|R| = 0.90$, front/rear semi-diameter ratio no greater than 1.25 for each element, positive element edge thickness, and cross-gap sag intrusion no greater than 90% of each air gap. Surface 4 is the limiting curvature surface at $sd/|R| \approx 0.890$. The tightest non-stop air-gap clearance is the surface 8 to surface 9 gap at about 88% of the allowed 0.6412 mm scaled gap.
+
+The patent does not split the stop gap numerically. The data file places `STO` inside the 18.08 normalized air gap after surface 6 by splitting the gap as 14.00 + 4.08 before scaling. This agrees with FIG. 1 and preserves the total patent spacing. The stop semi-diameter is set to 6.4 mm; in the adopted stop placement this gives an entrance-pupil semi-diameter of about 5.00 mm and an effective f-number of about f/2.80 at the scaled EFL.
+
+## Manufacturer Specifications vs. Patent
+
+Where the manufacturer and the patent differ, the manufacturer’s production specifications govern hard product metadata.
+
+| Specification | Patent Example 1, scaled | Ricoh archived production specification | Adopted in data file |
+|---|---:|---:|---:|
+| Focal length | 28.0 mm | 28 mm | 28 mm |
+| Maximum aperture | F.No. 1:2.9 | F2.8 | f/2.8 nominal |
+| Diagonal field | 75.8° from $2\omega$ | 75° | 75° production metadata |
+| Elements / groups | 5 / 5 | 5 / 5 | 5 / 5 |
+| Minimum focus | not published | 0.25 m | 0.25 m |
+| Maximum magnification | not published | 0.18× | 0.18× |
+| Diaphragm blades | not published | 8 | 8 |
+| Minimum aperture | not published | f/22 | f/22 |
+| Filter thread | not published | 49 mm | metadata only; no filter modeled |
+
+## Design Heritage and Context
+
+The patent’s motivation is explicit: conventional soft-focus interchangeable lenses were associated with narrower-view portrait use, so the invention aims to provide a soft-focus lens suitable for landscape photography. The resulting design is not a portrait soft lens scaled down mechanically; it is a retrofocus wide-angle layout that uses a negative front group to obtain the field and back focus while controlling oblique aberrations around a deliberately soft spherical-aberration core.
+
+The smc Pentax-FA 28mm F2.8 Soft is the production lens that fits that technical pattern: a full-frame 28 mm soft-focus lens whose aperture ring is the practical softness control.
+
+## Sources and References
+
+- US Patent 5,822,132, “Soft Focus Lens,” Jun Hirakawa, Asahi Kogaku Kogyo K.K.; filed 1996-12-23, granted 1998-10-13. Prescription and conditions from TABLE 1 and TABLE 5; assignee correction from the Certificate of Correction.
+- Ricoh Imaging, “ソフトレンズ・マクロレンズ,” Beautiful Photo-life archive. Production specifications and aperture/softness-operation description for smc PENTAX-FA Soft 28mm F2.8. https://www.ricoh-imaging.co.jp/japan/photo-life/archives/lens/001/index.html
+- SCHOTT Optical Glass Datasheets: N-SK5, N-SK16, N-LAF34, SF56A.
+- OHARA S-BSM16 and S-LAH66 catalog pages and datasheets.
+- Hikari / Nikon J-series optical glass catalog: J-SFS3.

--- a/src/lens-data/pentax/PentaxFA28mmf28Soft.data.ts
+++ b/src/lens-data/pentax/PentaxFA28mmf28Soft.data.ts
@@ -1,0 +1,155 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║           LENS DATA — PENTAX SMC PENTAX-FA 28mm f/2.8 Soft          ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: US 5,822,132 Example 1 (Asahi Optical / Hirakawa).    ║
+ * ║  Retrofocus wide-angle soft-focus prime: negative front group,      ║
+ * ║  positive rear group, and an aperture stop inside the rear group.   ║
+ * ║  5 elements / 5 groups, all spherical.                              ║
+ * ║                                                                    ║
+ * ║  Scaling: patent normalized at f = 100.00; all radii and axial      ║
+ * ║  spacings scaled ×0.28 for the 28 mm production lens.               ║
+ * ║                                                                    ║
+ * ║  Stop: patent drawing places S in the air gap between r6 and r7     ║
+ * ║  but Table 1 does not split d6. The data file splits d6 = 18.08     ║
+ * ║  normalized as 14.00 + 4.08 before scaling. This preserves the      ║
+ * ║  published optical prescription; only pupil placement/rendering is  ║
+ * ║  affected.                                                          ║
+ * ║                                                                    ║
+ * ║  Semi-diameters: not published in the patent. Values were estimated ║
+ * ║  from paraxial marginal/chief-ray clearance, the patent figures,    ║
+ * ║  49 mm filter envelope, and renderer constraints: sd/|R| < 0.90,    ║
+ * ║  element front/rear SD ratio ≤ 1.25, positive edge thickness, and   ║
+ * ║  cross-gap sag intrusion ≤ 90% of the air gap.                      ║
+ * ║                                                                    ║
+ * ║  Focus: the patent publishes only infinity focus. The production    ║
+ * ║  0.25 m / 0.18× close-focus specification is modeled as unit focus  ║
+ * ║  by increasing the final back-focus gap by m × f ≈ 5.04 mm.         ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "pentax-fa-28mm-f28-soft",
+  maker: "Pentax",
+  name: "PENTAX SMC PENTAX-FA 28mm f/2.8 Soft",
+  subtitle: "US 5,822,132 Example 1 — Asahi Optical / Hirakawa",
+  specs: [
+    "5 elements / 5 groups",
+    "f = 28 mm",
+    "F/2.8 nominal; patent F.No. 1:2.9",
+    "2ω = 75° production; 75.8° patent",
+    "All-spherical soft-focus retrofocus",
+  ],
+
+  focalLengthMarketing: 28,
+  focalLengthDesign: 28.0006,
+  apertureMarketing: 2.8,
+  apertureDesign: 2.9,
+  lensMounts: ["pentax-k"],
+  imageFormat: "135-full-frame",
+  patentYear: 1998,
+  elementCount: 5,
+  groupCount: 5,
+  apertureBlades: 8,
+
+  elements: [
+    {
+      id: 1,
+      name: "E1",
+      label: "Element 1",
+      type: "Weak Biconvex Positive",
+      nd: 1.58913,
+      vd: 61.2,
+      fl: 339.34,
+      glass: "N-SK5 / BACD5 class",
+      role: "Very weak positive entrance element ahead of the front negative meniscus.",
+    },
+    {
+      id: 2,
+      name: "E2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.62041,
+      vd: 60.3,
+      fl: -29.34,
+      glass: "N-SK16 / S-BSM16 class",
+      role: "Front-group negative meniscus, convex to object; primary retrofocus negative power.",
+    },
+    {
+      id: 3,
+      name: "E3",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.7725,
+      vd: 49.6,
+      fl: 21.85,
+      glass: "S-LAH66 / N-LAF34 / TAF1 class",
+      role: "Strong rear-group collector and main spherical-aberration generating positive element.",
+    },
+    {
+      id: 4,
+      name: "E4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.7847,
+      vd: 26.2,
+      fl: -17.74,
+      glass: "J-SFS3 / SF56A class dense flint",
+      role: "High-dispersion negative element behind the stop; chromatic balancing partner for the rear positives.",
+    },
+    {
+      id: 5,
+      name: "E5",
+      label: "Element 5",
+      type: "Near-Plano-Convex Positive",
+      nd: 1.7725,
+      vd: 49.6,
+      fl: 21.5,
+      glass: "S-LAH66 / N-LAF34 / TAF1 class",
+      role: "Rear positive lens completing the positive rear group.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 378.28, d: 2.9204, nd: 1.58913, elemId: 1, sd: 15.2 },
+    { label: "2", R: -422.7832, d: 0.098, nd: 1.0, elemId: 0, sd: 13.4 },
+    { label: "3", R: 63.112, d: 2.3352, nd: 1.62041, elemId: 2, sd: 13.0 },
+    { label: "4", R: 13.9272, d: 19.474, nd: 1.0, elemId: 0, sd: 12.4 },
+    { label: "5", R: 23.5956, d: 10.7044, nd: 1.7725, elemId: 3, sd: 12.0 },
+    { label: "6", R: -47.5944, d: 3.92, nd: 1.0, elemId: 0, sd: 10.0 },
+    { label: "STO", R: 1e15, d: 1.1424, nd: 1.0, elemId: 0, sd: 6.4 },
+    { label: "7", R: -23.688, d: 1.946, nd: 1.7847, elemId: 4, sd: 7.2 },
+    { label: "8", R: 34.9692, d: 0.6412, nd: 1.0, elemId: 0, sd: 6.9 },
+    { label: "9", R: 192.234, d: 3.1192, nd: 1.7725, elemId: 5, sd: 7.3 },
+    { label: "10", R: -18.0516, d: 35.63, nd: 1.0, elemId: 0, sd: 9.1 },
+  ],
+
+  asph: {},
+
+  var: {
+    "10": [35.63, 40.67],
+  },
+  varLabels: [["10", "BF"]],
+
+  groups: [
+    { text: "GF", fromSurface: "1", toSurface: "4" },
+    { text: "GR", fromSurface: "5", toSurface: "10" },
+  ],
+
+  doublets: [],
+
+  closeFocusM: 0.25,
+  focusDescription:
+    "Patent publishes infinity only. Close focus is modeled as inferred unit focus: final back-focus gap increases by about 5.04 mm from the Ricoh 0.18× maximum-magnification specification.",
+
+  nominalFno: 2.8,
+  fstopSeries: [2.8, 4, 5.6, 8, 11, 16, 22],
+  maxFstop: 22,
+
+  scFill: 0.54,
+  yScFill: 0.44,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/optics/trace/generalizedTrace.ts
+++ b/src/optics/trace/generalizedTrace.ts
@@ -23,7 +23,6 @@ import {
   resolvedNextIndex,
 } from "./interactions.js";
 import {
-  fallbackSurfacePoint,
   findNearestGeneralizedSurfaceHit,
   generalizedHitTolerance,
   intersectImagePlane,
@@ -190,33 +189,7 @@ export function traceGeneralized(
       failureReason = nextSurfaceHit.failureReason;
       terminationReason = "trace-failure";
       pushClipEvent(clipEvents, state, nextSurfaceIndex, "intersection-failure", nextSurfaceHit.failureReason);
-      if (!ghost) break;
-
-      const fallback = fallbackSurfacePoint(
-        origin,
-        direction,
-        state,
-        nextSurfaceIndex,
-        targetedSurfaceMaxT(state, nextSurfaceIndex, origin, direction, launchBoundT),
-      );
-      if (fallback === null) continue;
-      const radius = Math.hypot(fallback.point[0], fallback.point[1]);
-      hits.push({
-        surfaceIndex: nextSurfaceIndex,
-        surfaceLabel: surfaceLabel(state, nextSurfaceIndex),
-        point: fallback.point,
-        normal: fallback.normal,
-        incidentDirection: [direction[0], direction[1], direction[2]],
-        radius,
-        clipped: true,
-        fallback: true,
-        failureReason: nextSurfaceHit.failureReason,
-        clipReason: "intersection-failure",
-      });
-      terminalPoint = fallback.point;
-      terminalSurfaceIndex = nextSurfaceIndex;
-      if (stopOnClip) break;
-      continue;
+      break;
     }
 
     const surface = state.surfaces[nextSurfaceIndex];

--- a/src/optics/trace/generalizedTrace.ts
+++ b/src/optics/trace/generalizedTrace.ts
@@ -185,6 +185,8 @@ export function traceGeneralized(
     }
 
     if (!nextSurfaceHit.ok) {
+      // A miss is terminal even in ghost mode: prior hits still display, while
+      // fabricated fallback points can create unbounded SVG paths.
       clipped = true;
       failureReason = nextSurfaceHit.failureReason;
       terminationReason = "trace-failure";

--- a/src/optics/trace/pathPlanner.ts
+++ b/src/optics/trace/pathPlanner.ts
@@ -1,7 +1,7 @@
 /**
  * Trace path planning — surface and image-plane intersection selection for exact tracing.
  *
- * Supplies bounded hit searches, nearest-surface selection, loop guards, and fallback geometry
+ * Supplies bounded hit searches, nearest-surface selection, and loop guards
  * used by sequential and generalized paths.
  */
 
@@ -250,57 +250,6 @@ export function loopStateKey(surfaceIndex: number, point: Vec3, direction: Vec3,
     bucket(direction[2], 1e-7),
     bucket(n, 1e-9),
   ].join(":");
-}
-
-/**
- * Build best-effort hit geometry when a diagnostic trace reaches a target without a solved hit.
- *
- * @param origin - current ray origin
- * @param direction - normalized ray direction
- * @param state - prepared optical state
- * @param surfaceIndex - target surface index
- * @param maxT - search bound used for sampling
- * @returns approximate surface point and normal, or null when no finite point is available
- */
-export function fallbackSurfacePoint(
-  origin: Vec3,
-  direction: Vec3,
-  state: PreparedOpticalState,
-  surfaceIndex: number,
-  maxT: number,
-): { point: Vec3; normal: Vec3 } | null {
-  const surface = state.surfaces[surfaceIndex];
-  const projectedT = Math.abs(direction[2]) > 1e-12 ? (surface.z - origin[2]) / direction[2] : NaN;
-  let t =
-    Number.isFinite(projectedT) && projectedT >= 0 && (!Number.isFinite(maxT) || projectedT <= maxT) ? projectedT : NaN;
-
-  if (!Number.isFinite(t)) {
-    if (!Number.isFinite(maxT) || maxT <= 0) return null;
-    const samples = 32;
-    let bestT = NaN;
-    let bestResidual = Infinity;
-    for (let i = 0; i <= samples; i++) {
-      const candidateT = (maxT * i) / samples;
-      const point: Vec3 = [
-        origin[0] + direction[0] * candidateT,
-        origin[1] + direction[1] * candidateT,
-        origin[2] + direction[2] * candidateT,
-      ];
-      const surfaceZ = surface.profile.pointAt(surface.z, point[0], point[1])[2];
-      const residual = Math.abs(point[2] - surfaceZ);
-      if (Number.isFinite(residual) && residual < bestResidual) {
-        bestResidual = residual;
-        bestT = candidateT;
-      }
-    }
-    if (!Number.isFinite(bestT)) return null;
-    t = bestT;
-  }
-
-  const x = origin[0] + direction[0] * t;
-  const y = origin[1] + direction[1] * t;
-  const point = surface.profile.pointAt(surface.z, x, y);
-  return { point, normal: surface.profile.normalAt(point, surface.z) };
 }
 
 function isPassiveAutoSurface(

--- a/src/optics/trace/runtimeRayResult.ts
+++ b/src/optics/trace/runtimeRayResult.ts
@@ -86,6 +86,8 @@ function appendTracePoints(result: EngineTraceResult, pts: number[][], ghostPts:
     const point = [hit.point[2], hit.point[1]];
     if (!Number.isFinite(point[0]) || !Number.isFinite(point[1])) continue;
     if (hit.clipped) {
+      // Intersection misses terminate before adding a hit; ghost points here
+      // are only real clipped surface hits.
       if (ghost) ghostPts.push(point);
     } else {
       pts.push(point);

--- a/src/optics/trace/sequentialTrace.ts
+++ b/src/optics/trace/sequentialTrace.ts
@@ -11,7 +11,7 @@ import type { PreparedOpticalState, Ray3, Vec3 } from "../types.js";
 import { evaluateAperture } from "./aperture.js";
 import { pushClipEvent } from "./foldedDiagnostics.js";
 import { refractedDirection } from "./interactions.js";
-import { fallbackSurfacePoint, intersectStateSurface, sequentialSurfaceMaxT } from "./pathPlanner.js";
+import { intersectStateSurface, sequentialSurfaceMaxT } from "./pathPlanner.js";
 import type { EngineTraceResult, TraceFailureReason, TraceHit, TraceOptions } from "./types.js";
 import {
   clampTraceCount,
@@ -77,31 +77,16 @@ export function traceSequential(
     const maxT = sequentialSurfaceMaxT(state, i, origin, direction, launchBoundT);
     const hit = intersectStateSurface({ origin, direction }, state, i, { maxT, refractiveIndex: n });
 
-    let point: Vec3;
-    let normal: Vec3;
-    let radius: number;
-    let fallback = false;
-    let hitFailure: TraceFailureReason | null = null;
-
-    if (hit.ok) {
-      point = hit.point;
-      normal = hit.normal;
-      radius = hit.radius;
-    } else {
+    if (!hit.ok) {
       clipped = true;
       failureReason = hit.failureReason;
       pushClipEvent(clipEvents, state, i, "intersection-failure", hit.failureReason);
-      if (!ghost) break;
-
-      const fallbackPoint = fallbackSurfacePoint(origin, direction, state, i, maxT);
-      if (fallbackPoint === null) continue;
-      point = fallbackPoint.point;
-      normal = fallbackPoint.normal;
-      radius = Math.hypot(point[0], point[1]);
-      fallback = true;
-      hitFailure = hit.failureReason;
+      break;
     }
 
+    const point = hit.point;
+    const normal = hit.normal;
+    const radius = hit.radius;
     terminalPoint = point;
     terminalSurfaceIndex = i;
     if (recordHeights) {
@@ -126,8 +111,8 @@ export function traceSequential(
       incidentDirection,
       radius,
       clipped: hitClipped,
-      fallback,
-      failureReason: hitFailure,
+      fallback: false,
+      failureReason: null,
       clipReason,
     };
 

--- a/src/optics/trace/sequentialTrace.ts
+++ b/src/optics/trace/sequentialTrace.ts
@@ -78,6 +78,8 @@ export function traceSequential(
     const hit = intersectStateSurface({ origin, direction }, state, i, { maxT, refractiveIndex: n });
 
     if (!hit.ok) {
+      // A miss is terminal even in ghost mode: prior hits still display, while
+      // fabricated fallback points can create unbounded SVG paths.
       clipped = true;
       failureReason = hit.failureReason;
       pushClipEvent(clipEvents, state, i, "intersection-failure", hit.failureReason);

--- a/src/optics/trace/types.ts
+++ b/src/optics/trace/types.ts
@@ -66,6 +66,7 @@ export interface TraceOptions {
   recordHeights?: boolean;
   checkSemiDiameter?: boolean;
   stopSemiDiameter?: number;
+  /** Retain clipped surface hits as ghost points; missed surfaces still terminate without fallback hits. */
   ghost?: boolean;
   stopOnClip?: boolean;
   launchBoundT?: number;

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -22,8 +22,13 @@ export const CHANGELOG: ChangelogEntry[] = [
   // ── 2026-06-22 ──────────────────────────────────────────────────────────
   {
     date: "2026-06-22",
+    type: "lens",
+    summary: "Added three Pentax K-mount lenses, including the A★ 200mm f/4 Macro ED",
+  },
+  {
+    date: "2026-06-22",
     type: "fix",
-    summary: "Fixed slow zoom rendering from clipped and missed ray paths",
+    summary: "Stopped ray traces after missed surfaces and limited clipped ghost rays",
   },
   // ── 2026-06-21 ──────────────────────────────────────────────────────────
   {

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -19,6 +19,12 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-06-22 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-06-22",
+    type: "fix",
+    summary: "Fixed slow zoom rendering from clipped and missed ray paths",
+  },
   // ── 2026-06-21 ──────────────────────────────────────────────────────────
   {
     date: "2026-06-21",


### PR DESCRIPTION
## Summary
- add Pentax 200mm lens data from the current branch
- limit displayed ghost rays to the first clipped point
- stop prepared-state sequential and generalized traces after missed surface intersections while preserving preceding hits
- update docs, changelog, branch record, and inline trace comments

## Verification
- npm run typecheck
- npm run format:check
- npm run lint
- npm run test