### PR TITLE
Add Rodenstock large-format lens data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart TD
 
 ## Current Scope
 
-- `358` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
+- `364` visible lens pages are currently published from [`src/lens-data/`](src/lens-data/)
 - The catalog spans classic and modern designs from Canon, Carl Zeiss Jena, Carl Zeiss Oberkochen, Fujifilm,
   Hasselblad, Laowa, Leica, Minolta, Nikon, Olympus, Panasonic, Pentax, Ricoh, Schneider-Kreuznach, Sigma, Sony,
   Vivitar, and Voigtländer

--- a/agent_docs/generated/catalog-mismatches.generated.md
+++ b/agent_docs/generated/catalog-mismatches.generated.md
@@ -13,13 +13,29 @@ with words like "probable" or "approx").
 
 ## Summary
 
-- **366** lenses scanned
-- **4124** glass surfaces examined
-- **4118** surfaces with non-empty `glass` strings
-- **3327** of those resolved to a catalog entry
-- **0** mismatches found (0.0% of resolved surfaces)
-- **0** distinct lens files affected
+- **372** lenses scanned
+- **4165** glass surfaces examined
+- **4159** surfaces with non-empty `glass` strings
+- **3343** of those resolved to a catalog entry
+- **2** mismatches found (0.1% of resolved surfaces)
+- **1** distinct lens files affected
 
-## No mismatches
+## Most-frequent mismatched catalog targets
 
-Every catalog-resolved surface agrees with its stored `nd` within tolerance. ✓
+Glass labels that get rejected most often. A high count here often points to a single glass
+annotation pattern (e.g. an obsolete name, a `probable` guess) that's used across many lenses.
+
+| Catalog entry | Rejected surfaces | Notes |
+|---|---|---|
+| SF10 | 1 | |
+| S-TIH18 | 1 | |
+
+## Mismatches by lens
+
+### [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) — DE 26
+
+| Surface | Glass annotation | Catalog match | Stored nd | Catalog nd | Δnd |
+|---|---|---|---|---|---|
+| 3 | `SF10 class (Schott legacy; stored patent n_e)` | SF10 | 1.73430 | 1.72825 | -0.0060 |
+| 7 | `SF18 / S-TIH18 class (stored patent n_e)` | S-TIH18 | 1.72730 | 1.72151 | -0.0058 |
+

--- a/agent_docs/generated/glass-coverage-opportunities.generated.md
+++ b/agent_docs/generated/glass-coverage-opportunities.generated.md
@@ -9,13 +9,13 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **366** lenses scanned (**358** visible)
-- **3327 / 4124** non-air surfaces use strict catalog Sellmeier data (80.7%)
-- **3351 / 4124** non-air surfaces use trusted chromatic data (Sellmeier or measured line indices, 81.3%)
-- **0** mismatch surfaces in Sweep 1 across **0** lens files
-- **0** Sweep 1 surfaces have a matching untracked local patent PDF
+- **372** lenses scanned (**364** visible)
+- **3341 / 4165** non-air surfaces use strict catalog Sellmeier data (80.2%)
+- **3370 / 4165** non-air surfaces use trusted chromatic data (Sellmeier or measured line indices, 80.9%)
+- **2** mismatch surfaces in Sweep 1 across **1** lens files
+- **2** Sweep 1 surfaces have a matching untracked local patent PDF
 - **206** code-only missing-Sellmeier elements in Sweep 2
-- **135** unresolved named-token elements in Sweep 2B
+- **148** unresolved named-token elements in Sweep 2B
 - **0** Tier A proprietary backfill rows in Sweep 3
 
 ## Sweep 1 - Relabel Mismatches
@@ -24,6 +24,8 @@ Patent PDFs under `patents/` are untracked local references. A missing local pat
 
 | Lens | Patent | Surface | Current label | Stored nd/vd | Best candidate(s) | localPatentPath | localPatentStatus |
 |---|---|---|---|---|---|---|---|
+| [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) | DE 26 | 7 | `SF18 / S-TIH18 class (stored patent n_e)` | 1.72730 / 29.02 | S-TIH10 (Δnd=+0.0009, Δvd=-0.56)<br>E-FD10 (Δnd=+0.0009, Δvd=-0.70)<br>H-ZF4A (Δnd=+0.0010, Δvd=-0.70) | patents/20260118637.pdf | Ambiguous untracked local match; also see patents/DE_1268404_B.pdf, patents/DE_2635415_B1.pdf, patents/JP_2000292689_A.pdf |
+| [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) | DE 26 | 3 | `SF10 class (Schott legacy; stored patent n_e)` | 1.73430 / 28.47 | No catalog candidate | patents/20260118637.pdf | Ambiguous untracked local match; also see patents/DE_1268404_B.pdf, patents/DE_2635415_B1.pdf, patents/JP_2000292689_A.pdf |
 
 ## Near-Complete Visible Lenses
 
@@ -179,6 +181,7 @@ These unresolved catalog-style labels are often better first catalog targets tha
 
 | Token | Elements | Lens files | localPatentStatus | Representative rows |
 |---|---:|---:|---|---|
+| SF5 | 5 | 5 | patents/US3108152.pdf<br>patents/DE_2444954_A1.pdf<br>patents/JP_2002090622_A.pdf | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) Element 4 (1.67764 / 32.00; abbe)<br>[RODENSTOCK GRANDAGON-N 65mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts) Element 2 (1.67760 / 31.97; abbe)<br>[RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) Element 2 (1.67270 / 32.21; lineIndices) |
 | S-NPH7 | 4 | 4 | patents/US20230213745A1.pdf<br>patents/US20190265441A1.pdf<br>patents/JP2021179551A.pdf<br>patents/WO_2025263124_A1.pdf | [CANON RF 135mm f/1.8 L IS USM](../../src/lens-data/canon/CanonRF135f18.data.ts) Element 14 (2.00069 / 25.50; abbe)<br>[CANON RF 50mm f/1.2 L USM](../../src/lens-data/canon/CanonRF50mmf12L.data.ts) Element 3 (2.00100 / 29.13; abbe)<br>[PANASONIC LUMIX S 20-60mm f/3.5-5.6](../../src/lens-data/panasonic/PanasonicLumixS2060mmf3556.data.ts) Element 11 (1.92286 / 20.90; abbe) |
 | S-TIF6 | 3 | 3 | patents/US20150212302A1.pdf<br>patents/US20200049962A1.pdf<br>patents/JP2012003015A.pdf | [FUJIFILM FUJINON XF 56mm f/1.2 R](../../src/lens-data/fujifilm/FujifilmXF56mmf12.data.ts) Element 9 (1.66680 / 33.00; abbe)<br>[NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) Element 18 (1.64769 / 33.70; abbe)<br>[RICOH GR LENS A12 28mm f/2.5 (Ricoh GXR A12)](../../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) Element 6 (1.67270 / 32.20; abbe) |
 | H-LAF3 | 2 | 2 | patents/CN205427291U.pdf<br>patents/JPWO2020157904A1.pdf | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) Element 7b (1.80420 / 46.50; abbe)<br>[NIKON NIKKOR Z 24-200mm f/4-6.3 VR](../../src/lens-data/nikon/NikonNikkorZ24200mmf463VR.data.ts) Element 18 (1.82080 / 42.51; abbe) |
@@ -186,24 +189,23 @@ These unresolved catalog-style labels are often better first catalog targets tha
 | N-BAK4 | 2 | 2 | patents/20260118637.pdf<br>patents/US5243468.pdf | [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) Element 1 (1.57125 / 55.80; abbe)<br>[NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) Element 6 (1.56883 / 56.00; abbe) |
 | N-LAK9 | 2 | 2 | patents/US3038380.pdf<br>patents/FR_1471493_A.pdf | [CARL ZEISS B-DISTAGON 35mm f/4 (Contarex)](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf4.data.ts) LVII (1.69067 / 54.90; abbe)<br>[LEICA ELMARIT-R 35mm f/2.8](../../src/lens-data/leica/LeicaElmaritR35mmf28.data.ts) Element 7 (1.69400 / 54.60; abbe) |
 | N-LASF44 | 2 | 2 | patents/WO2024195273A1.pdf<br>patents/JP2014145954A.pdf | [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) Element L32 (1.80420 / 46.50; abbe)<br>[SIGMA 60mm f/2.8 DN | Art](../../src/lens-data/sigma/Sigma60mmf28DN.data.ts) Element 1 (1.80420 / 46.50; abbe) |
+| N-PSK53A | 2 | 2 | patents/US4871239.pdf<br>patents/DE_3907928_A1.pdf | [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) Element 7 (1.61800 / 63.39; abbe)<br>[RODENSTOCK APO-SIRONAR-W 150mm f/5.6](../../src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.data.ts) Element 2 (1.62000 / 63.50; abbe) |
+| N-SF5 | 2 | 2 | patents/JP2012003015A.pdf<br>patents/DE_2444954_A1.pdf | [RICOH GR LENS A12 28mm f/2.5 (Ricoh GXR A12)](../../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) Element 6 (1.67270 / 32.20; abbe)<br>[RODENSTOCK GRANDAGON-N 65mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts) Element 2 (1.67760 / 31.97; abbe) |
+| N-SSK2 | 2 | 2 | patents/DE_2444954_A1.pdf | [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) Element 3 (1.62229 / 53.27; abbe)<br>[RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) Element 3 (1.62229 / 53.27; abbe) |
 | NBFD10 | 2 | 2 | patents/JP2004302170A.pdf<br>patents/JP2012063403A.pdf | [HASSELBLAD HC Macro 120mm f/4](../../src/lens-data/hasselblad/HasselbladHC120mmf4Macro.data.ts) Element 8 (1.80440 / 39.60; abbe)<br>[SIGMA APO MACRO 150mm f/2.8 EX DG OS HSM](../../src/lens-data/sigma/SigmaAPOMacro150mmf28OSHSM.data.ts) Element 19 (1.83400 / 37.35; lineIndices) |
 | NBFD32 | 2 | 2 | patents/20260118637.pdf<br>patents/CN_121454749_A.pdf | [FUJIFILM FUJINON XF 23mm f/2.8 R WR](../../src/lens-data/fujifilm/FujifilmXF23mmf28RWR.data.ts) L21 negative in first rear doublet (1.73037 / 32.23; abbe)<br>[SIGMA 17-40mm f/1.8 DC | Art](../../src/lens-data/sigma/Sigma1740mmf18DCA.data.ts) Element 11 (1.73037 / 32.23; abbe) |
 | S-BAH10 | 2 | 2 | patents/US3748022.pdf | [CANON FD 35mm f/2 S.S.C. (I)](../../src/lens-data/canon/CanonFD35mmf2.data.ts) Element 3 (1.70154 / 41.10; abbe)<br>[CARL ZEISS TOUIT MAKRO-PLANAR T* 50mm f/2.8 Macro](../../src/lens-data/carl-zeiss-oberkochen/ZeissTouit50mmf28Macro.data.ts) L63 (1.67003 / 47.23; abbe) |
 | S-FPM5 | 2 | 2 | patents/CN_120386081_A.pdf<br>patents/WO_2025263124_A1.pdf | [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) Element 2 (1.55200 / 70.70; abbe)<br>[SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) Element 17 (1.59456 / 66.90; abbe) |
 | S-LAL61 | 2 | 2 | patents/JP2017227799A.pdf | [NIKON AF-S NIKKOR 28mm f/1.4 E ED](../../src/lens-data/nikon/NikonAFS28f14E.data.ts) Element 8 (1.69680 / 55.50; abbe)<br>[NIKON AF-S DX NIKKOR 55-300mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonAFSDX55300mmf4556G.data.ts) L21 (1.74100 / 52.67; abbe) |
 | S-NBH53 | 2 | 2 | patents/US20160274335A1.pdf<br>patents/US20110273780A1.pdf | [FUJIFILM FUJINON XF 90mm f/2 R LM WR](../../src/lens-data/fujifilm/FujifilmXF90mmf2.data.ts) Element 4 (1.74950 / 35.33; abbe)<br>[SONY E 18-55mm f/3.5-5.6 OSS](../../src/lens-data/sony/SonyE1855mmf3556.data.ts) Element 3 (1.91082 / 35.25; abbe) |
-| SF5 | 2 | 2 | patents/US3108152.pdf<br>patents/JP_2002090622_A.pdf | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) Element 4 (1.67764 / 32.00; abbe)<br>[VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) Element 4 (1.67270 / 32.20; abbe) |
+| SK3 | 2 | 2 | patents/DE_2444954_A1.pdf | [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) Element 6 (1.60881 / 58.90; lineIndices)<br>[RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) Element 6 (1.60881 / 58.86; abbe) |
 | TAF1 | 2 | 2 | patents/JP2012063403A.pdf<br>patents/US10191254.pdf | [SIGMA APO MACRO 150mm f/2.8 EX DG OS HSM](../../src/lens-data/sigma/SigmaAPOMacro150mmf28OSHSM.data.ts) Element 5 (1.77250 / 49.62; lineIndices)<br>[SONY FE 28mm f/2](../../src/lens-data/sony/SonyFE28mmf2.data.ts) Element 5 (1.77250 / 49.50; abbe) |
 | E-FDS3HT | 2 | 1 | patents/WO2022097401A1.pdf | [NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) Element 7 (1.94595 / 17.98; abbe)<br>[NIKON NIKKOR Z MC 105mm f/2.8 VR S](../../src/lens-data/nikon/NikonZ105f28.data.ts) Element 13 (1.94595 / 17.98; abbe) |
 | H-K6 | 2 | 1 | Missing from untracked local patents/ references (US4568150, 4568150) | [OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) Element 8 (1.51112 / 60.48; abbe)<br>[OLYMPUS OM-SYSTEM ZUIKO AUTO-ZOOM 65-200mm f/4](../../src/lens-data/olympus/OlympusZuikoAutoZoom65200mmf4.data.ts) Element 14 (1.51112 / 60.48; abbe) |
 | H-ZLAF4A | 2 | 1 | patents/CN210573001U.pdf | [LAOWA 24mm f/14 2× Macro Probe](../../src/lens-data/laowa/Laowa24mmf14Probe.data.ts) Element 1 (1.83481 / 42.72; abbe)<br>[LAOWA 24mm f/14 2× Macro Probe](../../src/lens-data/laowa/Laowa24mmf14Probe.data.ts) Element 27 (1.83481 / 42.72; abbe) |
 | K-LAFK50 | 2 | 1 | patents/US20150192839A1.pdf | [PANASONIC LEICA DG NOCTICRON 42.5mm f/1.2 ASPH POWER O.I.S.](../../src/lens-data/panasonic/PanasonicDGNocticron42mmf12.data.ts) Element 8 (1.77010 / 49.70; lineIndices)<br>[PANASONIC LEICA DG NOCTICRON 42.5mm f/1.2 ASPH POWER O.I.S.](../../src/lens-data/panasonic/PanasonicDGNocticron42mmf12.data.ts) Element 11 (1.77010 / 49.70; lineIndices) |
+| N-K5 | 2 | 1 | patents/20260118637.pdf | [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) Element 1 (1.52460 / 59.22; abbe)<br>[RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) Element 6 (1.52460 / 59.22; abbe) |
 | N-LAF2 | 2 | 1 | Missing from untracked local patents/ references (DE2359156A1, DE2359156, 2359156) | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) Pre-stop negative meniscus (1.74400 / 44.77; abbe)<br>[CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) Positive doublet front element (1.74400 / 44.77; abbe) |
-| S-APL1 | 2 | 1 | patents/US3850509.pdf | [OLYMPUS OM ZUIKO 16mm f/3.5 Fisheye](../../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) Element 8 (1.51728 / 69.60; abbe)<br>[OLYMPUS OM ZUIKO 16mm f/3.5 Fisheye](../../src/lens-data/olympus/OlympusZuiko16mmf35.data.ts) Element 10 (1.51728 / 69.60; abbe) |
-| S-LAM73 | 2 | 1 | patents/WO_2025263124_A1.pdf | [SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) Element 16 (1.85659 / 40.10; abbe)<br>[SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) Element 20 (1.85659 / 40.10; abbe) |
-| SK18 | 2 | 1 | patents/US2681594.pdf | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) Element 5 (1.63850 / 55.50; abbe)<br>[CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) Element 6 (1.63850 / 55.50; abbe) |
-| BACD14 | 1 | 1 | patents/US5267086.pdf | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) Element 1 (1.65844 / 50.90; abbe) |
-| BACD8 | 1 | 1 | patents/US4046459A.pdf | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) Element 1 (1.61117 / 55.90; abbe) |
 
 ## Sweep 3 - Proprietary Line-Index Backfill
 

--- a/agent_docs/generated/glass-relabel-by-lens.generated.md
+++ b/agent_docs/generated/glass-relabel-by-lens.generated.md
@@ -9,11 +9,17 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **0** mismatched surfaces across **0** lens files
-- **0** surfaces have at least one candidate
+- **2** mismatched surfaces across **1** lens files
+- **1** surfaces have at least one candidate
 - **0** surfaces have high-confidence candidate ranking
-- **0** surfaces have no catalog candidate and need patent review
+- **1** surfaces have no catalog candidate and need patent review
 
-## No Relabel Work
+## Relabels by Lens
 
-Every catalog-resolved surface agrees with stored `nd` within tolerance.
+### [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) - DE 26
+
+| Surface | Current label | Stored nd/vd | Rejected as | Best candidate(s) | Confidence | Patent review |
+|---|---|---|---|---|---|---|
+| 3 | `SF10 class (Schott legacy; stored patent n_e)` | 1.73430 / 28.47 | SF10 (Δnd=-0.0060) | No catalog candidate | Patent review | Yes - no catalog match |
+| 7 | `SF18 / S-TIH18 class (stored patent n_e)` | 1.72730 / 29.02 | S-TIH18 (Δnd=-0.0058) | S-TIH10 (Δnd=+0.0009, Δvd=-0.56)<br>E-FD10 (Δnd=+0.0009, Δvd=-0.70)<br>H-ZF4A (Δnd=+0.0010, Δvd=-0.70) | Choose by context | Yes - choose candidate |
+

--- a/agent_docs/generated/glass-relabel-candidates.generated.md
+++ b/agent_docs/generated/glass-relabel-candidates.generated.md
@@ -19,11 +19,29 @@ both match the stored values within tolerance (nd ±0.005, vd ±3).
 - **No candidate**: relabel as `Unmatched (...reason)` and add a row to
   [glass-relabel-followup.md](../glass-relabel-followup.md) for per-lens patent verification.
 
-**Scope**: 0 mismatched surfaces across 0 unique groups.
+**Scope**: 2 mismatched surfaces across 2 unique groups.
+
+## stored (nd=1.72730, vd=29.02)  — 1 surface, current label resolves to S-TIH18
+
+Candidates:
+- **S-TIH10** (nd=1.72825, vd=28.46, Δnd=+0.0009, Δvd=-0.56)
+- **E-FD10** (nd=1.72825, vd=28.32, Δnd=+0.0009, Δvd=-0.70)
+- **H-ZF4A** (nd=1.72825, vd=28.32, Δnd=+0.0010, Δvd=-0.70)
+- **SF10** (nd=1.72825, vd=28.41, Δnd=+0.0010, Δvd=-0.61)
+
+Surfaces:
+- [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) `7`: `SF18 / S-TIH18 class (stored patent n_e)`
+
+## stored (nd=1.73430, vd=28.47)  — 1 surface, current label resolves to SF10
+
+**No catalog candidate within tolerance** — needs per-lens follow-up.
+
+Surfaces:
+- [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) `3`: `SF10 class (Schott legacy; stored patent n_e)`
 
 ---
 
 ## Summary
 
-- **0** (nd, vd) groups have at least one candidate (0 surfaces) — actionable relabels.
-- **0** (nd, vd) groups have NO candidate (0 surfaces) — needs patent verification or Unmatched relabeling.
+- **1** (nd, vd) groups have at least one candidate (1 surfaces) — actionable relabels.
+- **1** (nd, vd) groups have NO candidate (1 surfaces) — needs patent verification or Unmatched relabeling.

--- a/agent_docs/generated/sellmeier-coverage.generated.md
+++ b/agent_docs/generated/sellmeier-coverage.generated.md
@@ -10,18 +10,18 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **366** lenses scanned
-- **358** visible lenses scanned
-- **107** lenses fully covered by trusted chromatic data
-- **107** visible lenses fully covered by trusted chromatic data
+- **372** lenses scanned
+- **364** visible lenses scanned
+- **108** lenses fully covered by trusted chromatic data
+- **108** visible lenses fully covered by trusted chromatic data
 - **101** lenses fully covered by strict Sellmeier data
 - **101** visible lenses fully covered by strict Sellmeier data
-- **6** lenses fully covered only after measured line-index data
-- **6** visible lenses fully covered only after measured line-index data
-- **3327 / 4124** non-air surfaces use strict catalog Sellmeier data
-- **80.7%** strict Sellmeier surface coverage overall
-- **3351 / 4124** non-air surfaces use trusted chromatic data
-- **81.3%** trusted chromatic coverage overall
+- **7** lenses fully covered only after measured line-index data
+- **7** visible lenses fully covered only after measured line-index data
+- **3341 / 4165** non-air surfaces use strict catalog Sellmeier data
+- **80.2%** strict Sellmeier surface coverage overall
+- **3370 / 4165** non-air surfaces use trusted chromatic data
+- **80.9%** trusted chromatic coverage overall
 
 ## Fully Strict Sellmeier Lenses
 
@@ -141,6 +141,7 @@ These lenses are complete for chromatic tracing but not strict catalog-Sellmeier
 | [PANASONIC LEICA DG SUMMILUX 12mm f/1.4 ASPH.](../../src/lens-data/panasonic/PanasonicDGSummilux12mmf14.data.ts) | 15/15 | 13/15 | 15 | 13/15 | 2 | Line indices |
 | [PANASONIC LEICA DG NOCTICRON 42.5mm f/1.2 ASPH POWER O.I.S.](../../src/lens-data/panasonic/PanasonicDGNocticron42mmf12.data.ts) | 14/14 | 12/14 | 14 | 12/14 | 2 | Line indices |
 | [SIGMA APO MACRO 150mm f/2.8 EX DG OS HSM](../../src/lens-data/sigma/SigmaAPOMacro150mmf28OSHSM.data.ts) | 19/19 | 7/19 | 19 | 7/19 | 12 | Line indices |
+| [RODENSTOCK GERONAR 210mm f/6.8](../../src/lens-data/rodenstock/RodenstockGeronar210mmf68.data.ts) | 3/3 | 2/3 | 3 | 2/3 | 1 | Line indices |
 
 ## Incomplete Lenses by Completeness
 
@@ -284,142 +285,147 @@ Fully strict and line-index-complete trusted lenses are listed above; this table
 | 129 | [CANON RF 24-50mm f/4.5-6.3 IS STM](../../src/lens-data/canon/CanonRF2450mmf463.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
 | 130 | [OLYMPUS M.ZUIKO DIGITAL 14-42mm f/3.5-5.6 II R](../../src/lens-data/olympus/OlympusMZuiko1442mmf3556II.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
 | 131 | [SIGMA 45mm f/2.8 DG DN | Contemporary](../../src/lens-data/sigma/Sigma45mmf28DGDN.data.ts) | 75.0% | 75.0% | 6/8 | 6/8 | 2 | abbe: 2 |
-| 132 | [CANON TS-E 50mm f/2.8L MACRO](../../src/lens-data/canon/CanonTSE50mmf28L.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
-| 133 | [NIKON FISHEYE-NIKKOR 6mm f/2.8](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
-| 134 | [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
-| 135 | [LAOWA 12mm f/2.8 Zero-D](../../src/lens-data/laowa/Laowa12mmf28ZeroD.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
-| 136 | [Nikon AI Zoom-Nikkor 50-135mm f/3.5S](../../src/lens-data/nikon/NikonAIZoomNikko50135mmf35S.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 132 | [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) | 75.0% | 25.0% | 6/8 | 2/8 | 2 | abbe: 2 |
+| 133 | [CANON TS-E 50mm f/2.8L MACRO](../../src/lens-data/canon/CanonTSE50mmf28L.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
+| 134 | [NIKON FISHEYE-NIKKOR 6mm f/2.8](../../src/lens-data/nikon/NikonFisheyeNikkor6mmf28.data.ts) | 75.0% | 75.0% | 9/12 | 9/12 | 3 | abbe: 3 |
+| 135 | [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 136 | [LAOWA 12mm f/2.8 Zero-D](../../src/lens-data/laowa/Laowa12mmf28ZeroD.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
+| 137 | [Nikon AI Zoom-Nikkor 50-135mm f/3.5S](../../src/lens-data/nikon/NikonAIZoomNikko50135mmf35S.data.ts) | 75.0% | 75.0% | 12/16 | 12/16 | 4 | abbe: 4 |
 |  | **70-74.9% coverage** |  |  |  |  |  |  |
-| 137 | [CANON RF 50mm f/1.2 L USM](../../src/lens-data/canon/CanonRF50mmf12L.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
-| 138 | [SIGMA 35mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
-| 139 | [PANASONIC LUMIX S 20-60mm f/3.5-5.6](../../src/lens-data/panasonic/PanasonicLumixS2060mmf3556.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
-| 140 | [PANASONIC LUMIX S 35mm f/1.8](../../src/lens-data/panasonic/PanasonicS35mmf18.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
-| 141 | [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) | 72.2% | 72.2% | 13/18 | 13/18 | 5 | abbe: 5 |
-| 142 | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 143 | [CANON New FD 50mm f/1.2](../../src/lens-data/canon/CanonFDn50f12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 144 | [CANON SERENAR 85mm f/1.5](../../src/lens-data/canon/CanonSerenar85mmf15.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 145 | [FUJIFILM FUJINON 18.5mm f/2.8 (Fujifilm X70)](../../src/lens-data/fujifilm/FujifilmX7018mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 146 | [NIKON AI-S NIKKOR 50mm f/1.2](../../src/lens-data/nikon/NikonAISNikkor50mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 147 | [OLYMPUS G.ZUIKO AUTO-S 55mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS55mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 148 | [PANASONIC LUMIX G 14mm f/2.5 II ASPH](../../src/lens-data/panasonic/PanasonicG14mmf25II.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 149 | [SIGMA 24mm f/2.8 (Sigma DP2x)](../../src/lens-data/sigma/SigmaDP2X24mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
-| 150 | [LAOWA 65mm f/2.8 2× Ultra Macro APO](../../src/lens-data/laowa/Laowa65mmf28MacroAPO.data.ts) | 71.4% | 71.4% | 10/14 | 10/14 | 4 | abbe: 4 |
-| 151 | [FUJIFILM FUJINON XF 60mm f/2.4 R Macro](../../src/lens-data/fujifilm/FujifilmXF60mmf24R.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 152 | [Nikon AI Micro-Nikkor 105mm f/2.8S](../../src/lens-data/nikon/NikonAIMicroNikkor105mmf28S.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 153 | [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 154 | [SIGMA 50mm f/2.8 (Sigma DP3 Merrill)](../../src/lens-data/sigma/SigmaDP3M50mmf28.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
-| 155 | [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) | 70.0% | 70.0% | 14/20 | 14/20 | 6 | abbe: 6 |
+| 138 | [CANON RF 50mm f/1.2 L USM](../../src/lens-data/canon/CanonRF50mmf12L.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
+| 139 | [SIGMA 35mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA35mmf14.data.ts) | 73.3% | 73.3% | 11/15 | 11/15 | 4 | abbe: 4 |
+| 140 | [PANASONIC LUMIX S 20-60mm f/3.5-5.6](../../src/lens-data/panasonic/PanasonicLumixS2060mmf3556.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
+| 141 | [PANASONIC LUMIX S 35mm f/1.8](../../src/lens-data/panasonic/PanasonicS35mmf18.data.ts) | 72.7% | 72.7% | 8/11 | 8/11 | 3 | abbe: 3 |
+| 142 | [SIGMA 28-45mm f/1.8 DG DN | Art](../../src/lens-data/sigma/Sigma2845mmf18DN.data.ts) | 72.2% | 72.2% | 13/18 | 13/18 | 5 | abbe: 5 |
+| 143 | [Canon FD 28mm f/2.8 S.C.](../../src/lens-data/canon/CanonFD28mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 144 | [CANON New FD 50mm f/1.2](../../src/lens-data/canon/CanonFDn50f12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 145 | [CANON SERENAR 85mm f/1.5](../../src/lens-data/canon/CanonSerenar85mmf15.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 146 | [FUJIFILM FUJINON 18.5mm f/2.8 (Fujifilm X70)](../../src/lens-data/fujifilm/FujifilmX7018mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 147 | [NIKON AI-S NIKKOR 50mm f/1.2](../../src/lens-data/nikon/NikonAISNikkor50mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 148 | [OLYMPUS G.ZUIKO AUTO-S 55mm f/1.2](../../src/lens-data/olympus/OlympusZuikoAutoS55mmf12.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 149 | [PANASONIC LUMIX G 14mm f/2.5 II ASPH](../../src/lens-data/panasonic/PanasonicG14mmf25II.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 150 | [SIGMA 24mm f/2.8 (Sigma DP2x)](../../src/lens-data/sigma/SigmaDP2X24mmf28.data.ts) | 71.4% | 71.4% | 5/7 | 5/7 | 2 | abbe: 2 |
+| 151 | [LAOWA 65mm f/2.8 2× Ultra Macro APO](../../src/lens-data/laowa/Laowa65mmf28MacroAPO.data.ts) | 71.4% | 71.4% | 10/14 | 10/14 | 4 | abbe: 4 |
+| 152 | [FUJIFILM FUJINON XF 60mm f/2.4 R Macro](../../src/lens-data/fujifilm/FujifilmXF60mmf24R.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 153 | [Nikon AI Micro-Nikkor 105mm f/2.8S](../../src/lens-data/nikon/NikonAIMicroNikkor105mmf28S.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 154 | [Nikon AI-S Zoom-Nikkor 35–70mm f/3.5](../../src/lens-data/nikon/NikonAIZoomNikkor3570mmf35.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 155 | [SIGMA 50mm f/2.8 (Sigma DP3 Merrill)](../../src/lens-data/sigma/SigmaDP3M50mmf28.data.ts) | 70.0% | 70.0% | 7/10 | 7/10 | 3 | abbe: 3 |
+| 156 | [NIKON AF-S NIKKOR 80-400mm f/4.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS80400mmf4556G.data.ts) | 70.0% | 70.0% | 14/20 | 14/20 | 6 | abbe: 6 |
 |  | **65-69.9% coverage** |  |  |  |  |  |  |
-| 156 | [SIGMA 10-18mm f/2.8 DC DN | Contemporary](../../src/lens-data/sigma/Sigma1018mmf28DCDN.data.ts) | 69.2% | 69.2% | 9/13 | 9/13 | 4 | abbe: 4 |
-| 157 | [NIKON Gyogyotto 20mm f/8](../../src/lens-data/nikon/NikonGyogyotto20mmf8.data.ts) | 66.7% | 66.7% | 2/3 | 2/3 | 1 | abbe: 1 |
-| 158 | [CANON SERENAR 28mm f/3.5](../../src/lens-data/canon/CanonSerenar28mmf35.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 159 | [LEICA MACRO-ELMARIT-R 60mm f/2.8](../../src/lens-data/leica/LeicaMacroElmaritR60mmf28.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 160 | [NIKON AI NIKKOR 135mm f/2](../../src/lens-data/nikon/NikonAI135mmf2.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 161 | [NIKON REFLEX-NIKKOR·C 500mm f/8](../../src/lens-data/nikon/NikonReflexNikkorC500mmf8.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 162 | [SCHNEIDER-KREUZNACH APO-SYMMAR 100mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 163 | [SCHNEIDER-KREUZNACH SUPER-SYMMAR XL 110mm f/5.6 ASPHERIC](../../src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
-| 164 | [CANON FD 35mm f/2 S.S.C. (I)](../../src/lens-data/canon/CanonFD35mmf2.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 165 | [HASSELBLAD HC Macro 120mm f/4](../../src/lens-data/hasselblad/HasselbladHC120mmf4Macro.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 166 | [NIKON AF-S NIKKOR 58mm f/1.4 G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
-| 167 | [HASSELBLAD XCD 90mm f/2.5 V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 66.7% | 66.7% | 8/9 | 8/9 | 4 | constant: 3, abbe: 1 |
-| 168 | [VIVITAR SERIES 1 35-85mm f/2.8 VMC](../../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) | 66.7% | 66.7% | 8/12 | 8/12 | 4 | abbe: 4 |
+| 157 | [SIGMA 10-18mm f/2.8 DC DN | Contemporary](../../src/lens-data/sigma/Sigma1018mmf28DCDN.data.ts) | 69.2% | 69.2% | 9/13 | 9/13 | 4 | abbe: 4 |
+| 158 | [NIKON Gyogyotto 20mm f/8](../../src/lens-data/nikon/NikonGyogyotto20mmf8.data.ts) | 66.7% | 66.7% | 2/3 | 2/3 | 1 | abbe: 1 |
+| 159 | [CANON SERENAR 28mm f/3.5](../../src/lens-data/canon/CanonSerenar28mmf35.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 160 | [LEICA MACRO-ELMARIT-R 60mm f/2.8](../../src/lens-data/leica/LeicaMacroElmaritR60mmf28.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 161 | [NIKON AI NIKKOR 135mm f/2](../../src/lens-data/nikon/NikonAI135mmf2.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 162 | [NIKON REFLEX-NIKKOR·C 500mm f/8](../../src/lens-data/nikon/NikonReflexNikkorC500mmf8.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 163 | [SCHNEIDER-KREUZNACH APO-SYMMAR 100mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 164 | [SCHNEIDER-KREUZNACH SUPER-SYMMAR XL 110mm f/5.6 ASPHERIC](../../src/lens-data/schneider-kreuznach/SchneiderSuperSymmarXL110mmf56.data.ts) | 66.7% | 66.7% | 4/6 | 4/6 | 2 | abbe: 2 |
+| 165 | [CANON FD 35mm f/2 S.S.C. (I)](../../src/lens-data/canon/CanonFD35mmf2.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 166 | [HASSELBLAD HC Macro 120mm f/4](../../src/lens-data/hasselblad/HasselbladHC120mmf4Macro.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 167 | [NIKON AF-S NIKKOR 58mm f/1.4 G](../../src/lens-data/nikon/Nikon58f14GDesignCandidate.data.ts) | 66.7% | 66.7% | 6/9 | 6/9 | 3 | abbe: 3 |
+| 168 | [HASSELBLAD XCD 90mm f/2.5 V](../../src/lens-data/hasselblad/HasselbladXCD90mmf25V.data.ts) | 66.7% | 66.7% | 8/9 | 8/9 | 4 | constant: 3, abbe: 1 |
+| 169 | [VIVITAR SERIES 1 35-85mm f/2.8 VMC](../../src/lens-data/vivitar/VivitarSeries13585mmf28.data.ts) | 66.7% | 66.7% | 8/12 | 8/12 | 4 | abbe: 4 |
 |  | **60-64.9% coverage** |  |  |  |  |  |  |
-| 169 | [NIKON AF NIKKOR 28mm f/1.4 D](../../src/lens-data/nikon/NikonAF28f14D.data.ts) | 63.6% | 63.6% | 7/11 | 7/11 | 4 | abbe: 4 |
-| 170 | [FUJIFILM FUJINON 23mm f/2 (Fujifilm X100V)](../../src/lens-data/fujifilm/FujifilmX100V23mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 171 | [LEICA ELMARIT-R 28mm f/2.8](../../src/lens-data/leica/LeicaElmarit28mmf28.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 172 | [NIKON AI NIKKOR 35mm f/2](../../src/lens-data/nikon/NikonAINikkor35mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 173 | [NIKON NIKKOR Z 40mm f/2](../../src/lens-data/nikon/NikonNikkorZ40mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 174 | [SONY PLANAR T* 50mm f/1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
-| 175 | [NIKON AF ZOOM-MICRO NIKKOR ED 70-180mm f/4.5-5.6D](../../src/lens-data/nikon/NikonAFZoomMicro70180mmf4556D.data.ts) | 61.1% | 61.1% | 11/18 | 11/18 | 7 | abbe: 7 |
-| 176 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 61.1% | 61.1% | 11/17 | 11/17 | 7 | abbe: 6, constant: 1 |
-| 177 | [OLYMPUS E.ZUIKO AUTO-T 135mm f/3.5](../../src/lens-data/olympus/OlympusZuiko135mmf35.data.ts) | 60.0% | 60.0% | 3/5 | 3/5 | 2 | abbe: 2 |
-| 178 | [MINOLTA AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
-| 179 | [OLYMPUS ZUIKO AUTO-FISHEYE 8mm f/2.8](../../src/lens-data/olympus/OlympusZuikoAutoFisheye8mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
-| 180 | [NIKON AF-S NIKKOR 28-300mm f/3.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS28300mmf3556G.data.ts) | 60.0% | 60.0% | 12/20 | 12/20 | 8 | abbe: 8 |
+| 170 | [NIKON AF NIKKOR 28mm f/1.4 D](../../src/lens-data/nikon/NikonAF28f14D.data.ts) | 63.6% | 63.6% | 7/11 | 7/11 | 4 | abbe: 4 |
+| 171 | [FUJIFILM FUJINON 23mm f/2 (Fujifilm X100V)](../../src/lens-data/fujifilm/FujifilmX100V23mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 172 | [LEICA ELMARIT-R 28mm f/2.8](../../src/lens-data/leica/LeicaElmarit28mmf28.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 173 | [NIKON AI NIKKOR 35mm f/2](../../src/lens-data/nikon/NikonAINikkor35mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 174 | [NIKON NIKKOR Z 40mm f/2](../../src/lens-data/nikon/NikonNikkorZ40mmf2.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 175 | [SONY PLANAR T* 50mm f/1.4 ZA SSM](../../src/lens-data/sony/SonyPlanarT50mmf14ZA.data.ts) | 62.5% | 62.5% | 5/8 | 5/8 | 3 | abbe: 3 |
+| 176 | [NIKON AF ZOOM-MICRO NIKKOR ED 70-180mm f/4.5-5.6D](../../src/lens-data/nikon/NikonAFZoomMicro70180mmf4556D.data.ts) | 61.1% | 61.1% | 11/18 | 11/18 | 7 | abbe: 7 |
+| 177 | [NIKON NIKKOR Z 58mm f/0.95 S Noct](../../src/lens-data/nikon/NikonZ58f095SNoct.data.ts) | 61.1% | 61.1% | 11/17 | 11/17 | 7 | abbe: 6, constant: 1 |
+| 178 | [OLYMPUS E.ZUIKO AUTO-T 135mm f/3.5](../../src/lens-data/olympus/OlympusZuiko135mmf35.data.ts) | 60.0% | 60.0% | 3/5 | 3/5 | 2 | abbe: 2 |
+| 179 | [MINOLTA AF APO TELE 300mm f/2.8](../../src/lens-data/minolta/MinoltaAF300mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
+| 180 | [OLYMPUS ZUIKO AUTO-FISHEYE 8mm f/2.8](../../src/lens-data/olympus/OlympusZuikoAutoFisheye8mmf28.data.ts) | 60.0% | 60.0% | 6/10 | 6/10 | 4 | abbe: 4 |
+| 181 | [NIKON AF-S NIKKOR 28-300mm f/3.5-5.6 G ED VR](../../src/lens-data/nikon/NikonNikkorAFS28300mmf3556G.data.ts) | 60.0% | 60.0% | 12/20 | 12/20 | 8 | abbe: 8 |
 |  | **55-59.9% coverage** |  |  |  |  |  |  |
-| 181 | [CARL ZEISS B-DISTAGON 35mm f/4 (Contarex)](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf4.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 182 | [CARL ZEISS CONTAREX PLANAR 55mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissContarexPlanar55mmf14.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 183 | [MINOLTA AF Reflex 500mm f/8](../../src/lens-data/minolta/MinoltaAFReflex500mmf8.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 184 | [NIKON NIKKOR 28mm f/2.8 (Nikon 28Ti)](../../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 185 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR / GR II)](../../src/lens-data/ricoh/RicohGR218mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
-| 186 | [SONY FE 14mm f/1.8 GM](../../src/lens-data/sony/SonyFE14mmf18GM.data.ts) | 57.1% | 57.1% | 8/14 | 8/14 | 6 | abbe: 6 |
-| 187 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 56.3% | 56.3% | 9/16 | 9/16 | 7 | abbe: 7 |
-| 188 | [OLYMPUS ZUIKO AUTO-MACRO 50mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro50mmf2.data.ts) | 55.6% | 55.6% | 5/9 | 5/9 | 4 | abbe: 4 |
+| 182 | [CARL ZEISS B-DISTAGON 35mm f/4 (Contarex)](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon35mmf4.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 183 | [CARL ZEISS CONTAREX PLANAR 55mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissContarexPlanar55mmf14.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 184 | [MINOLTA AF Reflex 500mm f/8](../../src/lens-data/minolta/MinoltaAFReflex500mmf8.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 185 | [NIKON NIKKOR 28mm f/2.8 (Nikon 28Ti)](../../src/lens-data/nikon/Nikon28Ti28mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 186 | [RICOH GR LENS 18.3mm f/2.8 (Ricoh GR / GR II)](../../src/lens-data/ricoh/RicohGR218mmf28.data.ts) | 57.1% | 57.1% | 4/7 | 4/7 | 3 | abbe: 3 |
+| 187 | [SONY FE 14mm f/1.8 GM](../../src/lens-data/sony/SonyFE14mmf18GM.data.ts) | 57.1% | 57.1% | 8/14 | 8/14 | 6 | abbe: 6 |
+| 188 | [NIKON NIKKOR Z 135mm f/1.8 S Plena](../../src/lens-data/nikon/NikonZ135f18.data.ts) | 56.3% | 56.3% | 9/16 | 9/16 | 7 | abbe: 7 |
+| 189 | [OLYMPUS ZUIKO AUTO-MACRO 50mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro50mmf2.data.ts) | 55.6% | 55.6% | 5/9 | 5/9 | 4 | abbe: 4 |
 |  | **50-54.9% coverage** |  |  |  |  |  |  |
-| 189 | [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
-| 190 | [PENTAX HD D FA* 50mm f/1.4 SDM AW](../../src/lens-data/pentax/PentaxDFA50mmf14SDM.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
-| 191 | [Nikon AI Zoom-Nikkor 35-200mm f/3.5-4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35200mmf3545S.data.ts) | 52.9% | 52.9% | 9/17 | 9/17 | 8 | abbe: 8 |
-| 192 | [MINOLTA AF 70-200mm f/2.8 APO G (D) SSM](../../src/lens-data/minolta/MinoltaAF70200mmf28APO.data.ts) | 52.6% | 52.6% | 10/19 | 10/19 | 9 | abbe: 9 |
-| 193 | [CARL ZEISS HOLOGON 15mm f/8 (Contarex Hologon / Leica M)](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) | 50.0% | 50.0% | 2/3 | 2/3 | 2 | abbe: 2 |
-| 194 | [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 195 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 196 | [NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
-| 197 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
-| 198 | [VIVITAR SERIES 1 200mm f/3.0 VMC](../../src/lens-data/vivitar/VivitarSeries1200mmf3.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
-| 199 | [MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
-| 200 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 50.0% | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
-| 201 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 202 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
-| 203 | [NIKON AF-P DX NIKKOR 10-20mm f/4.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
+| 190 | [OLYMPUS ZUIKO AUTO-ZOOM 85-250mm f/5](../../src/lens-data/olympus/OlympusZuikoAutoZoom85250mmf5.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
+| 191 | [PENTAX HD D FA* 50mm f/1.4 SDM AW](../../src/lens-data/pentax/PentaxDFA50mmf14SDM.data.ts) | 53.3% | 53.3% | 8/15 | 8/15 | 7 | abbe: 7 |
+| 192 | [Nikon AI Zoom-Nikkor 35-200mm f/3.5-4.5S](../../src/lens-data/nikon/NikonAIZoomNikkor35200mmf3545S.data.ts) | 52.9% | 52.9% | 9/17 | 9/17 | 8 | abbe: 8 |
+| 193 | [MINOLTA AF 70-200mm f/2.8 APO G (D) SSM](../../src/lens-data/minolta/MinoltaAF70200mmf28APO.data.ts) | 52.6% | 52.6% | 10/19 | 10/19 | 9 | abbe: 9 |
+| 194 | [CARL ZEISS HOLOGON 15mm f/8 (Contarex Hologon / Leica M)](../../src/lens-data/carl-zeiss-oberkochen/ZeissHologon15mmf8.data.ts) | 50.0% | 50.0% | 2/3 | 2/3 | 2 | abbe: 2 |
+| 195 | [CARL ZEISS JENA TESSAR 50mm f/2.8](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaTessar50mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 196 | [CARL ZEISS TESSAR 50mm f/3.5](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissTessar50mmf35.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 197 | [NIKON SERIES E 135mm f/2.8](../../src/lens-data/nikon/NikonSeriesE135mmf28.data.ts) | 50.0% | 50.0% | 2/4 | 2/4 | 2 | abbe: 2 |
+| 198 | [CANON SERENAR 35mm f/3.2](../../src/lens-data/canon/CanonSerenar35mmf32.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
+| 199 | [VIVITAR SERIES 1 200mm f/3.0 VMC](../../src/lens-data/vivitar/VivitarSeries1200mmf3.data.ts) | 50.0% | 50.0% | 3/6 | 3/6 | 3 | abbe: 3 |
+| 200 | [MINOLTA AF APO Tele 200mm f/2.8](../../src/lens-data/minolta/MinoltaAF200mmf28.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
+| 201 | [RODENSTOCK APO-SIRONAR-W 150mm f/5.6](../../src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
+| 202 | [RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) | 50.0% | 50.0% | 4/8 | 4/8 | 4 | abbe: 4 |
+| 203 | [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) | 50.0% | 50.0% | 5/10 | 5/10 | 5 | abbe: 5 |
+| 204 | [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 205 | [NIKON NIKKOR Z 24-50mm f/4-6.3](../../src/lens-data/nikon/NikonNikkorZ2450mmf463.data.ts) | 50.0% | 50.0% | 6/12 | 6/12 | 6 | abbe: 6 |
+| 206 | [NIKON AF-P DX NIKKOR 10-20mm f/4.5-5.6 G VR](../../src/lens-data/nikon/NikonAFPDX1020mmf4556G.data.ts) | 50.0% | 50.0% | 8/16 | 8/16 | 8 | abbe: 8 |
 |  | **45-49.9% coverage** |  |  |  |  |  |  |
-| 204 | [SIGMA 17-40mm f/1.8 DC | Art](../../src/lens-data/sigma/Sigma1740mmf18DCA.data.ts) | 47.1% | 47.1% | 8/17 | 8/17 | 9 | abbe: 9 |
-| 205 | [Nikon AI Zoom-Nikkor 25-50mm f/4](../../src/lens-data/nikon/NikonAIZoomNikkor2550mmf4.data.ts) | 45.5% | 45.5% | 5/11 | 5/11 | 6 | abbe: 6 |
-| 206 | [Nikon AI Zoom-Nikkor 360-1200mm f/11 ED](../../src/lens-data/nikon/NikonAIZoomNikkor3601200mmf11ED.data.ts) | 45.0% | 45.0% | 9/20 | 9/20 | 11 | abbe: 11 |
+| 207 | [SIGMA 17-40mm f/1.8 DC | Art](../../src/lens-data/sigma/Sigma1740mmf18DCA.data.ts) | 47.1% | 47.1% | 8/17 | 8/17 | 9 | abbe: 9 |
+| 208 | [Nikon AI Zoom-Nikkor 25-50mm f/4](../../src/lens-data/nikon/NikonAIZoomNikkor2550mmf4.data.ts) | 45.5% | 45.5% | 5/11 | 5/11 | 6 | abbe: 6 |
+| 209 | [Nikon AI Zoom-Nikkor 360-1200mm f/11 ED](../../src/lens-data/nikon/NikonAIZoomNikkor3601200mmf11ED.data.ts) | 45.0% | 45.0% | 9/20 | 9/20 | 11 | abbe: 11 |
 |  | **40-44.9% coverage** |  |  |  |  |  |  |
-| 207 | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 208 | [MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 209 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
-| 210 | [CARL ZEISS JENA BIOGON 35mm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 211 | [MINOLTA AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 212 | [SONY SONNAR T* FE 35mm f/2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
-| 213 | [LAOWA 58mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
-| 214 | [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 215 | [NIKON AI NIKKOR 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 216 | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
-| 217 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 210 | [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 211 | [MINOLTA AF 28mm f/2](../../src/lens-data/minolta/MinoltaAF28mmf2.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 212 | [VOIGTLÄNDER NOKTON 50mm f/1.0](../../src/lens-data/voigtlander/VoigtlanderNokton50f1.data.ts) | 44.4% | 44.4% | 4/9 | 4/9 | 5 | abbe: 5 |
+| 213 | [CARL ZEISS JENA BIOGON 35mm f/2.8 (pre-war)](../../src/lens-data/carl-zeiss-jena/ZeissBiogon35mmf28Prewar.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 214 | [MINOLTA AF Zoom 35-70mm f/4](../../src/lens-data/minolta/MinoltaAF3570mmf4.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 215 | [SONY SONNAR T* FE 35mm f/2.8 ZA](../../src/lens-data/sony/SonyFE35mmf28ZA.data.ts) | 42.9% | 42.9% | 3/7 | 3/7 | 4 | abbe: 4 |
+| 216 | [LAOWA 58mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) | 42.9% | 42.9% | 6/14 | 6/14 | 8 | abbe: 8 |
+| 217 | [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 218 | [NIKON AI NIKKOR 180mm f/2.8 ED](../../src/lens-data/nikon/NikonAINikkor180mmf28.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 219 | [PENTAX F 85mm f/2.8 Soft](../../src/lens-data/pentax/PentaxF85mmf28Soft.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
+| 220 | [VOIGTLÄNDER HELIAR (Symmetric) f/4](../../src/lens-data/voigtlander/VoigtlanderHeliar.data.ts) | 40.0% | 40.0% | 2/5 | 2/5 | 3 | abbe: 3 |
 |  | **35-39.9% coverage** |  |  |  |  |  |  |
-| 218 | [NIKON AF-P NIKKOR 70-300mm f/4.5-5.6 E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
-| 219 | [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
-| 220 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
-| 221 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
-| 222 | [NIKON NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
-| 223 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
-| 224 | [SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
+| 221 | [NIKON AF-P NIKKOR 70-300mm f/4.5-5.6 E ED VR](../../src/lens-data/nikon/NikonAFP70300mmf4556E.data.ts) | 38.9% | 38.9% | 7/18 | 7/18 | 11 | abbe: 11 |
+| 222 | [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) | 38.5% | 38.5% | 5/13 | 5/13 | 8 | abbe: 8 |
+| 223 | [CARL ZEISS BIOGON 21mm f/4.5](../../src/lens-data/carl-zeiss-oberkochen/ZeissBiogon21mmf45.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
+| 224 | [SCHNEIDER-KREUZNACH SUPER-ANGULON 75mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderSuperAngulon75mmf56.data.ts) | 37.5% | 37.5% | 3/8 | 3/8 | 5 | abbe: 5 |
+| 225 | [NIKON NIKKOR Z DX 50-250mm f/4.5-6.3 VR](../../src/lens-data/nikon/NikonZDX50250mmf4564VR.data.ts) | 37.5% | 37.5% | 6/16 | 6/16 | 10 | abbe: 10 |
+| 226 | [OLYMPUS OM ZUIKO AUTO-W 21mm f/2](../../src/lens-data/olympus/OlympusZuikoAuto21mmf2.data.ts) | 36.4% | 36.4% | 4/11 | 4/11 | 7 | abbe: 7 |
+| 227 | [SONY FE 70-200mm f/2.8 GM OSS II](../../src/lens-data/sony/SonyFE70200mmf28GMII.data.ts) | 35.3% | 35.3% | 6/17 | 6/17 | 11 | abbe: 11 |
 |  | **30-34.9% coverage** |  |  |  |  |  |  |
-| 225 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 226 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 227 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 228 | [NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 229 | [PENTAX DA 70mm f/2.4 Limited](../../src/lens-data/pentax/PentaxDA70mmf24Limited.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 230 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
-| 231 | [SIGMA 85mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
-| 232 | [NIKON AF-S DX NIKKOR 55-200mm f/4-5.6 G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
-| 233 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
+| 228 | [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 229 | [CARL ZEISS JENA SONNAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/ZeissJenaSonnar50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 230 | [MINOLTA VARISOFT ROKKOR 85mm f/2.8](../../src/lens-data/minolta/MinoltaVarisoft85mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 231 | [NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 232 | [PENTAX DA 70mm f/2.4 Limited](../../src/lens-data/pentax/PentaxDA70mmf24Limited.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 233 | [VOIGTLÄNDER ULTRON 50mm f/2](../../src/lens-data/voigtlander/VoigtlanderUltron50f2.data.ts) | 33.3% | 33.3% | 2/6 | 2/6 | 4 | abbe: 4 |
+| 234 | [SIGMA 85mm f/1.4 DG DN | Art](../../src/lens-data/sigma/SigmaDGDNA85mmf14.data.ts) | 33.3% | 33.3% | 5/15 | 5/15 | 10 | abbe: 10 |
+| 235 | [NIKON AF-S DX NIKKOR 55-200mm f/4-5.6 G ED VR II](../../src/lens-data/nikon/NikonAFSDX55200mmf456G.data.ts) | 30.8% | 30.8% | 4/13 | 4/13 | 9 | abbe: 9 |
+| 236 | [VOIGTLÄNDER APO-LANTHAR 50mm f/2.0 Aspherical](../../src/lens-data/voigtlander/VoigtlanderApoLanthar50f2.data.ts) | 30.0% | 30.0% | 3/10 | 3/10 | 7 | abbe: 7 |
 |  | **25-29.9% coverage** |  |  |  |  |  |  |
-| 234 | [LEICA ELMARIT-R 35mm f/2.8](../../src/lens-data/leica/LeicaElmaritR35mmf28.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
-| 235 | [NIKON W-NIKKOR 35mm f/1.8](../../src/lens-data/nikon/NikonWNikkor35mmf18.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
+| 237 | [LEICA ELMARIT-R 35mm f/2.8](../../src/lens-data/leica/LeicaElmaritR35mmf28.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
+| 238 | [NIKON W-NIKKOR 35mm f/1.8](../../src/lens-data/nikon/NikonWNikkor35mmf18.data.ts) | 28.6% | 28.6% | 2/7 | 2/7 | 5 | abbe: 5 |
+| 239 | [RODENSTOCK GRANDAGON-N 65mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts) | 25.0% | 25.0% | 2/8 | 2/8 | 6 | abbe: 6 |
 |  | **20-24.9% coverage** |  |  |  |  |  |  |
-| 236 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
+| 240 | [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) | 20.0% | 20.0% | 1/5 | 1/5 | 4 | abbe: 4 |
 |  | **15-19.9% coverage** |  |  |  |  |  |  |
-| 237 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
-| 238 | [SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
+| 241 | [FUJIFILM FUJINON XF 50mm f/1.0 R WR](../../src/lens-data/fujifilm/FujifilmXF50f1.data.ts) | 16.7% | 16.7% | 2/12 | 2/12 | 10 | abbe: 10 |
+| 242 | [SONY FE 28-70mm f/2 GM](../../src/lens-data/sony/SonyFE2870mmf2GM.data.ts) | 15.0% | 15.0% | 3/20 | 3/20 | 17 | abbe: 17 |
 |  | **10-14.9% coverage** |  |  |  |  |  |  |
-| 239 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
-| 240 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 243 | [OLYMPUS ZUIKO AUTO-MACRO 90mm f/2](../../src/lens-data/olympus/OlympusZuikoAutoMacro90mmf2.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
+| 244 | [PANASONIC LEICA DG SUMMILUX 15mm f/1.7 ASPH](../../src/lens-data/panasonic/PanasonicLeicaDG15mmf17.data.ts) | 11.1% | 11.1% | 1/9 | 1/9 | 8 | abbe: 8 |
 |  | **0-4.9% coverage** |  |  |  |  |  |  |
-| 241 | [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) *(hidden)* | 0.0% | 0.0% | 0/3 | 0/3 | 1 | abbe: 1 |
-| 242 | [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) *(hidden)* | 0.0% | 0.0% | 0/1 | 0/1 | 1 | abbe: 1 |
-| 243 | [CARL ZEISS JENA TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 244 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
-| 245 | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) | 0.0% | 0.0% | 0/5 | 0/5 | 5 | abbe: 5 |
-| 246 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 247 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 248 | [LEICA SUMMICRON-R 50mm f/2](../../src/lens-data/leica/LeicaSummicronR50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 249 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 250 | [NIKON AI NIKKOR 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
-| 251 | [CARL ZEISS JENA SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 252 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
-| 253 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
+| 245 | [REFERENCE Maksutov Cassegrain Meniscus](../../src/lens-data/reference/ReferenceMaksutovCassegrainMeniscus.data.ts) *(hidden)* | 0.0% | 0.0% | 0/3 | 0/3 | 1 | abbe: 1 |
+| 246 | [REFERENCE Mangin Second-Surface Mirror](../../src/lens-data/reference/ReferenceManginSecondSurfaceMirror.data.ts) *(hidden)* | 0.0% | 0.0% | 0/1 | 0/1 | 1 | abbe: 1 |
+| 247 | [CARL ZEISS JENA TESSAR 144mm f/5.5](../../src/lens-data/carl-zeiss-jena/ZeissTessar144f55.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 248 | [LEICA ELCAN 50mm f/2](../../src/lens-data/leica/LeicaElcan50mmf2.data.ts) | 0.0% | 0.0% | 0/4 | 0/4 | 4 | abbe: 4 |
+| 249 | [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) | 0.0% | 0.0% | 0/5 | 0/5 | 5 | abbe: 5 |
+| 250 | [CARL ZEISS JENA PANCOLAR 50mm f/2](../../src/lens-data/carl-zeiss-jena/CarlZeissJenaPancolar50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 251 | [LEICA SUMMICRON-M 50mm f/2](../../src/lens-data/leica/LeicaSummicronV550mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 252 | [LEICA SUMMICRON-R 50mm f/2](../../src/lens-data/leica/LeicaSummicronR50mmf2.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 253 | [MINOLTA MD ROKKOR 45mm f/2](../../src/lens-data/minolta/MinoltaRokkor45mmf2MD.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 254 | [NIKON AI NIKKOR 28mm f/3.5](../../src/lens-data/nikon/NikonAI28mmf35.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 255 | [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) | 0.0% | 0.0% | 0/6 | 0/6 | 6 | abbe: 6 |
+| 256 | [CARL ZEISS JENA SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 257 | [CARL ZEISS PLANAR T* 50mm f/1.4](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissPlanarT50mmf14.data.ts) | 0.0% | 0.0% | 0/7 | 0/7 | 7 | abbe: 7 |
+| 258 | [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) | 0.0% | 0.0% | 0/8 | 0/8 | 8 | abbe: 8 |
 
 ## Missing Surface Details
 
@@ -1283,6 +1289,13 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 | 1A | Element 1 | abbe | `M-TAF105 (HOYA)` | No catalog match |
 | 15 | Element 8 | abbe | `FDS16-W (HOYA)` | No catalog match |
 
+### [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) - 75.0% trusted (6/8); 25.0% Sellmeier (2/8) - DE 2444954 A1
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 4 | Element 3 | abbe | `SSK2 / N-SSK2 class (Schott)` | No catalog match |
+| 5 | Element 4 | abbe | `Unmatched (short-flint / barium-crown boundary; patent ne=1.5629, ve=46.88)` | Explicit unmatched/proprietary annotation |
+
 ### [CANON TS-E 50mm f/2.8L MACRO](../../src/lens-data/canon/CanonTSE50mmf28L.data.ts) - 75.0% trusted (9/12); 75.0% Sellmeier (9/12) - US 10,571,651 B2
 
 | Surface | Element | Runtime quality | Glass annotation | Reason |
@@ -1864,6 +1877,24 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 | 5 | Element 3 | abbe | `Unmatched high-index lanthanum crown (720/521)` | Explicit unmatched/proprietary annotation |
 | 7 | Element 4 | abbe | `Unmatched dense lanthanum flint (721/334)` | Explicit unmatched/proprietary annotation |
 
+### [RODENSTOCK APO-SIRONAR-W 150mm f/5.6](../../src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.data.ts) - 50.0% trusted (4/8); 50.0% Sellmeier (4/8) - DE 3907928 A1
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 3 | Element 2 | abbe | `N-PSK53A class (Schott equivalent; patent-rounded nd/vd)` | No catalog match |
+| 4 | Element 3 | abbe | `Unmatched (dense lanthanum/barium flint class; patent-rounded nd=1.69, vd=49.6)` | Explicit unmatched/proprietary annotation |
+| 6 | Element 4 | abbe | `K10 class (Schott equivalent; patent-rounded nd/vd)` | No catalog match |
+| 12 | Element 8 | abbe | `Unmatched (dense crown / short-flint class; patent-rounded nd=1.62, vd=53.2)` | Explicit unmatched/proprietary annotation |
+
+### [RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) - 50.0% trusted (4/8); 50.0% Sellmeier (4/8) - DE 2444954 A1
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 3 | Element 2 | abbe | `SF5 (Schott)` | No catalog match |
+| 4 | Element 3 | abbe | `SSK2 / N-SSK2 (Schott)` | No catalog match |
+| 5 | Element 4 | abbe | `LLF3 / QF2 class (inferred, d-code 561468)` | No catalog match |
+| 8 | Element 6 | abbe | `SK3 / H-ZK4 class (Schott/CDGM equivalent)` | No catalog match |
+
 ### [NIKON NIKKOR Z 28mm f/2.8](../../src/lens-data/nikon/NikonZ28f28.data.ts) - 50.0% trusted (5/10); 50.0% Sellmeier (5/10) - WO 2022/071249 A1
 
 | Surface | Element | Runtime quality | Glass annotation | Reason |
@@ -2251,6 +2282,17 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 | 10 | Element 6 | abbe | `J-LAK9 class (Nikon J-series match)` | No catalog match |
 | 11 | Element 7 | abbe | `J-SF11 class (Nikon J-series match)` | No catalog match |
 
+### [RODENSTOCK GRANDAGON-N 65mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts) - 25.0% trusted (2/8); 25.0% Sellmeier (2/8) - DE 2444954 A1
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 3 | Element 2 | abbe | `SF5 / N-SF5 class (Schott; patent e-line values)` | No catalog match |
+| 4 | Element 3 | abbe | `SSK2 class (Schott dense special crown; patent e-line values)` | No catalog match |
+| 5 | Element 4 | abbe | `Unmatched barium-flint / short-flint class (patent e-line values)` | Explicit unmatched/proprietary annotation |
+| 7 | Element 5 | abbe | `Unmatched barium crown / BaK class (patent e-line values)` | Explicit unmatched/proprietary annotation |
+| 8 | Element 6 | abbe | `Unmatched dense crown, SK-class (patent e-line values)` | Explicit unmatched/proprietary annotation |
+| 9 | Element 7 | abbe | `Unmatched high-index barium-flint class (patent e-line values; Claim 4 prints v_e = 46.13)` | Explicit unmatched/proprietary annotation |
+
 ### [LEICA ELMARIT 90mm f/2.8](../../src/lens-data/leica/LeicaElmarit90mmf28.data.ts) - 20.0% trusted (1/5); 20.0% Sellmeier (1/5) - US 2,995,980
 
 | Surface | Element | Runtime quality | Glass annotation | Reason |
@@ -2396,6 +2438,17 @@ Incomplete visible lenses, still ordered by descending trusted chromatic complet
 | 7 | Element 4 | abbe | `J-SF4 (HIKARI)` | No catalog match |
 | 9 | Element 5 | abbe | `J-SK16 (HIKARI)` | No catalog match |
 | 11 | Element 6 | abbe | `J-SK5 (HIKARI)` | No catalog match |
+
+### [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) - 0.0% trusted (0/6); 0.0% Sellmeier (0/6) - DE 26
+
+| Surface | Element | Runtime quality | Glass annotation | Reason |
+|---|---|---|---|---|
+| 1 | Element 1 | abbe | `K5 / N-K5 class (Schott; stored patent n_e)` | No catalog match |
+| 3 | Element 2 | abbe | `SF10 class (Schott legacy; stored patent n_e)` | SF10 rejected by nd safety net (Δnd=-0.0060) |
+| 4 | Element 3 | abbe | `BaF8 / J-BAF8 class (stored patent n_e)` | No catalog match |
+| 6 | Element 4 | abbe | `BaSF4 class (Schott/Sumita equivalent; stored patent n_e)` | No catalog match |
+| 7 | Element 5 | abbe | `SF18 / S-TIH18 class (stored patent n_e)` | S-TIH18 rejected by nd safety net (Δnd=-0.0058) |
+| 9 | Element 6 | abbe | `K5 / N-K5 class (Schott; stored patent n_e)` | No catalog match |
 
 ### [CARL ZEISS JENA SONNAR 50mm f/1.5](../../src/lens-data/carl-zeiss-jena/ZeissSonnar50f15.data.ts) - 0.0% trusted (0/7); 0.0% Sellmeier (0/7) - US 1,975,678
 

--- a/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes-missing-sellmeier.generated.md
@@ -9,7 +9,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **366** lenses scanned
+- **372** lenses scanned
 - **306** total code-only elements found
 - **206** elements in this report
 - **83** distinct lens files affected

--- a/agent_docs/generated/six-digit-glass-codes.generated.md
+++ b/agent_docs/generated/six-digit-glass-codes.generated.md
@@ -9,7 +9,7 @@ Regenerate the full glass report set with `npm run generate:glass-reports`.
 
 ## Summary
 
-- **366** lenses scanned
+- **372** lenses scanned
 - **306** total code-only elements found
 - **306** elements in this report
 - **108** distinct lens files affected

--- a/agent_docs/generated/unresolved-glass.generated.md
+++ b/agent_docs/generated/unresolved-glass.generated.md
@@ -8,16 +8,17 @@ or per-lens patent backfills.
 
 ## Summary
 
-- **366** lenses scanned
-- **4124** non-air surfaces examined
-- **4128** element glass declarations examined
-- **638** non-explicit-unmatched annotations did not resolve
-- **224** distinct unresolved glass-like tokens found
+- **372** lenses scanned
+- **4165** non-air surfaces examined
+- **4169** element glass declarations examined
+- **656** non-explicit-unmatched annotations did not resolve
+- **230** distinct unresolved glass-like tokens found
 
 ## Tokens by Frequency
 
 | Token | Occurrences | Lens files | Notes |
 |---|---:|---:|---|
+| SF5 | 5 | 5 | |
 | 670571 | 4 | 2 | |
 | 863252 | 4 | 2 | |
 | S-NPH7 | 4 | 4 | |
@@ -50,9 +51,13 @@ or per-lens patent backfills.
 | K-LAFK50 | 2 | 1 | |
 | N-BAF4 | 2 | 2 | |
 | N-BAK4 | 2 | 2 | |
+| N-K5 | 2 | 1 | |
 | N-LAF2 | 2 | 1 | |
 | N-LAK9 | 2 | 2 | |
 | N-LASF44 | 2 | 2 | |
+| N-PSK53A | 2 | 2 | |
+| N-SF5 | 2 | 2 | |
+| N-SSK2 | 2 | 2 | |
 | NBFD10 | 2 | 2 | |
 | NBFD32 | 2 | 2 | |
 | S-APL1 | 2 | 1 | |
@@ -61,8 +66,8 @@ or per-lens patent backfills.
 | S-LAL61 | 2 | 2 | |
 | S-LAM73 | 2 | 1 | |
 | S-NBH53 | 2 | 2 | |
-| SF5 | 2 | 2 | |
 | SK18 | 2 | 1 | |
+| SK3 | 2 | 2 | |
 | TAF1 | 2 | 2 | |
 | 157957 | 1 | 1 | |
 | 182080 | 1 | 1 | |
@@ -81,6 +86,7 @@ or per-lens patent backfills.
 | 553555 | 1 | 1 | |
 | 554381 | 1 | 1 | |
 | 561453 | 1 | 1 | |
+| 561468 | 1 | 1 | |
 | 571560 | 1 | 1 | |
 | 574425 | 1 | 1 | |
 | 575413 | 1 | 1 | |
@@ -183,6 +189,7 @@ or per-lens patent backfills.
 | H-ZF39 | 1 | 1 | |
 | H-ZF52A | 1 | 1 | |
 | H-ZF72 | 1 | 1 | |
+| H-ZK4 | 1 | 1 | |
 | H-ZLAF2 | 1 | 1 | |
 | H-ZLAF55C | 1 | 1 | |
 | H-ZLAF68N | 1 | 1 | |
@@ -205,8 +212,6 @@ or per-lens patent backfills.
 | N-LAK7 | 1 | 1 | |
 | N-LASF43 | 1 | 1 | |
 | N-PK51 | 1 | 1 | |
-| N-PSK53A | 1 | 1 | |
-| N-SF5 | 1 | 1 | |
 | NBFD12 | 1 | 1 | |
 | NBFD30 | 1 | 1 | |
 | S-BAH32 | 1 | 1 | |
@@ -232,6 +237,7 @@ or per-lens patent backfills.
 | SF14 | 1 | 1 | |
 | SF19 | 1 | 1 | |
 | SF3 | 1 | 1 | |
+| SK12 | 1 | 1 | |
 | SK4 | 1 | 1 | |
 | SK7 | 1 | 1 | |
 | SK8 | 1 | 1 | |
@@ -244,6 +250,14 @@ or per-lens patent backfills.
 | TAFL3 | 1 | 1 | |
 
 ## Occurrences
+
+### SF5 — 5 occurrences
+
+- [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) 6: `SF5-class dense flint (Schott; e-line source values)`
+- [RODENSTOCK GRANDAGON-N 65mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts) 3: `SF5 / N-SF5 class (Schott; patent e-line values)`
+- [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) 3: `SF5 (Schott legacy dense flint)`
+- [RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) 3: `SF5 (Schott)`
+- [VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) 7: `SF5 (Schott) / K-SFS5 (Sumita)`
 
 ### 670571 — 4 occurrences
 
@@ -416,6 +430,11 @@ or per-lens patent backfills.
 - [LEICA ELMAR-M 135mm f/4](../../src/lens-data/leica/LeicaElmarM135mmf4.data.ts) 1: `N-BAK4 / BaK4 class (Schott; patent e-line value stored)`
 - [NIKON NIKKOR 35mm f/2.8 (Nikon 35Ti)](../../src/lens-data/nikon/Nikon35Ti35mmf28.data.ts) 9: `Schott N-BAK4 (nd=1.56883 / νd=56.04; Δnd≈0, Δνd=−0.04)`
 
+### N-K5 — 2 occurrences
+
+- [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) 1: `K5 / N-K5 class (Schott; stored patent n_e)`
+- [RODENSTOCK GRANDAGON-N 75mm f/6.8](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts) 9: `K5 / N-K5 class (Schott; stored patent n_e)`
+
 ### N-LAF2 — 2 occurrences
 
 - [CARL ZEISS DISTAGON T* 28mm f/2](../../src/lens-data/carl-zeiss-oberkochen/ZeissDistagon28mmf2.data.ts) 5: `LAF2 / N-LAF2 class (Schott, 744448; patent values retained)`
@@ -430,6 +449,21 @@ or per-lens patent backfills.
 
 - [FUJIFILM FUJINON GF 30mm f/5.6 T/S](../../src/lens-data/fujifilm/FujifilmGF30mmf56TS.data.ts) 26: `N-LASF44 (Schott)`
 - [SIGMA 60mm f/2.8 DN | Art](../../src/lens-data/sigma/Sigma60mmf28DN.data.ts) 1: `TAF3 / N-LASF44 class (804/465 dense lanthanum flint)`
+
+### N-PSK53A — 2 occurrences
+
+- [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) 12: `N-PSK53A (Schott exact match; production vendor unproven)`
+- [RODENSTOCK APO-SIRONAR-W 150mm f/5.6](../../src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.data.ts) 3: `N-PSK53A class (Schott equivalent; patent-rounded nd/vd)`
+
+### N-SF5 — 2 occurrences
+
+- [RICOH GR LENS A12 28mm f/2.5 (Ricoh GXR A12)](../../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) 10: `S-TIF6 (OHARA) / N-SF5 (SCHOTT)`
+- [RODENSTOCK GRANDAGON-N 65mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts) 3: `SF5 / N-SF5 class (Schott; patent e-line values)`
+
+### N-SSK2 — 2 occurrences
+
+- [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) 4: `SSK2 / N-SSK2 class (Schott)`
+- [RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) 4: `SSK2 / N-SSK2 (Schott)`
 
 ### NBFD10 — 2 occurrences
 
@@ -471,15 +505,15 @@ or per-lens patent backfills.
 - [FUJIFILM FUJINON XF 90mm f/2 R LM WR](../../src/lens-data/fujifilm/FujifilmXF90mmf2.data.ts) 6: `S-NBH53 (OHARA)`
 - [SONY E 18-55mm f/3.5-5.6 OSS](../../src/lens-data/sony/SonyE1855mmf3556.data.ts) 4: `S-NBH53 (OHARA)`
 
-### SF5 — 2 occurrences
-
-- [LEICA ELMARIT-M 135mm f/2.8](../../src/lens-data/leica/LeicaElmaritM135mmf28.data.ts) 6: `SF5-class dense flint (Schott; e-line source values)`
-- [VOIGTLÄNDER MACRO APO-LANTHAR 125mm f/2.5 SL](../../src/lens-data/voigtlander/VoigtlanderMacroApoLanthar125mmf25.data.ts) 7: `SF5 (Schott) / K-SFS5 (Sumita)`
-
 ### SK18 — 2 occurrences
 
 - [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) 7: `SK18 (Schott)`
 - [CANON SERENAR 50mm f/1.8](../../src/lens-data/canon/CanonSerenar50mmf18.data.ts) 9: `SK18 (Schott)`
+
+### SK3 — 2 occurrences
+
+- [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) 8: `SK3 (Schott legacy dense crown)`
+- [RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) 8: `SK3 / H-ZK4 class (Schott/CDGM equivalent)`
 
 ### TAF1 — 2 occurrences
 
@@ -553,6 +587,10 @@ or per-lens patent backfills.
 ### 561453 — 1 occurrence
 
 - [HASSELBLAD HC 150mm f/3.2](../../src/lens-data/hasselblad/HasselbladHC150mmf32.data.ts) 12: `561453 - barium light flint (patent e-line Ne=1.56433, vd=45.3; no exact public catalog match)`
+
+### 561468 — 1 occurrence
+
+- [RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) 5: `LLF3 / QF2 class (inferred, d-code 561468)`
 
 ### 571560 — 1 occurrence
 
@@ -962,6 +1000,10 @@ or per-lens patent backfills.
 
 - [LAOWA 58mm f/2.8 2× Ultra-Macro APO](../../src/lens-data/laowa/Laowa58mmf28MacroAPO.data.ts) 9: `H-ZF72 (CDGM)`
 
+### H-ZK4 — 1 occurrence
+
+- [RODENSTOCK GRANDAGON-N 90mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts) 8: `SK3 / H-ZK4 class (Schott/CDGM equivalent)`
+
 ### H-ZLAF2 — 1 occurrence
 
 - [LAOWA 15mm f/4 Wide Angle 1:1 Macro](../../src/lens-data/laowa/Laowa15mmf4Macro.data.ts) 3: `H-ZLAF2 (CDGM)`
@@ -1049,14 +1091,6 @@ or per-lens patent backfills.
 ### N-PK51 — 1 occurrence
 
 - [SCHNEIDER-KREUZNACH APO-SYMMAR 100mm f/5.6](../../src/lens-data/schneider-kreuznach/SchneiderAPOSymmar100mmf56.data.ts) 6: `N-PK51 (Schott)`
-
-### N-PSK53A — 1 occurrence
-
-- [MINOLTA AF 35-105mm f/3.5-4.5 New (v2)](../../src/lens-data/minolta/MinoltaAF35105mmf3545v2.data.ts) 12: `N-PSK53A (Schott exact match; production vendor unproven)`
-
-### N-SF5 — 1 occurrence
-
-- [RICOH GR LENS A12 28mm f/2.5 (Ricoh GXR A12)](../../src/lens-data/ricoh/RicohGXRA1218mmf25.data.ts) 10: `S-TIF6 (OHARA) / N-SF5 (SCHOTT)`
 
 ### NBFD12 — 1 occurrence
 
@@ -1157,6 +1191,10 @@ or per-lens patent backfills.
 ### SF3 — 1 occurrence
 
 - [CARL ZEISS PRO-TESSAR 35mm f/3.2](../../src/lens-data/carl-zeiss-oberkochen/CarlZeissProTessar35mmf32.data.ts) 1: `SF3 (Schott)`
+
+### SK12 — 1 occurrence
+
+- [RODENSTOCK GRANDAGON-N 75mm f/4.5](../../src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts) 7: `SK12 (Schott legacy dense crown)`
 
 ### SK4 — 1 occurrence
 

--- a/src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.analysis.md
+++ b/src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.analysis.md
@@ -1,0 +1,158 @@
+# Rodenstock Apo-Sironar-W 150 mm f/5.6
+
+## Patent Reference and Design Identification
+
+**Patent:** DE 3,907,928 A1
+**Filed:** 11 March 1989
+**Published:** 20 September 1990
+**Inventors:** Ernst Rothe; Josef Weiss
+**Applicant:** Optische Werke G. Rodenstock, München, DE
+**Classification:** G02B 9/60
+**Title:** *Objektiv mit großem Bildwinkel*
+**Embodiment analyzed:** Table 5, with an EFL-reconciled reconstruction
+**Total worked examples:** Five numerical tables
+
+DE 3,907,928 A1 describes a large-format wide-angle objective whose worked examples are stated to have an image angle of 80° and an aperture ratio of about f/5.6. The patent's general construction is a four-lens front group and a three-lens rear group separated by a diaphragm. Table 5 is the only example with a stated focal length near 150 mm: `f = 148.7` mm.
+
+The production identification is strong but not mechanically exact. Product literature for the Apo-Sironar-W 150 mm f/5.6 lists an 80° field at f/22, a 252 mm image circle, maximum recommended 5×7 in. format, and a 7-element / 5-group construction. Table 5 supplies the 148.7 mm patent focal length and the same 80° / f/5.6 design class, so it is the relevant patent example for the 150 mm Apo-Sironar-W. The unresolved problem is that the literal patent claim and figure describe a 7-element rear-group topology, while the printed Table 5 numerical data cannot reproduce the stated focal length under that topology.
+
+The accompanying data file therefore transcribes an EFL-reconciled reconstruction of Table 5, not an unqualified measured production prescription. It uses the patent's stated surface-medium convention, assigns an inferred CaF2-class medium after surface 8, and adds an implicit flat rear surface after the final printed glass thickness. This produces the printed `f = 148.7` mm exactly, but it gives an 8-element / 5-group reconstruction. The production literature remains authoritative for the public product count: 7 elements in 5 groups.
+
+## Optical Architecture
+
+The patent architecture is a wide-angle plasmat-derived large-format objective. The front group consists of four lenses: L1, a cemented L2+L3 doublet, and L4. The rear group in the claim and drawing consists of three lenses, with the second and third rear lenses cemented in at least the claimed form. All principal lens surfaces are curved toward the diaphragm, a symmetry condition explicitly stated in the claims.
+
+The reconstructed Table 5 data model has five air-spaced groups: L1, L2+L3, L4, L5+L6, and L7+L8. The additional rear element is not asserted as proven production construction. It is the minimum paraxial reconstruction that reconciles Table 5 with the printed focal length.
+
+The front group is net negative in the reconstructed model. Independent paraxial tracing gives a front-group focal length of approximately −400.13 mm. The rear group is strongly positive, with a focal length of approximately +91.10 mm. The full system focal length is 148.700 mm, and the computed back focal distance from the explicit flat rear surface is 116.091 mm.
+
+Table 5 gives the surface-7 air space as `d7 = 8.60` mm and separately gives `Blende = 7.45` mm. The Figure 1 section places the diaphragm close to the first rear surface, so the data file interprets this as 7.45 mm from surface 7 to the stop and 1.15 mm from the stop to surface 8.
+
+## Element-by-Element Analysis
+
+### L1 — Positive Meniscus, convex to object
+
+`nd = 1.52`, `νd = 64.2`. Glass: N-BK7 class, Schott-equivalent after patent rounding. `f = +297.3 mm`.
+
+L1 is a weak positive meniscus with `R1 = +32.66` mm and `R2 = +39.24` mm. Its role is front collection with limited individual power. The claim condition `R2 > R3` is satisfied because `39.24 > 32.90`.
+
+The rounded glass data match a common borosilicate crown class rather than a distinctive special glass. Because the patent rounds the index to two decimals, the catalog label should be read as a class-equivalent assignment, not a melt-level identification.
+
+### L2+L3 — Front Cemented Doublet
+
+**L2:** `nd = 1.62`, `νd = 63.5`. Glass: N-PSK53A / phosphate-crown class, Schott-equivalent after patent rounding. `f = +64.2 mm`.
+
+**L3:** `nd = 1.69`, `νd = 49.6`. Glass: unmatched dense lanthanum/barium flint class. `f = −33.0 mm`.
+
+The L2+L3 doublet is the main front chromatic-correction component. L2 is a strong positive meniscus; L3 overcorrects it with a high-index lower-Abbe negative meniscus. The cemented assembly is net negative, with a reconstructed standalone focal length of approximately −92.21 mm.
+
+The cemented radius `R4 = +169.09` mm satisfies the claim condition `f < R4 < 2f`: for Table 5, `148.7 < 169.09 < 297.4`. The very small L1-L2 air gap, `d2 = 0.10` mm, also satisfies `d2 < 0.01 f`, since `0.01 f = 1.487` mm.
+
+### L4 — Positive Meniscus, convex to object
+
+`nd = 1.50`, `νd = 56.4`. Glass: K10 class, Schott-equivalent after patent rounding. `f = +220.6 mm`.
+
+L4 is the fourth front-group element required by the patent's principal construction. Its individual focal length is longer than the 148.7 mm system focal length, so it is a moderate-power correction element rather than the main power source. It contributes to field and oblique-aberration control while preserving the large stop space required for a shuttered large-format objective.
+
+### Aperture Stop
+
+The diaphragm is positioned in the air space between L4 and the rear group. For the data file, the stop semi-diameter is computed from the f/5.6 entrance pupil. With `EFL = 148.7` mm, the entrance-pupil semi-diameter is `13.2768` mm. A paraxial marginal ray of unit object-side height reaches the stop at height `0.827921`, giving a physical stop semi-diameter of `10.9921` mm.
+
+### L5+L6 — Reconstructed First Rear Cemented Doublet
+
+**L5:** `nd = 1.43384`, `νd = 95.23`. Glass: inferred CaF2-class medium. `f = +177.9 mm` in the selected reconstruction.
+
+**L6:** `nd = 1.46`, `νd = 65.8`. Glass: FK3 / fluor-crown class, Schott legacy-equivalent after patent rounding. `f = +109.6 mm`.
+
+Surface 8 in Table 5 lists only a radius, `R8 = −163.71` mm, and omits thickness, refractive index, and Abbe number. That omission is the source of the principal reconstruction problem. The data file chooses a CaF2-class medium for surface 8 to 9 and solves its center thickness to match the printed system focal length. The resulting thickness is `d8 = 2.640884` mm.
+
+This choice is not presented as a patent-disclosed glass name. It is a paraxial reconciliation. Calcium fluoride and S-FPL53-class fluorophosphate glasses occupy the same very-low-index, very-high-Abbe region needed by the reconstruction, but the patent does not publish line indices or partial-dispersion data for surface 8.
+
+The L5+L6 reconstructed cemented group has a standalone focal length of approximately +68.35 mm. It supplies a large fraction of the rear-group positive power.
+
+### L7+L8 — Final Cemented Doublet and Rear Field Corrector
+
+**L7:** `nd = 1.65`, `νd = 39.6`. Glass: N-KZFS5 / KZFS-class short flint special, Schott-equivalent after patent rounding. `f = +54.2 mm`.
+
+**L8:** `nd = 1.62`, `νd = 53.2`. Glass: unmatched dense crown / short-flint class. `f = −45.5 mm`.
+
+L7 is a high-dispersion positive meniscus with both surfaces concave toward the object side. Its catalog class is consistent with KZFS-family glass, but the patent values are rounded, so the identification remains class-level.
+
+L8 is the final negative element. Table 5 prints a 9.55 mm glass thickness after surface 12 but gives no rear radius. The data file therefore adds surface 13 as an explicit flat exit face. Surface 13 is not a patent-numbered surface; it is a data-model closure used to express the final printed glass thickness under the EFL-reconciled convention. The L7+L8 cemented assembly has a weak net negative focal length of approximately −270.39 mm and functions primarily as a rear correction and field-flattening group.
+
+## Glass Identification and Selection
+
+The following assignments are class-level identifications from rounded patent values. The patent gives only `nd` and `νd`, and in many rows `nd` is rounded to two decimal places. Exact melt identification is therefore not justified.
+
+| Element | Patent or reconstructed `nd` | `νd` | Assignment used | Status |
+|---|---:|---:|---|---|
+| L1 | 1.52 | 64.2 | N-BK7 class | Schott-equivalent after rounding |
+| L2 | 1.62 | 63.5 | N-PSK53A / phosphate-crown class | Schott-equivalent after rounding |
+| L3 | 1.69 | 49.6 | Dense lanthanum/barium flint class | Unmatched |
+| L4 | 1.50 | 56.4 | K10 crown class | Schott-equivalent after rounding |
+| L5 | 1.43384 | 95.23 | CaF2 class | Inferred by EFL reconciliation |
+| L6 | 1.46 | 65.8 | FK3 / fluor-crown class | Legacy Schott-equivalent after rounding |
+| L7 | 1.65 | 39.6 | N-KZFS5 / KZFS class | Schott-equivalent after rounding |
+| L8 | 1.62 | 53.2 | Dense crown / short-flint class | Unmatched |
+
+The chromatic strategy is consistent with an apochromatic large-format lens: low-dispersion and anomalous-partial-dispersion glass classes appear in the rear group, while a phosphate-crown/high-index-flint doublet provides front-group chromatic correction. However, the patent table does not publish `nC`, `nF`, `ng`, `PgF`, or `ΔPgF` values. Any secondary-spectrum discussion must therefore remain inferential rather than spectrally proven from the patent data alone.
+
+## Focus Mechanism
+
+The Apo-Sironar-W is a large-format lens in shutter, so focusing is by moving the entire lens standard on the camera. There are no internal focus groups or floating spacings in the patent table.
+
+The data file models unit focus with a single variable back-focus distance. At infinity, the reconstructed BFD is `116.0913` mm. At the illustrative 3.5 m endpoint, paraxial focus moves to `122.6703` mm, a bellows extension of `6.5790` mm. This endpoint is included only for viewer interaction; it is not a manufacturer minimum-focus specification.
+
+## Aspherical Surfaces
+
+The design is all-spherical. DE 3,907,928 A1 provides no aspherical coefficients for Table 5 or for the other worked examples.
+
+## Conditional Expressions
+
+The patent states five conditions for the worked examples:
+
+| Condition | Table 5 result | Status |
+|---|---:|---|
+| `d2 < 0.01 f` | `0.10 < 1.487` | Satisfied |
+| `f < R4 < 2f` | `148.7 < 169.09 < 297.4` | Satisfied |
+| `n5 - n7 <= 0.06` | Indexing-dependent | Ambiguous under Table 5 anomaly |
+| `n10 - n11 <= 0.05` | Indexing-dependent | Ambiguous under Table 5 anomaly |
+| `ν11 - ν10 >= 15` | Indexing-dependent | Ambiguous under Table 5 anomaly |
+
+The spacing and radius conditions are unambiguous and are satisfied directly from Table 5. The refractive-index and Abbe-number conditions are not treated as cleanly verified for the EFL-reconciled Table 5 model because the model adds an inferred medium after surface 8 and an explicit flat surface 13. Those additions alter the literal mapping between the claim's rear-group indexing and the data-file surfaces. A canonical 7-element reading follows the claim and figure more closely, but it fails the printed `f = 148.7` mm focal length.
+
+## Verification Summary
+
+Independent paraxial tracing was rerun from the Table 5 radii, thicknesses, and refractive indices. The following values are from the reconstructed data file prescription.
+
+| Quantity | Computed value |
+|---|---:|
+| Inferred L5 medium | `nd = 1.43384`, `νd = 95.23` |
+| Solved L5 center thickness | `d8 = 2.640884` mm |
+| Effective focal length | `148.7000` mm |
+| Back focal distance from surface 13 | `116.0913` mm |
+| Front vertex to surface 13 | `49.2209` mm |
+| Front vertex to image plane | `165.3122` mm |
+| Front-group focal length | `−400.13` mm |
+| Rear-group focal length | `+91.10` mm |
+| Petzval sum | `+0.0034338 mm^-1` |
+| Petzval radius | `291.22` mm |
+| f/5.6 entrance-pupil semi-diameter | `13.2768` mm |
+| Physical stop semi-diameter | `10.9921` mm |
+
+A direct 7-element shifted-row interpretation of the rear group was also tested. It gives `EFL ≈ 312.0` mm and `BFD ≈ 301.7` mm, so it cannot represent the printed Table 5 focal length. This is the reason the delivered data file uses the EFL-reconciled 8-element reconstruction while the analysis keeps the production 7-element count separate.
+
+The semi-diameters were not supplied by the patent. The delivered semi-diameters were checked for element edge thickness, element front/rear semi-diameter ratio, and cross-gap sag intrusion. The tightest checks are the L7 edge thickness, about `0.322` mm at the chosen semi-diameter, and the L3-L4 air gap, which retains about `0.416` mm axial clearance at the chosen rim.
+
+## Design Heritage and Context
+
+The Apo-Sironar-W occupies the late-1980s large-format wide-angle plasmat lineage. Its public product distinction was coverage: the 150 mm Apo-Sironar-S was a 75° / 231 mm image-circle lens, while the Apo-Sironar-W 150 mm was specified at 80° / 252 mm.
+
+The patent's principal design idea is the fourth front-group lens. The specification states that this fourth lens allows correction to be distributed between the front and rear groups while retaining a large diaphragm space for a shutter. That is consistent with the large-format application, where the shutter is normally located near the diaphragm rather than in the camera body.
+
+## Sources
+
+- DE 3,907,928 A1, *Objektiv mit großem Bildwinkel*, Optische Werke G. Rodenstock, published 20 September 1990. Primary source for Table 5 prescription, claims, and the Figure 1 lens section.
+- B&H Photo / Rodenstock large-format catalog listing, “Specifications of Apo Sironar W Lenses.” Source for production Apo-Sironar-W 150 mm specifications: 80° field, 252 mm image circle at f/22, 5×7 in. maximum recommended film format, and 7 elements in 5 groups.
+- SCHOTT optical-glass datasheets for N-BK7, N-PSK53A, and N-KZFS5 reference values.
+- OHARA S-FPL53 datasheet and calcium-fluoride material data for comparison with the inferred Table 5 L5 medium.

--- a/src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.data.ts
+++ b/src/lens-data/rodenstock/RodenstockApoSironarW150mmf56.data.ts
@@ -1,0 +1,217 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Rodenstock Apo-Sironar-W 150mm f/5.6
+ *
+ * Data source: DE 3907928 A1, Table 5, Optische Werke G. Rodenstock.
+ * The patent table is internally inconsistent: the production literature and
+ * patent claim/figure indicate a 7-element, 5-group lens, but the printed
+ * Table 5 cannot reproduce f = 148.7 mm under that reading. This prescription
+ * is therefore an EFL-reconciled reconstruction of Table 5 using the patent's
+ * stated surface-medium convention, an inferred CaF2-class medium after
+ * surface 8, and an implicit flat rear surface for the final printed glass
+ * thickness. The added surface 13 is not a patent-numbered surface; it is a
+ * data-model closure for the EFL-reconciled convention.
+ *
+ * Reconstructed table: 8 elements / 5 groups, all spherical.
+ * Production product line: 7 elements / 5 groups, 80 degrees published field,
+ * 252 mm image circle at f/22 for the 150 mm lens.
+ *
+ * Stop placement: Table 5 gives d7 = 8.60 and a separate Blende distance of
+ * 7.45. Fig. 1 places the stop close to the first rear surface, so the data
+ * file splits the surface 7 -> 8 air space into 7.45 mm from surface 7 to STO
+ * and 1.15 mm from STO to surface 8.
+ *
+ * Semi-diameters: The patent omits clear-aperture semi-diameters. The values
+ * below are conservative renderer semi-diameters sized from paraxial f/5.6
+ * rays and reduced where necessary to satisfy edge-thickness and cross-gap sag
+ * constraints. They should not be read as measured production clear apertures
+ * or as proof of full f/5.6 coverage at the 80 degree published field.
+ *
+ * Focus: Unit focus on the view-camera bellows. The close-focus endpoint is an
+ * illustrative 3.5 m object distance used only to expose the unit-focus BF
+ * slider in LensVisualizer; the original lens has no fixed minimum focus
+ * distance independent of the camera.
+ */
+
+const LENS_DATA = {
+  key: "rodenstock-apo-sironar-w-150f56",
+  maker: "Rodenstock",
+  name: "RODENSTOCK APO-SIRONAR-W 150mm f/5.6",
+  subtitle: "DE 3907928 A1 Table 5 - EFL-reconciled reconstruction",
+  specs: [
+    "150mm marketed / 148.7mm design",
+    "f/5.6",
+    "8 elements / 5 groups in reconstructed table",
+    "80° published field",
+    "all-spherical",
+  ],
+
+  focalLengthMarketing: 150,
+  focalLengthDesign: 148.7,
+  apertureMarketing: 5.6,
+  apertureDesign: 5.6,
+  imageFormat: "5x7",
+  patentYear: 1990,
+  elementCount: 8,
+  groupCount: 5,
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 80,
+    maxTraceFieldDeg: 40,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Positive Meniscus",
+      nd: 1.52,
+      vd: 64.2,
+      fl: 297.3,
+      glass: "N-BK7 class (Schott equivalent; patent-rounded nd/vd)",
+      apd: false,
+      role: "Weak positive front collector in the object-side wide-angle meniscus set.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Positive Meniscus",
+      nd: 1.62,
+      vd: 63.5,
+      fl: 64.2,
+      glass: "N-PSK53A class (Schott equivalent; patent-rounded nd/vd)",
+      apd: "inferred",
+      apdNote: "Phosphate-crown / ED-class assignment inferred from rounded nd/vd only.",
+      role: "Positive component of the front cemented chromatic-correction doublet.",
+      cemented: "D1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Negative Meniscus",
+      nd: 1.69,
+      vd: 49.6,
+      fl: -33.0,
+      glass: "Unmatched (dense lanthanum/barium flint class; patent-rounded nd=1.69, vd=49.6)",
+      apd: false,
+      role: "High-index negative partner that overcorrects L2 and makes the front cemented group net negative.",
+      cemented: "D1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Positive Meniscus",
+      nd: 1.5,
+      vd: 56.4,
+      fl: 220.6,
+      glass: "K10 class (Schott equivalent; patent-rounded nd/vd)",
+      apd: false,
+      role: "Fourth front-group meniscus required by the patent to redistribute power and field curvature.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Positive Meniscus",
+      nd: 1.43384,
+      vd: 95.23,
+      fl: 177.9,
+      glass: "CaF2 class (inferred; EFL-reconciled Table 5 model)",
+      apd: "inferred",
+      apdNote:
+        "CaF2-class medium inferred because Table 5 omits the surface-8 glass data; no patent line-index data published.",
+      role: "Inferred ultra-low-dispersion first component of the reconstructed rear doublet.",
+      cemented: "D2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Positive Meniscus",
+      nd: 1.46,
+      vd: 65.8,
+      fl: 109.6,
+      glass: "FK3 class (Schott legacy equivalent; patent-rounded nd/vd)",
+      apd: "inferred",
+      apdNote: "Legacy fluor-crown class assignment inferred from rounded nd/vd only.",
+      role: "Rear component of the first reconstructed rear cemented doublet.",
+      cemented: "D2",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Positive Meniscus",
+      nd: 1.65,
+      vd: 39.6,
+      fl: 54.2,
+      glass: "N-KZFS5 class (Schott equivalent; patent-rounded nd/vd)",
+      apd: "inferred",
+      apdNote: "KZFS-class negative anomalous-partial-dispersion role inferred from rounded nd/vd and design position.",
+      role: "High-dispersion positive component of the final cemented field-corrector doublet.",
+      cemented: "D3",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Plano-Concave Negative",
+      nd: 1.62,
+      vd: 53.2,
+      fl: -45.5,
+      glass: "Unmatched (dense crown / short-flint class; patent-rounded nd=1.62, vd=53.2)",
+      apd: false,
+      role: "Negative rear field-flattener; the flat rear face is implicit in the printed table and explicit here as surface 13.",
+      cemented: "D3",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 32.66, d: 5.0, nd: 1.52, elemId: 1, sd: 15.0 },
+    { label: "2", R: 39.24, d: 0.1, nd: 1.0, elemId: 0, sd: 15.0 },
+    { label: "3", R: 32.9, d: 9.2, nd: 1.62, elemId: 2, sd: 15.0 },
+    { label: "4", R: 169.09, d: 2.1, nd: 1.69, elemId: 3, sd: 15.0 },
+    { label: "5", R: 19.95, d: 2.91, nd: 1.0, elemId: 0, sd: 13.2 },
+    { label: "6", R: 36.13, d: 2.45, nd: 1.5, elemId: 4, sd: 13.2 },
+    { label: "7", R: 52.52, d: 7.45, nd: 1.0, elemId: 0, sd: 12.0 },
+    { label: "STO", R: 1e15, d: 1.15, nd: 1.0, elemId: 0, sd: 10.992131162998318 },
+    { label: "8", R: -163.71, d: 2.6408840731727103, nd: 1.43384, elemId: 5, sd: 12.0 },
+    { label: "9", R: -52.71, d: 2.35, nd: 1.46, elemId: 6, sd: 12.5 },
+    { label: "10", R: -26.13, d: 1.92, nd: 1.0, elemId: 0, sd: 12.5 },
+    { label: "11", R: -136.26, d: 2.4, nd: 1.65, elemId: 7, sd: 11.8 },
+    { label: "12", R: -28.18, d: 9.55, nd: 1.62, elemId: 8, sd: 11.8 },
+    { label: "13", R: 1e15, d: 116.09130644532162, nd: 1.0, elemId: 0, sd: 14.0 },
+  ],
+
+  asph: {},
+  var: {
+    "13": [116.09130644532162, 122.67034675574259],
+  },
+  varLabels: [["13", "BF"]],
+
+  groups: [
+    { text: "FRONT", fromSurface: "1", toSurface: "7" },
+    { text: "REAR", fromSurface: "8", toSurface: "13" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "3", toSurface: "5" },
+    { text: "D2", fromSurface: "8", toSurface: "10" },
+    { text: "D3", fromSurface: "11", toSurface: "13" },
+  ],
+
+  closeFocusM: 3.5,
+  focusDescription:
+    "Unit focus on a view-camera bellows; close endpoint is an illustrative 3.5 m object distance, not a manufacturer minimum-focus specification.",
+  nominalFno: 5.6,
+  fstopSeries: [5.6, 8, 11, 16, 22, 32, 45],
+  maxFstop: 45,
+  scFill: 0.62,
+  yScFill: 0.55,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/rodenstock/RodenstockGeronar210mmf68.analysis.md
+++ b/src/lens-data/rodenstock/RodenstockGeronar210mmf68.analysis.md
@@ -1,0 +1,111 @@
+# Rodenstock Geronar 210 mm f/6.8
+
+## Patent Reference and Design Identification
+
+**Patent:** DE 28 18 394 B1
+**Application Number:** P 28 18 394.0-51
+**Filed:** 27 April 1978
+**Published:** 12 April 1979
+**Inventors:** Franz Schlegel; Josef Weiß
+**Applicant:** Optische Werke G. Rodenstock, 8000 München
+**Title:** Fotografisches Aufnahmeobjektiv für Großformat
+**Classification:** G 02 B 9/16
+**Embodiment analyzed:** Sole numerical example
+
+DE 28 18 394 B1 discloses a three-element photographic taking lens for large-format work. The claim describes two positive collecting lenses, one intervening negative lens, and a diaphragm between the two rear lenses. The numerical example is normalized to $f' = 100$ at $1{:}6.8$, and the patent text states that the preferred objective can have a focal length of 210 mm.
+
+The sole example maps to the Rodenstock Geronar 210 mm f/6.8 by convergent evidence:
+
+1. **Configuration:** the patent prescription is a 3-element / 3-group positive-negative-positive triplet, matching the documented Geronar architecture.
+2. **Focal length:** the patent is normalized to $f' = 100$ and explicitly states a preferred 210 mm production focal length.
+3. **Aperture:** the patent aperture is $1{:}6.8$, matching the production lens designation.
+4. **Coverage:** the patent states a full field of at least 56° and vignetting-free operation at half aperture ("bei halber Blende"). At 210 mm, 56° corresponds to an image circle of about 223 mm, just over the 5×7 inch diagonal of 218.5 mm. Archival/retailer specifications for the production lens commonly list a 60° field and approximately 230-242 mm image-circle class; the original draft's 340 mm f/22 claim was not retained because it could not be tied to a reliable Geronar 210 mm source.
+5. **Glass palette:** the patent explicitly names SK 16, LLF 1, and BK 7, and describes them as inexpensive glasses. This aligns with the Geronar's position as Rodenstock's economy large-format triplet rather than a Sironar-family plasmat.
+6. **Applicant and date:** Rodenstock filed the application in April 1978, consistent with the production era of the Geronar / Caltar II-E 210 mm f/6.8.
+
+## Optical Architecture
+
+The design is a Cooke-type triplet: three air-separated singlets in positive-negative-positive order. L1 is a strong front positive element, L2 is a thin biconcave negative element close behind it, and L3 is a much weaker rear positive element beyond the stop. All six refracting surfaces are spherical.
+
+The patent table gives the first air space as $l_1 = 1.62$ and the second air space as $l_2 = 7.74 + 2.29 = 10.03$ on the $f' = 100$ scale. The numerical value $l_2/l_1 = 10.03/1.62 = 6.19$ is the tabulated relationship behind the patent's approximate 6:1 air-space statement. The figure places the stop closer to L2, so the data file uses $r_4 \rightarrow \mathrm{STO} = 2.29$ and $\mathrm{STO} \rightarrow r_5 = 7.74$, before the ×2.1 production scaling.
+
+The standalone element powers are deliberately strong in the first two elements: at production scale, L1 is approximately +52.1 mm and L2 approximately −46.3 mm, while L3 is approximately +200.1 mm. On the patent's normalized scale these are +24.8, −22.0, and +95.3 respectively. The front positive-negative pair supplies most of the chromatic and spherical-aberration balancing, while the rear positive element completes the image formation and back-focus placement.
+
+## Element-by-Element Analysis
+
+### L1 — Biconvex Positive, Nearly Plano-Convex
+
+$n_d = 1.62041$, $\nu_d = 60.32$. Glass: SK 16 / N-SK16 (Schott). $f = +52.1$ mm at 210 mm scale. Patent e-line values: $n_e = 1.6229$, $\nu_e = 60.07$.
+
+L1 has $r_1 = +15.85$ and $r_2 = -490.61$ on the normalized patent scale. The rear radius is about 31 times weaker than the front radius, so the element behaves almost as a plano-convex collector with the steep surface facing the object. This geometry gives the triplet its strong front positive power without requiring exotic glass.
+
+SK 16 is a dense crown. The modern Schott N-SK16 datasheet gives $n_d = 1.62041$, $\nu_d = 60.32$, $n_e = 1.62286$, and $\nu_e = 60.08$, matching the patent's e-line values within the patent's rounding.
+
+### L2 — Biconcave Negative
+
+$n_d = 1.54814$, $\nu_d = 45.75$. Glass: LLF 1 (Schott). $f = -46.3$ mm at 210 mm scale. Patent e-line values: $n_e = 1.5510$, $\nu_e = 45.47$.
+
+L2 has $r_3 = -72.10$, $r_4 = +14.54$, and a center thickness of only 0.38 on the normalized scale. It is a thin biconcave negative element, with the stronger curvature on the image side. Its close spacing behind L1 forms the correcting counter-power that a Cooke-type triplet needs for axial color and spherical-aberration balance.
+
+LLF 1 is an extra-light flint. Its $\nu_d = 45.75$ puts it in flint territory despite its moderate index. It supplies the required dispersion contrast against the two crown elements without the density and cost of heavier flints.
+
+### L3 — Biconvex Positive, Weak Rear Collector
+
+$n_d = 1.51680$, $\nu_d = 64.17$. Glass: BK 7 / N-BK7 (Schott). $f = +200.1$ mm at 210 mm scale. Patent e-line values: $n_e = 1.5187$, $\nu_e = 63.96$.
+
+L3 has $r_5 = +179.80$ and $r_6 = -67.33$ on the normalized scale. The front surface is weakly curved and the rear surface carries the stronger curvature, making L3 approximately the mirror image of L1 in bending but with far weaker net power. Its principal function is not to dominate system power but to close the triplet, set the final conjugate, and contribute to field and astigmatic balance.
+
+BK 7 is the standard borosilicate crown. The modern Schott N-BK7 datasheet gives $n_d = 1.51680$, $\nu_d = 64.17$, $n_e = 1.51872$, and $\nu_e = 63.96$, again matching the patent's e-line data to the published precision.
+
+## Glass Selection
+
+The patent explicitly names SK 16, LLF 1, and BK 7 and describes the group as inexpensive glasses. This is a central design point. The cited prior art, DE-AS 27 06 498, used LAK 9 and SF 5 and covered only 38°. The present patent instead accepts a slower $f/6.8$ aperture and uses ordinary Schott crown/flint glasses to obtain a substantially wider field.
+
+| Element | Patent glass | Data-file glass | $n_d$ | $\nu_d$ | $\Delta P_{g,F}$ | Role |
+|---|---:|---:|---:|---:|---:|---|
+| L1 | SK 16 | N-SK16 / SK16 (Schott) | 1.62041 | 60.32 | −0.0011 | Dense crown front positive |
+| L2 | LLF 1 | LLF1 (Schott) | 1.54814 | 45.75 | −0.0009 | Extra-light flint negative corrector |
+| L3 | BK 7 | N-BK7 / BK7 (Schott) | 1.51680 | 64.17 | −0.0009 | Borosilicate crown rear positive |
+
+All three glasses lie close to the Schott normal partial-dispersion line. The chromatic correction is therefore a conventional achromatic balance, not an apochromatic or anomalous-partial-dispersion strategy. The data file includes $n_C$, $n_F$, $n_g$, and $\Delta P_{g,F}$ from Schott datasheets so the chromatic model is not limited to Abbe-only interpolation.
+
+## Focus Mechanism
+
+The patent does not publish moving-group data and does not describe an internal focus mechanism. As a view-camera large-format lens, the Geronar focuses by moving the complete optical assembly relative to the film plane using the camera's bellows or rail. There are no floating or internal focusing groups in the patent prescription.
+
+The `.data.ts` file therefore models focusing as unit focus by varying only the final back-focus gap. Because the lens itself has no fixed minimum focus distance, the close-focus endpoint in the data file is an illustrative 2.0 m object distance from the image plane. The corresponding d-line back-focus gap is 206.359 mm, compared with 177.897 mm at infinity; this is a +28.462 mm unit-focus extension and corresponds to a paraxial magnification of approximately 0.135× when the object distance is measured from the image plane. This focus endpoint is an implementation convenience, not a patent-published close-focus specification.
+
+## Verification Summary
+
+The prescription was re-entered from the patent table and independently traced using a paraxial $y$-$n u$ matrix trace. The patent uses e-line indices, while the data file uses Schott d-line catalog indices.
+
+| Quantity | Basis | Computed value | Notes |
+|---|---:|---:|---|
+| EFL, normalized | e-line patent data | 99.97575 | Matches $f'=100$ to −0.024% |
+| BFD, normalized | e-line patent data | 84.63686 | From last surface to paraxial image |
+| EFL, normalized | d-line Schott data | 100.04930 | Slightly longer because d-line indices differ from e-line |
+| BFD, normalized | d-line Schott data | 84.71282 | Stored data-file basis |
+| EFL, production scale | d-line Schott data, ×2.1 | 210.10354 mm | Data-file design focal length |
+| BFD, production scale | d-line Schott data, ×2.1 | 177.89691 mm | Data-file infinity BF gap |
+| Front vertex to image | d-line Schott data, ×2.1 | 216.51591 mm | Total optical track including BFD |
+| Entrance-pupil diameter | d-line, f/6.8 | 30.89758 mm | Stop SD set to 13.342 mm after front-group pupil magnification at the printed stop position |
+| 5×7 half field | 177.8 × 127 mm frame | 27.4735° | Diagonal 218.499 mm |
+
+Standalone element focal lengths at production scale are L1 = +52.069 mm, L2 = −46.284 mm, and L3 = +200.118 mm. These values confirm the patent's description of the two entry-side elements as strongly powered lenses.
+
+The surface-by-surface d-line Petzval sum is +0.00263003 on the normalized $f'=100$ scale. After ×2.1 scaling this becomes +0.00125240 mm⁻¹, corresponding to a Petzval radius of approximately +798.47 mm. This is modest field curvature for a large-format triplet and is expected to be used stopped down.
+
+## Design Heritage and Context
+
+The design is a late, economy-oriented large-format triplet rather than a six-element plasmat. Its premise is conservative: obtain practical large-format coverage with three ordinary spherical singlets and ordinary Schott glass. The patent's contrast with DE-AS 27 06 498 is explicit: the earlier objective used more expensive LAK 9 and SF 5 glass and offered a narrower 38° field, while the present design targets at least 56° with inexpensive SK 16, LLF 1, and BK 7.
+
+That makes the Geronar 210 mm f/6.8 a rational budget alternative below the Sironar and Apo-Sironar families. It is not an apochromat and should not be described as one. Its design value is economy, compactness, and adequate stopped-down coverage for large-format field work.
+
+## Sources
+
+- DE 28 18 394 B1, *Fotografisches Aufnahmeobjektiv für Großformat*, Optische Werke G. Rodenstock, published 12 April 1979.
+- SCHOTT, *Optical Glass Datasheet N-SK16*, official datasheet, https://media.schott.com/api/public/content/5e904e6952b54f05be70518c4b669395
+- SCHOTT, *Optical Glass Datasheet LLF1*, official datasheet, https://media.schott.com/api/public/content/f05114adf7e64ed197741923913b3f89
+- SCHOTT, *Optical Glass Datasheet N-BK7*, official datasheet, https://media.schott.com/api/public/content/41e799d0bf874807a0bb8e702fbb75b5
+- B&H Photo, *Toyo-View 45CX View Camera with 210mm f/6.8 Geronar Lens*, retailer specification page listing 60° field, 242 mm image circle, and 49 mm filter size.
+- Graflex.org, *Large-Format Lens Specifications*, archival table listing Rodenstock Geronar 210 mm f/6.8 as 3/3 with 230 mm image-circle class and 195 mm flange figure.

--- a/src/lens-data/rodenstock/RodenstockGeronar210mmf68.data.ts
+++ b/src/lens-data/rodenstock/RodenstockGeronar210mmf68.data.ts
@@ -1,0 +1,145 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║       LENS DATA — RODENSTOCK GERONAR 210mm f/6.8                   ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: DE 28 18 394 B1, sole numerical example.             ║
+ * ║  Three-element / three-group large-format Cooke-type triplet.      ║
+ * ║  All surfaces are spherical.                                       ║
+ * ║  Focus: whole-lens unit focus by camera bellows/rail.              ║
+ * ║                                                                    ║
+ * ║  NOTE ON SCALING:                                                  ║
+ * ║    Patent prescription is normalized to f' = 100 at the e-line.    ║
+ * ║    All radii, center thicknesses, air spaces, inferred SDs, and    ║
+ * ║    BFD are scaled ×2.1 to the 210 mm production focal length.      ║
+ * ║    The stored glass indices are d-line Schott catalog values, so   ║
+ * ║    the computed d-line EFL is 210.10 mm rather than exactly        ║
+ * ║    210.00 mm.                                                      ║
+ * ║                                                                    ║
+ * ║  NOTE ON STOP POSITION:                                            ║
+ * ║    The patent table gives l2 as 7.74 + 2.29 = 10.03 but does not   ║
+ * ║    label the two terms by axial order. The figure places the stop  ║
+ * ║    closer to L2, so this data file uses r4→STO = 2.29 and         ║
+ * ║    STO→r5 = 7.74 before scaling.                                   ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    The patent does not publish clear apertures. SDs were inferred  ║
+ * ║    from the f/6.8 entrance-pupil geometry and the 5×7 field, then  ║
+ * ║    constrained by edge thickness, rim slope, and cross-gap sag.    ║
+ * ║    Full-field full-aperture rays are intentionally not forced      ║
+ * ║    through L1 because the patent only claims vignetting-free       ║
+ * ║    coverage at reduced aperture.                                   ║
+ * ║                                                                    ║
+ * ║  NOTE ON FOCUS RANGE:                                              ║
+ * ║    The production lens has no lens-limited MFD; close focus is     ║
+ * ║    camera-bellows dependent. The focus slider uses an illustrative ║
+ * ║    unit-focus close end at 2.0 m from the image plane.             ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "rodenstock-geronar-210mm-f68",
+  maker: "Rodenstock",
+  name: "RODENSTOCK GERONAR 210mm f/6.8",
+  subtitle: "DE 28 18 394 B1 — sole numerical example",
+  specs: ["3 elements / 3 groups", "f' = 210.10 mm (d-line)", "f/6.8", "2ω ≥ 56° patent field", "all-spherical"],
+
+  focalLengthMarketing: 210,
+  focalLengthDesign: 210.1035,
+  apertureMarketing: 6.8,
+  apertureDesign: 6.8,
+  imageFormat: "5x7",
+  patentYear: 1979,
+  elementCount: 3,
+  groupCount: 3,
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Biconvex Positive",
+      nd: 1.62041,
+      vd: 60.32,
+      fl: 52.07,
+      glass: "N-SK16 / SK16 (Schott)",
+      apd: false,
+      dPgF: -0.0011,
+      nC: 1.61727,
+      nF: 1.62756,
+      ng: 1.63312,
+      role: "Strong front positive crown; the rear radius is nearly plano relative to the front curvature.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Biconcave Negative",
+      nd: 1.54814,
+      vd: 45.75,
+      fl: -46.28,
+      glass: "LLF1 (Schott)",
+      apd: false,
+      dPgF: -0.0009,
+      nC: 1.54457,
+      nF: 1.55655,
+      ng: 1.56333,
+      role: "Thin extra-light flint negative corrector tightly spaced behind L1.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.5168,
+      vd: 64.17,
+      fl: 200.12,
+      glass: "N-BK7 / BK7 (Schott)",
+      apd: false,
+      dPgF: -0.0009,
+      nC: 1.51432,
+      nF: 1.52238,
+      ng: 1.52668,
+      role: "Weak rear positive crown completing the triplet and setting the back focal position.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 33.285, d: 5.25, nd: 1.62041, elemId: 1, sd: 16.9 },
+    { label: "2", R: -1030.281, d: 3.402, nd: 1.0, elemId: 0, sd: 16.9 },
+    { label: "3", R: -151.41, d: 0.798, nd: 1.54814, elemId: 2, sd: 15.5 },
+    { label: "4", R: 30.534, d: 4.809, nd: 1.0, elemId: 0, sd: 15.5 },
+    { label: "STO", R: 1e15, d: 16.254, nd: 1.0, elemId: 0, sd: 13.342 },
+    { label: "5", R: 377.58, d: 8.106, nd: 1.5168, elemId: 3, sd: 28.0 },
+    { label: "6", R: -141.393, d: 177.896912, nd: 1.0, elemId: 0, sd: 28.0 },
+  ],
+
+  asph: {},
+
+  var: {
+    "6": [177.896912, 206.359055],
+  },
+
+  varLabels: [["6", "BF"]],
+
+  groups: [
+    { text: "G1", fromSurface: "1", toSurface: "2" },
+    { text: "G2", fromSurface: "3", toSurface: "4" },
+    { text: "G3", fromSurface: "5", toSurface: "6" },
+  ],
+
+  doublets: [],
+
+  closeFocusM: 2.0,
+  focusDescription: "Whole-lens unit focus by view-camera rail/bellows; close-focus slider endpoint is illustrative, not lens-limited.",
+
+  nominalFno: 6.8,
+  fstopSeries: [6.8, 8, 11, 16, 22, 32, 45],
+  maxFstop: 45,
+
+  scFill: 0.55,
+  yScFill: 0.72,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.analysis.md
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.analysis.md
@@ -1,0 +1,192 @@
+## Patent Reference and Design Identification
+
+**Patent:** DE 2444954 A1 (Offenlegungsschrift, Deutsches Patentamt)
+**Application Number:** P 24 44 954.5-51
+**Filed:** 20 September 1974
+**Published:** 1 April 1976
+**Inventors:** Franz Schlegel; Josef Weiß
+**Applicant:** Optische Werke G. Rodenstock, München
+**Title:** Achtlinsiges Weitwinkelobjektiv
+**Embodiment analyzed:** Claim 4 / worked data set 4, f′ = 65 mm, 1:4.5
+**Worked data sets in patent:** f′ = 100, 90, 75, and 65 mm
+
+The prescription used here is the fourth worked data set in DE 2444954 A1. It is the only data set in the patent with f′ = 65 mm and an aperture ratio of 1:4.5. The production match to the Rodenstock Grandagon-N 65mm f/4.5 rests on convergent evidence:
+
+1. The patent data set states f′ = 65 mm and 1:4.5, matching the production lens designation.
+2. The prescription is an eight-element, four-group wide-angle objective. Rodenstock's Grandagon-N f/4.5 data sheet describes the 65, 75, and 90 mm f/4.5 Grandagon-N lenses as eight elements in four groups.
+3. Rodenstock's production data for the 65 mm f/4.5 lists 105° coverage and a 170 mm image circle at the recommended working apertures, which agrees with the patent's stated design class and with the computed field from the 65 mm data set.
+4. The applicant is Optische Werke G. Rodenstock, and the filing date is consistent with the Grandagon-N f/4.5 large-format wide-angle line.
+5. The patent's other worked focal lengths, 90 and 75 mm, align with the published Grandagon-N f/4.5 focal-length family. The descriptive text says the special examples are for f = 90, 75, and 60, but the numerical fourth claim and table clearly give f′ = 65; the table is treated as authoritative.
+
+The patent gives all refractive indices and Abbe numbers on the e-line convention, not the d-line convention. The data file therefore preserves the patent's n_e and ν_e values in the single-index `nd` / `vd` fields used by the LensVisualizer format. This is a field-name compromise for single-wavelength tracing, not a claim that the patent prescription was published at the d line.
+
+## Optical Architecture
+
+The design is a quasi-symmetric large-format wide-angle objective with eight elements in four air-spaced groups:
+
+**negative meniscus — cemented positive triplet — STOP — cemented positive triplet — negative meniscus**
+
+The two outer menisci are negative, strongly curved, and low-dispersion. They expand the angular acceptance of the system and help cancel the positive Petzval contribution of the central triplets. The two cemented triplets carry the main positive power and provide the crown/flint interfaces used for axial and lateral color correction.
+
+The aperture stop lies inside the central air gap l₂. Claim 4 gives l₂ = 1.65 + 0.36 = 2.01 mm, meaning 1.65 mm from r₆ to the stop and 0.36 mm from the stop to r₇. This split has been retained in the data file rather than collapsing the stop into a single air space.
+
+The patent emphasizes two design constraints: an image angle of at least 90° and an aperture ratio at least as fast as 1:5, while keeping construction length and lens diameters small. The 65 mm claim exceeds those minima: it is specified at 1:4.5, and the production Grandagon-N 65mm f/4.5 is rated for 105° coverage.
+
+The total patent axial track from r₁ to r₁₂ is 65.96 mm. Independent paraxial tracing gives a back focal distance from r₁₂ of 44.82 mm, so the distance from the front vertex to the paraxial image plane is 110.78 mm. This optical back focal distance should not be confused with Rodenstock's production flange focal distance of 70.0 mm, which is a mechanical mounting reference for the shuttered large-format lens.
+
+## Element-by-Element Analysis
+
+### L1 — Negative Meniscus, Convex to Object
+
+n_e = 1.4662, ν_e = 65.56. Glass: Schott FK3 class, legacy fluorite crown. Standalone f = −48.67 mm.
+
+L1 is the front negative field-widening meniscus, with r₁ = +65.88 and r₂ = +16.49. Both centers of curvature lie to the image side, so the element is a negative meniscus with its convex side facing the object. Its low index and low dispersion limit the chromatic burden of the strongly refracting outer group while providing negative Petzval contribution.
+
+The element is not a retrofocus front group by itself. It is the front half of a near-symmetric wide-angle construction; its role is better described as angular compression and aberration balancing ahead of the positive triplet.
+
+### Front Cemented Triplet — L2 + L3 + L4
+
+The front cemented triplet is the first main positive group. Its three glasses step down in index from the outer element toward the stop: L2 n_e = 1.6776, L3 n_e = 1.6250, and L4 n_e = 1.5629. This follows the patent's stated rule that the refractive indices of the cemented groups increase from the stop outward.
+
+#### L2 — Negative Meniscus, Convex to Object
+
+n_e = 1.6776, ν_e = 31.97. Glass: Schott SF5 / N-SF5 class. Standalone f = −84.58 mm.
+
+L2 is the high-index, high-dispersion outer component of the front triplet. Its r₃ = +26.23 and r₄ = +14.96 form a negative meniscus in air. In situ, it supplies the flint side of the front achromatizing cemented interfaces.
+
+The patent value is very close to current Schott N-SF5 e-line data, so the SF5 identification is one of the stronger glass matches in the design. The small difference is within the range expected between a 1974 patent value and current catalog rounding.
+
+#### L3 — Biconvex Positive
+
+n_e = 1.6250, ν_e = 52.86. Glass: Schott SSK2 class, dense special crown. Standalone f = +13.55 mm.
+
+L3 is the main positive element of the front triplet. The nearly opposed radii r₄ = +14.96 and r₅ = −14.54, together with a 9.90 mm center thickness, make it a strong biconvex positive component.
+
+Its crown-like dispersion makes it the positive partner between L2's dense flint and L4's intermediate-dispersion negative element. The r₄ and r₅ cemented surfaces therefore carry much of the front group's color correction and spherical/comatic balancing.
+
+#### L4 — Biconcave Negative, Stop-Side Component
+
+n_e = 1.5629, ν_e = 46.88. Glass: unmatched barium-flint / short-flint class. Standalone f = −22.97 mm.
+
+L4 is the inner negative element of the front triplet. It is biconcave by sign convention, with r₅ = −14.54 and r₆ = +118.85. The r₅ cemented interface is strong; the r₆ surface is weak and faces the stop space.
+
+No exact current catalog match was verified for the pair n_e = 1.5629 and ν_e = 46.88. The Abbe number places it on the flint side of the crown/flint boundary despite the moderate index. It is therefore kept as an unmatched class identification rather than assigned a precise modern catalog name.
+
+### Rear Cemented Triplet — L5 + L6 + L7
+
+The rear triplet is the second main positive group. It is not a mirror copy of the front triplet, but it repeats the same functional pattern: a weak stop-side negative component, a strong biconvex positive crown component, and a higher-index outer negative component.
+
+#### L5 — Negative Meniscus, Stop-Side Component
+
+n_e = 1.5846, ν_e = 59.19. Glass: unmatched barium crown / BaK class. Standalone f = −23.39 mm.
+
+L5 begins the rear triplet immediately after the stop. It has a very weak front radius, r₇ = +292.16, and a much stronger rear radius, r₈ = +13.05. In air this is a negative meniscus.
+
+The high Abbe number means L5 supplies negative power with comparatively low chromatic dispersion. This differs from the high-dispersion role of L2 and helps tune the rear half's chromatic balance.
+
+#### L6 — Biconvex Positive
+
+n_e = 1.6113, ν_e = 58.65. Glass: unmatched dense crown, SK-class. Standalone f = +11.47 mm.
+
+L6 is the strongest single positive element in the prescription. Its r₈ = +13.05 and r₉ = −10.94 surfaces, combined with 9.55 mm center thickness, make it a short-focal-length biconvex element.
+
+The glass is a dense crown by dispersion class. The current Schott N-SK4 catalog is close in Abbe number but not an exact refractive-index match to the patent's e-line value, so the element is identified by class rather than by a hard catalog assignment.
+
+#### L7 — Negative Meniscus, Concave to Object
+
+n_e = 1.6700, ν_e = 46.13 as printed in Claim 4. Glass: unmatched high-index barium-flint class. Standalone f = −42.75 mm.
+
+L7 is the outer component of the rear triplet, bounded by r₉ = −10.94 and r₁₀ = −22.96. Both centers of curvature lie to the object side, so the element is a negative meniscus concave to the object.
+
+The prior analysis treated the Abbe number as 48.13 by analogy to Claims 1–3. That analogy is understandable because the first three worked data sets print n_e = 1.6700 / ν_e = 48.13 in the same glass position, and a BaF11-class glass fits that value. Claim 4, however, prints ν_e = 46.13. The corrected analysis and data file preserve the Claim 4 value and mark the glass as unmatched. If the original Rodenstock table contains a typographical error, the evidence is circumstantial; it is not appropriate to overwrite the transcribed claim value in the prescription.
+
+### L8 — Negative Meniscus, Concave to Object
+
+n_e = 1.4891, ν_e = 70.22. Glass: Schott FK5 / N-FK5 class. Standalone f = −43.55 mm.
+
+L8 is the rear negative field-widening meniscus, bounded by r₁₁ = −16.79 and r₁₂ = −83.54. It mirrors L1 functionally, though it uses a different fluorite-crown glass.
+
+The current Schott N-FK5 e-line values are an excellent match to the patent. L8 is therefore one of the secure glass identifications in the design.
+
+## Glass Identification and Selection
+
+The patent does not name glass catalogs. It publishes only n_e and ν_e values. The table below therefore distinguishes exact or close catalog-class identifications from unmatched class assignments.
+
+| Element | Patent n_e | Patent ν_e | Identification used | Confidence | Note |
+|---|---:|---:|---|---|---|
+| L1 | 1.4662 | 65.56 | Schott FK3 class | High class match | Legacy fluorite crown; not a current standard N-glass entry. |
+| L2 | 1.6776 | 31.97 | Schott SF5 / N-SF5 class | High | Current N-SF5 e-line data closely matches. |
+| L3 | 1.6250 | 52.86 | Schott SSK2 class | Moderate-high | Dense special crown class. |
+| L4 | 1.5629 | 46.88 | Unmatched barium-flint / short-flint class | Class only | No exact current public catalog match verified. |
+| L5 | 1.5846 | 59.19 | Unmatched barium crown / BaK class | Class only | Crown-like dispersion; likely historical Schott BaK/BAL-family glass. |
+| L6 | 1.6113 | 58.65 | Unmatched dense crown, SK-class | Class only | Current N-SK4 is nearby but not exact. |
+| L7 | 1.6700 | 46.13 | Unmatched high-index barium-flint class | Class only | Claim 4 prints 46.13; 48.13 would fit BaF11 by analogy to Claims 1–3, but was not adopted. |
+| L8 | 1.4891 | 70.22 | Schott FK5 / N-FK5 class | High | Current N-FK5 e-line data closely matches. |
+
+The glass strategy is conventional but carefully balanced. The two outer elements use low-dispersion fluorite crowns to keep strongly curved field-widening elements from dominating chromatic error. The two central positive elements are dense crowns. The negative elements inside the cemented triplets provide the dispersion contrast needed for achromatization without exceeding the patent's stated index ceiling of n ≤ 1.7.
+
+No anomalous partial-dispersion data is published, and no apochromatic claim is made from the Abbe numbers alone.
+
+## Focus Mechanism
+
+The optical prescription has no internal variable spacings. Focusing is by unit movement of the complete lens relative to the image plane, as is normal for a large-format shutter-mounted lens used on a view camera or helicoid-mounted technical camera.
+
+The data file models the focus slider as a change in the final back-focus distance only. The infinity value is the computed paraxial BFD from r₁₂, 44.8246 mm. The close-focus value, 52.6393 mm, models a 0.7 m subject distance measured from the image plane, corresponding to approximately 0.12× magnification. This is a practical visualization state rather than an internal optical prescription from the patent; the patent itself provides only the infinity-focus design.
+
+| Focus state | Modeled subject distance | Final air space from r₁₂ | Notes |
+|---|---:|---:|---|
+| Infinity | ∞ | 44.8246 mm | Paraxial BFD from the Claim 4 prescription. |
+| Close | 0.7 m | 52.6393 mm | Unit-focus extension; camera/helicoid dependent. |
+
+## Aspherical Surfaces
+
+The design is entirely spherical. DE 2444954 A1 gives only spherical radii and does not provide aspherical coefficients.
+
+## Chromatic Correction Strategy
+
+Chromatic correction is concentrated in the two cemented triplets. The front triplet pairs the high-dispersion SF5-class L2 with a strong SSK2-class positive element and an intermediate-dispersion negative stop-side element. The rear triplet uses a lower-dispersion stop-side negative element, a dense crown positive element, and a high-index negative outer element.
+
+The near-symmetric layout also suppresses lateral color. In a fully symmetric wide-angle lens, odd aberrations and lateral color cancel strongly at unit magnification. This design is not perfectly symmetric and is used at infinity, but the front/rear balancing remains central to its distortion and lateral-color control.
+
+## Verification Summary
+
+The prescription was re-extracted from Claim 4 and independently traced at the patent's e-line indices. The following values are from a paraxial y–n·u matrix trace, not from the prior analysis.
+
+| Quantity | Patent / production reference | Recomputed value | Comment |
+|---|---:|---:|---|
+| Stated focal length | 65 mm | 64.8270 mm | 0.27% below nominal; consistent with rounded patent data. |
+| Aperture ratio | 1:4.5 | 1:4.5 by stop sizing | Stop semi-diameter set to 7.5445 mm. |
+| Total axial track r₁→r₁₂ | — | 65.9600 mm | Sum of all patent thicknesses and air spaces. |
+| BFD from r₁₂ | — | 44.8246 mm | Optical back focus, not mechanical flange focal distance. |
+| Front vertex to image | — | 110.7846 mm | Track plus BFD. |
+| Production image circle | 170 mm | 105.28° from 85 mm / 64.827 mm | Matches the 105° production specification. |
+| Petzval sum | — | +0.0002175 mm⁻¹ | Surface-by-surface Σ φ/(n·n′). |
+| Petzval radius | — | +4598 mm | Approximately 71× the computed EFL. |
+
+Group and element focal lengths, recomputed in air from the extracted prescription:
+
+| Component | Focal length |
+|---|---:|
+| L1 | −48.67 mm |
+| Front triplet L2+L3+L4 | +44.17 mm |
+| Rear triplet L5+L6+L7 | +36.45 mm |
+| L8 | −43.55 mm |
+| Front half L1–L4 | +203.36 mm |
+| Rear half L5–L8 | +103.55 mm |
+| Complete objective | +64.83 mm |
+
+The Petzval value was computed surface by surface using φ/(n·n′). Element-level thin-lens approximations were not used.
+
+## Design Heritage and Context
+
+DE 2444954 A1 positions the invention against earlier German wide-angle objective designs that either reached only about f/5.6 or required excessive construction length and outer element diameter. Rodenstock's solution keeps the Biogon-like near-symmetry but uses cemented triplets on both sides of the stop to reduce the number of air-glass interfaces and to concentrate chromatic correction at cemented surfaces.
+
+The result is not a retrofocus lens in the SLR sense. Its optical back focal distance is shorter than the production mechanical flange focal distance and is only about 0.69× the focal length when measured from r₁₂. The lens achieves large-format wide-angle coverage through the near-symmetric negative-positive-positive-negative power distribution rather than by forcing a long back focus.
+
+## Sources
+
+**Primary patent:** DE 2444954 A1, *Achtlinsiges Weitwinkelobjektiv*, Optische Werke G. Rodenstock, filed 20 September 1974, published 1 April 1976. Claim 4 supplies the f′ = 65 mm prescription.
+
+**Production specifications:** Rodenstock / LINOS Grandagon-N data sheet, *Photo Optics / Digital Imaging: Lenses for Analog Professional Photography*, confirming the Grandagon-N f/4.5 65–90 mm lenses as eight elements in four groups, 105° field angle, and the 65 mm f/4.5 as 4×5 in. coverage with 170 mm image circle. B&H / Arca-Swiss product data confirms 65 mm, f/4.5, 4×5 in., 105°, 8 elements / 4 groups, 170 mm image circle, and 70.0 mm mechanical flange focal distance.
+
+**Glass references:** SCHOTT optical glass data sheets for N-SF5, N-FK5, and N-SK4 were used as current catalog checks. Historical FK3, SSK2, BaK/BaF, and SK-class assignments remain class-level identifications unless explicitly marked as secure above.

--- a/src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN65mmf45.data.ts
@@ -1,0 +1,206 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║          LENS DATA — RODENSTOCK GRANDAGON-N 65mm f/4.5             ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: DE 2444954 A1, Claim 4 / worked data set 4.          ║
+ * ║  Rodenstock eight-element quasi-symmetric large-format wide angle. ║
+ * ║  8 elements / 4 groups, all spherical.                             ║
+ * ║  Focus: unit focus; final air space models extension from infinity ║
+ * ║  to a representative 0.7 m subject distance from the image plane.  ║
+ * ║                                                                    ║
+ * ║  NOTE ON REFERENCE LINE:                                           ║
+ * ║    The patent publishes refractive indices and Abbe numbers at the ║
+ * ║    e line (n_e / v_e). The LensVisualizer schema names these fields║
+ * ║    nd / vd, but the values below intentionally preserve the patent ║
+ * ║    e-line prescription for paraxial agreement with DE 2444954 A1.  ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║    The patent omits clear apertures. Semi-diameters are conservative║
+ * ║    estimates from exact-ray stop geometry, the patent drawing, and  ║
+ * ║    renderer constraints: sd/|R| < 0.90, element surface ratio ≤1.25,║
+ * ║    positive edge thickness, and signed cross-gap sag clearance.     ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  /* ── Identity ── */
+  key: "rodenstock-grandagon-n-65mm-f45",
+  maker: "Rodenstock",
+  name: "RODENSTOCK GRANDAGON-N 65mm f/4.5",
+  subtitle: "DE 2444954 A1 Claim 4 — Rodenstock / Schlegel & Weiß",
+  specs: [
+    "8 ELEMENTS / 4 GROUPS",
+    "f′ = 65 mm; EFL ≈ 64.83 mm",
+    "F/4.5",
+    "105° COVERAGE / 170 mm IMAGE CIRCLE",
+    "ALL SPHERICAL",
+  ],
+
+  focalLengthMarketing: 65,
+  focalLengthDesign: 64.827,
+  apertureMarketing: 4.5,
+  apertureDesign: 4.5,
+  imageFormat: "4x5",
+  patentYear: 1976,
+  elementCount: 8,
+  groupCount: 4,
+
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 105,
+    maxTraceFieldDeg: 52.5,
+  },
+
+  focusDescription:
+    "Unit focus by view-camera bellows or helicoid; final air space varies from infinity to a representative 0.7 m subject distance.",
+
+  /* ── Elements ── */
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.4662,
+      vd: 65.56,
+      fl: -48.67,
+      glass: "FK3 class (Schott legacy fluorite crown; patent e-line values)",
+      role: "Front negative field-widening meniscus.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.6776,
+      vd: 31.97,
+      fl: -84.58,
+      glass: "SF5 / N-SF5 class (Schott; patent e-line values)",
+      cemented: "T1",
+      role: "High-dispersion outer component of the front cemented triplet.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.625,
+      vd: 52.86,
+      fl: 13.55,
+      glass: "SSK2 class (Schott dense special crown; patent e-line values)",
+      cemented: "T1",
+      role: "Main positive element of the front cemented triplet.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.5629,
+      vd: 46.88,
+      fl: -22.97,
+      glass: "Unmatched barium-flint / short-flint class (patent e-line values)",
+      cemented: "T1",
+      role: "Stop-side negative component of the front cemented triplet.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.5846,
+      vd: 59.19,
+      fl: -23.39,
+      glass: "Unmatched barium crown / BaK class (patent e-line values)",
+      cemented: "T2",
+      role: "Stop-side negative component of the rear cemented triplet.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.6113,
+      vd: 58.65,
+      fl: 11.47,
+      glass: "Unmatched dense crown, SK-class (patent e-line values)",
+      cemented: "T2",
+      role: "Main positive element of the rear cemented triplet.",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.67,
+      vd: 46.13,
+      fl: -42.75,
+      glass: "Unmatched high-index barium-flint class (patent e-line values; Claim 4 prints v_e = 46.13)",
+      cemented: "T2",
+      role: "Outer negative component of the rear cemented triplet.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Negative Meniscus",
+      nd: 1.4891,
+      vd: 70.22,
+      fl: -43.55,
+      glass: "FK5 / N-FK5 class (Schott fluorite crown; patent e-line values)",
+      role: "Rear negative field-widening meniscus.",
+    },
+  ],
+
+  /* ── Surfaces ── */
+  surfaces: [
+    { label: "1", R: 65.88, d: 4.75, nd: 1.4662, elemId: 1, sd: 18.0 },
+    { label: "2", R: 16.49, d: 8.55, nd: 1.0, elemId: 0, sd: 14.4 },
+
+    { label: "3", R: 26.23, d: 10.95, nd: 1.6776, elemId: 2, sd: 12.7 },
+    { label: "4", R: 14.96, d: 9.9, nd: 1.625, elemId: 3, sd: 9.3 },
+    { label: "5", R: -14.54, d: 0.65, nd: 1.5629, elemId: 4, sd: 9.3 },
+    { label: "6", R: 118.85, d: 1.65, nd: 1.0, elemId: 0, sd: 8.8 },
+
+    { label: "STO", R: 1e15, d: 0.36, nd: 1.0, elemId: 0, sd: 7.5445 },
+
+    { label: "7", R: 292.16, d: 0.75, nd: 1.5846, elemId: 5, sd: 8.8 },
+    { label: "8", R: 13.05, d: 9.55, nd: 1.6113, elemId: 6, sd: 9.3 },
+    { label: "9", R: -10.94, d: 8.1, nd: 1.67, elemId: 7, sd: 9.3 },
+    { label: "10", R: -22.96, d: 8.0, nd: 1.0, elemId: 0, sd: 12.7 },
+
+    { label: "11", R: -16.79, d: 2.75, nd: 1.4891, elemId: 8, sd: 14.4 },
+    { label: "12", R: -83.54, d: 44.8246, nd: 1.0, elemId: 0, sd: 18.0 },
+  ],
+
+  asph: {},
+
+  var: {
+    "12": [44.8246, 52.6393],
+  },
+  varLabels: [["12", "BF"]],
+
+  groups: [
+    { text: "G1", fromSurface: "1", toSurface: "2" },
+    { text: "G2 / T1", fromSurface: "3", toSurface: "6" },
+    { text: "G3 / T2", fromSurface: "7", toSurface: "10" },
+    { text: "G4", fromSurface: "11", toSurface: "12" },
+  ],
+  doublets: [
+    { text: "T1", fromSurface: "3", toSurface: "6" },
+    { text: "T2", fromSurface: "7", toSurface: "10" },
+  ],
+
+  closeFocusM: 0.7,
+  nominalFno: 4.5,
+  fstopSeries: [4.5, 5.6, 8, 11, 16, 22, 32, 45],
+  maxFstop: 45,
+
+  scFill: 0.62,
+  yScFill: 0.72,
+  offAxisFieldFrac: 0.5,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.analysis.md
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.analysis.md
@@ -1,0 +1,167 @@
+# Rodenstock Grandagon-N 75mm f/4.5
+
+## Patent Reference and Design Identification
+
+**Patent:** DE 2444954 A1 (Offenlegungsschrift)
+**Filed:** 20 September 1974
+**Published:** 1 April 1976
+**Inventors:** Franz Schlegel; Josef Weiß
+**Applicant:** Optische Werke G. Rodenstock, München
+**Title:** Achtlinsiges Weitwinkelobjektiv
+**Classification:** G 02 B 13/06
+**Embodiment analyzed:** Claim 3 / Example 3, f′ = 75 mm, 1:4.5
+
+DE 2444954 A1 discloses an eight-element wide-angle objective for a field angle of at least 90° and an aperture ratio of at least 1:5. The stated design goal is a better-corrected f/4.5 wide-angle lens with compact optical assembly length and with all refractive indices below 1.7. The prescription tables use e-line refractive index and Abbe number (`n_e`, `ν_e`), which is also the convention stated explicitly in the patent text.
+
+Example 3 is the embodiment used here. It matches the production Rodenstock Grandagon-N 75mm f/4.5 on the following points:
+
+1. The patent example is f′ = 75 mm and 1:4.5.
+2. The prescription has eight elements in four air-spaced groups, matching Rodenstock's published Grandagon-N f/4.5 construction for the 65, 75, and 90 mm lenses.
+3. Rodenstock's published 75 mm f/4.5 specification gives a 195 mm image circle at the recommended working aperture and a 105° image angle; the patent trace gives 104.98° for a 195 mm image circle.
+4. The production lens is listed for 9×12 cm / 4×5 in. coverage, consistent with the 195 mm image-circle specification.
+5. The applicant is Optische Werke G. Rodenstock, the production maker.
+
+A minor patent-text inconsistency does not affect the selected embodiment: the descriptive prose states that Claims 2 through 4 cover f = 90, f = 75, and f = 60, while the actual Claim 4 prescription table is f′ = 65. The numerical prescription tables are internally consistent, and Claim 3 is unambiguous for the 75 mm design.
+
+The page-8 prescription was re-read directly from the rasterized patent image. Surface `r4` in Example 3 is `17,22`. The neighboring `20,83` value belongs to the f′ = 90 example, not to the 75 mm example. With `r4 = 17.22`, the e-line paraxial EFL is 74.846 mm; with the erroneous `r4 = 20.83`, the EFL falls to 71.725 mm.
+
+## Optical Architecture
+
+The lens is a near-symmetric Biogon-type wide-angle design: negative field lens, positive cemented triplet, aperture stop, positive cemented triplet, negative field lens. In power form it is:
+
+`(−)  (+)  [stop]  (+)  (−)`
+
+The four air-spaced groups are:
+
+| Group | Elements | Function | d-line focal length |
+|---|---:|---|---:|
+| G1 | L1 | Front negative field meniscus | −56.2 mm |
+| G2 | L2–L4 | Front positive cemented triplet | +50.9 mm |
+| Stop | — | Aperture between the two triplets | — |
+| G3 | L5–L7 | Rear positive cemented triplet | +42.1 mm |
+| G4 | L8 | Rear negative field meniscus | −50.3 mm |
+
+The patent lists the central air space between surfaces `r6` and `r7` as `l2 = 1.75 + 0.50 = 2.25 mm`, placing the aperture stop 1.75 mm behind the rear surface of the front triplet and 0.50 mm in front of the rear triplet. The patent does not list a separate stop surface, so the data file inserts a flat `STO` surface at that split while preserving the total patented air space.
+
+The two cemented triplets satisfy the index-gradient rule stated in Claim 1: within each triplet, refractive index increases from the stop outward. In the front triplet this sequence is L4 → L3 → L2 (`n_e = 1.5629 → 1.6251 → 1.6776`); in the rear triplet it is L5 → L6 → L7 (`n_e = 1.5855 → 1.6113 → 1.6700`). That gradient is one of the patent's defining structural constraints rather than a later interpretation.
+
+The front-vertex to rear-vertex optical assembly length is 76.0 mm, or 1.02× the e-line EFL. That is the construction length relevant to the patent's compactness claim. The front-vertex to image-plane distance is 127.8 mm after adding computed back focal distance; that larger number is the total optical track to the film plane and should not be confused with the patent's compact assembly-length claim.
+
+The design is only moderately asymmetric. That departure from perfect symmetry is necessary because the lens is optimized for distant objects rather than for unit magnification. The symmetry still suppresses odd-order aberrations, while the unequal glass selection and unequal triplet powers give the designer latitude to correct residual field curvature, astigmatism, and lateral color at the 105° coverage angle.
+
+## Element-by-Element Analysis
+
+### L1 — Negative Meniscus, Convex to Object
+
+`nd = 1.46450, νd = 65.77. Glass: FK3 (Schott inquiry glass). f = −56.2 mm.`
+
+L1 is the front negative field lens. Both surfaces have positive radii, so the element is convex toward the object and more steeply curved on the image side. Its low index and high Abbe number make it a fluor-crown field element rather than a high-index bending element. It bends oblique bundles inward toward the central stop while keeping chromatic contribution low.
+
+The rear surface, `r2 = 18.97 mm`, carries most of the element's negative power. This steep surface is also the limiting surface for the clear-aperture estimate used in the data file, so the modeled semi-diameter is intentionally conservative.
+
+### L2 + L3 + L4 — Front Cemented Triplet
+
+`L2: nd = 1.67270, νd = 32.21. Glass: SF5 (Schott legacy dense flint). f = −97.9 mm.`
+`L3: nd = 1.62229, νd = 53.27. Glass: SSK2 / N-SSK2 class (Schott dense crown). f = +15.7 mm.`
+`L4: nd ≈ 1.5600, νd ≈ 47.1. Glass: Unmatched short-flint / barium-crown boundary glass. f = −26.6 mm.`
+
+The front triplet is the first strong positive group. It is cemented, so the two steep internal surfaces work as glass-to-glass refracting interfaces rather than as air-glass surfaces. This keeps the group compact and avoids placing highly curved air spaces close to the stop.
+
+L3 is the power core of the group. Its biconvex form, `r4 = 17.22 mm` and `r5 = −16.73 mm`, gives the group most of its positive convergence. L2 and L4 provide negative flanking power and chromatic balancing. L2 is an ordinary dense flint. L4 is the only glass that does not resolve cleanly to a public catalog name; its patent values, `n_e = 1.5629` and `ν_e = 46.88`, place it near historical short-flint and barium-crown catalog positions but not on an exact public Schott, Ohara, Hoya, Hikari, CDGM, or Sumita match available for this review.
+
+The resulting front-triplet focal length is +50.9 mm in the d-line data model. This positive group is deliberately weaker than the rear triplet in the same model, contributing to the residual asymmetry needed for infinity-conjugate correction.
+
+### L5 + L6 + L7 — Rear Cemented Triplet
+
+`L5: nd = 1.58313, νd = 59.3. Glass: SK12 (Schott legacy dense crown). f = −27.0 mm.`
+`L6: nd = 1.60881, νd = 58.9. Glass: SK3 (Schott legacy dense crown). f = +13.2 mm.`
+`L7: nd = 1.66672, νd = 48.4. Glass: BaF11 (Schott legacy barium flint). f = −49.3 mm.`
+
+The rear triplet is the image-side positive group. It has a net d-line focal length of +42.1 mm and is the stronger of the two cemented triplets. L6 is the strongest individual element in the lens and provides most of the group convergence.
+
+L5 is a thin negative meniscus ahead of L6. L6 is a steep biconvex dense-crown power element. L7 is a barium-flint negative meniscus that moderates the exit convergence and contributes chromatic correction. This crown-crown-flint order is not a mirror copy of the front triplet's flint-crown-flint order; the asymmetry is a design degree of freedom, not an extraction error.
+
+### L8 — Negative Meniscus, Concave to Object
+
+`nd = 1.48749, νd = 70.4. Glass: FK5 / N-FK5 class (Schott fluor-crown). f = −50.3 mm.`
+
+L8 is the rear field lens. Both radii are negative, so the meniscus is concave toward the object. It is the image-side counterpart to L1, but it uses a still lower-dispersion fluor-crown glass. Its negative power helps flatten the Petzval field and controls the final ray bundle as it approaches the image plane.
+
+The rear radius, `r12 = −96.12 mm`, is comparatively weak. This helps keep the exit geometry benign for a large-format image plane while the front surface of L8 supplies most of the element's negative field-lens action.
+
+## Glass Identification and Selection
+
+The patent publishes e-line optical constants. The data file stores d-line values, because the project prescription format defines `nd` as the 587.6 nm d-line index. For public catalog glasses, the d-line values were taken from manufacturer catalog data or manufacturer-type legacy catalog tables. L4 remains unresolved and is stored as an approximate d-line conversion rather than as a named catalog glass.
+
+| Elem | Patent `n_e / ν_e` | Stored `nd / νd` | Glass assignment | Confidence |
+|---|---:|---:|---|---|
+| L1 | 1.4662 / 65.56 | 1.46450 / 65.77 | FK3, Schott | High |
+| L2 | 1.6776 / 31.97 | 1.67270 / 32.21 | SF5, Schott | High |
+| L3 | 1.6251 / 52.86 | 1.62229 / 53.27 | SSK2 / N-SSK2 class, Schott | High |
+| L4 | 1.5629 / 46.88 | ≈1.5600 / ≈47.1 | Unmatched short-flint / barium-crown boundary | Low |
+| L5 | 1.5855 / 59.19 | 1.58313 / 59.3 | SK12, Schott legacy | High |
+| L6 | 1.6113 / 58.65 | 1.60881 / 58.9 | SK3, Schott legacy | High |
+| L7 | 1.6700 / 48.13 | 1.66672 / 48.4 | BaF11, Schott legacy | High |
+| L8 | 1.4891 / 70.22 | 1.48749 / 70.4 | FK5 / N-FK5 class, Schott | High |
+
+The design uses five crowns and three flints by Abbe-number classification. FK3, SSK2, SK12, SK3, and FK5 are the crowns. SF5, L4, and BaF11 are the flint-side glasses. The outer field lenses use the lowest-index glasses in the design, which gives negative Petzval contribution without requiring high-index lanthanum glass. This is consistent with the patent's stated requirement that no element exceed refractive index 1.7.
+
+The e-line surface-by-surface Petzval sum is:
+
+`Σ φ/(n · n′) = +0.0001724 mm⁻¹`
+
+With the sign convention used here, this corresponds to a Petzval radius of about −5800 mm and `Petzval × f = 0.0129`. The d-line data-file model gives `+0.0002003 mm⁻¹`, still a very small field-curvature term relative to the focal length. These values were computed surface by surface; element-level thin-lens sums were not used.
+
+## Focus Mechanism
+
+The patent gives only the infinity prescription and does not disclose an internal focusing mechanism. The production lens is a fixed optical assembly for view-camera use. In ordinary large-format use, focus is obtained by changing the lens-to-film distance with bellows extension. Rodenstock also listed a Focus-Mount helical accessory for shutter-size-0 lenses, with the Grandagon-N 75 mm f/4.5 covering infinity to 1.0 m.
+
+The data file therefore models focus as unit extension only: all internal spacings remain fixed and the final back-focus distance changes.
+
+| State | Modeled d-line BFD |
+|---|---:|
+| Infinity | 51.855 mm |
+| 1.0 m object distance | 57.769 mm |
+
+The close-focus value is a paraxial unit-focus model. It is not a patented floating-group spacing.
+
+## Verification Summary
+
+The prescription was re-derived from the patent table and traced independently with a reduced-angle paraxial ray trace. The e-line trace uses the patent's printed indices. The d-line trace is the data-file model after catalog conversion of known glasses and approximate conversion of L4.
+
+| Quantity | E-line patent trace | d-line data model | Note |
+|---|---:|---:|---|
+| Effective focal length | 74.846 mm | 74.932 mm | Patent states f′ = 75 mm |
+| Back focal distance | 51.785 mm | 51.855 mm | Computed from last vertex |
+| Optical assembly length | 76.000 mm | 76.000 mm | Front vertex to rear vertex |
+| Front vertex to image plane | 127.785 mm | 127.855 mm | Assembly length + BFD |
+| Full field for 195 mm IC | 104.98° | 104.91° | Production specification is 105° |
+| Petzval sum | +0.0001724 mm⁻¹ | +0.0002003 mm⁻¹ | Surface formula |
+| Petzval × focal length | +0.0129 | +0.0150 | Dimensionless |
+
+The `r4` extraction check is decisive. Using the printed `17.22` value gives a 74.846 mm e-line focal length. Substituting the `20.83` value from the f′ = 90 example gives 71.725 mm and fails the 75 mm patent example.
+
+The d-line group focal lengths used in the element discussion are:
+
+| Group | d-line focal length |
+|---|---:|
+| L1 | −56.2 mm |
+| L2–L4 | +50.9 mm |
+| L5–L7 | +42.1 mm |
+| L8 | −50.3 mm |
+
+The modeled stop semi-diameter is 8.72 mm. Tracing the axial marginal ray through the front half gives an entrance-pupil semi-diameter of 8.324 mm, so the d-line data model opens at f/4.501. This is consistent with the patent's 1:4.5 aperture.
+
+## Design Heritage and Context
+
+The Grandagon-N 75 mm f/4.5 is a mature large-format implementation of the symmetric wide-angle, Biogon-derived design family. The key architectural idea is not extreme retrofocus clearance but near-symmetric correction around a central stop. That is appropriate for a view-camera lens, where the film plane is accessible by bellows extension and the optical priority is wide rectilinear coverage with controlled distortion and field curvature.
+
+Rodenstock's published Grandagon-N line separated the f/4.5 eight-element lenses from the slower f/6.8 six-element alternative. The 75 mm f/4.5 version occupies the middle focal length of the f/4.5 group, sharing the 105° image-angle specification with the 65 mm and 90 mm variants while covering 9×12 cm / 4×5 in. formats.
+
+## Sources
+
+- DE 2444954 A1, *Achtlinsiges Weitwinkelobjektiv*, Optische Werke G. Rodenstock, filed 20 September 1974, published 1 April 1976.
+- Rodenstock Photo Optics / LINOS, *Lenses for Analog Professional Photography*, Grandagon-N data sheets and Focus-Mount table.
+- SCHOTT, *Optical Glass* catalog, 2003 edition, optical-constant conventions and current/legacy Schott glass positions.
+- SCHOTT, *Optical Glass Inquiry Glass Collection Datasheets*, 2019 edition, FK3 data sheet.
+- Sumita legacy optical-glass tables for Schott-type FK5, SF5, SK12, SK3, and BaF11 line indices.

--- a/src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN75mmf45.data.ts
@@ -1,0 +1,196 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * Rodenstock Grandagon-N 75mm f/4.5
+ *
+ * Source prescription:
+ *   DE 2444954 A1, Claim 3 / Example 3, f' = 75 mm, 1:4.5.
+ *
+ * The patent table publishes e-line indices (ne / ve). This data file stores
+ * d-line nd / vd values per the LensVisualizer convention. L4 has no secure
+ * public catalog match and is stored as an approximate d-line conversion of
+ * the patent's ne = 1.5629, ve = 46.88.
+ *
+ * Semi-diameters are estimated for rendering from the patented geometry,
+ * the computed f/4.5 stop, spherical rim limits, edge-thickness checks, and
+ * the production 67 mm filter / 60 mm rear-barrel envelope. The patent does
+ * not publish clear-aperture diameters.
+ */
+const LENS_DATA = {
+  key: "rodenstock-grandagon-n-75mm-f45",
+  maker: "Rodenstock",
+  name: "RODENSTOCK GRANDAGON-N 75mm f/4.5",
+  subtitle: "DE 2444954 A1 Example 3",
+  specs: ["8 elements / 4 groups", "f′ = 75 mm", "1:4.5", "105° / 195 mm image circle", "All-spherical"],
+  focalLengthMarketing: 75,
+  focalLengthDesign: 74.932,
+  apertureMarketing: 4.5,
+  apertureDesign: 4.501,
+  imageFormat: "4x5",
+  patentYear: 1976,
+  elementCount: 8,
+  groupCount: 4,
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 105,
+    maxTraceFieldDeg: 52.5,
+  },
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.4645,
+      vd: 65.77,
+      fl: -56.2,
+      glass: "FK3 (Schott inquiry glass)",
+      nC: 1.46232,
+      nF: 1.46939,
+      ng: 1.47315,
+      role: "Front low-index negative field meniscus.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.6727,
+      vd: 32.21,
+      fl: -97.9,
+      glass: "SF5 (Schott legacy dense flint)",
+      nC: 1.66661,
+      nF: 1.6875,
+      ng: 1.69986,
+      role: "Leading flint element of the front cemented triplet.",
+      cemented: "T1",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.62229,
+      vd: 53.27,
+      fl: 15.7,
+      glass: "SSK2 / N-SSK2 class (Schott)",
+      role: "Strong positive dense-crown core of the front cemented triplet.",
+      cemented: "T1",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.56,
+      vd: 47.1,
+      fl: -26.6,
+      glass: "Unmatched (short-flint / barium-crown boundary; patent ne=1.5629, ve=46.88)",
+      role: "Trailing negative element of the front cemented triplet; catalog identity unresolved.",
+      cemented: "T1",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.58313,
+      vd: 59.3,
+      fl: -27.0,
+      glass: "SK12 (Schott legacy dense crown)",
+      nC: 1.58014,
+      nF: 1.58997,
+      ng: 1.59532,
+      role: "Thin leading negative element of the rear cemented triplet.",
+      cemented: "T2",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.60881,
+      vd: 58.9,
+      fl: 13.2,
+      glass: "SK3 (Schott legacy dense crown)",
+      nC: 1.60567,
+      nF: 1.61601,
+      ng: 1.62163,
+      role: "Strong positive dense-crown core of the rear cemented triplet.",
+      cemented: "T2",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.66672,
+      vd: 48.4,
+      fl: -49.3,
+      glass: "BaF11 (Schott legacy barium flint)",
+      nC: 1.6626,
+      nF: 1.67638,
+      ng: 1.68412,
+      role: "Trailing barium-flint corrector of the rear cemented triplet.",
+      cemented: "T2",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Negative Meniscus",
+      nd: 1.48749,
+      vd: 70.4,
+      fl: -50.3,
+      glass: "FK5 / N-FK5 class (Schott)",
+      nC: 1.48535,
+      nF: 1.49227,
+      ng: 1.49593,
+      role: "Rear low-index negative field meniscus.",
+    },
+  ],
+  surfaces: [
+    { label: "1", R: 75.8, d: 5.5, nd: 1.4645, elemId: 1, sd: 21.0 },
+    { label: "2", R: 18.97, d: 9.85, nd: 1.0, elemId: 0, sd: 16.8 },
+
+    { label: "3", R: 30.18, d: 12.6, nd: 1.6727, elemId: 2, sd: 14.6 },
+    { label: "4", R: 17.22, d: 11.4, nd: 1.62229, elemId: 3, sd: 10.6 },
+    { label: "5", R: -16.73, d: 0.85, nd: 1.56, elemId: 4, sd: 10.6 },
+    { label: "6", R: 136.75, d: 1.75, nd: 1.0, elemId: 0, sd: 10.2 },
+
+    { label: "STO", R: 1e15, d: 0.5, nd: 1.0, elemId: 0, sd: 8.72 },
+
+    { label: "7", R: 334.97, d: 0.85, nd: 1.58313, elemId: 5, sd: 10.2 },
+    { label: "8", R: 15.02, d: 11.0, nd: 1.60881, elemId: 6, sd: 10.6 },
+    { label: "9", R: -12.59, d: 9.3, nd: 1.66672, elemId: 7, sd: 10.6 },
+    { label: "10", R: -26.42, d: 9.2, nd: 1.0, elemId: 0, sd: 14.6 },
+
+    { label: "11", R: -19.32, d: 3.2, nd: 1.48749, elemId: 8, sd: 16.8 },
+    { label: "12", R: -96.12, d: 51.855139, nd: 1.0, elemId: 0, sd: 21.0 },
+  ],
+  asph: {},
+  var: {
+    "12": [51.855139, 57.76854],
+  },
+  varLabels: [["12", "BF"]],
+  groups: [
+    { text: "G1", fromSurface: "1", toSurface: "2" },
+    { text: "G2", fromSurface: "3", toSurface: "6" },
+    { text: "G3", fromSurface: "7", toSurface: "10" },
+    { text: "G4", fromSurface: "11", toSurface: "12" },
+  ],
+  doublets: [
+    { text: "T1", fromSurface: "3", toSurface: "6" },
+    { text: "T2", fromSurface: "7", toSurface: "10" },
+  ],
+  closeFocusM: 1.0,
+  focusDescription: "Unit focus by bellows or helical extension; no internal focusing groups in the patent.",
+  nominalFno: 4.5,
+  fstopSeries: [4.5, 5.6, 8, 11, 16, 22, 32, 45],
+  maxFstop: 45,
+  offAxisFieldFrac: 0.45,
+  scFill: 0.62,
+  yScFill: 0.72,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.analysis.md
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.analysis.md
@@ -1,0 +1,131 @@
+# Rodenstock Grandagon-N 75mm f/6.8
+
+## Patent Reference and Design Identification
+
+**Patent:** DE 26 35 415 B1 / DT 26 35 415 B1
+**Filed:** 6 August 1976
+**Announced / published:** 18 May 1977
+**Inventors:** Franz Schlegel; Josef Weiss
+**Applicant:** Optische Werke G. Rodenstock, Munich
+**Title:** Sechslinsiges Weitwinkelobjektiv
+**Classification:** G 02 B 13/06
+**Embodiment analyzed:** Example 1 / claim 1, normalized to $f' = 100$
+
+DE 26 35 415 B1 discloses a six-element wide-angle objective with a field angle of at least 104° and an aperture ratio of at least 1:6.8. The numerical examples are normalized to $f' = 100$ and report refractive indices at the mercury e-line, $n_e$, with the corresponding $\nu_e$ dispersion convention. Example 1 is the prescription used here.
+
+The production identification is strong but not quite as direct as a modern data sheet naming this exact patent example. The patent prose states that the described embodiments have focal lengths of 75 mm, 90 mm, and 114 mm. Because the worked examples are presented in that three-example sequence, Example 1 is treated here as the 75 mm member. Its six-element, four-group, f/6.8 topology matches the compact Grandagon / Grandagon-N f/6.8 family. Archived large-format specification tables list a Grandagon N 75 mm f/6.8 in Copal 0 with 4x5 coverage, a 102° angle of coverage, a 187 mm image circle at f/22, and a 58 mm filter thread. Later Rodenstock/LINOS literature omits the 75 mm f/6.8 from the active Grandagon-N lens tables but still lists its E58/77 center filter and marks that 75 mm f/6.8 lens as no longer produced. That combination supports treating the patent's 75 mm scaling of Example 1 as the discontinued Rodenstock Grandagon-N 75 mm f/6.8.
+
+The production scaling applied in the data file is therefore uniform: all patent radii, axial thicknesses, baffle positions, and inferred semi-diameters are multiplied by 0.75. The resulting paraxial focal length is $74.982$ mm at the patent e-line prescription.
+
+## Optical Architecture
+
+The design is an all-spherical, six-element, four-group wide-angle objective of the Biogon-derived symmetric type. The power sequence is negative-positive-stop-positive-negative:
+
+- Group 1: L1, a negative meniscus ahead of the main converging groups.
+- Group 2: L2+L3, a cemented positive doublet immediately in front of the stop.
+- Aperture stop: located in the patent's split air space $l_2 = 1.28 + 1.34$.
+- Group 3: L4+L5, a cemented positive doublet immediately behind the stop.
+- Group 4: L6, a negative rear meniscus.
+
+This is not a retrofocus design in the strict optical sense. The verified back focal distance is 68.779 in the normalized patent units, or 51.584 mm after 0.75x scaling. Since the production-scaled paraxial EFL is 74.982 mm, $\mathrm{BFD}/\mathrm{EFL} = 0.688$, not greater than one. It is better described as a compact quasi-symmetric wide-angle design with enough rear clearance for a large-format shutter and lens board.
+
+The Petzval sum, computed surface by surface as $\sum \phi/(n n')$, is $+8.165 \times 10^{-5}$ in normalized patent units. That near-cancellation is central to the design: the positive cemented groups provide the imaging power, while the outer negative menisci counterbalance field curvature and distortion across the wide field.
+
+## Element-by-Element Analysis
+
+### L1 — Negative Meniscus, Convex to Object
+
+$n_e = 1.5246$, $\nu_e = 59.22$. Glass: K5 / N-K5 class, Schott match. Standalone $f = -44.17$ mm after scaling.
+
+L1 uses modest-index crown glass and has radii $r_1 = +102.18$ and $r_2 = +23.46$ in the normalized patent table. The stronger rear curvature makes it a negative meniscus. Its function is to accept the steep field bundle, bend it toward the central doublets, and supply negative Petzval curvature at the front of the lens.
+
+The same glass appears again in L6. That reuse is consistent with the quasi-symmetric correction strategy: the outer elements bracket the powered cemented groups with similar negative curvature contributions.
+
+### L2 + L3 — Front Cemented Positive Doublet
+
+#### L2 — Negative Meniscus
+
+$n_e = 1.7343$, $\nu_e = 28.47$. Glass: SF10 class, Schott legacy dense flint. Standalone $f = -50.48$ mm after scaling.
+
+L2 is the high-index, high-dispersion member of the front cemented group. Its negative meniscus form provides chromatic leverage without allowing the cemented group to become too strongly positive.
+
+#### L3 — Positive Meniscus
+
+$n_e = 1.6269$, $\nu_e = 46.71$. Glass: BaF8 / J-BAF8 class. Standalone $f = +17.50$ mm after scaling.
+
+L3 is the positive partner of the front doublet. The cemented pair has a verified net focal length of $+43.90$ mm after scaling. The patent also places the first internal stray-light baffle, $b_1$, inside this element at $db_1 = 4.46$ normalized units behind the cemented radius $r_4$, with $b_1 = 15.66$ full diameter in the normalized prescription.
+
+The doublet is not a simple crown-flint pair in the modern catalog sense; both glasses lie in flint territory by Abbe number. The correction comes from their relative dispersion difference, not from a crown/flint boundary at $\nu_d \approx 50$.
+
+### L4 + L5 — Rear Cemented Positive Doublet
+
+#### L4 — Biconvex Positive
+
+$n_e = 1.6541$, $\nu_e = 38.86$. Glass: BaSF4 class, Schott/Sumita equivalent. Standalone $f = +15.24$ mm after scaling.
+
+L4 is the strongest individual positive element in the system. Its very weak front radius and strongly curved cemented rear radius form a biconvex element that supplies most of the rear doublet's positive power. The patent places the second internal stray-light baffle, $b_2$, inside this element at $db_2 = 4.23$ normalized units behind $r_6$, with $b_2 = 14.94$ full diameter.
+
+#### L5 — Negative Meniscus
+
+$n_e = 1.7273$, $\nu_e = 29.02$. Glass: SF18 / S-TIH18 class dense flint. Standalone $f = -35.03$ mm after scaling.
+
+L5 partially cancels L4's strong positive power and provides the high-dispersion partner needed for the rear doublet's chromatic correction. The verified rear doublet net focal length is $+36.11$ mm after scaling, making it slightly stronger than the front doublet.
+
+### L6 — Negative Meniscus, Concave to Object
+
+$n_e = 1.5246$, $\nu_e = 59.22$. Glass: K5 / N-K5 class, Schott match. Standalone $f = -46.66$ mm after scaling.
+
+L6 mirrors the front meniscus in glass choice and function but is not a numerically symmetric copy. Its radii, $r_9 = -27.48$ and $r_{10} = -179.75$, form a negative rear meniscus that helps control field curvature, distortion, and chief-ray geometry before the final image plane.
+
+## Glass Identification and Selection
+
+The patent gives $n_e$ and $\nu_e$, so direct comparison to current catalog $n_d$ / $\nu_d$ values must be treated with care. The data file preserves the patent e-line indices for geometry; the catalog values below document the nearest glass identifications.
+
+| Element | Patent $n_e$ / $\nu_e$ | Catalog identification | Catalog $n_d$ / $\nu_d$ | Assessment |
+|---|---:|---|---:|---|
+| L1, L6 | 1.5246 / 59.22 | K5 / N-K5, Schott | 1.52249 / 59.48 | Exact e-line match to Schott N-K5 within rounding. |
+| L2 | 1.7343 / 28.47 | SF10, Schott legacy | 1.72825 / 28.41 | Index match at $n_e$; $\nu_e$ differs from the current Schott SF10 data, so this is treated as legacy/melt-equivalent. |
+| L3 | 1.6269 / 46.71 | BaF8 / J-BAF8 class | 1.62374 / 47.01 | Strong match to Hikari J-BAF8 / BaF8-class glass. |
+| L4 | 1.6541 / 38.86 | BaSF4 class | about 1.6513 / 38.3 | BaSF4-class match; current public catalogs do not make a melt-identical Schott BaSF4 assertion safe. |
+| L5 | 1.7273 / 29.02 | SF18 / S-TIH18 class | 1.72151 / 29.23 | Strong match to the SF18/S-TIH18 dense-flint position. |
+
+The glass palette is economical. No ED, fluorite, lanthanum crown, or anomalous partial-dispersion glass is required. The front doublet has the larger dispersion separation; the rear doublet has a smaller separation but greater positive power.
+
+## Focus Mechanism
+
+The optical design is unit-focused. In ordinary large-format use, the entire shutter-mounted lens moves as a unit relative to the film plane, and the camera bellows or focusing rail supplies the extension. The patent does not publish separate close-focus air-spacing tables and does not describe internal focusing.
+
+The `.data.ts` file therefore models focus by varying only the final back-focus gap. The infinity value is the verified e-line back focal distance after scaling, 51.584 mm. The close-focus value, 58.453 mm, is a 1.0 m object-to-image visualization reference solved by paraxial unit-focus tracing. It should not be read as a manufacturer minimum-focus specification.
+
+## Verification Summary
+
+All load-bearing paraxial quantities were re-derived from the patent prescription, not copied from the previous analysis.
+
+| Quantity | Patent / source value | Recomputed value | Note |
+|---|---:|---:|---|
+| Patent normalized EFL | $f' = 100$ | 99.9758 | e-line prescription, Example 1. |
+| Production-scaled EFL | 75 mm nominal | 74.9818 mm | 0.75x scale from patent. |
+| Patent normalized BFD | not separately tabulated | 68.7792 | Computed from final surface to paraxial image. |
+| Production-scaled BFD | not separately tabulated | 51.5844 mm | 0.75x scale. |
+| Mechanical optical track, L1 front to L6 rear | patent table | 83.990 normalized / 62.993 mm scaled | Sum excludes back focus. |
+| Petzval sum | not tabulated | $+8.165 \times 10^{-5}$ | Surface-by-surface $\phi/(n n')$. |
+| L2+L3 focal length | not tabulated | +58.533 normalized / +43.900 mm scaled | Standalone in-air cemented group. |
+| L4+L5 focal length | not tabulated | +48.142 normalized / +36.106 mm scaled | Standalone in-air cemented group. |
+
+Semi-diameters are not given by the patent. The data file uses conservative estimates constrained by the patent baffle diameters, the 58 mm production filter thread, on-axis f/6.8 marginal-ray tracing, a 0.6-field displayed chief-ray envelope, surface-rim constraints, cross-gap sag clearance, and element front/rear semi-diameter ratios.
+
+## Design Heritage and Context
+
+The Grandagon-N f/6.8 family belongs to the same broad wide-angle design tradition as the Biogon and Super-Angulon types: negative outer menisci surround positive interior groups at a central stop. The symmetry helps suppress odd-order aberrations, while the negative outer menisci help flatten the field and reduce distortion. DE 26 35 415 B1 is specifically framed as a six-element, economical alternative to more complex wide-angle objectives while preserving high field angle and f/6.8 aperture.
+
+The internal baffles $b_1$ and $b_2$ are a notable practical feature of this patent. They are not ordinary aperture stops; they are dye-blackened internal light traps placed inside the thick positive doublet elements to suppress stray light in a lens whose outer field rays pass through the cemented groups at steep angles.
+
+## Sources
+
+1. DE 26 35 415 B1 / DT 26 35 415 B1, *Sechslinsiges Weitwinkelobjektiv*, Optische Werke G. Rodenstock, announced 18 May 1977. Primary prescription source.
+2. Rodenstock/LINOS, *Lenses for Analog Professional Photography*, Grandagon-N and center-filter tables, <https://www.mr-alvandi.com/downloads/large-format/rodenstock-analog-lenses.pdf>.
+3. Photoscapes / large-format lens specification scan, *LargeFormatLenses*, Grandagon N specification table, <https://photoscapes.com/wp-content/uploads/LgFormatLenses.pdf>.
+4. Schott optical glass datasheets for N-K5 and SF10.
+5. Hikari / Nikon optical-glass cross-reference and J-series glass tables for BaF8-class equivalents.
+6. Ohara S-TIH18 catalog/datasheet.
+7. Sumita optical glass data book, BaSF4/SF-series Schott-type equivalents.

--- a/src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN75mmf68.data.ts
@@ -1,0 +1,164 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════════════╗
+ * ║ RODENSTOCK GRANDAGON-N 75mm f/6.8                                         ║
+ * ╠══════════════════════════════════════════════════════════════════════════════╣
+ * ║ Data source: DE 26 35 415 B1, claim/example 1, Optische Werke G.           ║
+ * ║ Rodenstock. Six-element, four-group all-spherical wide-angle objective.    ║
+ * ║                                                                            ║
+ * ║ Patent normalization: f' = 100 at the mercury e-line. All radii, axial     ║
+ * ║ distances, back focus, and semi-diameters are scaled by 0.75 to the        ║
+ * ║ 75 mm production focal length.                                             ║
+ * ║                                                                            ║
+ * ║ Index convention: the patent reports n_e / ν_e, not n_d / ν_d. The         ║
+ * ║ LensDataInput field names are retained, but the stored optical indices     ║
+ * ║ below preserve the patent e-line prescription so the paraxial geometry     ║
+ * ║ reproduces the patent's f' = 100 design. Catalog d-line equivalents are    ║
+ * ║ documented in the companion analysis.                                      ║
+ * ║                                                                            ║
+ * ║ Semi-diameters: not patent-listed. They are conservative estimates from    ║
+ * ║ paraxial marginal/chief-ray envelopes, the patent baffle diameters,        ║
+ * ║ the 58 mm production filter thread, and renderer constraints.              ║
+ * ║                                                                            ║
+ * ║ Focus: unit focus by view-camera bellows. The close-focus state below is   ║
+ * ║ a 1.0 m visualization reference; the real close-focus limit depends on     ║
+ * ║ the camera bellows or helical mount.                                       ║
+ * ╚══════════════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "rodenstock-grandagon-n-75mm-f68",
+  maker: "Rodenstock",
+  name: "RODENSTOCK GRANDAGON-N 75mm f/6.8",
+  subtitle: "DE 26 35 415 B1 Example 1 — Optische Werke G. Rodenstock",
+  specs: ["6 ELEMENTS / 4 GROUPS", "f = 75 mm", "F/6.8", "2ω = 102°", "IMAGE CIRCLE 187 mm", "ALL-SPHERICAL"],
+
+  focalLengthMarketing: 75,
+  focalLengthDesign: 74.98183,
+  apertureMarketing: 6.8,
+  apertureDesign: 6.8,
+  imageFormat: "4x5",
+  patentYear: 1977,
+  elementCount: 6,
+  groupCount: 4,
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 102,
+    maxTraceFieldDeg: 51,
+  },
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.5246,
+      vd: 59.22,
+      fl: -44.17,
+      glass: "K5 / N-K5 class (Schott; stored patent n_e)",
+      role: "Front negative meniscus; outer Petzval counterweight and front ray bender.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.7343,
+      vd: 28.47,
+      fl: -50.48,
+      glass: "SF10 class (Schott legacy; stored patent n_e)",
+      cemented: "D1",
+      role: "High-index flint member of the front cemented positive group.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Positive Meniscus",
+      nd: 1.6269,
+      vd: 46.71,
+      fl: 17.5,
+      glass: "BaF8 / J-BAF8 class (stored patent n_e)",
+      cemented: "D1",
+      role: "Lower-dispersion partner of the front cemented group; contains the b1 stray-light baffle in the patent drawing.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconvex Positive",
+      nd: 1.6541,
+      vd: 38.86,
+      fl: 15.24,
+      glass: "BaSF4 class (Schott/Sumita equivalent; stored patent n_e)",
+      cemented: "D2",
+      role: "Strong positive member of the rear cemented group; contains the b2 stray-light baffle in the patent drawing.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.7273,
+      vd: 29.02,
+      fl: -35.03,
+      glass: "SF18 / S-TIH18 class (stored patent n_e)",
+      cemented: "D2",
+      role: "Dense-flint negative partner of the rear cemented positive group.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Negative Meniscus",
+      nd: 1.5246,
+      vd: 59.22,
+      fl: -46.66,
+      glass: "K5 / N-K5 class (Schott; stored patent n_e)",
+      role: "Rear negative meniscus; balances the front meniscus and helps flatten the image field.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 76.635, d: 2.4675, nd: 1.5246, elemId: 1, sd: 19.0 },
+    { label: "2", R: 17.595, d: 10.0275, nd: 1.0, elemId: 0, sd: 15.8 },
+    { label: "3", R: 19.6725, d: 10.9425, nd: 1.7343, elemId: 2, sd: 10.6 },
+    { label: "4", R: 9.825, d: 8.8125, nd: 1.6269, elemId: 3, sd: 8.5 },
+    { label: "5", R: 61.53, d: 0.96, nd: 1.0, elemId: 0, sd: 6.8 },
+    { label: "STO", R: 1e15, d: 1.005, nd: 1.0, elemId: 0, sd: 5.58 },
+    { label: "6", R: 127.2675, d: 7.8525, nd: 1.6541, elemId: 4, sd: 6.8 },
+    { label: "7", R: -10.5525, d: 8.895, nd: 1.7273, elemId: 5, sd: 8.5 },
+    { label: "8", R: -24.405, d: 10.0275, nd: 1.0, elemId: 0, sd: 10.6 },
+    { label: "9", R: -20.61, d: 2.0025, nd: 1.5246, elemId: 6, sd: 15.8 },
+    { label: "10", R: -134.8125, d: 51.58441, nd: 1.0, elemId: 0, sd: 19.0 },
+  ],
+
+  asph: {},
+  var: {
+    "10": [51.58441, 58.45311],
+  },
+  varLabels: [["10", "BF"]],
+  groups: [
+    { text: "G1", fromSurface: "1", toSurface: "2" },
+    { text: "G2", fromSurface: "3", toSurface: "5" },
+    { text: "G3", fromSurface: "6", toSurface: "8" },
+    { text: "G4", fromSurface: "9", toSurface: "10" },
+  ],
+  doublets: [
+    { text: "D1", fromSurface: "3", toSurface: "5" },
+    { text: "D2", fromSurface: "6", toSurface: "8" },
+  ],
+
+  focusDescription: "Unit focus by camera bellows; BF close state is a 1.0 m visualization reference.",
+  closeFocusM: 1.0,
+  nominalFno: 6.8,
+  fstopSeries: [6.8, 8, 11, 16, 22, 32, 45],
+  maxFstop: 45,
+  offAxisFieldFrac: 0.6,
+  scFill: 0.58,
+  yScFill: 0.82,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.analysis.md
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.analysis.md
@@ -1,0 +1,145 @@
+## Patent Reference and Design Identification
+
+**Patent:** DE 2444954 A1
+**Filed:** 20 September 1974
+**Published:** 1 April 1976
+**Inventors:** Franz Schlegel; Josef Weiß
+**Applicant:** Optische Werke G. Rodenstock, 8000 München
+**Title:** Achtlinsiges Weitwinkelobjektiv
+**Embodiment analyzed:** Patentanspruch 2 — f′ = 90 mm, 1:4.5
+**Prescription basis:** Native patent data are tabulated at the e-line, with $n_e$ and $ν_e$ explicitly stated by the patent.
+
+Claim 2 is the appropriate prescription for the Rodenstock Grandagon-N 90mm f/4.5. The identification is based on the patent's f′ = 90 mm and 1:4.5 claim table, the eight-element/four-group construction, the two cemented triplets surrounding a central stop, and the Rodenstock/LINOS product documentation for the Grandagon-N f/4.5 family, which describes the 65–90 mm f/4.5 lenses as eight elements in four groups with a 105° field angle. The f/6.8 90 mm Grandagon-N belongs to the separate six-element version and is not this prescription.
+
+The patent's description states the design goal directly: a compact, well-corrected wide-angle objective at approximately 1:4.5 using ordinary optical glasses with refractive indices not exceeding 1.7. It also specifies the structural principle: two cemented triplets, one on each side of the stop, with the refractive indices in each triplet increasing from the diaphragm outward.
+
+## Optical Architecture
+
+The design is a quasi-symmetric wide-angle objective with eight elements in four air-separated groups:
+
+| Group | Elements | Standalone focal length | Role                              |
+| ----- | -------: | ----------------------: | --------------------------------- |
+| G1    |       L1 |                −67.8 mm | Front diverging meniscus          |
+| G2    |    L2–L4 |                +61.5 mm | Front cemented positive triplet   |
+| Stop  |        — |                       — | Aperture between the two triplets |
+| G3    |    L5–L7 |                +50.8 mm | Rear cemented positive triplet    |
+| G4    |       L8 |                −60.6 mm | Rear diverging meniscus           |
+
+The power order is negative–positive–positive–negative. This is not a retrofocus layout in the strict sense: the computed back focal distance is about 62.8 mm at the patent e-line, shorter than the effective focal length. The lens instead relies on a near-symmetric wide-angle form, with outer negative menisci bending oblique bundles and the two triplets supplying the principal positive power.
+
+The patent's refractive-index gradient is present in the numerical example. In the front triplet, the e-line index increases outward from L4 to L3 to L2: 1.5629 < 1.6251 < 1.6776. In the rear triplet, it increases outward from L5 to L6 to L7: 1.5855 < 1.6113 < 1.6700. This reduces the need for very high-index glass while maintaining compact curvatures and useful wide-angle correction.
+
+A surface-by-surface Petzval calculation gives +0.0001320 mm⁻¹ at the patent e-line, corresponding to a Petzval radius of about 7,574 mm, or roughly 83.5× the computed e-line EFL. That value is calculated from the actual refracting surfaces, not from thin-lens element sums.
+
+## Element-by-Element Analysis
+
+The first line of each element gives the d-line glass assignment used in the data file. The patent itself gives $n_e$ and $ν_e$; those native patent values are summarized in the glass table below.
+
+### L1 — Negative Meniscus, Convex to Object
+
+nd = 1.46450, νd = 65.77. Glass: FK3 (Schott inquiry glass). f = −67.8 mm.
+
+L1 is the front diverging meniscus. Its two positive radii, r₁ = +91.73 mm and r₂ = +22.96 mm, give a convex object-side form with strong negative optical power. The glass is a low-index, high-Abbe fluorophosphate crown, appropriate for an outer field-bending element where ray heights are comparatively large.
+
+The d-line value used here follows the Schott FK3 inquiry-glass data: nd = 1.46450 and νd = 65.77, corresponding closely to the patent's nₑ = 1.4662 and νₑ = 65.56.
+
+### L2 — Negative Meniscus, Front Triplet Outer Element
+
+nd = 1.67270, νd = 32.21. Glass: SF5 (Schott). f = −117.8 mm.
+
+L2 is the high-index dense-flint outer element of the front cemented triplet. Its weak negative standalone power balances the much stronger positive L3 and provides the high-dispersion partner in the front triplet. The patent e-line pair, nₑ = 1.6776 and νₑ = 31.97, matches Schott SF5 closely.
+
+### L3 — Biconvex Positive, Front Triplet Middle Element
+
+nd = 1.62229, νd = 53.27. Glass: SSK2 / N-SSK2 (Schott). f = +18.9 mm.
+
+L3 is the main positive element of the front triplet. Its nearly opposed curvatures, r₄ = +20.83 mm and r₅ = −20.24 mm, form a strongly powered biconvex element. The SSK2-class crown provides high enough index for the short focal length while keeping dispersion moderate.
+
+### L4 — Biconcave Negative, Front Triplet Inner Element
+
+nd ≈ 1.56091, νd ≈ 46.78. Glass: LLF3 / QF2 class, inferred from d-code 561468. f = −32.0 mm.
+
+L4 is the inner negative element of the front triplet, next to the aperture stop. Its patent e-line values are nₑ = 1.5629 and νₑ = 46.88. A close d-line cross-reference places this element in the LLF3 / QF2 class. The assignment remains marked as inferred because a directly matching Schott historical datasheet was not available in the checked sources.
+
+### L5 — Negative Meniscus, Rear Triplet Inner Element
+
+nd = 1.58313, νd = 59.38. Glass: SK12 / S-BAL42 class. f = −32.5 mm.
+
+L5 is the rear-side counterpart to L4 in position, but not in dispersion. Its patent value, νₑ = 59.19, makes it a crown-like barium glass rather than a moderate flint. Its weakly curved front surface and strongly curved cemented rear surface create negative power while allowing the rear triplet to use a different chromatic strategy from the front triplet.
+
+### L6 — Biconvex Positive, Rear Triplet Middle Element
+
+nd = 1.60881, νd = 58.86. Glass: SK3 / H-ZK4 class. f = +16.0 mm.
+
+L6 is the strongest individual positive element in the lens. The d-line pair nd = 1.60881 and νd = 58.86 corresponds to the SK3 / H-ZK4 class. Modern N-SK4 is a different nearby glass at approximately nd = 1.61272 and νd = 58.6, so SK4 is not the preferred identification for this element.
+
+### L7 — Negative Meniscus, Rear Triplet Outer Element
+
+nd = 1.66672, νd = 48.33. Glass: BaF11 / S-BAH11 class. f = −59.4 mm.
+
+L7 is the high-index outer element of the rear triplet. It is a negative meniscus concave toward the object side, using a barium-flint-class glass with substantially higher Abbe number than the front triplet's SF5. This asymmetry is part of the lens's chromatic balance: the two halves are geometrically similar but not glass-symmetric.
+
+### L8 — Negative Meniscus, Concave to Object
+
+nd = 1.48749, νd = 70.41. Glass: N-FK5 / FK5 (Schott). f = −60.6 mm.
+
+L8 is the rear diverging meniscus. Its two negative radii place the concave side toward the object and the convex side toward the image. It supplies rear field bending and Petzval compensation while leaving a long enough back focus for large-format shutter and bellows clearance.
+
+## Glass Identification and Selection
+
+The patent's native spectral convention is e-line. The data file stores d-line values because the LensVisualizer data model uses d-line `nd` and `νd` fields for elements and refracting media.
+
+| Element | Patent nₑ | Patent νₑ | d-line assignment used    |       nd |     νd | Confidence                   |
+| ------- | --------: | --------: | ------------------------- | -------: | -----: | ---------------------------- |
+| L1      |    1.4662 |     65.56 | FK3, Schott inquiry glass |  1.46450 |  65.77 | Direct Schott match          |
+| L2      |    1.6776 |     31.97 | SF5, Schott               |  1.67270 |  32.21 | Direct Schott match          |
+| L3      |    1.6251 |     52.86 | SSK2 / N-SSK2, Schott     |  1.62229 |  53.27 | Direct class match           |
+| L4      |    1.5629 |     46.88 | LLF3 / QF2 class          | ≈1.56091 | ≈46.78 | Inferred; close d-code match |
+| L5      |    1.5855 |     59.19 | SK12 / S-BAL42 class      |  1.58313 |  59.38 | Cross-reference match        |
+| L6      |    1.6113 |     58.65 | SK3 / H-ZK4 class         |  1.60881 |  58.86 | Cross-reference match        |
+| L7      |    1.6700 |     48.13 | BaF11 / S-BAH11 class     |  1.66672 |  48.33 | Cross-reference match        |
+| L8      |    1.4891 |     70.22 | N-FK5 / FK5, Schott       |  1.48749 |  70.41 | Direct Schott match          |
+
+The SK3 / H-ZK4 class is the best match for L6. A SK4-class assignment is too high in refractive index for the stored d-line values and would not match the patent-derived pair as closely.
+
+L4 remains the lowest-confidence glass assignment. The numerical pair is close to the LLF3 / QF2 cross-reference class, but it is safer to retain the "class" and "inferred" wording than to assert a recovered Schott catalog identity.
+
+## Focus Mechanism
+
+The patent publishes a fixed infinity-focus prescription. No internal focusing, floating group, or variable air-space table is present. The production Grandagon-N is a large-format lens focused by moving the whole lens on the camera bellows.
+
+The companion `.data.ts` file models focus as a representative unit-focus back-focus change only: the final image-space gap is variable, while all inter-element spacings remain fixed. The close-focus slider endpoint is therefore a visualization convention, not a manufacturer-published minimum-focus specification.
+
+## Aspherical Surfaces
+
+No aspherical surfaces are present. The prescription consists of twelve spherical refracting surfaces and one flat aperture stop inserted in the central air gap.
+
+## Verification Summary
+
+Independent paraxial verification was re-run from the Claim 2 table.
+
+| Quantity                                   | Patent / source value | Recomputed value | Note                        |
+| ------------------------------------------ | --------------------: | ---------------: | --------------------------- |
+| Patent focal length                        |                 90 mm |         90.70 mm | e-line prescription trace   |
+| Total optical track, first to last surface |                     — |         91.90 mm | Sum of fixed axial spacings |
+| Back focal distance                        |                     — |         62.76 mm | e-line prescription trace   |
+| First vertex to image plane                |                     — |        154.66 mm | Track + BFD                 |
+| Petzval sum                                |                     — |  +0.0001320 mm⁻¹ | Surface-by-surface φ/(n·n′) |
+| Petzval radius                             |                     — |         7,574 mm | 1 / Petzval sum             |
+
+Using the d-line glass substitutions stored in the data file, the same geometry gives EFL ≈ 91.27 mm and BFD ≈ 63.31 mm. The data file therefore uses a final image-space distance of 63.3142 mm so that the d-line model focuses at infinity.
+
+The semi-diameters in the data file are not patent values. They were estimated conservatively for rendering: the checks used spherical rim limits, common-aperture edge thickness, and cross-gap sag intrusion. The limiting elements are the strongly biconvex L3 and L6, where edge thickness binds before full-field paraxial ray envelopes.
+
+## Design Heritage and Context
+
+The patent cites DE 1,447,216 and DE OS 2,012,489 as earlier related wide-angle constructions. Its claimed improvement is not a new element count alone, but the specific combination of a compact eight-element form, two cemented triplets near the stop, outward-increasing triplet indices, and ordinary glasses with refractive indices not over 1.7.
+
+The patent description lists special examples for f = 90, f = 75, and f = 60, but Claim 4's numerical table itself specifies f′ = 65. The claim table governs the prescription family: 90 mm, 75 mm, and 65 mm examples.
+
+## Sources
+
+- DE 2444954 A1, "Achtlinsiges Weitwinkelobjektiv," Optische Werke G. Rodenstock, published 1 April 1976.
+- Rodenstock / LINOS Grandagon-N large-format lens documentation for production family matching.
+- SCHOTT Optical Glass datasheets and inquiry-glass data for FK3, SF5, SSK2 / N-SSK2, and N-FK5 / FK5.
+- HOYA Glass Cross Reference Index and CDGM cross-reference tables for equivalent glass-class assignments.

--- a/src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts
+++ b/src/lens-data/rodenstock/RodenstockGrandagonN90mmf45.data.ts
@@ -1,0 +1,195 @@
+import type { LensDataInput } from "../../types/optics.js";
+
+/**
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║   LENS DATA — RODENSTOCK GRANDAGON-N 90mm f/4.5                    ║
+ * ╠══════════════════════════════════════════════════════════════════════╣
+ * ║  Data source: DE 2444954 A1, Patentanspruch 2.                    ║
+ * ║  Eight-element quasi-symmetric wide-angle objective with two       ║
+ * ║  cemented triplets around a central aperture stop.                 ║
+ * ║  8 elements / 4 groups, all spherical.                            ║
+ * ║  Focus: unit displacement by camera bellows; the data model varies ║
+ * ║  only the final back-focus gap as a representative bellows travel. ║
+ * ║                                                                    ║
+ * ║  NOTE ON GLASS DATA:                                               ║
+ * ║  The patent tabulates n_e / ν_e. The surface prescription here     ║
+ * ║  stores d-line catalog or cross-reference values for the renderer. ║
+ * ║  The companion analysis records the native e-line verification.    ║
+ * ║                                                                    ║
+ * ║  NOTE ON SEMI-DIAMETERS:                                           ║
+ * ║  The patent does not publish clear semi-diameters. Values below    ║
+ * ║  are conservative renderer-safe estimates constrained by element   ║
+ * ║  edge thickness, spherical rim limits, and cross-gap sag clearance.║
+ * ║  They should not be read as factory mechanical clear apertures.    ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
+ */
+
+const LENS_DATA = {
+  key: "rodenstock-grandagon-n-90mm-f45",
+  maker: "Rodenstock",
+  name: "RODENSTOCK GRANDAGON-N 90mm f/4.5",
+  subtitle: "DE 2444954 A1 Claim 2 — f′ = 90 mm",
+  specs: ["8 ELEMENTS / 4 GROUPS", "f′ = 90 mm patent example", "F/4.5", "105° published coverage", "ALL-SPHERICAL"],
+
+  focalLengthMarketing: 90,
+  focalLengthDesign: 91.27,
+  apertureMarketing: 4.5,
+  apertureDesign: 4.5,
+  imageFormat: "5x7",
+  patentYear: 1976,
+  elementCount: 8,
+  groupCount: 4,
+  projection: {
+    kind: "rectilinear",
+    fullFieldDeg: 105,
+    maxTraceFieldDeg: 52.5,
+  },
+  focusDescription:
+    "Unit focus by camera bellows; no internal focus groups. The focus slider varies only the final back-focus gap.",
+
+  elements: [
+    {
+      id: 1,
+      name: "L1",
+      label: "Element 1",
+      type: "Negative Meniscus",
+      nd: 1.4645,
+      vd: 65.77,
+      fl: -67.78,
+      glass: "FK3 (Schott inquiry glass)",
+      role: "Front diverging meniscus for wide-angle field bending and Petzval compensation.",
+    },
+    {
+      id: 2,
+      name: "L2",
+      label: "Element 2",
+      type: "Negative Meniscus",
+      nd: 1.6727,
+      vd: 32.21,
+      fl: -117.8,
+      glass: "SF5 (Schott)",
+      cemented: "T1",
+      role: "High-index dense-flint outer element of the front cemented triplet.",
+    },
+    {
+      id: 3,
+      name: "L3",
+      label: "Element 3",
+      type: "Biconvex Positive",
+      nd: 1.62229,
+      vd: 53.27,
+      fl: 18.86,
+      glass: "SSK2 / N-SSK2 (Schott)",
+      cemented: "T1",
+      role: "Strong positive crown element in the front triplet.",
+    },
+    {
+      id: 4,
+      name: "L4",
+      label: "Element 4",
+      type: "Biconcave Negative",
+      nd: 1.56091,
+      vd: 46.78,
+      fl: -31.96,
+      glass: "LLF3 / QF2 class (inferred, d-code 561468)",
+      cemented: "T1",
+      role: "Inner negative element of the front triplet, adjacent to the stop.",
+    },
+    {
+      id: 5,
+      name: "L5",
+      label: "Element 5",
+      type: "Negative Meniscus",
+      nd: 1.58313,
+      vd: 59.38,
+      fl: -32.52,
+      glass: "SK12 / S-BAL42 class (Schott/Ohara equivalent)",
+      cemented: "T2",
+      role: "Inner negative crown element of the rear cemented triplet.",
+    },
+    {
+      id: 6,
+      name: "L6",
+      label: "Element 6",
+      type: "Biconvex Positive",
+      nd: 1.60881,
+      vd: 58.86,
+      fl: 15.97,
+      glass: "SK3 / H-ZK4 class (Schott/CDGM equivalent)",
+      cemented: "T2",
+      role: "Strong positive element in the rear triplet.",
+    },
+    {
+      id: 7,
+      name: "L7",
+      label: "Element 7",
+      type: "Negative Meniscus",
+      nd: 1.66672,
+      vd: 48.33,
+      fl: -59.44,
+      glass: "BaF11 / S-BAH11 class (Schott/Ohara equivalent)",
+      cemented: "T2",
+      role: "High-index outer negative element of the rear triplet.",
+    },
+    {
+      id: 8,
+      name: "L8",
+      label: "Element 8",
+      type: "Negative Meniscus",
+      nd: 1.48749,
+      vd: 70.41,
+      fl: -60.62,
+      glass: "N-FK5 / FK5 (Schott)",
+      role: "Rear diverging meniscus and field-flattening outer element.",
+    },
+  ],
+
+  surfaces: [
+    { label: "1", R: 91.73, d: 6.65, nd: 1.4645, elemId: 1, sd: 25.2 },
+    { label: "2", R: 22.96, d: 11.9, nd: 1.0, elemId: 0, sd: 20.2 },
+
+    { label: "3", R: 36.52, d: 15.25, nd: 1.6727, elemId: 2, sd: 17.5 },
+    { label: "4", R: 20.83, d: 13.8, nd: 1.62229, elemId: 3, sd: 13.0 },
+    { label: "5", R: -20.24, d: 1.0, nd: 1.56091, elemId: 4, sd: 13.0 },
+    { label: "6", R: 164.89, d: 2.1, nd: 1.0, elemId: 0, sd: 12.2 },
+
+    { label: "STO", R: 1e15, d: 0.65, nd: 1.0, elemId: 0, sd: 10.63 },
+
+    { label: "7", R: 405.33, d: 1.0, nd: 1.58313, elemId: 5, sd: 12.2 },
+    { label: "8", R: 18.17, d: 13.3, nd: 1.60881, elemId: 6, sd: 13.0 },
+    { label: "9", R: -15.23, d: 11.25, nd: 1.66672, elemId: 7, sd: 13.0 },
+    { label: "10", R: -31.97, d: 11.15, nd: 1.0, elemId: 0, sd: 17.5 },
+
+    { label: "11", R: -23.37, d: 3.85, nd: 1.48749, elemId: 8, sd: 20.2 },
+    { label: "12", R: -116.31, d: 63.3142, nd: 1.0, elemId: 0, sd: 25.2 },
+  ],
+
+  asph: {},
+  var: {
+    "12": [63.3142, 72.482],
+  },
+  varLabels: [["12", "BF"]],
+
+  groups: [
+    { text: "G1", fromSurface: "1", toSurface: "2" },
+    { text: "G2", fromSurface: "3", toSurface: "6" },
+    { text: "G3", fromSurface: "7", toSurface: "10" },
+    { text: "G4", fromSurface: "11", toSurface: "12" },
+  ],
+  doublets: [
+    { text: "Front triplet", fromSurface: "3", toSurface: "6" },
+    { text: "Rear triplet", fromSurface: "7", toSurface: "10" },
+  ],
+
+  closeFocusM: 1.0,
+  nominalFno: 4.5,
+  fstopSeries: [4.5, 5.6, 8, 11, 16, 22, 32, 45, 64],
+  maxFstop: 64,
+
+  scFill: 0.72,
+  yScFill: 0.82,
+  offAxisFieldFrac: 0.35,
+  rayLeadFrac: 0.28,
+} satisfies LensDataInput;
+
+export default LENS_DATA;

--- a/src/utils/content/changelogData.ts
+++ b/src/utils/content/changelogData.ts
@@ -19,6 +19,12 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  // ── 2026-06-25 ──────────────────────────────────────────────────────────
+  {
+    date: "2026-06-25",
+    type: "lens",
+    summary: "Added six Rodenstock large-format lenses",
+  },
   // ── 2026-06-22 ──────────────────────────────────────────────────────────
   {
     date: "2026-06-22",


### PR DESCRIPTION
## Summary
- Add Rodenstock Apo-Sironar-W 150mm f/5.6 and Geronar 210mm f/6.8 data with analysis notes
- Add Grandagon-N 65/75/90mm f/4.5 and 75mm f/6.8 prescriptions with companion analysis files
- Tune Grandagon semi-diameters for symmetric patent-style rendering and correct Geronar stop-position analysis text

## Tests
- npm run typecheck
- npm run format:check
- npm run lint
- npm run test -- __tests__/src/optics/exactTraceCatalog.test.ts